### PR TITLE
[WIP] Fix requeue and to ignore local subscriptions

### DIFF
--- a/config/samples/pvc.yaml
+++ b/config/samples/pvc.yaml
@@ -6,7 +6,6 @@ metadata:
     appclass: gold
     environment: dev.AZ1
 spec:
-  storageClassName: "local-storage"
   accessModes:
     - ReadWriteOnce
   resources:

--- a/config/samples/ramendr_v1alpha1_applicationvolumereplication.yaml
+++ b/config/samples/ramendr_v1alpha1_applicationvolumereplication.yaml
@@ -1,11 +1,6 @@
 apiVersion: ramendr.openshift.io/v1alpha1
 kind: ApplicationVolumeReplication
 metadata:
-  name: ApplicationVolumeReplication-sample
-  namespace: default
+  name: applicationvolumereplication-sample
 spec:
-  placement:
-    placementRef:
-      kind: PlacementRule
-      name: towhichcluster
   failedCluster: empty

--- a/main.go
+++ b/main.go
@@ -20,6 +20,10 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+	spokeClusterV1 "github.com/open-cluster-management/api/cluster/v1"
+	ocmworkv1 "github.com/open-cluster-management/api/work/v1"
+	plrv1 "github.com/open-cluster-management/multicloud-operators-placementrule/pkg/apis/apps/v1"
+	subv1 "github.com/open-cluster-management/multicloud-operators-subscription/pkg/apis/apps/v1"
 	volrep "github.com/shyamsundarr/volrep-shim-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -44,6 +48,10 @@ func init() {
 
 	utilruntime.Must(ramendrv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(volrep.AddToScheme(scheme))
+	utilruntime.Must(subv1.SchemeBuilder.AddToScheme(scheme))
+	utilruntime.Must(plrv1.AddToScheme(scheme))
+	utilruntime.Must(ocmworkv1.AddToScheme(scheme))
+	utilruntime.Must(spokeClusterV1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
- We should requeue the AVR in case there are
multiple subscriptions and one or more of them
fail to create the required manifest work

- We should ignore local subscriptions, typical when
the hub is a managed cluster as well, using the
subscription.status.phase

- Also fixed adding various CRDs to the scheme as
the reconciler failed on a minikube cluster without
the required schemes

- Cleaned up AVR sample to remove placement reference

- Removed StorageClass on PVC sample, to make it easier
to kustomize in a test deployment (as otherwise it keeps
going to the default namespace)

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>