### PR TITLE
Add helper scripts to setup rook-ceph

### DIFF
--- a/hack/dev-rook-cluster.yaml
+++ b/hack/dev-rook-cluster.yaml
@@ -1,0 +1,39 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: rook-config-override
+  namespace: rook-ceph
+data:
+  config: |
+    [global]
+    osd_pool_default_size = 1
+    mon_warn_on_pool_no_redundancy = false
+---
+apiVersion: ceph.rook.io/v1
+kind: CephCluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  dataDirHostPath: /var/lib/rook
+  cephVersion:
+    image: ceph/ceph:v15
+    allowUnsupported: true
+  mon:
+    count: 1
+    allowMultiplePerNode: true
+  dashboard:
+    enabled: true
+  crashCollector:
+    disable: true
+  storage:
+    useAllNodes: true
+    useAllDevices: true
+  network:
+    provider: host
+  healthCheck:
+    daemonHealth:
+      mon:
+        interval: 45s
+        timeout: 600s

--- a/hack/dev-rook-rbdpool.yaml
+++ b/hack/dev-rook-rbdpool.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: replicapool
+  namespace: rook-ceph
+spec:
+  replicated:
+    size: 1
+  mirroring:
+    enabled: true
+    mode: image
+    snapshotSchedules:
+      - interval: 5m
+        startTime: 14:00:00-05:00

--- a/hack/dev-rook-sc.yaml
+++ b/hack/dev-rook-sc.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+    name: rook-ceph-block
+provisioner: rook-ceph.rbd.csi.ceph.com
+parameters:
+    clusterID: rook-ceph
+    pool: replicapool
+    imageFormat: "2"
+    imageFeatures: layering
+    csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+    csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+    csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+    csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+    csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+    csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+    csi.storage.k8s.io/fstype: ext4
+reclaimPolicy: Delete

--- a/hack/minikube-rook-mirror-setup.sh
+++ b/hack/minikube-rook-mirror-setup.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+set -x
+set -e -o pipefail
+
+## Variables
+PRIMARY_CLUSTER="${PRIMARY_CLUSTER:-hub}"
+SECONDARY_CLUSTER="${SECONDARY_CLUSTER:-cluster1}"
+POOL_NAME="replicapool"
+
+## Usage
+usage()
+{
+	set +x
+	echo "Usage:"
+	echo "  $0"
+	echo "  Available environment variables:"
+	echo "    minikube primary cluster PRIMARY_CLUSTER ${PRIMARY_CLUSTER}"
+	echo "    minikube secondary cluster SECONDARY_CLUSTER ${SECONDARY_CLUSTER}"
+	exit 0
+}
+
+function wait_for_condition() {
+    local count=15
+    local condition=${1}
+    local result
+    shift
+
+    while ((count > 0)); do
+        result=$("${@}")
+        if [[ "$result" == "$condition" ]]; then
+            return 0
+        fi
+        count=$((count - 1))
+        sleep 5
+    done
+
+    echo "Failed to meet $condition for command $*"
+    exit 1
+}
+
+SECONDARY_CLUSTER_PEER_TOKEN_SECRET_NAME=$(kubectl get cephblockpools.ceph.rook.io "${POOL_NAME}" --context="${SECONDARY_CLUSTER}" -nrook-ceph -o jsonpath='{.status.info.rbdMirrorBootstrapPeerSecretName}')
+SECONDARY_CLUSTER_SECRET=$(kubectl get secret -n rook-ceph "${SECONDARY_CLUSTER_PEER_TOKEN_SECRET_NAME}" --context="${SECONDARY_CLUSTER}" -o jsonpath='{.data.token}'| base64 -d)
+SECONDARY_CLUSTER_SITE_NAME=$(kubectl get cephblockpools.ceph.rook.io "${POOL_NAME}" --context="${SECONDARY_CLUSTER}" -nrook-ceph -o jsonpath='{.status.mirroringInfo.site_name}')
+
+echo SECONDARY_CLUSTER_PEER_TOKEN_SECRET_NAME is "$SECONDARY_CLUSTER_PEER_TOKEN_SECRET_NAME"
+echo Token for the secondary cluster is "$SECONDARY_CLUSTER_SECRET"
+echo SECONDARY_CLUSTER_SITE_NAME is "${SECONDARY_CLUSTER_SITE_NAME}"
+
+kubectl -n rook-ceph create secret generic --context="${PRIMARY_CLUSTER}" "${SECONDARY_CLUSTER_SITE_NAME}" \
+        --from-literal=token="${SECONDARY_CLUSTER_SECRET}" \
+        --from-literal=pool="${POOL_NAME}"
+
+cat <<EOF | kubectl --context="${PRIMARY_CLUSTER}" apply -f -
+apiVersion: ceph.rook.io/v1
+kind: CephRBDMirror
+metadata:
+  name: my-rbd-mirror
+  namespace: rook-ceph
+spec:
+  count: 1
+  peers:
+    secretNames:
+      - "${SECONDARY_CLUSTER_SITE_NAME}"
+EOF
+
+kubectl wait deployments -n rook-ceph --for condition=available rook-ceph-rbd-mirror-a --timeout=60s --context="${PRIMARY_CLUSTER}"
+
+wait_for_condition "OK" kubectl get cephblockpools.ceph.rook.io replicapool --context="${PRIMARY_CLUSTER}" -nrook-ceph -o jsonpath='{.status.mirroringStatus.summary.daemon_health}'
+echo RBD mirror daemon health OK
+wait_for_condition "OK" kubectl get cephblockpools.ceph.rook.io replicapool --context="${PRIMARY_CLUSTER}" -nrook-ceph -o jsonpath='{.status.mirroringStatus.summary.health}'
+echo RBD mirror status health OK
+wait_for_condition "OK" kubectl get cephblockpools.ceph.rook.io replicapool --context="${PRIMARY_CLUSTER}" -nrook-ceph -o jsonpath='{.status.mirroringStatus.summary.image_health}'
+echo RBD mirror image summary health OK
+
+kubectl apply -f ./dev-rook-sc.yaml --context="${PRIMARY_CLUSTER}"
+
+cat <<EOF | kubectl --context="${PRIMARY_CLUSTER}" apply -f -
+apiVersion: replication.storage.openshift.io/v1alpha1
+kind: VolumeReplicationClass
+metadata:
+  name: vrc-sample
+spec:
+  provisioner: rook-ceph.rbd.csi.ceph.com
+  parameters:
+    replication.storage.openshift.io/replication-secret-name: rook-csi-rbd-provisioner
+    replication.storage.openshift.io/replication-secret-namespace: rook-ceph
+EOF
+
+echo "Setup successfull!"
+
+exit 0

