### PR TITLE
ocm-minikube-ramen.sh create

### DIFF
--- a/hack/curl-install.sh
+++ b/hack/curl-install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# shellcheck disable=2086
+if ! command -v curl; then
+	wget -O ${1}/curl https://github.com/moparisthebest/static-curl/releases/download/v7.76.0/curl-amd64
+	chmod +x ${1}/curl
+fi

--- a/hack/docker-install.sh
+++ b/hack/docker-install.sh
@@ -2,6 +2,9 @@
 # shellcheck disable=2046,2086
 docker_install()
 {
+	if command -v podman; then
+		return
+	fi
 	if test -w /var/run/docker.sock; then
 		DOCKER_HOST=unix:///var/run/docker.sock
 		return

--- a/hack/docker-install.sh
+++ b/hack/docker-install.sh
@@ -9,6 +9,7 @@ docker_install()
 		DOCKER_HOST=unix:///var/run/docker.sock
 		return
 	fi
+	# https://docs.docker.com/engine/security/rootless/#install
 	if ! command -v dockerd-rootless-setuptool.sh
 	# TODO or less than version ${2}
 	then

--- a/hack/docker-install.sh
+++ b/hack/docker-install.sh
@@ -2,9 +2,6 @@
 # shellcheck disable=2046,2086
 docker_install()
 {
-	if command -v podman; then
-		return
-	fi
 	if test -w /var/run/docker.sock; then
 		DOCKER_HOST=unix:///var/run/docker.sock
 		return

--- a/hack/docker-install.sh
+++ b/hack/docker-install.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# shellcheck disable=2046,2086
+docker_install()
+{
+	if test -w /var/run/docker.sock; then
+		DOCKER_HOST=unix:///var/run/docker.sock
+		return
+	fi
+	if ! command -v dockerd-rootless-setuptool.sh
+	# TODO or less than version ${2}
+	then
+		$(dirname ${0})/curl-install.sh ${1}
+		version_name=20.10.6
+		curl -L https://download.docker.com/linux/static/stable/x86_64/docker-${version_name}.tgz | tar -xzvC${1} --strip-components 1
+		curl -L https://download.docker.com/linux/static/stable/x86_64/docker-rootless-extras-${version_name}.tgz | tar -xzvC${1} --strip-components 1
+		unset -v version_name
+	fi
+	$(dirname ${0})/uidmap-install.sh
+	dockerd-rootless-setuptool.sh install
+	# shellcheck disable=2034
+	DOCKER_HOST=unix:///run/user/$(id -u)/docker.sock
+}

--- a/hack/docker-uninstall.sh
+++ b/hack/docker-uninstall.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -x
+set -e
+if test -x "${1}"/dockerd-rootless-setuptool.sh; then
+	# https://docs.docker.com/engine/security/rootless/#uninstall
+	"${1}"/dockerd-rootless-setuptool.sh uninstall
+	rootlesskit rm -rf ~/.local/share/docker
+	rm -f\
+		"${1}"/containerd\
+		"${1}"/containerd-shim\
+		"${1}"/containerd-shim-runc-v2\
+		"${1}"/ctr\
+		"${1}"/docker\
+		"${1}"/docker-init\
+		"${1}"/docker-proxy\
+		"${1}"/dockerd\
+		"${1}"/dockerd-rootless-setuptool.sh\
+		"${1}"/dockerd-rootless.sh\
+		"${1}"/rootlesskit\
+		"${1}"/rootlesskit-docker-proxy\
+		"${1}"/runc\
+		"${1}"/vpnkit
+fi

--- a/hack/go-install.sh
+++ b/hack/go-install.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# shellcheck disable=2046,2086
+go_install()
+{
+	if ! command -v go
+	# TODO or version less than ${2}
+	#|| $(go version | { read _ _ v _; echo ${v#go}; })
+	then
+		PATH=${1}/go/bin:${PATH}
+		if ! command -v go
+		then
+			mkdir -p ${1}/bin
+			$(dirname ${0})/curl-install.sh ${1}/bin
+			curl -L https://golang.org/dl/go1.16.2.linux-amd64.tar.gz | tar -C${1} -xz
+		fi
+	fi
+}

--- a/hack/kubectl-install.sh
+++ b/hack/kubectl-install.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# shellcheck disable=2046,2086
+if ! command -v kubectl\
+||\
+        test $(kubectl version --client --short|cut -dv -f2|cut -d. -f1) -lt ${2}\
+||\
+{
+        test $(kubectl version --client --short|cut -dv -f2|cut -d. -f1) -eq ${2}\
+        &&\
+        test $(kubectl version --client --short|cut -dv -f2|cut -d. -f2) -lt ${3}
+}
+then
+	# https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-kubectl-binary-with-curl-on-linux
+	$(dirname ${0})/curl-install.sh ${1}
+	curl -LRo ${1}/kubectl https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl
+	chmod +x ${1}/kubectl
+fi

--- a/hack/kustomize-install.sh
+++ b/hack/kustomize-install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# shellcheck disable=2046,2086
+if ! command -v kustomize; then
+	$(dirname ${0})/curl-install.sh ${1}
+        curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.0.5/kustomize_v4.0.5_linux_amd64.tar.gz | tar -C${1} -xz
+fi

--- a/hack/minikube-install.sh
+++ b/hack/minikube-install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# shellcheck disable=2046,2086
+if ! command -v minikube; then
+	# https://minikube.sigs.k8s.io/docs/start/
+	$(dirname ${0})/curl-install.sh ${1}
+	minikube_version=latest
+	minikube_version=v1.18.1
+	curl -LRo ${1}/minikube https://storage.googleapis.com/minikube/releases/${minikube_version}/minikube-linux-amd64
+	unset -v minikube_version
+	chmod +x ${1}/minikube
+fi

--- a/hack/minikube-rook-setup.sh
+++ b/hack/minikube-rook-setup.sh
@@ -8,7 +8,10 @@ scriptdir="$(dirname "$(realpath "$0")")"
 PROFILE="${PROFILE:-hub}"
 POOL_NAME="minikube"
 
-IMAGE_DIR="${IMAGE_DIR:-"$HOME/.minikube/images"}"
+if test -z "${IMAGE_DIR}"; then
+	IMAGE_DIR="$HOME/.minikube/images"
+	mkdir -p "${IMAGE_DIR}"
+fi
 IMAGE_NAME="osd0"
 
 ROOK_SRC="${ROOK_SRC:-"https://raw.githubusercontent.com/rook/rook/v1.6.5/cluster/examples/kubernetes/ceph/"}"

--- a/hack/minio-deployment.yaml
+++ b/hack/minio-deployment.yaml
@@ -1,0 +1,142 @@
+# Copyright 2017 the Velero contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minio
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: minio
+  name: minio-config-pvc
+  labels:
+    component: minio
+spec:
+  accessModes: [ "ReadWriteOnce" ]
+  storageClassName: "rook-ceph-block"
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: minio
+  name: minio-storage-pvc
+  labels:
+    component: minio
+spec:
+  accessModes: [ "ReadWriteOnce" ]
+  storageClassName: "rook-ceph-block"
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: minio
+  name: minio
+  labels:
+    component: minio
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      component: minio
+  template:
+    metadata:
+      labels:
+        component: minio
+    spec:
+      volumes:
+      - name: storage
+        persistentVolumeClaim:
+          claimName: minio-storage-pvc
+          readOnly: false
+      - name: config
+        persistentVolumeClaim:
+          claimName: minio-config-pvc
+          readOnly: false
+      containers:
+      - name: minio
+        image: minio/minio:latest
+        imagePullPolicy: IfNotPresent
+        args:
+        - server
+        - /storage
+        - --config-dir=/config
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        ports:
+        - containerPort: 9000
+          hostPort: 9000
+        volumeMounts:
+        - name: storage
+          mountPath: "/storage"
+        - name: config
+          mountPath: "/config"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: minio
+  name: minio
+  labels:
+    component: minio
+spec:
+  type: NodePort
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+      nodePort: 30000
+  selector:
+    component: minio
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: minio
+  name: minio-setup
+  labels:
+    component: minio
+spec:
+  template:
+    metadata:
+      name: minio-setup
+    spec:
+      restartPolicy: OnFailure
+      volumes:
+      - name: config
+        persistentVolumeClaim:
+          claimName: minio-config-pvc
+          readOnly: false
+      containers:
+      - name: mc
+        image: minio/mc:latest
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mc --config-dir=/config config host add ramen http://minio:9000 minio minio123 && mc --config-dir=/config mb -p ramen/bucket"
+        volumeMounts:
+        - name: config
+          mountPath: "/config"

--- a/hack/minio-deployment.yaml
+++ b/hack/minio-deployment.yaml
@@ -25,7 +25,7 @@ metadata:
   labels:
     component: minio
 spec:
-  accessModes: [ "ReadWriteOnce" ]
+  accessModes: ["ReadWriteOnce"]
   storageClassName: "rook-ceph-block"
   resources:
     requests:
@@ -39,7 +39,7 @@ metadata:
   labels:
     component: minio
 spec:
-  accessModes: [ "ReadWriteOnce" ]
+  accessModes: ["ReadWriteOnce"]
   storageClassName: "rook-ceph-block"
   resources:
     requests:
@@ -64,35 +64,35 @@ spec:
         component: minio
     spec:
       volumes:
-      - name: storage
-        persistentVolumeClaim:
-          claimName: minio-storage-pvc
-          readOnly: false
-      - name: config
-        persistentVolumeClaim:
-          claimName: minio-config-pvc
-          readOnly: false
-      containers:
-      - name: minio
-        image: minio/minio:latest
-        imagePullPolicy: IfNotPresent
-        args:
-        - server
-        - /storage
-        - --config-dir=/config
-        env:
-        - name: MINIO_ACCESS_KEY
-          value: "minio"
-        - name: MINIO_SECRET_KEY
-          value: "minio123"
-        ports:
-        - containerPort: 9000
-          hostPort: 9000
-        volumeMounts:
         - name: storage
-          mountPath: "/storage"
+          persistentVolumeClaim:
+            claimName: minio-storage-pvc
+            readOnly: false
         - name: config
-          mountPath: "/config"
+          persistentVolumeClaim:
+            claimName: minio-config-pvc
+            readOnly: false
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - server
+            - /storage
+            - --config-dir=/config
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: "minio"
+            - name: MINIO_SECRET_KEY
+              value: "minio123"
+          ports:
+            - containerPort: 9000
+              hostPort: 9000
+          volumeMounts:
+            - name: storage
+              mountPath: "/storage"
+            - name: config
+              mountPath: "/config"
 ---
 apiVersion: v1
 kind: Service
@@ -125,18 +125,19 @@ spec:
     spec:
       restartPolicy: OnFailure
       volumes:
-      - name: config
-        persistentVolumeClaim:
-          claimName: minio-config-pvc
-          readOnly: false
-      containers:
-      - name: mc
-        image: minio/mc:latest
-        imagePullPolicy: IfNotPresent
-        command:
-        - /bin/sh
-        - -c
-        - "mc --config-dir=/config config host add ramen http://minio:9000 minio minio123 && mc --config-dir=/config mb -p ramen/bucket"
-        volumeMounts:
         - name: config
-          mountPath: "/config"
+          persistentVolumeClaim:
+            claimName: minio-config-pvc
+            readOnly: false
+      containers:
+        - name: mc
+          image: minio/mc:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - "mc --config-dir=/config config host add ramen http://minio:9000
+               minio minio123 && mc --config-dir=/config mb -p ramen/bucket"
+          volumeMounts:
+            - name: config
+              mountPath: "/config"

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -316,6 +316,7 @@ for command in "${@:-deploy}"; do
 		unset -v DOCKER_HOST
 		;;
 	undeploy)
+		. ${ramen_hack_directory_path_name}/go-install.sh; go_install ${HOME}/.local; unset -f go_install
 		for cluster_name in ${cluster_names}; do
 			ramen_undeploy ${ramen_directory_path_name} ${cluster_name}
 		done; unset -v cluster_name
@@ -341,6 +342,7 @@ for command in "${@:-deploy}"; do
 		unset -v cluster_name
 		;;
 	ramen_undeploy)
