### PR TITLE
Update wsl linter to enable err cuddling

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -41,6 +41,7 @@ linters-settings:
     locale: US
   wsl:
     allow-trailing-comment: true
+    enforce-err-cuddling: true
 
 linters:
   enable-all: true


### PR DESCRIPTION
Ref.: https://github.com/bombsimon/wsl/blob/master/doc/rules.md#if-statements-that-check-an-error-must-be-cuddled-with-the-statement-that-assigned-the-error

Config Ref: https://github.com/bombsimon/wsl/blob/master/doc/configuration.md#enforce-err-cuddling

Was attempting to allow looser cuddling for assignments and other statements, but that allowed cuddling to become too loose. As a result of looking at other parameters found this setting for cuddling which is useful to enforce.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>