--- a/hack/minikube-rook-mirror-test.sh
+++ b/hack/minikube-rook-mirror-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -x
+set -e -o pipefail
+
+## Variables
+PRIMARY_CLUSTER="${PRIMARY_CLUSTER:-hub}"
+SECONDARY_CLUSTER="${SECONDARY_CLUSTER:-cluster1}"
+STORAGECLASS_NAME="rook-ceph-block"
+PVC_NAME="rbd-pvc"
+
+## Usage
+usage()
+{
+	set +x
+	echo "Usage:"
+	echo "  $0"
+	echo "  Available environment variables:"
+	echo "    minikube primary cluster PRIMARY_CLUSTER ${PRIMARY_CLUSTER}"
+	echo "    minikube secondary cluster SECONDARY_CLUSTER ${SECONDARY_CLUSTER}"
+	exit 0
+}
+
+cat <<EOF | kubectl --context="${PRIMARY_CLUSTER}" apply -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "${PVC_NAME}"
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: "${STORAGECLASS_NAME}"
+EOF
+
+cat <<EOF | kubectl --context="${PRIMARY_CLUSTER}" apply -f -
+apiVersion: replication.storage.openshift.io/v1alpha1
+kind: VolumeReplication
+metadata:
+  name: vr-sample
+spec:
+  volumeReplicationClass: vrc-sample
+  replicationState: Primary
+  dataSource:
+    kind: PersistentVolumeClaim
+    name: "${PVC_NAME}"
+EOF
+
+echo Sleeping...
+sleep 20
+
+RBD_IMAGE_NAME=$(kubectl --context="${PRIMARY_CLUSTER}" get pv/"$(kubectl --context="${PRIMARY_CLUSTER}" get pvc/"${PVC_NAME}" -o jsonpath="{.spec.volumeName}")" -o jsonpath="{.spec.csi.volumeAttributes.imageName}")
+echo RBD_IMAGE_NAME is "${RBD_IMAGE_NAME}"
+
+CEPH_TOOLBOX_POD=$(kubectl --context="${PRIMARY_CLUSTER}" -n rook-ceph get pods -l  app=rook-ceph-tools -o jsonpath='{.items[0].metadata.name}')
+echo CEPH_TOOLBOX_POD on primary cluster is "$CEPH_TOOLBOX_POD"
+
+kubectl --context="${PRIMARY_CLUSTER}" -n rook-ceph exec "${CEPH_TOOLBOX_POD}" -- rbd info "${RBD_IMAGE_NAME}" --pool=replicapool
+
+CEPH_TOOLBOX_POD=$(kubectl --context="${SECONDARY_CLUSTER}" -n rook-ceph get pods -l  app=rook-ceph-tools -o jsonpath='{.items[0].metadata.name}')
+echo CEPH_TOOLBOX_POD on secondary cluster is "$CEPH_TOOLBOX_POD"
+
+kubectl --context="${SECONDARY_CLUSTER}" -n rook-ceph exec "${CEPH_TOOLBOX_POD}" -- rbd info "${RBD_IMAGE_NAME}" --pool=replicapool
+
+kubectl --context="${PRIMARY_CLUSTER}" get volumereplication vr-sample -o yaml
+
+kubectl --context="${PRIMARY_CLUSTER}" delete volumereplication vr-sample
+kubectl --context="${PRIMARY_CLUSTER}" delete pvc "${PVC_NAME}"
+
+echo "Tests succesful!"