+		. ${ramen_hack_directory_path_name}/go-install.sh; go_install ${HOME}/.local; unset -f go_install
 		for cluster_name in ${cluster_names}; do
                         ramen_undeploy ${ramen_directory_path_name} ${cluster_name}
                 done; unset -v cluster_name

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -18,11 +18,14 @@ exit_stack_push unset -v exit_stack
 exit_stack_push unset -f exit_stack_push
 exit_stack_pop()
 {
+	{ set +x; } 2>/dev/null
 	IFS=\; read -r x exit_stack <<-a
 	${exit_stack}
 	a
-	eval ${x}
+	eval set -x; ${x}
+	{ set +x; } 2>/dev/null
 	unset -v x
+	set -x
 }
 exit_stack_push unset -f exit_stack_pop
 rook_ceph_deploy()
@@ -79,8 +82,8 @@ ramen_branch_checkout()
 	exit_stack_pop
 	git --git-dir ${1}/.git --work-tree ${1} checkout ${2}
 	exit_stack_push git --git-dir ${1}/.git --work-tree ${1} checkout -
-	exit_stack_push git --git-dir ${1}/.git --work-tree ${1} checkout -- config
-	exit_stack_push git --git-dir ${1}/.git --work-tree ${1} status -s
+	exit_stack_push git --git-dir ${1}/.git --work-tree ${1} checkout -- :/config
+	exit_stack_push git --git-dir ${1}/.git --work-tree ${1} -c status.relativePaths=false status -s
 }
 exit_stack_push unset -f ramen_branch_checkout
 ramen_branch_checkout_undo()
@@ -90,13 +93,30 @@ ramen_branch_checkout_undo()
 	exit_stack_pop
 }
 exit_stack_push unset -f ramen_branch_checkout_undo
-ramen_image_name=ramen-operator:v0.Npr58
-exit_stack_push unset -v ramen_image_name
+ramen_operator_name=ramen-operator
+ramen_tag_name=v0.Npr58
+ramen_image_name=${ramen_operator_name}:${ramen_tag_name}
+exit_stack_push unset -v ramen_image_name ramen_tag_name ramen_operator_name
+podman_uninstall_docker_install()
+{
+	. ${ramen_hack_directory_path_name}/podman-uninstall.sh
+	. ${ramen_hack_directory_path_name}/docker-install.sh; docker_install ${HOME}/.local/bin; unset -f docker_install
+}
+exit_stack_push unset -v podman_uninstall_docker_install
+docker_uninstall_podman_install()
+{
+	${ramen_hack_directory_path_name}/docker-uninstall.sh ${HOME}/.local/bin
+	. ${ramen_hack_directory_path_name}/podman-docker-install.sh
+}
+exit_stack_push unset -v docker_uninstall_podman_install
 ramen_build()
 {
+	docker_uninstall_podman_install
 	ramen_branch_checkout ${1}
 	make -C ${1} docker-build IMG=${ramen_image_name} DOCKER_HOST=${DOCKER_HOST}
 	ramen_branch_checkout_undo
+	DOCKER_HOST=${DOCKER_HOST}\
+	docker save ${ramen_image_name} -o ${HOME}/.minikube/cache/images/${ramen_operator_name}_${ramen_tag_name}
 }
 exit_stack_push unset -f ramen_build
 kube_context_set()
@@ -112,13 +132,14 @@ kube_context_set_undo()
 exit_stack_push unset -f kube_context_set_undo
 ramen_deploy()
 {
-	DOCKER_HOST=${DOCKER_HOST} minikube -p ${2} image load ${ramen_image_name}
+	#DOCKER_HOST=${DOCKER_HOST}\
+	minikube -p ${2} image load ${ramen_image_name}
 	ramen_branch_checkout ${1}
 	kube_context_set ${2}
 	make -C ${1} deploy IMG=${ramen_image_name}
 	kube_context_set_undo
 	ramen_branch_checkout_undo
-	kubectl --context ${2} -n ramen-system wait deployments --all --for condition=available
+	kubectl --context ${2} -n ramen-system wait deployments --all --for condition=available --timeout 60s
 	kubectl --context ${hub_cluster_name} label managedclusters/${2} name=${2} --overwrite
 }
 exit_stack_push unset -f ramen_deploy
@@ -214,17 +235,17 @@ application_sample_deploy()
 	kubectl --context ${hub_cluster_name} apply -k ocm-ramen-samples/subscriptions/busybox-${USER}
 	ramen_samples_branch_checkout_undo
 	kubectl --context ${hub_cluster_name} -n busybox-sample get placementrules/busybox-placement
-	until_true_or_n 30 eval test \$\(kubectl --context ${hub_cluster_name} -n busybox-sample get subscriptions/busybox-sub -ojsonpath='{.status.phase}'\) = Propagated
+	until_true_or_n 30 eval test \"\$\(kubectl --context ${hub_cluster_name} -n busybox-sample get subscriptions/busybox-sub -ojsonpath='{.status.phase}'\)\" = Propagated
 	set -- $(kubectl --context ${hub_cluster_name} -n busybox-sample get placementrules/busybox-placement -ojsonpath='{.status.decisions[].clusterName}')
 	if test ${1} = ${hub_cluster_name}; then
 		subscription_name_suffix=-local
 	else
 		unset -v subscription_name_suffix
 	fi
-	until_true_or_n 30 eval test \$\(kubectl --context ${1} -n busybox-sample get subscriptions/busybox-sub${subscription_name_suffix} -ojsonpath='{.status.phase}'\) = Subscribed
+	until_true_or_n 30 eval test \"\$\(kubectl --context ${1} -n busybox-sample get subscriptions/busybox-sub${subscription_name_suffix} -ojsonpath='{.status.phase}'\)\" = Subscribed
 	unset -v subscription_name_suffix
 	until_true_or_n 60 kubectl --context ${1} -n busybox-sample wait pods/busybox --for condition=ready --timeout 0
-	until_true_or_n 30 eval test \$\(kubectl --context ${1} -n busybox-sample get persistentvolumeclaims/busybox-pvc -ojsonpath='{.status.phase}'\) = Bound
+	until_true_or_n 30 eval test \"\$\(kubectl --context ${1} -n busybox-sample get persistentvolumeclaims/busybox-pvc -ojsonpath='{.status.phase}'\)\" = Bound
 	date
 	until_true_or_n 90 kubectl --context ${1} -n busybox-sample get volumereplicationgroups/busybox-avr
 	date
@@ -260,7 +281,6 @@ ramen_hack_directory_path_name=$(dirname ${0})
 exit_stack_push unset -v ramen_hack_directory_path_name
 ramen_directory_path_name=${ramen_hack_directory_path_name}/..
 exit_stack_push unset -v ramen_directory_path_name
-exit_stack_push unset -v command
 hub_cluster_name=${hub_cluster_name:-hub}
 exit_stack_push unset -v hub_cluster_name
 spoke_cluster_names=${spoke_cluster_names:-${hub_cluster_name}\ cluster1}
@@ -272,6 +292,21 @@ for cluster_name in ${spoke_cluster_names}; do
 		cluster_names=${cluster_names}\ ${cluster_name}
 	fi
 done; unset -v cluster_name
+ramen_deploy_all()
+{
+	for cluster_name in ${cluster_names}; do
+		ramen_deploy ${ramen_directory_path_name} ${cluster_name}
+	done; unset -v cluster_name
+}
+exit_stack_push unset -v ramen_deploy_all
+ramen_undeploy_all()
+{
+	for cluster_name in ${cluster_names}; do
+		ramen_undeploy ${ramen_directory_path_name} ${cluster_name}
+	done; unset -v cluster_name
+}
+exit_stack_push unset -v ramen_undeploy_all
+exit_stack_push unset -v command
 for command in "${@:-deploy}"; do
 	case ${command} in
 	deploy)
