### PR TITLE
fix make install error in AVR CRD

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 - bases/ramendr.openshift.io_volumereplicationgroups.yaml
 - bases/ramendr.openshift.io_clusterids.yaml
 - bases/ramendr.openshift.io_clusterpeers.yaml
-- bases/ramendr.openshift.io_ApplicationVolumeReplications.yaml
+- bases/ramendr.openshift.io_applicationvolumereplications.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:


### PR DESCRIPTION
- found on c9de4dd28f4a3ad402078658e64afd99b35c13cc

`config/crd/kustomization.yaml` needs case-matched string for new AVR resource. 

PR #12 also contains this fix, and I'm not sure when that will be approved, but there is currently a compile error from a fresh install which passed our current approval process. This is a good opportunity to begin a conversation about CI tools.

Full error text for this issue: 
```
$ make install
/home/tjanssen/go/src/github.com/tjanssen3/ramen/bin/controller-gen "crd:trivialVersions=true,preserveUnknownFields=false" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/home/tjanssen/go/src/github.com/tjanssen3/ramen/bin/kustomize build config/crd | kubectl apply -f -
Error: accumulating resources: 2 errors occurred:
        * accumulateFile error: "accumulating resources from 'bases/ramendr.openshift.io_ApplicationVolumeReplications.yaml': evalsymlink failure on '/home/tjanssen/go/src/github.com/tjanssen3/ramen/config/crd/bases/ramendr.openshift.io_ApplicationVolumeReplications.yaml' : lstat /home/tjanssen/go/src/github.com/tjanssen3/ramen/config/crd/bases/ramendr.openshift.io_ApplicationVolumeReplications.yaml: no such file or directory"
        * loader.New error: "error loading bases/ramendr.openshift.io_ApplicationVolumeReplications.yaml with git: url lacks host: bases/ramendr.openshift.io_ApplicationVolumeReplications.yaml, dir: evalsymlink failure on '/home/tjanssen/go/src/github.com/tjanssen3/ramen/config/crd/bases/ramendr.openshift.io_ApplicationVolumeReplications.yaml' : lstat /home/tjanssen/go/src/github.com/tjanssen3/ramen/config/crd/bases/ramendr.openshift.io_ApplicationVolumeReplications.yaml: no such file or directory, get: invalid source string: bases/ramendr.openshift.io_ApplicationVolumeReplications.yaml"


error: no objects passed to apply
Makefile:45: recipe for target 'install' failed
make: *** [install] Error 1
```