### PR TITLE
Bug fixes, ObjectStoreGetter & ObjectStorer interface

### DIFF
--- a/api/v1alpha1/applicationvolumereplication_types.go
+++ b/api/v1alpha1/applicationvolumereplication_types.go
@@ -56,6 +56,9 @@ type ApplicationVolumeReplicationSpec struct {
 	// See VRG spec for more details.
 	S3Endpoint string `json:"s3Endpoint"`
 
+	// S3 Region: https://docs.aws.amazon.com/general/latest/gr/rande.html
+	S3Region string `json:"s3Region"`
+
 	// Name of k8s secret that contains the credentials to access the S3 endpoint.
 	// If S3Endpoint is used, also specify the k8s secret that contains the S3
 	// access key id and secret access key set using the keys: AWS_ACCESS_KEY_ID

--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -63,6 +63,9 @@ type VolumeReplicationGroupSpec struct {
 	// referred to as backup-less mode.
 	S3Endpoint string `json:"s3Endpoint,omitempty"`
 
+	// S3 Region: https://docs.aws.amazon.com/general/latest/gr/rande.html
+	S3Region string `json:"s3Region,omitempty"`
+
 	// Name of k8s secret that contains the credentials to access the S3 endpoint.
 	// If S3Endpoint is used, also specify the k8s secret that contains the S3
 	// access key id and secret access key set using the keys: AWS_ACCESS_KEY_ID

--- a/config/crd/bases/ramendr.openshift.io_applicationvolumereplications.yaml
+++ b/config/crd/bases/ramendr.openshift.io_applicationvolumereplications.yaml
@@ -101,6 +101,9 @@ spec:
                   VRGs. The value of this field, will be progated to every VRG. See
                   VRG spec for more details.
                 type: string
+              s3Region:
+                description: 'S3 Region: https://docs.aws.amazon.com/general/latest/gr/rande.html'
+                type: string
               s3SecretName:
                 description: 'Name of k8s secret that contains the credentials to
                   access the S3 endpoint. If S3Endpoint is used, also specify the
@@ -158,6 +161,7 @@ spec:
             required:
             - pvcSelector
             - s3Endpoint
+            - s3Region
             - s3SecretName
             - subscriptionSelector
             type: object

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -114,6 +114,9 @@ spec:
                   that the PV metadata is replicated by a different mechanism; this
                   mode of operation may be referred to as backup-less mode.'
                 type: string
+              s3Region:
+                description: 'S3 Region: https://docs.aws.amazon.com/general/latest/gr/rande.html'
+                type: string
               s3SecretName:
                 description: 'Name of k8s secret that contains the credentials to
                   access the S3 endpoint. If S3Endpoint is used, also specify the

--- a/controllers/applicationvolumereplication_controller.go
+++ b/controllers/applicationvolumereplication_controller.go
@@ -70,7 +70,7 @@ var ErrSameHomeCluster = errorswrapper.New("new home cluster is the same as curr
 
 type pvDownloader interface {
 	DownloadPVs(ctx context.Context, r client.Reader, objStoreGetter ObjectStoreGetter,
-		s3Endpoint string, s3SecretName types.NamespacedName,
+		s3Endpoint, s3Region string, s3SecretName types.NamespacedName,
 		callerTag string, s3Bucket string) ([]corev1.PersistentVolume, error)
 }
 
@@ -1069,15 +1069,16 @@ func (r *ApplicationVolumeReplicationReconciler) listPVsFromS3Store(
 	s3Bucket := constructBucketName(subscription.Namespace, subscription.Name)
 
 	return r.PVDownloader.DownloadPVs(
-		context.TODO(), r.Client, r.ObjStoreGetter, avr.Spec.S3Endpoint, s3SecretLookupKey, avr.Name, s3Bucket)
+		context.TODO(), r.Client, r.ObjStoreGetter, avr.Spec.S3Endpoint, avr.Spec.S3Region,
+		s3SecretLookupKey, avr.Name, s3Bucket)
 }
 
 type ObjectStorePVDownloader struct{}
 
 func (s ObjectStorePVDownloader) DownloadPVs(ctx context.Context, r client.Reader,
-	objStoreGetter ObjectStoreGetter, s3Endpoint string, s3SecretName types.NamespacedName,
+	objStoreGetter ObjectStoreGetter, s3Endpoint, s3Region string, s3SecretName types.NamespacedName,
 	callerTag string, s3Bucket string) ([]corev1.PersistentVolume, error) {
-	objectStore, err := objStoreGetter.objectStore(ctx, r, s3Endpoint, s3SecretName, callerTag)
+	objectStore, err := objStoreGetter.objectStore(ctx, r, s3Endpoint, s3Region, s3SecretName, callerTag)
 	if err != nil {
 		return nil, fmt.Errorf("error when downloading PVs, err %w", err)
 	}

--- a/controllers/applicationvolumereplication_controller.go
+++ b/controllers/applicationvolumereplication_controller.go
@@ -68,8 +68,8 @@ const (
 
 var ErrSameHomeCluster = errorswrapper.New("new home cluster is the same as current home cluster")
 
-type S3StoreInterface interface {
-	DownloadPVs(ctx context.Context, r client.Reader,
+type pvDownloader interface {
+	DownloadPVs(ctx context.Context, r client.Reader, objStoreGetter ObjectStoreGetter,
 		s3Endpoint string, s3SecretName types.NamespacedName,
 		callerTag string, s3Bucket string) ([]corev1.PersistentVolume, error)
 }
@@ -80,10 +80,11 @@ type ProgressCallback func(string, bool)
 // ApplicationVolumeReplicationReconciler reconciles a ApplicationVolumeReplication object
 type ApplicationVolumeReplicationReconciler struct {
 	client.Client
-	Log      logr.Logger
-	S3       S3StoreInterface
-	Scheme   *runtime.Scheme
-	Callback ProgressCallback
+	Log            logr.Logger
+	PVDownloader   pvDownloader
+	ObjStoreGetter ObjectStoreGetter
+	Scheme         *runtime.Scheme
+	Callback       ProgressCallback
 }
 
 func IsManifestInAppliedState(mw *ocmworkv1.ManifestWork) bool {
@@ -1067,20 +1068,19 @@ func (r *ApplicationVolumeReplicationReconciler) listPVsFromS3Store(
 
 	s3Bucket := constructBucketName(subscription.Namespace, subscription.Name)
 
-	return r.S3.DownloadPVs(
-		context.TODO(), r.Client, avr.Spec.S3Endpoint, s3SecretLookupKey, avr.Name, s3Bucket)
+	return r.PVDownloader.DownloadPVs(
+		context.TODO(), r.Client, r.ObjStoreGetter, avr.Spec.S3Endpoint, s3SecretLookupKey, avr.Name, s3Bucket)
 }
 
-type S3StoreWrapper struct{}
+type ObjectStorePVDownloader struct{}
 
-func (s *S3StoreWrapper) DownloadPVs(ctx context.Context, r client.Reader,
-	s3Endpoint string, s3SecretName types.NamespacedName,
+func (s ObjectStorePVDownloader) DownloadPVs(ctx context.Context, r client.Reader,
+	objStoreGetter ObjectStoreGetter, s3Endpoint string, s3SecretName types.NamespacedName,
 	callerTag string, s3Bucket string) ([]corev1.PersistentVolume, error) {
-	s3Conn, err := connectToS3Endpoint(
-		ctx, r, s3Endpoint, s3SecretName, callerTag)
+	objectStore, err := objStoreGetter.objectStore(ctx, r, s3Endpoint, s3SecretName, callerTag)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error when downloading PVs, err %w", err)
 	}
 
-	return s3Conn.downloadPVs(s3Bucket)
+	return objectStore.downloadPVs(s3Bucket)
 }

--- a/controllers/applicationvolumereplication_controller.go
+++ b/controllers/applicationvolumereplication_controller.go
@@ -68,7 +68,7 @@ const (
 
 var ErrSameHomeCluster = errorswrapper.New("new home cluster is the same as current home cluster")
 
-type pvDownloader interface {
+type PVDownloader interface {
 	DownloadPVs(ctx context.Context, r client.Reader, objStoreGetter ObjectStoreGetter,
 		s3Endpoint, s3Region string, s3SecretName types.NamespacedName,
 		callerTag string, s3Bucket string) ([]corev1.PersistentVolume, error)
@@ -81,7 +81,7 @@ type ProgressCallback func(string, bool)
 type ApplicationVolumeReplicationReconciler struct {
 	client.Client
 	Log            logr.Logger
-	PVDownloader   pvDownloader
+	PVDownloader   PVDownloader
 	ObjStoreGetter ObjectStoreGetter
 	Scheme         *runtime.Scheme
 	Callback       ProgressCallback

--- a/controllers/applicationvolumereplication_controller_test.go
+++ b/controllers/applicationvolumereplication_controller_test.go
@@ -86,10 +86,10 @@ func FakeProgressCallback(avrName string, done bool) {
 	safeToProceed = done
 }
 
-type FakeS3StoreWrapper struct{}
+type FakePVDownloader struct{}
 
-func (s *FakeS3StoreWrapper) DownloadPVs(ctx context.Context, r client.Reader,
-	s3Endpoint string, s3SecretName types.NamespacedName,
+func (s FakePVDownloader) DownloadPVs(ctx context.Context, r client.Reader,
+	objStoreGetter controllers.ObjectStoreGetter, s3Endpoint string, s3SecretName types.NamespacedName,
 	callerTag string, s3Bucket string) ([]corev1.PersistentVolume, error) {
 	pv1 := corev1.PersistentVolume{
 		TypeMeta: metav1.TypeMeta{

--- a/controllers/applicationvolumereplication_controller_test.go
+++ b/controllers/applicationvolumereplication_controller_test.go
@@ -89,8 +89,9 @@ func FakeProgressCallback(avrName string, done bool) {
 type FakePVDownloader struct{}
 
 func (s FakePVDownloader) DownloadPVs(ctx context.Context, r client.Reader,
-	objStoreGetter controllers.ObjectStoreGetter, s3Endpoint string, s3SecretName types.NamespacedName,
-	callerTag string, s3Bucket string) ([]corev1.PersistentVolume, error) {
+	objStoreGetter controllers.ObjectStoreGetter, s3Endpoint, s3Region string,
+	s3SecretName types.NamespacedName, callerTag string,
+	s3Bucket string) ([]corev1.PersistentVolume, error) {
 	pv1 := corev1.PersistentVolume{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PersistentVolume",

--- a/controllers/s3utils.go
+++ b/controllers/s3utils.go
@@ -81,8 +81,8 @@ import (
 // }
 // }
 
-// ObjectStoreGetter interface is exported because AVR test,
-// which is in controllers_test package, uses this interface.
+// ObjectStoreGetter interface is exported because test clients
+// use this interface.
 type ObjectStoreGetter interface {
 	// objectStore returns an object that satisfies objectStorer interface
 	objectStore(ctx context.Context, r client.Reader,
@@ -213,6 +213,7 @@ func (s *s3ObjectStore) createBucket(bucket string) (err error) {
 
 	defer func() {
 		if r := recover(); r != nil {
+			// change the named return err value
 			err = fmt.Errorf("create bucket recovered for %s, with %v",
 				bucket, r)
 		}

--- a/controllers/s3utils.go
+++ b/controllers/s3utils.go
@@ -86,7 +86,7 @@ import (
 type ObjectStoreGetter interface {
 	// objectStore returns an object that satisfies objectStorer interface
 	objectStore(ctx context.Context, r client.Reader,
-		endpoint string, secretName types.NamespacedName,
+		endpoint, region string, secretName types.NamespacedName,
 		callerTag string) (objectStorer, error)
 }
 
@@ -124,7 +124,7 @@ type s3ObjectStoreGetter struct{}
 // - Return error if endpoint or secret is not configured, or if
 //   client session creation fails
 func (s3ObjectStoreGetter) objectStore(ctx context.Context,
-	r client.Reader, endpoint string, secretName types.NamespacedName,
+	r client.Reader, endpoint, region string, secretName types.NamespacedName,
 	callerTag string) (objectStorer, error) {
 	if endpoint == "" {
 		return nil, fmt.Errorf("s3 endpoint has not been configured; tag:%s",
@@ -147,7 +147,7 @@ func (s3ObjectStoreGetter) objectStore(ctx context.Context,
 		Credentials: credentials.NewStaticCredentials(string(accessID),
 			string(secretAccessKey), ""),
 		Endpoint:         aws.String(endpoint),
-		Region:           aws.String("us-east-1"),
+		Region:           aws.String(region),
 		DisableSSL:       aws.Bool(true),
 		S3ForcePathStyle: aws.Bool(true),
 	})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -97,11 +97,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	avrReconciler := (&ramencontrollers.ApplicationVolumeReplicationReconciler{
-		Client:   k8sManager.GetClient(),
-		Log:      ctrl.Log.WithName("controllers").WithName("ApplicationVolumeReplication"),
-		S3:       &FakeS3StoreWrapper{},
-		Scheme:   k8sManager.GetScheme(),
-		Callback: FakeProgressCallback,
+		Client:       k8sManager.GetClient(),
+		Log:          ctrl.Log.WithName("controllers").WithName("ApplicationVolumeReplication"),
+		PVDownloader: FakePVDownloader{},
+		Scheme:       k8sManager.GetScheme(),
+		Callback:     FakeProgressCallback,
 	})
 	err = avrReconciler.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -512,6 +512,7 @@ func (v *VRGInstance) createVolumeReplication(
 func (v *VRGInstance) uploadPV(pvc corev1.PersistentVolumeClaim) (err error) {
 	vrgName := v.instance.Name
 	s3Endpoint := v.instance.Spec.S3Endpoint
+	s3Region := v.instance.Spec.S3Region
 	s3Bucket := constructBucketName(v.instance.Namespace, vrgName)
 
 	if err := v.validateS3Endpoint(s3Endpoint, s3Bucket); err != nil {
@@ -528,6 +529,7 @@ func (v *VRGInstance) uploadPV(pvc corev1.PersistentVolumeClaim) (err error) {
 	objectStore, err :=
 		v.reconciler.ObjStoreGetter.objectStore(v.ctx, v.reconciler,
 			s3Endpoint,
+			s3Region,
 			types.NamespacedName{ /* secretName */
 				Name:      v.instance.Spec.S3SecretName,
 				Namespace: v.instance.Namespace,

--- a/main.go
+++ b/main.go
@@ -99,20 +99,22 @@ func newManager() (ctrl.Manager, error) {
 
 func setupReconcilers(mgr ctrl.Manager) {
 	if err := (&controllers.VolumeReplicationGroupReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("VolumeReplicationGroup"),
-		Scheme: mgr.GetScheme(),
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("controllers").WithName("VolumeReplicationGroup"),
+		ObjStoreGetter: controllers.S3ObjectStoreGetter(),
+		Scheme:         mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VolumeReplicationGroup")
 		os.Exit(1)
 	}
 
 	avrReconciler := (&controllers.ApplicationVolumeReplicationReconciler{
-		Client:   mgr.GetClient(),
-		Log:      ctrl.Log.WithName("controllers").WithName("ApplicationVolumeReplication"),
-		S3:       &controllers.S3StoreWrapper{},
-		Scheme:   mgr.GetScheme(),
-		Callback: func(string, bool) {},
+		Client:         mgr.GetClient(),
+		Log:            ctrl.Log.WithName("controllers").WithName("ApplicationVolumeReplication"),
+		ObjStoreGetter: controllers.S3ObjectStoreGetter(),
+		PVDownloader:   controllers.ObjectStorePVDownloader{},
+		Scheme:         mgr.GetScheme(),
+		Callback:       func(string, bool) {},
 	})
 	if err := avrReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ApplicationVolumeReplication")


### PR DESCRIPTION
To reduce cognitive complexity, refactor creation of volume replication CRs.

Bug fixes:
- In s3utils: handle AWS error type correctly when createBucket fails
- In s3utils: bucket name should not have a forward slash
- In VRG: requeue VRG only if upload of PV metadata fails
- In VRG: fix panic error when VRG is running in backup-less mode

Add ObjectStoreGetter & ObjectStorer interface. Rename AVR's S3StoreWrapper to PVDownloader for clarity.