@@ -279,21 +314,13 @@ for command in "${@:-deploy}"; do
 		${ramen_hack_directory_path_name}/ocm-minikube.sh
 		rook_ceph_deploy ${ramen_hack_directory_path_name} ${cluster_names}
 		minio_deploy ${ramen_hack_directory_path_name} ${hub_cluster_name}
-		. ${ramen_hack_directory_path_name}/docker-install.sh; docker_install ${HOME}/.local/bin; unset -f docker_install
 		. ${ramen_hack_directory_path_name}/go-install.sh; go_install ${HOME}/.local; unset -f go_install
-		${ramen_hack_directory_path_name}/kubectl-install.sh ${HOME}/.local/bin
-		${ramen_hack_directory_path_name}/kustomize-install.sh ${HOME}/.local/bin
 		ramen_build ${ramen_directory_path_name}
-		for cluster_name in ${cluster_names}; do
-			ramen_deploy ${ramen_directory_path_name} ${cluster_name}
-		done; unset -v cluster_name
-		unset -v DOCKER_HOST
+		ramen_deploy_all
 		;;
 	undeploy)
 		. ${ramen_hack_directory_path_name}/go-install.sh; go_install ${HOME}/.local; unset -f go_install
-		for cluster_name in ${cluster_names}; do
-			ramen_undeploy ${ramen_directory_path_name} ${cluster_name}
-		done; unset -v cluster_name
+		ramen_undeploy_all
 		minio_undeploy ${ramen_hack_directory_path_name} ${hub_cluster_name}
 		rook_ceph_undeploy ${ramen_hack_directory_path_name} ${cluster_names}
 		;;
@@ -316,11 +343,17 @@ for command in "${@:-deploy}"; do
 		kubectl --context ${hub_cluster_name} label managedclusters/${cluster_name} region-
 		unset -v cluster_name
 		;;
+	ramen_build)
+		. ${ramen_hack_directory_path_name}/go-install.sh; go_install ${HOME}/.local; unset -f go_install
+		ramen_build ${ramen_directory_path_name}
+		;;
+	ramen_deploy)
+		. ${ramen_hack_directory_path_name}/go-install.sh; go_install ${HOME}/.local; unset -f go_install
+		ramen_deploy_all
+		;;
 	ramen_undeploy)
 		. ${ramen_hack_directory_path_name}/go-install.sh; go_install ${HOME}/.local; unset -f go_install
