### PR TITLE
Upload PV's k8s metadata to S3 object store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ testbin/*
 *.swp
 *.swo
 *~
+.vscode

--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -59,7 +59,8 @@ type VolumeReplicationGroupSpec struct {
 	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
 	// If this field is not set, VRG may be used to simply control the replication
 	// state of all PVs in this group, under the expectation that the PV metadata
-	// is replicated by a different mechanism.
+	// is replicated by a different mechanism; this mode of operation may be
+	// referred to as backup-less mode.
 	S3Endpoint string `json:"s3Endpoint,omitempty"`
 
 	// Name of k8s secret that contains the credentials to access the S3 endpoint.

--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -50,6 +50,24 @@ type VolumeReplicationGroupSpec struct {
 	// Desired state of all volumes [primary or secondary] in this replication group;
 	// this value is propagated to children VolumeReplication CRs
 	ReplicationState volrep.ReplicationState `json:"replicationState"`
+
+	// S3 Endpoint to replicate PV metadata; set this field, along with a secret
+	// that contains the access-key-id and secret-access-key to enable VRG to
+	// replicate the PV metadata to the given s3 endpoint to a bucket with
+	// VRG's name.  Thus the VRG name needs to be unique among other VRGs using
+	// the same S3Endpoint and it should also follow AWS bucket naming rules:
+	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+	// If this field is not set, VRG may be used to simply control the replication
+	// state of all PVs in this group, under the expectation that the PV metadata
+	// is replicated by a different mechanism.
+	S3Endpoint string `json:"s3Endpoint,omitempty"`
+
+	// Name of k8s secret that contains the credentials to access the S3 endpoint.
+	// If S3Endpoint is used, also specify the k8s secret that contains the S3
+	// access key id and secret access key set using the keys: AWS_ACCESS_KEY_ID
+	// and AWS_SECRET_ACCESS_KEY.  The secret should be present in the same namespace
+	// as the VRG
+	S3SecretName string `json:"s3SecretName,omitempty"`
 }
 
 // VolumeReplicationGroupStatus defines the observed state of VolumeReplicationGroup

--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -54,8 +54,9 @@ type VolumeReplicationGroupSpec struct {
 	// S3 Endpoint to replicate PV metadata; set this field, along with a secret
 	// that contains the access-key-id and secret-access-key to enable VRG to
 	// replicate the PV metadata to the given s3 endpoint to a bucket with
-	// VRG's name.  Thus the VRG name needs to be unique among other VRGs using
-	// the same S3Endpoint and it should also follow AWS bucket naming rules:
+	// a name created using VRG's namespace and name,  which needs to be unique
+	// among other VRGs using the same S3Endpoint and it should also follow the
+	// AWS bucket naming rules:
 	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
 	// If this field is not set, VRG may be used to simply control the replication
 	// state of all PVs in this group, under the expectation that the PV metadata

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -106,9 +106,9 @@ spec:
                 description: 'S3 Endpoint to replicate PV metadata; set this field,
                   along with a secret that contains the access-key-id and secret-access-key
                   to enable VRG to replicate the PV metadata to the given s3 endpoint
-                  to a bucket with VRG''s name.  Thus the VRG name needs to be unique
-                  among other VRGs using the same S3Endpoint and it should also follow
-                  AWS bucket naming rules: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+                  to a bucket with a name created using VRG''s namespace and name,  which
+                  needs to be unique among other VRGs using the same S3Endpoint and
+                  it should also follow the AWS bucket naming rules: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
                   If this field is not set, VRG may be used to simply control the
                   replication state of all PVs in this group, under the expectation
                   that the PV metadata is replicated by a different mechanism; this

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -102,6 +102,24 @@ spec:
                 - Primary
                 - Secondary
                 type: string
+              s3Endpoint:
+                description: 'S3 Endpoint to replicate PV metadata; set this field,
+                  along with a secret that contains the access-key-id and secret-access-key
+                  to enable VRG to replicate the PV metadata to the given s3 endpoint
+                  to a bucket with VRG''s name.  Thus the VRG name needs to be unique
+                  among other VRGs using the same S3Endpoint and it should also follow
+                  AWS bucket naming rules: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+                  If this field is not set, VRG may be used to simply control the
+                  replication state of all PVs in this group, under the expectation
+                  that the PV metadata is replicated by a different mechanism.'
+                type: string
+              s3SecretName:
+                description: 'Name of k8s secret that contains the credentials to
+                  access the S3 endpoint. If S3Endpoint is used, also specify the
+                  k8s secret that contains the S3 access key id and secret access
+                  key set using the keys: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.  The
+                  secret should be present in the same namespace as the VRG'
+                type: string
               volumeReplicationClass:
                 description: ReplicationClass of all volumes in this replication group;
                   this value is propagated to children VolumeReplication CRs

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -111,7 +111,8 @@ spec:
                   AWS bucket naming rules: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
                   If this field is not set, VRG may be used to simply control the
                   replication state of all PVs in this group, under the expectation
-                  that the PV metadata is replicated by a different mechanism.'
+                  that the PV metadata is replicated by a different mechanism; this
+                  mode of operation may be refered to as backup-less mode.'
                 type: string
               s3SecretName:
                 description: 'Name of k8s secret that contains the credentials to

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -112,7 +112,7 @@ spec:
                   If this field is not set, VRG may be used to simply control the
                   replication state of all PVs in this group, under the expectation
                   that the PV metadata is replicated by a different mechanism; this
-                  mode of operation may be refered to as backup-less mode.'
+                  mode of operation may be referred to as backup-less mode.'
                 type: string
               s3SecretName:
                 description: 'Name of k8s secret that contains the credentials to

--- a/controllers/s3utils.go
+++ b/controllers/s3utils.go
@@ -1,0 +1,404 @@
+/*
+Copyright 2021 The RamenDR authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	errorswrapper "github.com/pkg/errors"
+	"github.com/prometheus/common/log"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Example usage:
+// func example_code() {
+// *** setup a new s3 object store ***
+// s3endpoint := "http://127.0.0.1:9000"
+// s3secretname := types.namespacedname{name: s3secretname, namespace: parent.namespace}
+
+// s3conn, err := connecttos3endpoint(ctx, reconciler, s3endpoint, s3secretname)
+// if err != nil {
+// 	return err
+// }
+// *** create a new bucket ***
+// bucket := "subname-namespace" // should be all lowercase
+// if err := s3Conn.createBucket(bucket); err != nil {
+// 	fmt.Println(errorswrapper.Wrapf(err, "Unable to create a bucket: %s", bucket))
+// 	return
+// }
+
+// *** Upload objects, optionally using a key prefix to easily find the objects later ***
+// for i := 1; i < 10; i++ {
+// 	pvKey := fmt.Sprintf("PersistentVolumes/pv%v", i)
+// 	uploadPV := corev1.PersistentVolume{}
+// 	uploadPV.Name = pvKey
+// 	uploadPV.Spec.StorageClassName = "gold"
+// 	uploadPV.Spec.PersistentVolumeReclaimPolicy = corev1.PersistentVolumeReclaimRetain
+// 	if err := s3Conn.uploadObject(bucket, pvKey, uploadPV); err != nil {
+// 		fmt.Println(errorswrapper.Wrapf(err, "Unable to upload: %s:%s", bucket, pvKey))
+// 		return
+// 	}
+// }
+
+// *** Find objects in the bucket, optionally supplying a key prefix
+// keyPrefix := "v1.PersistentVolumes/"
+// if list, err := s3Conn.listKeys(bucket, keyPrefix); err != nil {
+// 	fmt.Println(errorswrapper.Wrapf(err, "Unable to download: %s:%s", bucket, keyPrefix))
+// 	return
+// } else {
+// 	for _, key := range list {
+// 		fmt.Printf("%v ", key)
+// 	}
+// }
+
+// *** Download from the given bucket an object with the given key
+// keyPrefix := "v1.PersistentVolumes/"
+// key := keyPrefix + "pv2"
+// var downloadPV corev1.PersistentVolume
+// if err := s3Conn.downloadObject(bucket, key, &downloadPV); err != nil {
+// 	fmt.Println(errorswrapper.Wrapf(err, "Unable to download: %s:%s", bucket, key))
+// 	return
+// }
+// }
+
+type s3Connection struct {
+	session    *session.Session
+	client     *s3.S3
+	uploader   *s3manager.Uploader
+	downloader *s3manager.Downloader
+	endpoint   string
+	callerTag  string
+}
+
+var objectStoreConnections = map[string]*s3Connection{}
+
+// Return a connection to the given S3 object store endpoint using
+// the given s3 secret
+// - Return error if endpoint or secret is not configured, or if
+//   session creation fails
+func connectToS3Endpoint(ctx context.Context, r client.Reader,
+	s3Endpoint string, s3SecretName types.NamespacedName,
+	callerTag string) (*s3Connection, error) {
+	if s3Endpoint == "" {
+		return nil, fmt.Errorf("s3 endpoint has not been configured; tag:%v",
+			callerTag)
+	}
+
+	// Use cached connection, if one exists
+	if s3Conn, ok := objectStoreConnections[s3Endpoint]; ok {
+		return s3Conn, nil
+	}
+
+	accessID, secretAccessKey, err := getS3Secret(ctx, r, s3SecretName)
+	if err != nil {
+		return nil, errorswrapper.Wrapf(err,
+			"failed to get secret %v; tag %v",
+			s3SecretName, callerTag)
+	}
+
+	// Create an S3 client session
+	s3Session, err := session.NewSession(&aws.Config{
+		Credentials: credentials.NewStaticCredentials(string(accessID),
+			string(secretAccessKey), ""),
+		Endpoint:         aws.String(s3Endpoint),
+		Region:           aws.String("us-east-1"),
+		DisableSSL:       aws.Bool(true),
+		S3ForcePathStyle: aws.Bool(true),
+	})
+	if s3Session == nil || err != nil {
+		return nil, errorswrapper.Wrapf(err,
+			"Failed to create new session for %v; tag %v",
+			s3Endpoint, callerTag)
+	}
+
+	// Create a client session
+	s3Client := s3.New(s3Session)
+
+	// Also create S3 uploader and S3 downloader which can be safely used
+	// concurrently across goroutines, whereas, the s3 client session
+	// does not support concurrent writers.
+	s3Uploader := s3manager.NewUploaderWithClient(s3Client)
+	s3Downloader := s3manager.NewDownloaderWithClient(s3Client)
+	s3Conn := &s3Connection{
+		session:    s3Session,
+		client:     s3Client,
+		uploader:   s3Uploader,
+		downloader: s3Downloader,
+		endpoint:   s3Endpoint,
+		callerTag:  callerTag,
+	}
+	objectStoreConnections[s3Endpoint] = s3Conn
+
+	return s3Conn, nil
+}
+
+func getS3Secret(ctx context.Context, r client.Reader,
+	s3SecretName types.NamespacedName) (
+	s3AccessID, s3SecretAccessKey []byte, err error) {
+	secret := corev1.Secret{}
+	if err := r.Get(ctx, s3SecretName, &secret); err != nil {
+		log.Infof("Failed to get secret %v", s3SecretName)
+
+		return nil, nil, errorswrapper.Wrapf(err,
+			"Failed to get secret %v", s3SecretName)
+	}
+
+	s3AccessID = secret.Data["AWS_ACCESS_KEY_ID"]
+	s3SecretAccessKey = secret.Data["AWS_SECRET_ACCESS_KEY"]
+
+	return
+}
+
+// Create a bucket; don't return error if the bucket exists already
+func (s *s3Connection) createBucket(bucket string) error {
+	if bucket == "" {
+		return fmt.Errorf("error: unspecified bucket name for "+
+			"endpoint %v tag %v",
+			s.endpoint, s.callerTag)
+	}
+
+	_, err := s.client.CreateBucket(
+		&s3.CreateBucketInput{Bucket: &bucket})
+	if err != nil {
+		if !errorswrapper.As(err, s3.ErrCodeBucketAlreadyOwnedByYou) {
+			return errorswrapper.Wrapf(err, "Failed to create bucket %s",
+				bucket)
+		}
+	}
+
+	return nil
+}
+
+// A convenience method
+// - OK to call UploadPV() concurrently from multiple goroutines safely.
+func (s *s3Connection) uploadPV(bucket string, pvKeySuffix string,
+	pv corev1.PersistentVolume) error {
+	return s.uploadTypedObject(bucket, pvKeySuffix /* key suffix */, pv)
+}
+
+// Upload to the given bucket the given uploadContent with a key of
+// <objectType/keySuffix>, where objectType is the type of the uploadContent
+// parameter
+// - OK to call UploadTypedObject() concurrently from multiple goroutines safely.
+func (s *s3Connection) uploadTypedObject(bucket string, keySuffix string,
+	uploadContent interface{}) error {
+	keyPrefix := reflect.TypeOf(uploadContent).String() + "/"
+	key := keyPrefix + keySuffix
+
+	return s.uploadObject(bucket, key, uploadContent)
+}
+
+// Upload the given object to the given bucket with the given key
+// - OK to call UploadObject() concurrently from multiple goroutines safely.
+// - Upload may fail due to many reasons: RequestError (connection error),
+//	 NoSuchBucket, NoSuchKey, InvalidParameter (e.g., empty key), etc.
+// - Multiple consecutive forward slashes in the key are sqaushed to
+//	 a single forward slash, for each such occurrence
+// - Any formatting changes to this method should also be reflected in the
+//	 downloadObject() method
+func (s *s3Connection) uploadObject(bucket string, key string,
+	uploadContent interface{}) error {
+	encodedUploadContent := &bytes.Buffer{}
+
+	gzWriter := gzip.NewWriter(encodedUploadContent)
+	if err := json.NewEncoder(gzWriter).Encode(uploadContent); err != nil {
+		return errorswrapper.Wrapf(err,
+			"Failed to json encode %s:%s", bucket, key)
+	}
+
+	if err := gzWriter.Close(); err != nil {
+		return errorswrapper.Wrapf(err,
+			"Failed to close gzip writer of %s:%s", bucket, key)
+	}
+
+	if _, err := s.uploader.Upload(&s3manager.UploadInput{
+		Bucket: &bucket,
+		Key:    &key,
+		Body:   encodedUploadContent,
+	}); err != nil {
+		return errorswrapper.Wrapf(err,
+			"Failed to upload data of %s:%s", bucket, key)
+	}
+
+	return nil
+}
+
+// Verify that the uploaded PV matches the given PV
+func (s *s3Connection) verifyPVUpload(bucket string, pvKeySuffix string,
+	verifyPV corev1.PersistentVolume) error {
+	var downloadedPV corev1.PersistentVolume
+
+	keyPrefix := reflect.TypeOf(verifyPV).String() + "/"
+	key := keyPrefix + pvKeySuffix
+
+	err := s.downloadObject(bucket, key, &downloadedPV)
+	if err != nil {
+		log.Infof("unable to downloadObject for caller %v from "+
+			"endpoint %v bucket %v key %v err %v",
+			s.callerTag, s.endpoint, bucket, key, err)
+
+		return err
+	}
+
+	if !reflect.DeepEqual(verifyPV, downloadedPV) {
+		log.Infof("failed to verify PV for caller %v want %v got %v",
+			s.callerTag, verifyPV, downloadedPV)
+
+		return fmt.Errorf("failed to verify PV for caller %v want %v got %v",
+			s.callerTag, verifyPV, downloadedPV)
+	}
+
+	return nil
+}
+
+// Download the list of PVs in the bucket
+// - Download objects with key prefix:  "v1.PersistentVolume/"
+// - If bucket doesn't exists, will return ErrCodeNoSuchBucket "NoSuchBucket"
+func (s *s3Connection) downloadPVs(bucket string) (pvList []corev1.PersistentVolume, err error) {
+	result, err := s.downloadTypedObjects(bucket,
+		reflect.TypeOf(corev1.PersistentVolume{}))
+	if err != nil {
+		return nil, errorswrapper.Wrapf(err, "Unable to download: %s", bucket)
+	}
+
+	pvList, ok := result.([]corev1.PersistentVolume)
+	if !ok {
+		err = fmt.Errorf("unable to download PV type: got %T", result)
+		// log.Info(err)
+
+		return nil, err
+	}
+
+	return pvList, nil
+}
+
+// Download all objects that have a key prefix of the given type and are also
+// of the given type
+// - Example key prefix:  v1.PersistentVolumeClaim/
+// - Objects being downloaded should meet the decoding expectations of
+// 	 the downloadObject() method.
+func (s *s3Connection) downloadTypedObjects(bucket string,
+	objectType reflect.Type) (interface{}, error) {
+	keyPrefix := objectType.String() + "/"
+
+	keys, err := s.listKeys(bucket, keyPrefix)
+	if err != nil {
+		log.Infof("unable to listKeys of type %v from endpoint %v bucket %v keyPrefix %v err %v",
+			objectType, s.endpoint, bucket, keyPrefix, err)
+
+		return nil, err
+	}
+
+	objects := reflect.MakeSlice(reflect.SliceOf(objectType),
+		len(keys), len(keys))
+
+	for i := range keys {
+		objectReceiver := objects.Index(i).Addr().Interface()
+		if err := s.downloadObject(bucket, keys[i], objectReceiver); err != nil {
+			log.Infof("unable to downloadObject endpoint %v bucket %v key %v err %v",
+				s.endpoint, bucket, keys[i], err)
+
+			return nil, err
+		}
+	}
+
+	// Return []objectType
+	return objects.Interface(), nil
+}
+
+// List the keys (of objects) with the given keyPrefix in the given bucket.
+// - If bucket doesn't exists, will return ErrCodeNoSuchBucket "NoSuchBucket"
+// - Refer to aws documentation of s3.ListObjectsV2Input for more list options
+func (s *s3Connection) listKeys(bucket string, keyPrefix string) (
+	keys []string, err error) {
+	var nextContinuationToken *string
+
+	for gotAllObjects := false; !gotAllObjects; {
+		result, err := s.client.ListObjectsV2(&s3.ListObjectsV2Input{
+			Bucket:            &bucket,
+			Prefix:            &keyPrefix,
+			ContinuationToken: nextContinuationToken,
+		})
+		if err != nil {
+			return nil,
+				errorswrapper.Wrapf(err, "Failed to list objects in bucket %s:%s",
+					bucket, keyPrefix)
+		}
+
+		for _, entry := range result.Contents {
+			keys = append(keys, *entry.Key)
+		}
+
+		if *result.IsTruncated {
+			nextContinuationToken = result.NextContinuationToken
+		} else {
+			gotAllObjects = true
+		}
+	}
+
+	return
+}
+
+// Download the given object from the given bucket with the given key
+// - OK to call DownloadObject() concurrently from multiple goroutines safely.
+// - Only those type field name in the downloaded json blob that are also present
+// 	 in the downloadContent type will be filled; other fields will be dropped
+//	 without returning any error.  More info at documentation of json.Unmarshall()
+// - Download may fail due to many reasons: RequestError (connection error),
+//	 NoSuchBucket, NoSuchKey, invalid gzip header, json unmarshall error,
+//	 InvalidParameter (e.g., empty key), etc.
+// - Assumes that the downloaded objects are json blobs that have been then gzipped
+//	 and hence, will attempt to unzip and decode the json blobs
+func (s *s3Connection) downloadObject(bucket string, key string,
+	downloadContent interface{}) error {
+	writerAt := &aws.WriteAtBuffer{}
+	if _, err := s.downloader.Download(writerAt, &s3.GetObjectInput{
+		Bucket: &bucket,
+		Key:    &key,
+	}); err != nil {
+		return errorswrapper.Wrapf(err,
+			"Failed to download data of %s:%s", bucket, key)
+	}
+
+	gzReader, err := gzip.NewReader(bytes.NewReader(writerAt.Bytes()))
+	if err != nil && !errorswrapper.Is(err, io.EOF) {
+		return errorswrapper.Wrapf(err,
+			"Failed to unzip data of %s:%s", bucket, key)
+	}
+
+	if err := json.NewDecoder(gzReader).Decode(downloadContent); err != nil {
+		return errorswrapper.Wrapf(err,
+			"Failed to decode json decoder of %s:%s", bucket, key)
+	}
+
+	if err := gzReader.Close(); err != nil {
+		return errorswrapper.Wrapf(err,
+			"Failed to close gzip reader of %s:%s", bucket, key)
+	}
+
+	return nil
+}