--- a/hack/minikube-rook-mirror-test.sh
+++ b/hack/minikube-rook-mirror-test.sh
@@ -9,7 +9,7 @@ STORAGECLASS_NAME="rook-ceph-block"
 PVC_NAME="rbd-pvc"
 
 function wait_for_condition() {
-    local count=15
+    local count=61
     local condition=${1}
     local result
     shift
@@ -36,7 +36,7 @@ usage()
 	echo "  Available environment variables:"
 	echo "    minikube primary cluster PRIMARY_CLUSTER ${PRIMARY_CLUSTER}"
 	echo "    minikube secondary cluster SECONDARY_CLUSTER ${SECONDARY_CLUSTER}"
-	exit 0
+	exit 1
 }
 
 cat <<EOF | kubectl --context="${PRIMARY_CLUSTER}" apply -f -
@@ -81,7 +81,7 @@ kubectl --context="${PRIMARY_CLUSTER}" -n rook-ceph exec "${CEPH_TOOLBOX_POD}" -
 CEPH_TOOLBOX_POD=$(kubectl --context="${SECONDARY_CLUSTER}" -n rook-ceph get pods -l  app=rook-ceph-tools -o jsonpath='{.items[0].metadata.name}')
 echo CEPH_TOOLBOX_POD on secondary cluster is "$CEPH_TOOLBOX_POD"
 
-kubectl --context="${SECONDARY_CLUSTER}" -n rook-ceph exec "${CEPH_TOOLBOX_POD}" -- rbd info "${RBD_IMAGE_NAME}" --pool=replicapool
+wait_for_condition "${RBD_IMAGE_NAME}" kubectl --context="${SECONDARY_CLUSTER}" -n rook-ceph exec "${CEPH_TOOLBOX_POD}" -- rbd ls "${RBD_IMAGE_NAME}" --pool=replicapool
 
 kubectl --context="${PRIMARY_CLUSTER}" get volumereplication vr-sample -o yaml
 