-		for cluster_name in ${cluster_names}; do
-                        ramen_undeploy ${ramen_directory_path_name} ${cluster_name}
-                done; unset -v cluster_name
+		ramen_undeploy_all
 		;;
 	rook_ceph_deploy)
 		rook_ceph_deploy ${ramen_hack_directory_path_name} ${cluster_names}

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -1,0 +1,357 @@
+#!/bin/sh
+# shellcheck disable=1090,2046,2086
+set -x
+set -e
+trap 'set -- ${?}; trap - EXIT; eval ${exit_stack}; echo exit status: ${1}' EXIT
+trap 'trap - ABRT' ABRT
+trap 'trap - QUIT' QUIT
+trap 'trap - TERM' TERM
+trap 'trap - INT' INT
+trap 'trap - HUP' HUP
+exit_stack_push()
+{
+	{ set +x; } 2>/dev/null
+	exit_stack=${*}\;${exit_stack}
+	set -x
+}
+exit_stack_push unset -v exit_stack
+exit_stack_push unset -f exit_stack_push
+exit_stack_pop()
+{
+	IFS=\; read -r x exit_stack <<-a
+	${exit_stack}
+	a
+	eval ${x}
+	unset -v x
+}
+exit_stack_push unset -f exit_stack_pop
+rook_ceph_branch_checkout()
+{
+return
+	git --git-dir ${1}/.git --work-tree ${1} checkout main
+	exit_stack_push git --git-dir ${1}/.git --work-tree ${1} checkout -
+	#git --git-dir ${1}/.git fetch https://github.com/ShyamsundarR/ramen rook-setup:rook-setup
+	git --git-dir ${1}/.git fetch https://github.com/hatfieldbrian/ramen rook-setup:rook-setup
+	exit_stack_pop
+	git --git-dir ${1}/.git --work-tree ${1} checkout rook-setup
+	exit_stack_push git --git-dir ${1}/.git --work-tree ${1} checkout -
+}
+exit_stack_push unset -f rook_ceph_branch_checkout
+rook_ceph_branch_checkout_undo()
+{
+return
+	exit_stack_pop
+}
+exit_stack_push unset -f rook_ceph_branch_checkout_undo
+rook_ceph_deploy()
+{
+	rook_ceph_branch_checkout ${1}/..
+	IMAGE_DIR=/var/lib/libvirt/images\
+	PROFILE=${2} ${1}/minikube-rook-setup.sh create
+	IMAGE_DIR=/var/lib/libvirt/images\
+	PROFILE=${3} ${1}/minikube-rook-setup.sh create
+	PRIMARY_CLUSTER=${2} SECONDARY_CLUSTER=${3} ${1}/minikube-rook-mirror-setup.sh
+	PRIMARY_CLUSTER=${3} SECONDARY_CLUSTER=${2} ${1}/minikube-rook-mirror-setup.sh
+	PRIMARY_CLUSTER=${2} SECONDARY_CLUSTER=${3} ${1}/minikube-rook-mirror-test.sh
+	PRIMARY_CLUSTER=${3} SECONDARY_CLUSTER=${2} ${1}/minikube-rook-mirror-test.sh
+	rook_ceph_branch_checkout_undo
+}
+exit_stack_push unset -f rook_ceph_deploy
+rook_ceph_undeploy()
+{
+	rook_ceph_branch_checkout ${1}/..
+	PROFILE=${3} ${1}/minikube-rook-setup.sh delete
+	PROFILE=${2} ${1}/minikube-rook-setup.sh delete
+	rook_ceph_branch_checkout_undo
+}
+exit_stack_push unset -f rook_ceph_undeploy
+ramen_branch_name=pr47_pr58_rbac2360357
+exit_stack_push unset -v ramen_branch_name
+ramen_branch_build()
+{
+	set -- ${1} ${ramen_branch_name}
+	git --git-dir ${1}/.git --work-tree ${1} checkout main -b ${2}
+	exit_stack_push git --git-dir ${1}/.git --work-tree ${1} checkout -
+	git --git-dir ${1}/.git --work-tree ${1} pull --rebase https://github.com/ramendr/ramen main
+	#git --git-dir ${1}/.git --work-tree ${1} pull --rebase https://github.com/BenamarMk/ramen avr_per_subscription_placement       #51
+	#git --git-dir ${1}/.git --work-tree ${1} pull --rebase https://github.com/ShyamsundarR/ramen pr-51-1
+	#git --git-dir ${1}/.git --work-tree ${1} pull --rebase https://github.com/BenamarMk/ramen add_avr_plrule_to_manage_user_plrule #55
+	git --git-dir ${1}/.git --work-tree ${1} pull --rebase https://github.com/ShyamsundarR/ramen 2360357b37e76f1bcd5909598d49c1756780cd8e
+	git --git-dir ${1}/.git --work-tree ${1} pull --rebase https://github.com/BenamarMk/ramen add_preferredcluster_targetcluster    #58
+	# controllers/applicationvolumereplication_controller.go
+	# config/crd/bases/ramendr.openshift.io_applicationvolumereplications.yaml
+	git --git-dir ${1}/.git --work-tree ${1} push git@github.com:hatfieldbrian/ramen ${2}
+	exit_stack_pop
+}
+exit_stack_push unset -f ramen_branch_build
+ramen_branch_checkout()
+{
+	set -- ${1} ${ramen_branch_name}
+	git --git-dir ${1}/.git --work-tree ${1} checkout main
+	exit_stack_push git --git-dir ${1}/.git --work-tree ${1} checkout -
+	git --git-dir ${1}/.git fetch https://github.com/hatfieldbrian/ramen ${2}:${2}
+	exit_stack_pop
+	git --git-dir ${1}/.git --work-tree ${1} checkout ${2}
+	exit_stack_push git --git-dir ${1}/.git --work-tree ${1} checkout -
+}
+exit_stack_push unset -f ramen_branch_checkout
+ramen_branch_checkout_undo()
+{
+	exit_stack_pop
+}
+exit_stack_push unset -f ramen_branch_checkout_undo
+ramen_image_name=ramen-operator:v0.Npr58
+exit_stack_push unset -v ramen_image_name
+ramen_build()
+{
+	ramen_branch_checkout ${1}
+	make -C ${1} docker-build IMG=${ramen_image_name} DOCKER_HOST=${DOCKER_HOST}
+	git --git-dir ${1}/.git --work-tree ${1} status -s
+	git --git-dir ${1}/.git --work-tree ${1} checkout -- config
+	ramen_branch_checkout_undo
+}
+exit_stack_push unset -f ramen_build
+kube_context_set()
+{
+	exit_stack_push kubectl config use-context $(kubectl config current-context)
+	kubectl config use-context ${1}
+}
+exit_stack_push unset -f kube_context_set
+kube_context_set_undo()
+{
+	exit_stack_pop
+}
+exit_stack_push unset -f kube_context_set_undo
+ramen_deploy()
+{
+	DOCKER_HOST=${DOCKER_HOST} minikube -p ${2} image load ${ramen_image_name}
+	ramen_branch_checkout ${1}
+	kube_context_set ${2}
+	make -C ${1} deploy IMG=${ramen_image_name}
+	kube_context_set_undo
+	git --git-dir ${1}/.git --work-tree ${1} status -s
+	git --git-dir ${1}/.git --work-tree ${1} checkout -- config
+	ramen_branch_checkout_undo
+	kubectl --context ${2} -n ramen-system wait deployments --all --for condition=available
+	kubectl --context ${hub_cluster_name} label managedclusters/${2} region=${3} --overwrite
+	kubectl --context ${hub_cluster_name} label managedclusters/${2} name=${2} --overwrite
+}
+exit_stack_push unset -f ramen_deploy
+ramen_undeploy()
+{
+	kubectl --context ${hub_cluster_name} label managedclusters/${2} name-
+	kubectl --context ${hub_cluster_name} label managedclusters/${2} region-
+	ramen_branch_checkout ${1}
+	kube_context_set ${2}
+	make -C ${1} undeploy
+	kube_context_set_undo
+	git --git-dir ${1}/.git --work-tree ${1} status -s
+	git --git-dir ${1}/.git --work-tree ${1} checkout -- config
+	ramen_branch_checkout_undo
+	set +e
+	kubectl --context ${2} -n ramen-system wait deployments --all --for delete
+	# error: no matching resources found
+	set -e
+}
+exit_stack_push unset -f ramen_undeploy
+ocm_operator_build()
+{
+	set +e
+	git clone https://github.com/ShyamsundarR/${1}
+	# fatal: destination path '${1}' already exists and is not an empty directory.
+	set -e
+	git --git-dir ${1}/.git fetch https://github.com/ShyamsundarR/${1} pause-on-plchange:pause-on-plchange
+	make -C ${1} build-images TRAVIS_BUILD=0 DOCKER_HOST=${DOCKER_HOST}
+}
+#ocm_operator_build multicloud-operators-deployable
+#ocm_operator_build multicloud-operators-subscription
+unset -f ocm_operator_build
+ramen_samples_branch_name=shyam_test_benamar_update_placement_to_avr
+exit_stack_push unset -v ramen_samples_branch_name
+ramen_samples_branch_build()
+{
+	set -- ocm-ramen-samples ${ramen_samples_branch_name}
+	set +e
+	git clone https://github.com/RamenDR/${1}
+	# fatal: destination path 'ocm-ramen-samples' already exists and is not an empty directory.
+	set -e
+	git --git-dir ${1}/.git --work-tree ${1} checkout main -b ${2}
+	git --git-dir ${1}/.git --work-tree ${1} pull --ff-only https://github.com/ShyamsundarR/${1} test
+	git --git-dir ${1}/.git --work-tree ${1} pull --rebase https://github.com/BenamarMk/${1} update_placement_to_avr
+	git --git-dir ${1}/.git --work-tree ${1} push git@github.com:hatfieldbrian/${1} ${2}:${2}
+	git --git-dir ${1}/.git --work-tree ${1} checkout -
+}
+exit_stack_push unset -f ramen_samples_branch_build
+ramen_samples_branch_checkout()
+{
+	set -- ocm-ramen-samples ${ramen_samples_branch_name}
+	set +e
+	git clone https://github.com/RamenDR/${1}
+	# fatal: destination path 'ocm-ramen-samples' already exists and is not an empty directory.
+	set -e
+	git --git-dir ${1}/.git --work-tree ${1} checkout main
+	exit_stack_push git --git-dir ${1}/.git --work-tree ${1} checkout -
+	git --git-dir ${1}/.git --work-tree ${1} fetch https://github.com/hatfieldbrian/${1} ${2}:${2}
+	exit_stack_pop
+	git --git-dir ${1}/.git --work-tree ${1} checkout ${2}
+	exit_stack_push git --git-dir ${1}/.git --work-tree ${1} checkout -
+}
+exit_stack_push unset -f ramen_samples_branch_checkout
+ramen_samples_branch_checkout_undo()
+{
+	exit_stack_pop
+}
+exit_stack_push unset -f ramen_samples_branch_checkout_undo
+application_sample_namespace_and_s3_deploy()
+{
+	ramen_samples_branch_checkout
+	kubectl --context ${1} apply -f ocm-ramen-samples/subscriptions/busybox/namespace.yaml
+	kubectl --context ${1} apply -f ocm-ramen-samples/subscriptions/busybox/s3secret.yaml
+	ramen_samples_branch_checkout_undo
+}
+exit_stack_push unset -f application_sample_namespace_and_s3_deploy
+application_sample_namespace_and_s3_undeploy()
+{
+	ramen_samples_branch_checkout
+	kubectl --context ${1} delete -f ocm-ramen-samples/subscriptions/busybox/s3secret.yaml
+	date
+	kubectl --context ${1} delete -f ocm-ramen-samples/subscriptions/busybox/namespace.yaml
+	date
+	ramen_samples_branch_checkout_undo
+}
+exit_stack_push unset -f application_sample_namespace_and_s3_undeploy
+application_sample_deploy()
+{
+	ramen_samples_branch_checkout
+	kubectl --context ${hub_cluster_name} apply -f ocm-ramen-samples/minio-deployment.yaml
+	kubectl --context ${hub_cluster_name} apply -k ocm-ramen-samples/subscriptions
+	kubectl --context ${hub_cluster_name} -n ramen-samples get channels/ramen-gitops
+	kubectl --context ${hub_cluster_name} apply -f ocm-ramen-samples/subscriptions/busybox/mw-pv.yaml
+	mkdir -p ocm-ramen-samples/subscriptions/busybox-${USER}
+	cat <<-a >ocm-ramen-samples/subscriptions/busybox-${USER}/kustomization.yaml
+	resources:
+	- ../busybox
+	patchesJson6902:
+	- target:
+	    group: ramendr.openshift.io
+	    version: v1alpha1
+	    kind: ApplicationVolumeReplication
+	    name: busybox-avr
+	  patch: |-
+	    - op: replace
+	      path: /spec/s3Endpoint
+	      value: $(minikube --profile=${hub_cluster_name} -n minio service --url minio)
+	a
+	kubectl --context ${hub_cluster_name} apply -k ocm-ramen-samples/subscriptions/busybox-${USER}
+	ramen_samples_branch_checkout_undo
+	kubectl --context ${hub_cluster_name} -n busybox-sample get placementrules/busybox-placement
+	until_true_or_n 30 eval test \$\(kubectl --context ${hub_cluster_name} -n busybox-sample get subscriptions/busybox-sub -ojsonpath='{.status.phase}'\) = Propagated
+	set -- $(kubectl --context ${hub_cluster_name} -n busybox-sample get placementrules/busybox-placement -ojsonpath='{.status.decisions[].clusterName}')
+	if test ${1} = ${hub_cluster_name}; then
+		subscription_name_suffix=-local
+	else
+		unset -v subscription_name_suffix
+	fi
+	until_true_or_n 30 eval test \$\(kubectl --context ${1} -n busybox-sample get subscriptions/busybox-sub${subscription_name_suffix} -ojsonpath='{.status.phase}'\) = Subscribed
+	unset -v subscription_name_suffix
+	until_true_or_n 60 kubectl --context ${1} -n busybox-sample wait pods/busybox --for condition=ready --timeout 0
+	until_true_or_n 30 eval test \$\(kubectl --context ${1} -n busybox-sample get persistentvolumeclaims/busybox-pvc -ojsonpath='{.status.phase}'\) = Bound
+	date
+	until_true_or_n 90 kubectl --context ${1} -n busybox-sample get volumereplicationgroups/busybox-avr
+	date
+}
+exit_stack_push unset -f application_sample_deploy
+application_sample_undeploy()
+{
+	set -- $(kubectl --context ${hub_cluster_name} -n busybox-sample get placementrules/busybox-placement -ojsonpath='{.status.decisions[].clusterName}')
+	kubectl --context ${1} delete persistentvolumes $(kubectl --context ${1} -n busybox-sample get persistentvolumeclaims/busybox-pvc -ojsonpath='{.spec.volumeName}') --wait=false
+	ramen_samples_branch_checkout
+	kubectl --context ${hub_cluster_name} delete -k ocm-ramen-samples/subscriptions/busybox-${USER}
+	rm -r ocm-ramen-samples/subscriptions/busybox-${USER}
+	date
+	set +e
+	kubectl --context ${1} -n busybox-sample wait pods/busybox --for delete --timeout 2m
+	# error: no matching resources found
+	set -e
+	date
+	# TODO remove
+	kubectl --context ${1} -n busybox-sample patch persistentvolumeclaims/busybox-pvc --type json -p '[{"op":test,"path":/metadata/finalizers/0,"value":volumereplicationgroups.ramendr.openshift.io/pvc-vr-protection},{"op":remove,"path":/metadata/finalizers/0}]'
+	date
+	# TODO applicationvolumereplication finalizer delete volumereplicationgroup manifest work instead
+	kubectl --context ${hub_cluster_name} -n ${1} delete manifestworks/busybox-sub-busybox-sample-vrg-mw
+	date
+	kubectl --context ${hub_cluster_name} delete -k ocm-ramen-samples/subscriptions
+	ramen_samples_branch_checkout_undo
+}
+exit_stack_push unset -f application_sample_undeploy
+ramen_hack_directory_path_name=$(dirname ${0})
+exit_stack_push unset -v ramen_hack_directory_path_name
+ramen_directory_path_name=${ramen_hack_directory_path_name}/..
+exit_stack_push unset -v ramen_directory_path_name
+exit_stack_push unset -v command
+hub_cluster_name=${hub_cluster_name:-hub}
+exit_stack_push unset -v hub_cluster_name
+spoke_cluster_names=${spoke_cluster_names:-${hub_cluster_name}\ cluster1}
+exit_stack_push unset -v spoke_cluster_names
+cluster_names=${hub_cluster_name}
+exit_stack_push unset -v cluster_names
+for cluster_name in ${spoke_cluster_names}; do
+	if test ${cluster_name} != ${hub_cluster_name}; then
+		cluster_names=${cluster_names}\ ${cluster_name}
+	fi
+done; unset -v cluster_name
+for command in "${@:-deploy}"; do
+	case ${command} in
+	rook_ceph_deploy)
+		rook_ceph_deploy ${ramen_hack_directory_path_name} ${cluster_names}
+		;;
+	deploy)
+		hub_cluster_name=${hub_cluster_name} spoke_cluster_names=${spoke_cluster_names}\
+		${ramen_hack_directory_path_name}/ocm-minikube.sh
+		rook_ceph_deploy ${ramen_hack_directory_path_name} ${cluster_names}
+		. ${ramen_hack_directory_path_name}/docker-install.sh; docker_install ${HOME}/.local/bin; unset -f docker_install
+		. ${ramen_hack_directory_path_name}/go-install.sh; go_install ${HOME}/.local; unset -f go_install
+		${ramen_hack_directory_path_name}/kubectl-install.sh ${HOME}/.local/bin
+		${ramen_hack_directory_path_name}/kustomize-install.sh ${HOME}/.local/bin
+		ramen_build ${ramen_directory_path_name}
+		i=0
+		for cluster_name in ${cluster_names}; do
+			ramen_deploy ${ramen_directory_path_name} ${cluster_name} region${i}
+			i=$((i+1))
+			application_sample_namespace_and_s3_deploy ${cluster_name}
+		done
+		kubectl --context ${hub_cluster_name} label managedclusters/${cluster_name} region=west --overwrite
+		unset -v cluster_name
+		unset -v i
+		unset -v DOCKER_HOST
+		. ${ramen_hack_directory_path_name}/until_true_or_n.sh
+		application_sample_deploy
+		unset -f until_true_or_n
+		;;
+	undeploy)
+		application_sample_undeploy
+		for cluster_name in ${cluster_names}; do
+			application_sample_namespace_and_s3_undeploy ${cluster_name}
+			ramen_undeploy ${ramen_directory_path_name} ${cluster_name}
+		done; unset -v cluster_name
+		rook_ceph_undeploy ${ramen_hack_directory_path_name} ${cluster_names}
+		;;
+	application_sample_undeploy)
+		application_sample_undeploy
+		for cluster_name in ${cluster_names}; do
+			application_sample_namespace_and_s3_undeploy ${cluster_name}
+		done; unset -v cluster_name
+		;;
+	ramen_undeploy)
+		for cluster_name in ${cluster_names}; do
+                        ramen_undeploy ${ramen_directory_path_name} ${cluster_name}
+                done; unset -v cluster_name
+		;;
+	rook_ceph_undeploy)
+		rook_ceph_undeploy ${ramen_hack_directory_path_name} ${cluster_names}
+		;;
+	*)
+		echo subcommand unsupported: ${command}
+		;;
+	esac
+done

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -46,9 +46,7 @@ exit_stack_push unset -f rook_ceph_branch_checkout_undo
 rook_ceph_deploy()
 {
 	rook_ceph_branch_checkout ${1}/..
-	IMAGE_DIR=/var/lib/libvirt/images\
 	PROFILE=${2} ${1}/minikube-rook-setup.sh create
-	IMAGE_DIR=/var/lib/libvirt/images\
 	PROFILE=${3} ${1}/minikube-rook-setup.sh create
 	PRIMARY_CLUSTER=${2} SECONDARY_CLUSTER=${3} ${1}/minikube-rook-mirror-setup.sh
 	PRIMARY_CLUSTER=${3} SECONDARY_CLUSTER=${2} ${1}/minikube-rook-mirror-setup.sh

--- a/hack/ocm-minikube.sh
+++ b/hack/ocm-minikube.sh
@@ -71,11 +71,8 @@ ocm_registration_operator_checkout()
 	set -e
 	git --git-dir ${1}/.git --work-tree ${1} checkout release-2.3
 	# managed cluster names other than cluster1 require
-	set +e
+	git --git-dir ${1}/.git --work-tree ${1} reset --hard f3b0287
 	git apply --directory ${1} ocm-minikube/${1}.diff
-	# error: patch failed: Makefile:36
-	# error: Makefile: patch does not apply
-	set -e
 }
 case ${NAME} in
 "Ubuntu")
