### PR TITLE
Improve output of 'Git branch sanity' github workflow

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -59,4 +59,4 @@ jobs:
       - name: Git branch sanity
         run: |
           echo "Failing if any auto generated files are updated, checking 'git status'"
-          git status --porcelain 2>&1 | tee /dev/stderr | (! read)
+          git status --porcelain 2>&1 | tee /dev/stderr | (! read || git diff && ! read a)


### PR DESCRIPTION
When 'Git branch sanity' fails, run 'git diff' to also show what lines of the
auto generated file(s) have changed.