--- a/controllers/s3utils.go
+++ b/controllers/s3utils.go
@@ -384,3 +384,9 @@ func (s *s3Connection) downloadObject(bucket string, key string,
 
 	return nil
 }
+
+func constructBucketName(namespace, name string) (bucket string) {
+	bucket = namespace + "/" + name
+
+	return
+}

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -485,8 +485,6 @@ func (v *VRGInstance) createVolumeReplicationResources() bool {
 			log.Info("Creating VolumeReplication resource for PersistentVolumeClaim")
 
 			if err = v.createVolumeReplicationForPVC(pvc); err == nil {
-				log.Error(err, "failed to upload PV metadata")
-
 				continue
 			}
 		}
@@ -512,7 +510,7 @@ func (v *VRGInstance) uploadPV(pvc corev1.PersistentVolumeClaim) error {
 	// the two with a forward slash.  Note: VRG's namespace and name may also
 	// have dots or hyphens in their names.
 	vrgName := v.instance.Name
-	s3Bucket := v.instance.Namespace + "/" + vrgName
+	s3Bucket := constructBucketName(v.instance.Namespace, vrgName)
 
 	s3Endpoint := v.instance.Spec.S3Endpoint
 	if err := validateS3Endpoint(s3Endpoint, s3Bucket, v.log); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ramendr/ramen
 go 1.15
 
 require (
+	github.com/aws/aws-sdk-go v1.38.3
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v0.3.0
 	github.com/onsi/ginkgo v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/aws/aws-sdk-go v1.17.4/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.38.3 h1:QCL/le04oAz2jELMRSuJVjGT7H+4hhoQc66eMPCfU/k=
+github.com/aws/aws-sdk-go v1.38.3/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -654,6 +656,9 @@ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJS
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=

--- a/go.sum
+++ b/go.sum
@@ -658,6 +658,7 @@ github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=


### PR DESCRIPTION
To configure VRG to replicate the k8s metadata of all managed PVs to s3 store,
specify the following fields in the VRG:
- set spec.S3Endpoint to the object store's URL
- set spec.S3Secret to the name of kubernetes secret in the managed cluster that
  is in the same namespace as the VRG.  This k8s secret should contain the
  access_key_id and secret_access_key to access the S3Endpoint in two keys in the
  spec.Data map: AWS_ACCESS_KEY_ID & AWS_SECRET_ACCESS_KEY.

  An example of how to create one such secret:
    kubectl create secret generic <secret-name>\
      --from-literal=AWS_ACCESS_KEY_ID='<access-key-id>' \
        --from-literal=AWS_SECRET_ACCESS_KEY='<secret-access-key>'

Includes S3 upload and download routines. AVR doesn't yet download the PV
metadata.