@@ -155,6 +152,7 @@ spoke_add()
 
 	# hub register managed cluster
 	until_true_or_n 30 kubectl --context ${hub_cluster_name} get managedclusters/${1}
+	kubectl --context ${1} apply -f registration-operator/vendor/github.com/open-cluster-management/api/work/v1/0000_00_work.open-cluster-management.io_manifestworks.crd.yaml
 	set +e
 	kubectl --context ${hub_cluster_name} certificate approve $(kubectl --context ${hub_cluster_name} get csr --field-selector spec.signerName=kubernetes.io/kube-apiserver-client --selector open-cluster-management.io/cluster-name=${1} -oname)
 	# error: one or more CSRs must be specified as <name> or -f <filename>

--- a/hack/ocm-minikube.sh
+++ b/hack/ocm-minikube.sh
@@ -1,39 +1,33 @@
 #!/bin/sh
-# shellcheck disable=SC2046,SC2086
+# shellcheck disable=1091,2046,2086
 
 # open cluster management (ocm) hub and managed minikube kvm amd64 clusters deploy
 # https://github.com/ShyamsundarR/ocm-minikube/README.md
 
 set -x
 set -e
-trap 'echo exit value: $?' EXIT
-
-#minikube delete -p cluster2
-#minikube delete -p cluster1
-#minikube delete -p hub
+trap 'echo exit value: $?;trap - EXIT' EXIT
 
 mkdir -p ${HOME}/.local/bin
 PATH=${HOME}/.local/bin:${PATH}
 
-if ! command -v curl; then
-	wget -O ${HOME}/.local/bin/curl https://github.com/moparisthebest/static-curl/releases/download/v7.76.0/curl-amd64
-	chmod +x ${HOME}/.local/bin/curl
-fi
-
-if ! command -v minikube; then
-	# https://minikube.sigs.k8s.io/docs/start/
-	minikube_version=latest
-	minikube_version=v1.18.1
-	curl -LRo ${HOME}/.local/bin/minikube https://storage.googleapis.com/minikube/releases/${minikube_version}/minikube-linux-amd64
-	unset -v minikube_version
-	chmod +x ${HOME}/.local/bin/minikube
-fi
+ramen_hack_directory_path_name=$(dirname ${0})
+${ramen_hack_directory_path_name}/minikube-install.sh ${HOME}/.local/bin
+# 1.11 wait support
+# 1.19 certificates.k8s.io/v1 https://github.com/kubernetes/kubernetes/pull/91685
+${ramen_hack_directory_path_name}/kubectl-install.sh ${HOME}/.local/bin 1 19
+${ramen_hack_directory_path_name}/kustomize-install.sh ${HOME}/.local/bin
+# shellcheck source=./until_true_or_n.sh
+. ${ramen_hack_directory_path_name}/until_true_or_n.sh
+# TODO registration-operator go version minimum determine programatically
+# shellcheck source=./go-install.sh
+. ${ramen_hack_directory_path_name}/go-install.sh; go_install ${HOME}/.local 1.15.2; unset -f go_install
+unset -v ramen_hack_directory_path_name
 
 minikube_start_options=--driver=kvm2
-# shellcheck disable=SC1091
 . /etc/os-release # NAME
 
-if false; then
+if ! command -v virsh; then
 	# https://minikube.sigs.k8s.io/docs/drivers/kvm2/
 	case ${NAME} in
 	"Red Hat Enterprise Linux Server")
@@ -43,267 +37,349 @@ if false; then
 	"Ubuntu")
 		# https://help.ubuntu.com/community/KVM/Installation
 		sudo apt-get update
-		if true || test ${VERSION_ID} -ge "18.10"; then
+		if false # test ${VERSION_ID} -ge "18.10"
+		then
 			sudo apt-get install qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils -y
 		else
 			sudo apt-get install qemu-kvm libvirt-bin ubuntu-vm-builder bridge-utils -y
 		fi
+		# shellcheck disable=SC2012
+		sudo adduser ${LOGNAME} $(ls -l /var/run/libvirt/libvirt-sock|cut -d\  -f4)
+		echo 'relogin for permission to access /var/run/libvirt/libvirt-sock, then rerun'
+		false; exit
 		;;
 	esac
-	sudo usermod -aG libvirt ${LOGNAME}
-	# groups refresh
-	exec su - ${LOGNAME}
 fi
 
-minikube start ${minikube_start_options} --profile=hub --cpus=4
-
-# TODO or less than version 1.11 (wait unsupported)
-if ! command -v kubectl; then
-	# https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-kubectl-binary-with-curl-on-linux
-	curl -LRo ${HOME}/.local/bin/kubectl https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl
-	chmod +x ${HOME}/.local/bin/kubectl
-fi
-
-if ! command -v kustomize; then
-	curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.0.5/kustomize_v4.0.5_linux_amd64.tar.gz | tar -C${HOME}/.local/bin -xz
-fi
-
-until_true_or_n()
+ocm_minikube_checkout()
 {
-	set +x
-	n=${1}
-	shift
-	i=0
-	date
-	while ! "${@}"
-	do
-		test ${i} -lt ${n}
-		sleep 1
-		i=$((i+1))
-	done
-	date
-	unset -v i
-	unset -v n
-	set -x
+	set +e
+	git clone https://github.com/ShyamsundarR/ocm-minikube
+	# fatal: destination path 'ocm-minikube' already exists and is not an empty directory.
+	set -e
+	git --git-dir ocm-minikube/.git --work-tree ocm-minikube checkout main
+	git --git-dir ocm-minikube/.git fetch https://github.com/ShyamsundarR/ocm-minikube main:shyam-main
+	git --git-dir ocm-minikube/.git --work-tree ocm-minikube checkout -
+	git --git-dir ocm-minikube/.git --work-tree ocm-minikube checkout shyam-main
 }
-
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/cluster-registry/master/cluster-registry-crd.yaml
-set +e
-git clone https://github.com/open-cluster-management/registration-operator
-# fatal: destination path 'registration-operator' already exists and is not an empty directory.
-git clone https://github.com/ShyamsundarR/ocm-minikube
-# fatal: destination path 'ocm-minikube' already exists and is not an empty directory.
-set -e
-# registration-operator make deploy-hub requires go version 1.14.4 or greater
-	# https://golang.org/ref/mod#versions
-	# https://semver.org/spec/v2.0.0.html
-
+ocm_registration_operator_checkout()
+{
+	set -- registration-operator
+	set +e
+	git clone https://github.com/open-cluster-management/${1}
+	# fatal: destination path 'registration-operator' already exists and is not an empty directory.
+	set -e
+	git --git-dir ${1}/.git --work-tree ${1} checkout release-2.3
+	# managed cluster names other than cluster1 require
+	set +e
+	git apply --directory ${1} ocm-minikube/${1}.diff
+	# error: patch failed: Makefile:36
+	# error: Makefile: patch does not apply
+	set -e
+}
 case ${NAME} in
 "Ubuntu")
