### PR TITLE
VolumeReplicationGroup Operator: Add watchers to monitor pvcs

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,14 +78,32 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.VolumeReplicationGroupReconciler{
+	r := &controllers.VolumeReplicationGroupReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("VolumeReplicationGroup"),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
+	}
+
+	// setup manager with a controller for volumereplicationgroup resource
+	if err = r.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VolumeReplicationGroup")
 		os.Exit(1)
 	}
+
+	setupLog.Info("Registering Components.")
+
+	// Setup Scheme for all resources
+	if err := controllers.AddToScheme(mgr.GetScheme()); err != nil {
+		setupLog.Error(err, "")
+		os.Exit(1)
+	}
+
+	// Setup all Controllers
+	if err := controllers.AddToManager(mgr); err != nil {
+		setupLog.Error(err, "")
+		os.Exit(1)
+	}
+
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {


### PR DESCRIPTION
* Adding watchers in the VolumeReplicationGroup operator to watch for
  pvcs and send reconcile request for pvc create/update/delete
  operations based on the following logic
  	- The pvc on which notification came must belong to one of
          the VolumeReplicationGroup CR's namespace
	- The pvc on which notification came must have labels that
          matches with the VolumeReplicationGroup CR from the namespace
	  to which the pvc belongs to.

Signed-off-by: Raghavendra M <raghavendra@redhat.com>