### PR TITLE
Update sanity check for git diff and kind

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -81,7 +81,8 @@ jobs:
       - name: Git branch sanity
         run: |
           echo "Failing if any auto generated files are updated, checking 'git status'"
-          git status --porcelain 2>&1 | tee /dev/stderr | (! read || git diff && ! read a)
+          git --no-pager diff
+          git status --porcelain 2>&1 | tee /dev/stderr | (! read)
 
   deploy-check:
     name: Check artifacts and operator deployment
@@ -90,11 +91,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        KUBERNETES_VERSIONS: ["1.20.2"]
+        kubernetes_version: ["1.20.7"]
+        include:
+          - kubernetes_version: "1.20.7"
+            kind_image: "1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9"
+            kind_version: "v0.11.1"
     env:
-      KUBERNETES_VERSION: ${{ matrix.KUBERNETES_VERSIONS }}
-      KIND_VERSION: "v0.10.0"
+      KUBERNETES_VERSION: ${{ matrix.kubernetes_version }}
+      KIND_VERSION: ${{ matrix.kind_version }}
+      KIND_IMAGE: ${{ matrix.kind_image }}
       KIND_CLUSTER_NAME: "sanity"
+
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -131,8 +138,21 @@ jobs:
         run: |
           make deploy
           kubectl get deployment -n ramen-system
-          sleep 15
-          kubectl get pods -A
+          kubectl -n ramen-system wait --for=condition=Available --timeout=60s deploy/ramen-controller-manager
+
+      - name: Display failure logs
+        if: ${{ failure() }}
+        run: |
+          echo "===> BEGIN failure details <==="
+          echo "===> NODE details <==="
+          kubectl get node -o yaml
+          echo "===> Ramen POD details <==="
+          kubectl get pods -n ramen-system -o yaml
+          echo "===> Ramen POD describe <==="
+          kubectl describe pods -n ramen-system
+          echo "===> Ramen POD logs <==="
+          kubectl logs -n ramen-system deployment/ramen-controller-manager -c manager
+          echo "===> END failure details <==="
 
   publish-image:
     name: Publish built image

--- a/go.mod
+++ b/go.mod
@@ -13,11 +13,11 @@ require (
 	github.com/open-cluster-management/multicloud-operators-placementrule v1.0.1-2020-06-08-14-28-27.0.20201118195339-05a8c4c89c12
 	github.com/open-cluster-management/multicloud-operators-subscription v1.2.2-2-20201130-59f96
 	github.com/pkg/errors v0.9.1
+	go.uber.org/zap v1.15.0
 	k8s.io/api v0.20.5
 	k8s.io/apimachinery v0.20.5
 	k8s.io/client-go v12.0.0+incompatible
 	sigs.k8s.io/controller-runtime v0.7.0
-	go.uber.org/zap v1.15.0
 )
 
 replace k8s.io/client-go => k8s.io/client-go v0.20.0

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -1,8 +1,8 @@
 #! /bin/bash
 set -e -o pipefail
 
-KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.20.2}"
-KIND_VERSION="${KIND_VERSION:-v0.10.0}"
+KIND_IMAGE="${KIND_IMAGE:-1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9}"
+KIND_VERSION="${KIND_VERSION:-v0.11.1}"
 KIND_DIR="$(mktemp -d --tmpdir kind-XXXXXX)"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-"$(basename "${KIND_DIR}" | tr "[:upper:]" "[:lower:]")"}"
 rmdir "${KIND_DIR}"
@@ -23,7 +23,7 @@ elif [[ ${KIND_VERSION} != v"$(${KIND_BIN} --version | cut -f 3 -d ' ')" ]]; the
 fi
 
 ${KIND_BIN} delete cluster --name "${KIND_CLUSTER_NAME}" || true
-${KIND_BIN} create cluster --name "${KIND_CLUSTER_NAME}" --image "kindest/node:v${KUBERNETES_VERSION}"
+${KIND_BIN} create cluster --name "${KIND_CLUSTER_NAME}" --image "kindest/node:v${KIND_IMAGE}" --wait 5m
 
 echo "${KIND_CLUSTER_NAME}"
 #kubectl config use-context kind-"${KIND_CLUSTER_NAME}"


### PR DESCRIPTION
Sanity check for any changed artifacts that are not
commited is not working right post the last change.

Changed the check to the prior version and also added
a "git diff" prior to it, for a listing of the changes
which was sought for based on the change in commit
id 1a863d7

Also, sanity check fails for kind clusters that are
using version 0.10.0 of kind. Change this to 0.11.1
and also add some debug log dumps on failures.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>