-	deploy_arguments=GO_REQUIRED_MIN_VERSION:=
+	ocm_registration_operator_make_arguments=GO_REQUIRED_MIN_VERSION:=
 	;;
 esac
-if ! command -v go
-# TODO or version less than 1.14.4?
-#|| $(go version | { read _ _ v _; echo ${v#go}; })
-then
-	PATH=${HOME}/.local/go/bin:${PATH}
-	if ! command -v go; then
-		curl -L https://golang.org/dl/go1.16.2.linux-amd64.tar.gz | tar -C${HOME}/.local -xz
-	fi
-fi
-
-cd registration-operator
-git checkout release-2.3
-# managed cluster names other than cluster1 require
-set +e
-git apply ../ocm-minikube/registration-operator.diff
-# error: patch failed: Makefile:36
-# error: Makefile: patch does not apply
-set -e
-set +e
-make deploy-hub ${deploy_arguments}
-# FATA[0000] Failed to run packagemanifests: create catalog: error creating catalog source: catalogsources.operators.coreos.com "cluster-manager-catalog" already exists
-set -e
-cd ..
-date
-kubectl --context hub -n olm                     wait deployments --all --for condition=available --timeout 1m
-date
-kubectl --context hub -n open-cluster-management wait deployments --all --for condition=available
-date
-# https://github.com/kubernetes/kubernetes/issues/83242
-until_true_or_n 90 kubectl --context hub -n open-cluster-management-hub wait deployments --all --for condition=available --timeout 0
-
-HUB_KUBECONFIG=/tmp/hub-config
-kubectl --context hub config view --flatten --minify >${HUB_KUBECONFIG}
-
-spoke_add()
+ocm_registration_operator_deploy_hub()
 {
-	cluster_name=${1}
-	cd registration-operator
-	kubectl config use-context ${cluster_name}
+	kubectl --context ${hub_cluster_name} apply -f https://raw.githubusercontent.com/kubernetes/cluster-registry/master/cluster-registry-crd.yaml
+	kubectl config use-context ${hub_cluster_name}
 	set +e
-	MANAGED_CLUSTER=${cluster_name}\
-	HUB_KUBECONFIG=${HUB_KUBECONFIG}\
-	make deploy-spoke ${deploy_arguments}
-	# FATA[0000] Failed to run packagemanifests: create catalog: error creating catalog source: catalogsources.operators.coreos.com "klusterlet-catalog" already exists
+	make -C registration-operator deploy-hub ${ocm_registration_operator_make_arguments} #OLM_VERSION=latest
+	# FATA[0000] Failed to run packagemanifests: create catalog: error creating catalog source: catalogsources.operators.coreos.com "cluster-manager-catalog" already exists
 	set -e
-	cd ..
-
 	date
-	kubectl --context ${cluster_name} -n open-cluster-management wait deployments --all --for condition=available
+	kubectl --context ${hub_cluster_name} -n olm                     wait deployments --all --for condition=available --timeout 1m
+	date
+	kubectl --context ${hub_cluster_name} -n open-cluster-management wait deployments --all --for condition=available
 	date
 	# https://github.com/kubernetes/kubernetes/issues/83242
-	until_true_or_n 60 kubectl --context ${cluster_name} -n open-cluster-management-agent wait deployments/klusterlet-registration-agent --for condition=available --timeout 0
-
-	# hub register managed cluster
-	until_true_or_n 30 kubectl --context hub get managedclusters/${cluster_name} --ignore-not-found=false
+	until_true_or_n 90 kubectl --context ${hub_cluster_name} -n open-cluster-management-hub wait deployments --all --for condition=available --timeout 0
+}
+ocm_registration_operator_undeploy_hub()
+{
+	kubectl config use-context ${hub_cluster_name}
 	set +e
-	kubectl --context hub certificate approve $(kubectl --context hub get csr --field-selector spec.signerName=kubernetes.io/kube-apiserver-client --selector open-cluster-management.io/cluster-name=${cluster_name} -oname)
-	# error: one or more CSRs must be specified as <name> or -f <filename>
+	make -C registration-operator clean-hub ${ocm_registration_operator_make_arguments}
+	# error: unable to recognize "deploy/cluster-manager/config/samples/operator_open-cluster-management_clustermanagers.cr.yaml": no matches for kind "ClusterManager" in version "operator.open-cluster-management.io/v1"
 	set -e
-	kubectl --context hub patch managedclusters/${cluster_name} -p='{"spec":{"hubAcceptsClient":true}}' --type=merge
-	date
-	kubectl --context hub wait managedclusters/${cluster_name} --for condition=ManagedClusterConditionAvailable
-	date
-	kubectl --context ${cluster_name} -n open-cluster-management-agent wait deployments --all --for condition=available
-	date
-
-	# test
-	mkdir -p /tmp/ocm-minikube
-	cp -R ocm-minikube/examples /tmp/ocm-minikube
-	sed -e "s,KIND_CLUSTER,${cluster_name}," -i /tmp/ocm-minikube/examples/kustomization.yaml
-	kubectl --context hub apply -k /tmp/ocm-minikube/examples
+}
+application_sample_0_deploy()
+{
+	mkdir -p /tmp/$USER/ocm-minikube
+	cp -R ocm-minikube/examples /tmp/$USER/ocm-minikube
+	sed -e "s,KIND_CLUSTER,${1}," -i /tmp/$USER/ocm-minikube/examples/kustomization.yaml
+	kubectl --context ${hub_cluster_name} apply -k /tmp/$USER/ocm-minikube/examples
 	condition=ready
 	condition=initialized
 	# Failed to pull image "busybox": rpc error: code = Unknown desc = Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
-	until_true_or_n 150 kubectl --context ${cluster_name} wait pods/hello --for condition=${condition} --timeout 0
+	until_true_or_n 150 kubectl --context ${1} wait pods/hello --for condition=${condition} --timeout 0
 	unset -v condition
+}
+application_sample_0_undeploy()
+{
 	# delete may exceed 30 seconds
 	date
-	kubectl --context hub delete -k /tmp/ocm-minikube/examples --wait=false
+	kubectl --context ${hub_cluster_name} delete -k /tmp/$USER/ocm-minikube/examples #--wait=false
 	date
-	# sed -e "s,${cluster_name},KIND_CLUSTER," -i /tmp/ocm-minikube/examples/kustomization.yaml
+	# sed -e "s,${1},KIND_CLUSTER," -i /tmp/$USER/ocm-minikube/examples/kustomization.yaml
 	set +e
-	kubectl --context ${cluster_name} wait pods/hello --for delete --timeout 0
+	kubectl --context ${1} wait pods/hello --for delete --timeout 0
 	# --wait=true  error: no matching resources found
 	# --wait=false error: timed out waiting for the condition on pods/hello
 	set -e
 	date
-	unset -v cluster_name
 }
