### PR TITLE
Move ManifestWork into its own utils

### DIFF
--- a/controllers/util/mw_util.go
+++ b/controllers/util/mw_util.go
@@ -1,0 +1,457 @@
+/*
+Copyright 2021 The RamenDR authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/go-logr/logr"
+	ocmworkv1 "github.com/open-cluster-management/api/work/v1"
+	errorswrapper "github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	rmn "github.com/ramendr/ramen/api/v1alpha1"
+)
+
+const (
+	// ManifestWorkNameFormat is a formated a string used to generate the manifest name
+	// The format is name-namespace-type-mw where:
+	// - name is the DRPC name
+	// - namespace is the DRPC namespace
+	// - type is either "vrg", "pv", or "roles"
+	ManifestWorkNameFormat string = "%s-%s-%s-mw"
+
+	// ManifestWork VRG Type
+	MWTypeVRG string = "vrg"
+
+	// ManifestWork PV Type
+	MWTypePV string = "pv"
+
+	// ManifestWork Roles Type
+	MWTypeRoles string = "roles"
+
+	// Annotations for MW and PlacementRule
+	DRPCNameAnnotation      = "drplacementcontrol.ramendr.openshift.io/drpc-name"
+	DRPCNamespaceAnnotation = "drplacementcontrol.ramendr.openshift.io/drpc-namespace"
+)
+
+type MWUtil struct {
+	client.Client
+	Ctx           context.Context
+	Log           logr.Logger
+	InstName      string
+	InstNamespace string
+}
+
+func ManifestWorkName(name, namespace, mwType string) string {
+	return fmt.Sprintf(ManifestWorkNameFormat, name, namespace, mwType)
+}
+
+func (mwu *MWUtil) BuildManifestWorkName(mwType string) string {
+	return ManifestWorkName(mwu.InstName, mwu.InstNamespace, mwType)
+}
+
+func (mwu *MWUtil) ManifestExistAndApplied(mwName, newPrimary string) (bool, error) {
+	// Try to find whether we have already created a ManifestWork for this
+	mw, err := mwu.FindManifestWork(mwName, newPrimary)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			mwu.Log.Error(err, "Failed to find 'PV restore' ManifestWork")
+
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	if mw != nil {
+		mwu.Log.Info(fmt.Sprintf("Found an existing manifest work (%v)", mw))
+		// Check if the MW is in Applied state
+		if IsManifestInAppliedState(mw) {
+			mwu.Log.Info(fmt.Sprintf("ManifestWork %s/%s in Applied state", mw.Namespace, mw.Name))
+
+			return true, nil
+		}
+
+		mwu.Log.Info("MW is not in applied state", "namespace/name", mw.Namespace+"/"+mw.Name)
+	}
+
+	return false, nil
+}
+
+func (mwu *MWUtil) FindManifestWork(mwName, managedCluster string) (*ocmworkv1.ManifestWork, error) {
+	if managedCluster == "" {
+		return nil, fmt.Errorf("invalid cluster for MW %s", mwName)
+	}
+
+	mw := &ocmworkv1.ManifestWork{}
+
+	err := mwu.Client.Get(mwu.Ctx, types.NamespacedName{Name: mwName, Namespace: managedCluster}, mw)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("MW not found (%w)", err)
+		}
+
+		return nil, fmt.Errorf("failed to retrieve manifestwork (%w)", err)
+	}
+
+	return mw, nil
+}
+
+func IsManifestInAppliedState(mw *ocmworkv1.ManifestWork) bool {
+	applied := false
+	degraded := false
+	conditions := mw.Status.Conditions
+
+	if len(conditions) > 0 {
+		// get most recent conditions that have ConditionTrue status
+		recentConditions := FilterByConditionStatus(GetMostRecentConditions(conditions), metav1.ConditionTrue)
+
+		for _, condition := range recentConditions {
+			if condition.Type == ocmworkv1.WorkApplied {
+				applied = true
+			} else if condition.Type == ocmworkv1.WorkDegraded {
+				degraded = true
+			}
+		}
+
+		// if most recent timestamp contains Applied and Degraded states, don't trust it's actually Applied
+		if degraded {
+			applied = false
+		}
+	}
+
+	return applied
+}
+
+func FilterByConditionStatus(conditions []metav1.Condition, status metav1.ConditionStatus) []metav1.Condition {
+	filtered := make([]metav1.Condition, 0)
+
+	for _, condition := range conditions {
+		if condition.Status == status {
+			filtered = append(filtered, condition)
+		}
+	}
+
+	return filtered
+}
+
+// return Conditions with most recent timestamps only (allows duplicates)
+func GetMostRecentConditions(conditions []metav1.Condition) []metav1.Condition {
+	recentConditions := make([]metav1.Condition, 0)
+
+	// sort conditions by timestamp. Index 0 = most recent
+	sort.Slice(conditions, func(a, b int) bool {
+		return conditions[b].LastTransitionTime.Before(&conditions[a].LastTransitionTime)
+	})
+
+	if len(conditions) == 0 {
+		return recentConditions
+	}
+
+	// len(conditions) > 0; conditions are sorted
+	mostRecentTimestamp := conditions[0].LastTransitionTime
+
+	// loop through conditions until not in the most recent one anymore
+	for index := range conditions {
+		// only keep conditions with most recent timestamp
+		if conditions[index].LastTransitionTime == mostRecentTimestamp {
+			recentConditions = append(recentConditions, conditions[index])
+		} else {
+			break
+		}
+	}
+
+	return recentConditions
+}
+
+func (mwu *MWUtil) CreateOrUpdateVRGManifestWork(
+	name, namespace, homeCluster, s3Endpoint, s3Region, s3SecretName string, pvcSelector metav1.LabelSelector) error {
+	mwu.Log.Info(fmt.Sprintf("Create or Update manifestwork %s:%s:%s:%s:%s",
+		name, namespace, homeCluster, s3Endpoint, s3SecretName))
+
+	manifestWork, err := mwu.generateVRGManifestWork(name, namespace, homeCluster,
+		s3Endpoint, s3Region, s3SecretName, pvcSelector)
+	if err != nil {
+		return err
+	}
+
+	return mwu.createOrUpdateManifestWork(manifestWork, homeCluster)
+}
+
+func (mwu *MWUtil) generateVRGManifestWork(
+	name, namespace, homeCluster, s3Endpoint, s3Region, s3SecretName string,
+	pvcSelector metav1.LabelSelector) (*ocmworkv1.ManifestWork, error) {
+	vrgClientManifest, err := mwu.generateVRGManifest(name, namespace, s3Endpoint,
+		s3Region, s3SecretName, pvcSelector)
+	if err != nil {
+		mwu.Log.Error(err, "failed to generate VolumeReplicationGroup manifest")
+
+		return nil, err
+	}
+
+	manifests := []ocmworkv1.Manifest{*vrgClientManifest}
+
+	return mwu.newManifestWork(
+		fmt.Sprintf(ManifestWorkNameFormat, name, namespace, MWTypeVRG),
+		homeCluster,
+		map[string]string{"app": "VRG"},
+		manifests), nil
+}
+
+func (mwu *MWUtil) generateVRGManifest(
+	name, namespace, s3Endpoint, s3Region, s3SecretName string,
+	pvcSelector metav1.LabelSelector) (*ocmworkv1.Manifest, error) {
+	return mwu.GenerateManifest(&rmn.VolumeReplicationGroup{
+		TypeMeta:   metav1.TypeMeta{Kind: "VolumeReplicationGroup", APIVersion: "ramendr.openshift.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: rmn.VolumeReplicationGroupSpec{
+			PVCSelector:            pvcSelector,
+			VolumeReplicationClass: "volume-rep-class",
+			ReplicationState:       rmn.Primary,
+			S3Endpoint:             s3Endpoint,
+			S3Region:               s3Region,
+			S3SecretName:           s3SecretName,
+		},
+	})
+}
+
+func (mwu *MWUtil) CreateOrUpdateVRGRolesManifestWork(namespace string) error {
+	manifestWork, err := mwu.generateVRGRolesManifestWork(namespace)
+	if err != nil {
+		return err
+	}
+
+	return mwu.createOrUpdateManifestWork(manifestWork, namespace)
+}
+
+func (mwu *MWUtil) generateVRGRolesManifestWork(namespace string) (*ocmworkv1.ManifestWork, error) {
+	vrgClusterRole, err := mwu.generateVRGClusterRoleManifest()
+	if err != nil {
+		mwu.Log.Error(err, "failed to generate VolumeReplicationGroup ClusterRole manifest")
+
+		return nil, err
+	}
+
+	vrgClusterRoleBinding, err := mwu.generateVRGClusterRoleBindingManifest()
+	if err != nil {
+		mwu.Log.Error(err, "failed to generate VolumeReplicationGroup ClusterRoleBinding manifest")
+
+		return nil, err
+	}
+
+	manifests := []ocmworkv1.Manifest{*vrgClusterRole, *vrgClusterRoleBinding}
+
+	return mwu.newManifestWork(
+		"ramendr-vrg-roles",
+		namespace,
+		map[string]string{},
+		manifests), nil
+}
+
+func (mwu *MWUtil) generateVRGClusterRoleManifest() (*ocmworkv1.Manifest, error) {
+	return mwu.GenerateManifest(&rbacv1.ClusterRole{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "open-cluster-management:klusterlet-work-sa:agent:volrepgroup-edit"},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"ramendr.openshift.io"},
+				Resources: []string{"volumereplicationgroups"},
+				Verbs:     []string{"create", "get", "list", "update", "delete"},
+			},
+		},
+	})
+}
+
+func (mwu *MWUtil) generateVRGClusterRoleBindingManifest() (*ocmworkv1.Manifest, error) {
+	return mwu.GenerateManifest(&rbacv1.ClusterRoleBinding{
+		TypeMeta:   metav1.TypeMeta{Kind: "ClusterRoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "open-cluster-management:klusterlet-work-sa:agent:volrepgroup-edit"},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "klusterlet-work-sa",
+				Namespace: "open-cluster-management-agent",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "open-cluster-management:klusterlet-work-sa:agent:volrepgroup-edit",
+		},
+	})
+}
+
+func (mwu *MWUtil) CreateOrUpdatePVsManifestWork(
+	name string, namespace string, homeClusterName string, pvList []corev1.PersistentVolume) error {
+	mwu.Log.Info("Create manifest work for PVs", "DRPC",
+		name, "cluster", homeClusterName, "PV count", len(pvList))
+
+	mwName := mwu.BuildManifestWorkName(MWTypePV)
+
+	manifestWork, err := mwu.generatePVManifestWork(mwName, homeClusterName, pvList)
+	if err != nil {
+		return err
+	}
+
+	return mwu.createOrUpdateManifestWork(manifestWork, homeClusterName)
+}
+
+func (mwu *MWUtil) generatePVManifestWork(
+	mwName, homeClusterName string, pvList []corev1.PersistentVolume) (*ocmworkv1.ManifestWork, error) {
+	manifests, err := mwu.generatePVManifest(pvList)
+	if err != nil {
+		return nil, err
+	}
+
+	return mwu.newManifestWork(
+		mwName,
+		homeClusterName,
+		map[string]string{"app": "PV"},
+		manifests), nil
+}
+
+// This function follow a slightly different pattern than the rest, simply because the pvList that come
+// from the S3 store will contain PV objects already converted to a string.
+func (mwu *MWUtil) generatePVManifest(
+	pvList []corev1.PersistentVolume) ([]ocmworkv1.Manifest, error) {
+	manifests := []ocmworkv1.Manifest{}
+
+	for _, pv := range pvList {
+		pvClientManifest, err := mwu.GenerateManifest(pv)
+		// Either all succeed or none
+		if err != nil {
+			mwu.Log.Error(err, "failed to generate manifest for PV")
+
+			return nil, err
+		}
+
+		manifests = append(manifests, *pvClientManifest)
+	}
+
+	return manifests, nil
+}
+
+func (mwu *MWUtil) GenerateManifest(obj interface{}) (*ocmworkv1.Manifest, error) {
+	objJSON, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal %v to JSON, error %w", obj, err)
+	}
+
+	manifest := &ocmworkv1.Manifest{}
+	manifest.RawExtension = runtime.RawExtension{Raw: objJSON}
+
+	return manifest, nil
+}
+
+func (mwu *MWUtil) newManifestWork(name string, mcNamespace string,
+	labels map[string]string, manifests []ocmworkv1.Manifest) *ocmworkv1.ManifestWork {
+	return &ocmworkv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: mcNamespace,
+			Labels:    labels,
+			Annotations: map[string]string{
+				DRPCNameAnnotation:      mwu.InstName,
+				DRPCNamespaceAnnotation: mwu.InstNamespace,
+			},
+		},
+		Spec: ocmworkv1.ManifestWorkSpec{
+			Workload: ocmworkv1.ManifestsTemplate{
+				Manifests: manifests,
+			},
+		},
+	}
+}
+
+func (mwu *MWUtil) createOrUpdateManifestWork(
+	mw *ocmworkv1.ManifestWork,
+	managedClusternamespace string) error {
+	foundMW := &ocmworkv1.ManifestWork{}
+
+	err := mwu.Client.Get(mwu.Ctx,
+		types.NamespacedName{Name: mw.Name, Namespace: managedClusternamespace},
+		foundMW)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return errorswrapper.Wrap(err, fmt.Sprintf("failed to fetch ManifestWork %s", mw.Name))
+		}
+
+		// Let DRPC receive notification for any changes to ManifestWork CR created by it.
+		// if err := ctrl.SetControllerReference(d.instance, mw, d.reconciler.Scheme); err != nil {
+		// 	return fmt.Errorf("failed to set owner reference to ManifestWork resource (%s/%s) (%v)",
+		// 		mw.Name, mw.Namespace, err)
+		// }
+
+		mwu.Log.Info("Creating ManifestWork for", "cluster", managedClusternamespace, "MW", mw)
+
+		return mwu.Client.Create(mwu.Ctx, mw)
+	}
+
+	if !reflect.DeepEqual(foundMW.Spec, mw.Spec) {
+		mw.Spec.DeepCopyInto(&foundMW.Spec)
+
+		mwu.Log.Info("ManifestWork exists.", "MW", mw)
+
+		return mwu.Client.Update(mwu.Ctx, foundMW)
+	}
+
+	return nil
+}
+
+func (mwu *MWUtil) DeletePVManifestWork(fromCluster string) error {
+	pvMWName := mwu.BuildManifestWorkName(MWTypePV)
+	pvMWNamespace := fromCluster
+
+	return mwu.deleteManifestWork(pvMWName, pvMWNamespace)
+}
+
+func (mwu *MWUtil) DeleteVRGManifestWork(fromCluster string) error {
+	vrgMWName := mwu.BuildManifestWorkName(MWTypeVRG)
+	vrgMWNamespace := fromCluster
+
+	return mwu.deleteManifestWork(vrgMWName, vrgMWNamespace)
+}
+
+func (mwu *MWUtil) deleteManifestWork(mwName, mwNamespace string) error {
+	mwu.Log.Info("Delete ManifestWork from", "namespace", mwNamespace, "name", mwName)
+
+	mw := &ocmworkv1.ManifestWork{}
+
+	err := mwu.Client.Get(mwu.Ctx, types.NamespacedName{Name: mwName, Namespace: mwNamespace}, mw)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to retrieve manifestwork for type: %s. Error: %w", mwName, err)
+	}
+
+	mwu.Log.Info("Deleting ManifestWork", "name", mw.Name, "namespace", mwNamespace)
+
+	return mwu.Client.Delete(mwu.Ctx, mw)
+}

--- a/controllers/util/mw_util_test.go
+++ b/controllers/util/mw_util_test.go
@@ -1,0 +1,217 @@
+package util_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	ocmworkv1 "github.com/open-cluster-management/api/work/v1"
+	rmnutil "github.com/ramendr/ramen/controllers/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("DRPlacementControl Reconciler", func() {
+	Context("IsManifestInAppliedState checks ManifestWork with single timestamp", func() {
+		timeOld := time.Now().Local()
+		timeMostRecent := timeOld.Add(time.Second)
+
+		It("'Applied' present, Status False", func() {
+			mw := &ocmworkv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ramendr-vrg-roles",
+				},
+				Status: ocmworkv1.ManifestWorkStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               ocmworkv1.WorkApplied,
+							LastTransitionTime: metav1.Time{Time: timeMostRecent},
+							Status:             metav1.ConditionFalse,
+						},
+					},
+				},
+			}
+
+			Expect(rmnutil.IsManifestInAppliedState(mw)).To(Equal(false))
+		})
+
+		It("'Applied' present, Status true", func() {
+			mw := &ocmworkv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ramendr-vrg-roles",
+				},
+				Status: ocmworkv1.ManifestWorkStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               ocmworkv1.WorkApplied,
+							LastTransitionTime: metav1.Time{Time: timeMostRecent},
+							Status:             metav1.ConditionTrue,
+						},
+					},
+				},
+			}
+
+			Expect(rmnutil.IsManifestInAppliedState(mw)).To(Equal(true))
+		})
+
+		It("'Applied' not present", func() {
+			mw := &ocmworkv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ramendr-vrg-roles",
+				},
+				Status: ocmworkv1.ManifestWorkStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               ocmworkv1.WorkProgressing,
+							LastTransitionTime: metav1.Time{Time: timeMostRecent},
+						},
+					},
+				},
+			}
+
+			Expect(rmnutil.IsManifestInAppliedState(mw)).To(Equal(false))
+		})
+	})
+
+	Context("IsManifestInAppliedState checks ManifestWork with multiple timestamps", func() {
+		timeOld := time.Now().Local()
+		timeMostRecent := timeOld.Add(time.Second)
+
+		It("no duplicate timestamps, 'Applied' is most recent", func() {
+			mw := &ocmworkv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ramendr-vrg-roles",
+				},
+				Status: ocmworkv1.ManifestWorkStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               ocmworkv1.WorkApplied,
+							LastTransitionTime: metav1.Time{Time: timeMostRecent},
+							Status:             metav1.ConditionTrue,
+						},
+						{
+							Type:               ocmworkv1.WorkProgressing,
+							LastTransitionTime: metav1.Time{Time: timeOld},
+						},
+					},
+				},
+			}
+
+			Expect(rmnutil.IsManifestInAppliedState(mw)).To(Equal(true))
+		})
+
+		It("no duplicates timestamps, 'Applied' is not most recent", func() {
+			mw := &ocmworkv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ramendr-vrg-roles",
+				},
+				Status: ocmworkv1.ManifestWorkStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               ocmworkv1.WorkProgressing,
+							LastTransitionTime: metav1.Time{Time: timeMostRecent},
+						},
+						{
+							Type:               ocmworkv1.WorkApplied,
+							LastTransitionTime: metav1.Time{Time: timeOld},
+						},
+					},
+				},
+			}
+
+			Expect(rmnutil.IsManifestInAppliedState(mw)).To(Equal(false))
+		})
+
+		It("with duplicate timestamps, 'Applied' is most recent", func() {
+			mw := &ocmworkv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ramendr-vrg-roles",
+				},
+				Status: ocmworkv1.ManifestWorkStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               ocmworkv1.WorkApplied,
+							LastTransitionTime: metav1.Time{Time: timeMostRecent},
+							Status:             metav1.ConditionTrue,
+						},
+						{
+							Type:               ocmworkv1.WorkProgressing,
+							LastTransitionTime: metav1.Time{Time: timeMostRecent},
+							Status:             metav1.ConditionUnknown,
+						},
+						{
+							Type:               ocmworkv1.WorkProgressing,
+							LastTransitionTime: metav1.Time{Time: timeOld},
+						},
+					},
+				},
+			}
+
+			Expect(rmnutil.IsManifestInAppliedState(mw)).To(Equal(true))
+		})
+
+		It("with duplicate timestamps, 'Applied' is not most recent", func() {
+			mw := &ocmworkv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ramendr-vrg-roles",
+				},
+				Status: ocmworkv1.ManifestWorkStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               ocmworkv1.WorkAvailable,
+							LastTransitionTime: metav1.Time{Time: timeMostRecent},
+						},
+						{
+							Type:               ocmworkv1.WorkProgressing,
+							LastTransitionTime: metav1.Time{Time: timeMostRecent},
+						},
+						{
+							Type:               ocmworkv1.WorkApplied,
+							LastTransitionTime: metav1.Time{Time: timeOld},
+						},
+					},
+				},
+			}
+
+			Expect(rmnutil.IsManifestInAppliedState(mw)).To(Equal(false))
+		})
+
+		It("duplicate timestamps with Degraded and Applied status", func() {
+			mw := &ocmworkv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ramendr-vrg-roles",
+				},
+				Status: ocmworkv1.ManifestWorkStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:               ocmworkv1.WorkApplied,
+							LastTransitionTime: metav1.Time{Time: timeMostRecent},
+						},
+						{
+							Type:               ocmworkv1.WorkDegraded,
+							LastTransitionTime: metav1.Time{Time: timeMostRecent},
+						},
+					},
+				},
+			}
+
+			Expect(rmnutil.IsManifestInAppliedState(mw)).To(Equal(false))
+		})
+	})
+
+	Context("IsManifestInAppliedState checks ManifestWork with no timestamps", func() {
+		It("manifest missing conditions", func() {
+			mw := &ocmworkv1.ManifestWork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ramendr-vrg-roles",
+				},
+				Status: ocmworkv1.ManifestWorkStatus{
+					Conditions: []metav1.Condition{
+						// empty
+					},
+				},
+			}
+
+			Expect(rmnutil.IsManifestInAppliedState(mw)).To(Equal(false))
+		})
+	})
+})

--- a/controllers/util/util_suite_test.go
+++ b/controllers/util/util_suite_test.go
@@ -1,0 +1,13 @@
+package util_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
+}

--- a/go.mod
+++ b/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/go-logr/logr v0.4.0
 	github.com/onsi/ginkgo v1.16.1
 	github.com/onsi/gomega v1.11.0
-	github.com/open-cluster-management/api v0.0.0-20210409125704-06f2aec1a73f
+	github.com/open-cluster-management/api v0.0.0-20210527013639-a6845f2ebcb1
 	github.com/open-cluster-management/multicloud-operators-placementrule v1.0.1-2020-06-08-14-28-27.0.20201118195339-05a8c4c89c12
 	github.com/open-cluster-management/multicloud-operators-subscription v1.2.2-2-20201130-59f96
 	github.com/pkg/errors v0.9.1
 	go.uber.org/zap v1.15.0
 	k8s.io/api v0.20.5
-	k8s.io/apimachinery v0.20.5
+	k8s.io/apimachinery v0.21.2
 	k8s.io/client-go v12.0.0+incompatible
 	sigs.k8s.io/controller-runtime v0.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -808,6 +808,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
 github.com/google/go-metrics-stackdriver v0.0.0-20190816035513-b52628e82e2a/go.mod h1:o93WzqysX0jP/10Y13hfL6aq9RoUvGaVdkrH5awMksE=
@@ -1358,6 +1360,7 @@ github.com/mitchellh/pointerstructure v0.0.0-20190430161007-f252a8fd71c8/go.mod 
 github.com/mitchellh/prefixedio v0.0.0-20190213213902-5733675afd51/go.mod h1:kB1naBgV9ORnkiTVeyJOI1DavaJkG4oNIq0Af6ZVKUo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/moby/term v0.0.0-20200915141129-7f0af18e79f2/go.mod h1:TjQg8pa4iejrUrjiz0MCtMV38jdMNW4doKSiBrEvCQQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -1445,6 +1448,8 @@ github.com/open-cluster-management/ansiblejob-go-lib v0.1.12/go.mod h1:dDL15yXQU
 github.com/open-cluster-management/api v0.0.0-20201007180356-41d07eee4294/go.mod h1:F1hDJHtWuV7BAUtfL4XRS9GZjUpksleLgEcisNXvQEw=
 github.com/open-cluster-management/api v0.0.0-20210409125704-06f2aec1a73f h1:s6z3k0jV0ccoYDPJWMSqVNevO1UoQLYb8f7dYFALSNk=
 github.com/open-cluster-management/api v0.0.0-20210409125704-06f2aec1a73f/go.mod h1:ot+A1DWq+v1IV+e1S7nhIteYAmNByFgtazvzpoeAfRQ=
+github.com/open-cluster-management/api v0.0.0-20210527013639-a6845f2ebcb1 h1:AaFycHD9YOfFXe9C5VsYxKf4LKCXKSLZgK2DnFdHY4M=
+github.com/open-cluster-management/api v0.0.0-20210527013639-a6845f2ebcb1/go.mod h1:ot+A1DWq+v1IV+e1S7nhIteYAmNByFgtazvzpoeAfRQ=
 github.com/open-cluster-management/applifecycle-backend-e2e v0.1.5/go.mod h1:epk+wzREODyT9Uu6B2fCo9v67b4QnL7l12CzkRXW5pI=
 github.com/open-cluster-management/multicloud-operators-channel v1.0.1-0.20201120143200-e505a259de45 h1:GuMOB2hJjZA1jxcoQ1PsTMtBSrDfN74E9/ex66hLT0M=
 github.com/open-cluster-management/multicloud-operators-channel v1.0.1-0.20201120143200-e505a259de45/go.mod h1:aL69GeyC51UBT9jmpogrvoJUQC5gVm+QvRY+e56NjH4=
@@ -2173,6 +2178,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb h1:eBmm0M9fYhWpKZLjQUUKka/LtIxf46G4fxeEz5KJr9U=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210224082022-3d97a244fca7 h1:OgUuv8lsRpBibGNbSizVwKWlysjaNzmC9gYMhPVfqFM=
+golang.org/x/net v0.0.0-20210224082022-3d97a244fca7/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -2296,11 +2303,16 @@ golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201202213521-69691e467435/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091 h1:DMyOG0U+gKfu8JZzg2UQe9MeaC1X+xQWlAKcRnjxjCw=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 h1:dXfMednGJh/SUUFjTLsWJz3P+TQt9qnR11GgeI3vWKs=
+golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -2755,6 +2767,8 @@ k8s.io/apimachinery v0.19.4/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlm
 k8s.io/apimachinery v0.20.0/go.mod h1:WlLqWAHZGg07AeltaI0MV5uk1Omp8xaN0JGLY6gkRpU=
 k8s.io/apimachinery v0.20.5 h1:wO/FxMVRn223rAKxnBbwCyuN96bS9MFTIvP0e/V7cps=
 k8s.io/apimachinery v0.20.5/go.mod h1:WlLqWAHZGg07AeltaI0MV5uk1Omp8xaN0JGLY6gkRpU=
+k8s.io/apimachinery v0.21.2 h1:vezUc/BHqWlQDnZ+XkrpXSmnANSLbpnlpwo0Lhk0gpc=
+k8s.io/apimachinery v0.21.2/go.mod h1:CdTY8fU/BlvAbJ2z/8kBwimGki5Zp8/fbVuLY8gJumM=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/apiserver v0.0.0-20191122221311-9d521947b1e1/go.mod h1:RbsZY5zzBIWnz4KbctZsTVjwIuOpTp4Z8oCgFHN4kZQ=
 k8s.io/apiserver v0.16.4/go.mod h1:kbLJOak655g6W7C+muqu1F76u9wnEycfKMqbVaXIdAc=
@@ -2881,6 +2895,8 @@ k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6/go.mod h1:UuqjUnNftUyPE5H
 k8s.io/kube-openapi v0.0.0-20200831175022-64514a1d5d59/go.mod h1:UuqjUnNftUyPE5H64/qeyjQoUZhGpeFDVdxjTeEVN2o=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd h1:sOHNzJIkytDF6qadMNKhhDRpc6ODik8lVC6nOur7B2c=
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
+k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 h1:vEx13qjvaZ4yfObSSXW7BrMc/KQBBT/Jyee8XtLf4x0=
+k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/kube-state-metrics v1.7.2/go.mod h1:U2Y6DRi07sS85rmVPmBFlmv+2peBcL8IWGjM+IjYA/E=
 k8s.io/kubectl v0.17.2/go.mod h1:y4rfLV0n6aPmvbRCqZQjvOp3ezxsFgpqL+zF5jH/lxk=
 k8s.io/kubectl v0.17.3/go.mod h1:NUn4IBY7f7yCMwSop2HCXlw/MVYP4HJBiUmOR3n9w28=
@@ -2974,6 +2990,8 @@ sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnM
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2 h1:YHQV7Dajm86OuqnIR6zAelnDWBRjo+YhYV9PmGrh1s8=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
+sigs.k8s.io/structured-merge-diff/v4 v4.1.0 h1:C4r9BgJ98vrKnnVCjwCSXcWjWe0NKcUQkmzDXZXGwH8=
+sigs.k8s.io/structured-merge-diff/v4 v4.1.0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=


### PR DESCRIPTION
Refactoring drpc controller to split into utils.

Moving MW related functions into it's own utils.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>