--- a/hack/minikube-rook-setup.sh
+++ b/hack/minikube-rook-setup.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+set -x
+set -e -o pipefail
+
+## Variables
+PROFILE="${PROFILE:-hub}"
+POOL_NAME="minikube"
+
+IMAGE_DIR="${IMAGE_DIR:-"/var/lib/libvirt/images"}"
+IMAGE_NAME="osd0"
+
+ROOK_SRC="${ROOK_SRC:-"https://raw.githubusercontent.com/rook/rook/release-1.6/cluster/examples/kubernetes/ceph/"}"
+
+## Usage
+usage()
+{
+	set +x
+	echo "Usage:"
+	echo "  $0 [create|start|stop|delete]"
+	echo "  Available environment variables:"
+	echo "    minikube PROFILE ${PROFILE}"
+	echo "    minikube kvm2 image dir IMAGE_DIR ${IMAGE_DIR}"
+	echo "    rook source ROOK_SRC ${ROOK_SRC}"
+	exit 0
+}
+
+function wait_for_ssh() {
+    local tries=60
+    while ((tries > 0)); do
+        if minikube ssh "echo connected" --profile="$1" &>/dev/null; then
+            return 0
+        fi
+        tries=$((tries - 1))
+        sleep 1
+    done
+    echo ERROR: ssh did not come up >&2
+    exit 1
+}
+
+set +x
+echo "Using environment:"
+echo "  minikube PROFILE ${PROFILE}"
+echo "  minikube kvm2 image dir IMAGE_DIR ${IMAGE_DIR}"
+echo "  rook source ROOK_SRC ${ROOK_SRC}"
+set -x
+
+if [[ $1 == "delete" ]]
+then
+	minikube delete --profile="${PROFILE}"
+	virsh vol-delete --pool "${POOL_NAME}" "${IMAGE_NAME}-${PROFILE}"
+    exit 0
+fi
+
+if [[ $1 == "stop" ]]; then
+	minikube stop --profile="${PROFILE}"
+    exit 0
+fi
+
+if [[ $1 == "start" ]]; then
+	sudo virsh start "${PROFILE}"
+	wait_for_ssh "$PROFILE"
+	minikube ssh "sudo mkdir -p /mnt/vda1/rook/ && sudo ln -sf /mnt/vda1/rook/ /var/lib/rook" --profile="${PROFILE}"
+	minikube start --profile="${PROFILE}"
+    exit 0
+fi
+
+if [[ $1 != "create" ]]; then
+	usage
+fi
+
+### $1 == "create"
+# TODO: Check if already created and bail out!
+## Preserve /var/lib/rook into existing vda1 disk ##
+# TODO: minikube instance is assumed to be kvm2 based, check it?
+minikube ssh "sudo mkdir -p /mnt/vda1/rook/ && sudo ln -sf /mnt/vda1/rook/ /var/lib/rook" --profile="${PROFILE}"
+
+## Create and attach an OSD disk for Ceph ##
+if [[ $(virsh pool-list | grep -wc "${POOL_NAME}") == 0 ]]; then
+	virsh pool-create-as --name "${POOL_NAME}" --type dir --target "${IMAGE_DIR}"
+fi
+virsh vol-create-as --pool "${POOL_NAME}" --name "${IMAGE_NAME}-${PROFILE}" --capacity 32G --format qcow2
+sudo virsh attach-disk --domain "${PROFILE}" --source "${IMAGE_DIR}/${IMAGE_NAME}-${PROFILE}" --target vdb --persistent --driver qemu --subdriver qcow2 --targetbus virtio
+minikube ssh 'echo 1 | sudo tee /sys/bus/pci/rescan > /dev/null ; dmesg | grep virtio_blk' --profile="${PROFILE}"
+
+## Install rook-ceph ##
+kubectl apply -f "${ROOK_SRC}/common.yaml" --context="${PROFILE}"
+kubectl apply -f "${ROOK_SRC}/crds.yaml" --context="${PROFILE}"
+# Fetch operator.yaml and enable CSI volume replication
+wget "${ROOK_SRC}/operator.yaml" -O /tmp/operator.yaml
+sed -e 's,CSI_ENABLE_VOLUME_REPLICATION: "false",CSI_ENABLE_VOLUME_REPLICATION: "true",' -i /tmp/operator.yaml
+sed -e 's,# CSI_VOLUME_REPLICATION_IMAGE: "quay.io/csiaddons/volumereplication-operator:v0.1.0",CSI_VOLUME_REPLICATION_IMAGE: "quay.io/csiaddons/volumereplication-operator:latest",' -i /tmp/operator.yaml
+sed -e 's,# CSI_ENABLE_OMAP_GENERATOR: "false",CSI_ENABLE_OMAP_GENERATOR: "true",' -i /tmp/operator.yaml
+kubectl apply -f /tmp/operator.yaml --context="${PROFILE}"
+# Create a dev ceph cluster
+kubectl apply -f ./dev-rook-cluster.yaml --context="${PROFILE}"
+kubectl apply -f "${ROOK_SRC}/toolbox.yaml" --context="${PROFILE}"
+
+# Create a mirroring enabled RBD pool
+kubectl apply -f ./dev-rook-rbdpool.yaml --context="${PROFILE}"
+
+# Ensure all deployments are up and running
+kubectl -n rook-ceph wait deployments --all --for condition=available --timeout=300s --context "${PROFILE}"

--- a/hack/rook-mirror-secret-template.yaml
+++ b/hack/rook-mirror-secret-template.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+stringData:
+  pool: <pool>
+  token: <token>
+kind: Secret
+metadata:
+  name: <name>
+  namespace: rook-ceph
+type: Opaque


### PR DESCRIPTION
- With RBD mirroring, VolumeReplication bits

This builds on ocm-minikube.sh which sets up the OCM
based minikube clusters 'hub' and 'cluster1'

Use as follows,
- Setup rook on hub:
  'hack/minikube-rook-setup.sh create'
- Setup rook on cluster1:
  'PROFILE=cluster1 hack/minikube-rook-setup.sh create'
- Setup hub to cluster1 mirroring:
  'hack/minikube-rook-mirror-setup.sh'
- Setup cluster1 to hub mirroring:
  'PRIMARY_CLUSTER=cluster1 SECONDARY_CLUSTER=hub hack/minikube-rook-mirror-setup.sh'
- Test hub to cluster1 mirroring:
  'hack/minikube-rook-mirror-test.sh'
- Test cluster1 to hub mirroring:
  'PRIMARY_CLUSTER=cluster1 SECONDARY_CLUSTER=hub hack/minikube-rook-mirror-test.sh'

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>