-
-# hub subscription operator
-set +e
-git clone https://github.com/open-cluster-management/multicloud-operators-subscription
-# fatal: destination path 'multicloud-operators-subscription' already exists and is not an empty directory.
-set -e
-cd multicloud-operators-subscription
-set +e
-git apply ../ocm-minikube/multicloud-operators-subscription.diff
-# error: patch failed: Makefile:209
-# error: Makefile: patch does not apply
-set -e
-kubectl config use-context hub
-USE_VENDORIZED_BUILD_HARNESS=faked make deploy-community-hub
-cd ..
-
-date
-kubectl --context hub -n multicluster-operators wait deployments --all --for condition=available --timeout 2m
-date
-
-spoke_add_hub()
+application_sample_0_test()
 {
-	spoke_add ${1}
-	kubectl --context hub patch managedclusters/${1} -p='{"metadata":{"labels":{"local-cluster":"true"}}}' --type=merge
-	# hub managed cluster subscription operator
-	cd multicloud-operators-subscription
-	cp -f ${HUB_KUBECONFIG} /tmp/kubeconfig
+	application_sample_0_deploy ${1}
+	application_sample_0_undeploy ${1}
+}
+spoke_add()
+{
+	kubectl config use-context ${1}
+	set +e
+	MANAGED_CLUSTER=${1}\
+	HUB_KUBECONFIG=${HUB_KUBECONFIG}\
+	make -C registration-operator deploy-spoke ${ocm_registration_operator_make_arguments}
+	# FATA[0000] Failed to run packagemanifests: create catalog: error creating catalog source: catalogsources.operators.coreos.com "klusterlet-catalog" already exists
+	set -e
+
+	date
+	kubectl --context ${1} -n open-cluster-management wait deployments --all --for condition=available
+	date
+	# https://github.com/kubernetes/kubernetes/issues/83242
+	until_true_or_n 90 kubectl --context ${1} -n open-cluster-management-agent wait deployments/klusterlet-registration-agent --for condition=available --timeout 0
+
+	# hub register managed cluster
+	until_true_or_n 30 kubectl --context ${hub_cluster_name} get managedclusters/${1}
+	set +e
+	kubectl --context ${hub_cluster_name} certificate approve $(kubectl --context ${hub_cluster_name} get csr --field-selector spec.signerName=kubernetes.io/kube-apiserver-client --selector open-cluster-management.io/cluster-name=${1} -oname)
+	# error: one or more CSRs must be specified as <name> or -f <filename>
+	kubectl --context ${hub_cluster_name} patch managedclusters/${1} -p '{"spec":{"hubAcceptsClient":true}}' --type=merge
+	# Error from server (InternalError): Internal error occurred: failed calling webhook "managedclustermutators.admission.cluster.open-cluster-management.io": the server is currently unable to handle the request
+	set -e
+	date
+	kubectl --context ${hub_cluster_name} wait managedclusters/${1} --for condition=ManagedClusterConditionAvailable
+	date
+	kubectl --context ${1} -n open-cluster-management-agent wait deployments --all --for condition=available --timeout 60s
+	date
+	#application_sample_0_test ${1}
+}
+ocm_registration_operator_undeploy_spoke()
+{
+	kubectl config use-context ${1}
+	set +e
+	make -C registration-operator clean-spoke ${ocm_registration_operator_make_arguments}
+	# error: unable to recognize "deploy/klusterlet/config/samples/operator_open-cluster-management_klusterlets.cr.yaml": no matches for kind "Klusterlet" in version "operator.open-cluster-management.io/v1"
+	set -e
+}
+ocm_subscription_operator_checkout()
+{
+	set -- multicloud-operators-subscription
+	set +e
+	git clone https://github.com/open-cluster-management/${1}
+	# fatal: destination path 'multicloud-operators-subscription' already exists and is not an empty directory.
+	set -e
+	set +e
+	git apply --directory ${1} ocm-minikube/${1}.diff
+	# error: patch failed: Makefile:209
+	# error: Makefile: patch does not apply
+	set -e
+}
+ocm_subscription_operator_deploy_hub()
+{
+	kubectl config use-context ${hub_cluster_name}
+	USE_VENDORIZED_BUILD_HARNESS=faked make -C multicloud-operators-subscription deploy-community-hub
+	date
+	kubectl --context ${hub_cluster_name} -n multicluster-operators wait deployments --all --for condition=available --timeout 2m
+	date
+}
+ocm_subscription_operator_deploy_spoke_hub()
+{
+	cp -f ${HUB_KUBECONFIG} /tmp/$USER/kubeconfig
 	kubectl --context ${1} -n multicluster-operators delete secret appmgr-hub-kubeconfig --ignore-not-found
-	kubectl --context ${1} -n multicluster-operators create secret generic appmgr-hub-kubeconfig --from-file=kubeconfig=/tmp/kubeconfig
-	mkdir -p munge-manifests
-	cp deploy/managed/operator.yaml munge-manifests/operator.yaml
-	sed -i 's/<managed cluster name>/'"${1}"'/g' munge-manifests/operator.yaml
-	sed -i 's/<managed cluster namespace>/'"${1}"'/g' munge-manifests/operator.yaml
-	sed -i '0,/name: multicluster-operators-subscription/{s/name: multicluster-operators-subscription/name: multicluster-operators-subscription-mc/}' munge-manifests/operator.yaml
-	kubectl --context ${1} apply -f munge-manifests/operator.yaml
+	kubectl --context ${1} -n multicluster-operators create secret generic appmgr-hub-kubeconfig --from-file=kubeconfig=/tmp/$USER/kubeconfig
+	mkdir -p multicloud-operators-subscription/munge-manifests
+	cp multicloud-operators-subscription/deploy/managed/operator.yaml multicloud-operators-subscription/munge-manifests/operator.yaml
+	sed -i 's/<managed cluster name>/'"${1}"'/g' multicloud-operators-subscription/munge-manifests/operator.yaml
+	sed -i 's/<managed cluster namespace>/'"${1}"'/g' multicloud-operators-subscription/munge-manifests/operator.yaml
+	sed -i '0,/name: multicluster-operators-subscription/{s/name: multicluster-operators-subscription/name: multicluster-operators-subscription-mc/}' multicloud-operators-subscription/munge-manifests/operator.yaml
+	kubectl --context ${1} apply -f multicloud-operators-subscription/munge-manifests/operator.yaml
 	date
 	kubectl --context ${1} -n multicluster-operators wait deployments --all --for condition=available
 	date
-	cd ..
+}
+ocm_subscription_operator_deploy_spoke_nonhub()
+{
+	kubectl config use-context ${1}
+	MANAGED_CLUSTER_NAME=${1}\
+	HUB_KUBECONFIG=${HUB_KUBECONFIG}\
+	USE_VENDORIZED_BUILD_HARNESS=faked\
+	make -C multicloud-operators-subscription deploy-community-managed
+	date
+	kubectl --context ${1} -n multicluster-operators wait deployments --all --for condition=available --timeout 1m
+	date
+}
+spoke_test_deploy()
+{
+	kubectl --context ${hub_cluster_name} apply -f multicloud-operators-subscription/examples/helmrepo-hub-channel
+	# https://github.com/kubernetes/kubernetes/issues/83242
+	until_true_or_n 60 kubectl --context ${1} wait deployments --selector app=nginx-ingress --for condition=available --timeout 0
+}
+spoke_test_undeploy()
+{
+	kubectl --context ${hub_cluster_name} delete -f multicloud-operators-subscription/examples/helmrepo-hub-channel
+	set +e
+	kubectl --context ${1} wait deployments --selector app=nginx-ingress --for delete --timeout 1m
+	# error: no matching resources found
+	set -e
+}
+spoke_test()
+{
+	spoke_test_deploy ${1}
+	spoke_test_undeploy ${1}
+}
+spoke_add_hub()
+{
+	spoke_add ${1}
+	kubectl --context ${hub_cluster_name} label managedclusters/${1} local-cluster=true --overwrite
+	ocm_subscription_operator_deploy_spoke_hub ${1}
 }
 spoke_add_nonhub()
 {
 	minikube start ${minikube_start_options} --profile=${1}
 	spoke_add ${1}
-	# managed cluster subscription operator
-	cd multicloud-operators-subscription
-	kubectl config use-context ${1}
-	MANAGED_CLUSTER_NAME=${1}\
-	HUB_KUBECONFIG=${HUB_KUBECONFIG}\
-	USE_VENDORIZED_BUILD_HARNESS=faked\
-	make deploy-community-managed
-	date
-	kubectl --context ${1} -n multicluster-operators wait deployments --all --for condition=available
-	date
-	# test
-	kubectl --context hub apply -f examples/helmrepo-hub-channel
-	# https://github.com/kubernetes/kubernetes/issues/83242
-	until_true_or_n 60 kubectl --context ${1} wait deployments --selector app=nginx-ingress --for condition=available --timeout 0
-	kubectl --context hub delete -f examples/helmrepo-hub-channel
+	ocm_subscription_operator_deploy_spoke_nonhub ${1}
+	#spoke_test ${1}
+}
+ocm_application_samples_checkout()
+{
+	set -- application-samples
 	set +e
-	kubectl --context ${1} wait deployments --selector app=nginx-ingress --for delete --timeout 1m
+	git clone https://github.com/open-cluster-management/${1}
+	# fatal: destination path 'application-samples' already exists and is not an empty directory.
+	set -e
+	set +e
+	git apply --directory ${1} ocm-minikube/${1}.diff
+	# error: patch failed: subscriptions/book-import/placementrule.yaml:9
+	# error: subscriptions/book-import/placementrule.yaml: patch does not apply
+	# error: patch failed: subscriptions/book-import/subscription.yaml:3
+	# error: subscriptions/book-import/subscription.yaml: patch does not apply
+	set -e
+}
+application_sample_deploy()
+{
+	kubectl --context ${hub_cluster_name} apply -k application-samples/subscriptions/channel
+	kubectl --context ${hub_cluster_name} label managedclusters/${1} usage=test --overwrite
+	set +e
+	kubectl --context ${hub_cluster_name} apply -k application-samples/subscriptions/book-import
+	# Error from server (InternalError): error when creating "subscriptions/book-import": Internal error occurred: failed calling webhook "applications.apps.open-cluster-management.webhook": Post "https://multicluster-operators-application-svc.multicluster-operators.svc:443/app-validate?timeout=10s": dial tcp 10.106.210.84:443: connect: connection refused
+	set -e
+	# https://github.com/kubernetes/kubernetes/issues/83242
+	until_true_or_n 30 kubectl --context ${1} -n book-import wait deployments --all --for condition=available --timeout 0
+}
+application_sample_undeploy()
+{
+	kubectl --context ${hub_cluster_name} delete -k application-samples/subscriptions/book-import --ignore-not-found
+	# Error from server (NotFound): error when deleting "application-samples/subscriptions/book-import": applications.app.k8s.io "book-import" not found
+	date
+	set +e
+	kubectl --context ${1} -n book-import wait pods --all --for delete --timeout 1m
 	# error: no matching resources found
 	set -e
-	cd ..
+	date
+	kubectl --context ${1} delete namespaces/book-import
+	date
+	kubectl --context ${hub_cluster_name} label managedclusters/${1} usage-
+	kubectl --context ${hub_cluster_name} delete -k application-samples/subscriptions/channel
 }
-spoke_add_nonhub cluster1
-spoke_add_hub hub
-#spoke_add_nonhub cluster2
+application_sample_test()
+{
+	ocm_application_samples_checkout
+	application_sample_deploy ${1}
+	application_sample_undeploy ${1}
+}
+hub_cluster_name=${hub_cluster_name:-hub}
+spoke_cluster_names=${spoke_cluster_names:-${hub_cluster_name}\ cluster1}
+for cluster_name in ${spoke_cluster_names}; do
+	if test ${cluster_name} = ${hub_cluster_name}; then
+		spoke_cluster_names_hub=${spoke_cluster_names_hub}\ ${cluster_name}
+	else
+		spoke_cluster_names_nonhub=${spoke_cluster_names_nonhub}\ ${cluster_name}
+	fi
+done
+for command in "${@:-deploy}"; do
+        case ${command} in
+        deploy)
+		minikube start ${minikube_start_options} --profile=${hub_cluster_name} --cpus=4
+		ocm_minikube_checkout
+		ocm_registration_operator_checkout
+		ocm_registration_operator_deploy_hub
+		ocm_subscription_operator_checkout
+		ocm_subscription_operator_deploy_hub
+		mkdir -p /tmp/$USER
+		HUB_KUBECONFIG=/tmp/$USER/${hub_cluster_name}-config
+		kubectl --context ${hub_cluster_name} config view --flatten --minify >${HUB_KUBECONFIG}
+		for cluster_name in ${spoke_cluster_names_hub}   ; do spoke_add_hub    ${cluster_name}; done; unset -v cluster_name
+		for cluster_name in ${spoke_cluster_names_nonhub}; do spoke_add_nonhub ${cluster_name}; done; unset -v cluster_name
+		unset -v HUB_KUBECONFIG
+		;;
+	test)
+		for cluster_name in ${spoke_cluster_names_nonhub}; do
+			application_sample_test ${cluster_name}
+			break
+		done; unset -v cluster_name
+		;;
+	ocm_registration_operator_undeploy_spoke_hub)
+		for cluster_name in ${spoke_cluster_names_hub}; do
+			ocm_registration_operator_undeploy_spoke ${cluster_name}
+		done; unset -v cluster_name
+		;;
+	ocm_registration_operator_undeploy_hub)
+		ocm_registration_operator_undeploy_hub
+		;;
+	undeploy)
+		for cluster_name in ${spoke_cluster_names_nonhub} ${spoke_cluster_names_hub}; do
+			ocm_registration_operator_undeploy_spoke ${cluster_name}
+		done; unset -v cluster_name
+		ocm_registration_operator_undeploy_hub
+		;;
+	delete)
+		for cluster_name in ${spoke_cluster_names_nonhub} ${hub_cluster_name}; do
+			minikube delete -p ${cluster_name}
+		done; unset -v cluster_name
+		;;
+	esac
+done
+unset -v spoke_cluster_names_nonhub
+unset -v spoke_cluster_names_hub
+unset -v spoke_cluster_names
+unset -v hub_cluster_name
+unset -f application_sample_test
+unset -f application_sample_undeploy
+unset -f application_sample_deploy
+unset -f ocm_application_samples_checkout
 unset -f spoke_add_nonhub
 unset -f spoke_add_hub
 unset -f spoke_add
-unset -v HUB_KUBECONFIG
-unset -v minikube_start_options
-unset -v deploy_arguments
-
-# application samples test
-cluster_name=cluster1
-kubectl --context hub patch managedclusters/${cluster_name} -p='{"metadata":{"labels":{"usage":"test"}}}' --type=merge
-set +e
-git clone https://github.com/open-cluster-management/application-samples
-# fatal: destination path 'application-samples' already exists and is not an empty directory.
-set -e
-cd application-samples
-set +e
-git apply ../ocm-minikube/application-samples.diff
-# error: patch failed: subscriptions/book-import/placementrule.yaml:9
-# error: subscriptions/book-import/placementrule.yaml: patch does not apply
-# error: patch failed: subscriptions/book-import/subscription.yaml:3
-# error: subscriptions/book-import/subscription.yaml: patch does not apply
-set -e
-kubectl --context hub apply -k subscriptions/channel
-set +e
-kubectl --context hub apply -k subscriptions/book-import
-# Error from server (InternalError): error when creating "subscriptions/book-import": Internal error occurred: failed calling webhook "applications.apps.open-cluster-management.webhook": Post "https://multicluster-operators-application-svc.multicluster-operators.svc:443/app-validate?timeout=10s": dial tcp 10.106.210.84:443: connect: connection refused
-kubectl --context hub apply -f subscriptions/book-import/application.yaml
-# Error from server (InternalError): error when creating "subscriptions/book-import/application.yaml": Internal error occurred: failed calling webhook "applications.apps.open-cluster-management.webhook": Post "https://multicluster-operators-application-svc.multicluster-operators.svc:443/app-validate?timeout=10s": dial tcp 10.106.210.84:443: connect: connection refused
-set -e
-# https://github.com/kubernetes/kubernetes/issues/83242
-until_true_or_n 30 kubectl --context ${cluster_name} -n book-import wait deployments --all --for condition=available --timeout 0
-set +e
-kubectl --context hub delete -f subscriptions/book-import/application.yaml
-# Error from server (NotFound): error when deleting "subscriptions/book-import/application.yaml": applications.app.k8s.io "book-import" not found
-kubectl --context hub delete -k subscriptions/book-import
-# Error from server (NotFound): error when deleting "subscriptions/book-import": applications.app.k8s.io "book-import" not found
-set -e
-kubectl --context hub delete -k subscriptions/channel
-date
-set +e
-kubectl --context ${cluster_name} -n book-import wait pods --all --for delete --timeout 1m
-# error: no matching resources found
-set -e
-date
-cd ../
-unset -v cluster_name
+unset -f spoke_test
+unset -f spoke_test_undeploy
+unset -f spoke_test_deploy
+unset -f application_sample_0_test
+unset -f application_sample_0_undeploy
+unset -f application_sample_0_deploy
+unset -f ocm_subscription_operator_deploy_spoke_nonhub
+unset -f ocm_subscription_operator_deploy_spoke_hub
+unset -f ocm_subscription_operator_deploy_hub
+unset -f ocm_subscription_operator_checkout
+unset -f ocm_registration_operator_undeploy_spoke
+unset -f ocm_registration_operator_undeploy_hub
+unset -f ocm_registration_operator_deploy_hub
+unset -v ocm_registration_operator_make_arguments
+unset -f ocm_registration_operator_checkout
+unset -f ocm_minikube_checkout
 unset -f until_true_or_n
+unset -v minikube_start_options

--- a/hack/podman-docker-install.sh
+++ b/hack/podman-docker-install.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# shellcheck disable=2046,2086
+if ! command -v docker; then
+	$(dirname ${0})/podman-install.sh
+	# shellcheck disable=1091
+	. /etc/os-release
+	case ${NAME} in
+	Ubuntu)
+		IFS=. read -r year month <<-a
+		${VERSION_ID}
+		a
+		# https://github.com/containers/podman/issues/1553#issuecomment-435984922
+		# https://packages.ubuntu.com/search?suite=all&arch=amd64&keywords=podman-docker
+		if test ${year} -gt 21 || { test ${year} -eq 21 && test ${month} -ge 10; }
+		then
+			sudo apt-get -y install podman-docker
+		else
+			sudo ln -s /usr/bin/podman /usr/bin/docker
+		fi
+		unset -v year month
+		docker --version
+		;;
+	esac
+fi

--- a/hack/podman-docker-uninstall.sh
+++ b/hack/podman-docker-uninstall.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# shellcheck disable=2086
+if test "$(file -h /usr/bin/docker)" = '/usr/bin/docker: symbolic link to /usr/bin/podman'
+then
+	# shellcheck disable=1091
+	. /etc/os-release
+	case ${NAME} in
+	Ubuntu)
+		IFS=. read -r year month <<-a
+		${VERSION_ID}
+		a
+		if test ${year} -gt 21 || { test ${year} -eq 21 && test ${month} -ge 10; }
+		then
+			sudo apt -y remove podman-docker
+		else
+			sudo rm -f /usr/bin/docker
+		fi
+		unset -v year month
+		;;
+	esac
+fi

--- a/hack/podman-install.sh
+++ b/hack/podman-install.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# shellcheck disable=2086
+if ! command -v podman; then
+	# https://podman.io/getting-started/installation#linux-distributions
+	# shellcheck disable=1091
+	. /etc/os-release
+	case ${NAME} in
+	Ubuntu)
+		echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_'${VERSION_ID}'/ /' | sudo tee /etc/apt/sources.list.d/podman.list >/dev/null
+		curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+		sudo apt-get update
+		#sudo apt-get -y upgrade
+		sudo apt-get -y install podman
+		podman --version
+		;;
+	esac
+fi

--- a/hack/podman-uninstall.sh
+++ b/hack/podman-uninstall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# shellcheck disable=2046,2086
+if command -v podman; then
+	$(dirname ${0})/podman-docker-uninstall.sh
+	# shellcheck disable=1091
+	. /etc/os-release
+	case ${NAME} in
+	Ubuntu)
+		sudo apt -y remove podman
+		;;
+	esac
+fi

--- a/hack/uidmap-install.sh
+++ b/hack/uidmap-install.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# shellcheck disable=1091
+if ! command -v newuidmap
+then
+	. /etc/os-release
+	case ${NAME} in
+	"Ubuntu")
+		set +e
+		sudo apt-get install -y uidmap
+		# dpkg: error processing package lvm2 (--configure):
+		# installed lvm2 package post-installation script subprocess returned error exit status 1
+		set -e
+		;;
+	esac
+fi

--- a/hack/until_true_or_n.sh
+++ b/hack/until_true_or_n.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# shellcheck disable=2086
+until_true_or_n()
+{
+	case ${-} in *x*) { set +x; } 2>/dev/null; x='unset -v x; set -x';; esac
+	n=${1}
+	shift
+	date
+	until test ${n} -eq 0 || "${@}"
+	do
+		sleep 1
+		n=$((n-1))
+	done
+	date
+	unset -v n
+	eval ${x}
+	"${@}"
+}

--- a/hack/until_true_or_n.sh
+++ b/hack/until_true_or_n.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=2086
 until_true_or_n()
 {
-	case ${-} in *x*) { set +x; } 2>/dev/null; x='unset -v x; set -x';; esac
+	{ case ${-} in *x*) set +x; x='unset -v x; set -x';; esac; } 2>/dev/null
 	n=${1}
 	shift
 	date


### PR DESCRIPTION
This pull request includes the following:

- ramen, sample application, and minio s3 store deployment and undeployment automate
- rook-ceph scripts call to create volumes and mirroring relationships
- directory path name pass to commands instead of cd
- program installation scripts define and use
- kubectl label subcommand use instead of patch
- temporary files stored in `$USER` subdirectory
- ramen image build includes pr58 and permissive rbac commit (fetched from github.com/hatfieldbrian/ramen branch `pr47_pr58_rbac2360357`)
- cluster name specification with `hub_cluster_name` and `spoke_cluster_names` variables which default to `hub` and `$hub_cluster_name cluster1` respectively

new script is named `ocm-minikube-ramen.sh`.  It is stored in ramen `hack` directory.

It takes zero or more subcommands.  Supported subcommands are:

- `deploy` (default)
- `undeploy`

Subcommands are executed in the order they are passed.

It and `hack/ocm-minikube.sh`, which it calls, clone repositories creating directories in the current working directory if not present.  Therefore, I prefer to run the script from my home directory.  For example:

to deploy issue:
`ramen/hack/ocm-minikube-ramen.sh deploy`
to undeploy issue:
`ramen/hack/ocm-minikube-ramen.sh undeploy`
to deploy and undeploy issue:
`ramen/hack/ocm-minikube-ramen.sh deploy undeploy`