### PR TITLE
Add ability to label managedclusters...

### DIFF
--- a/hack/dev-rook-rbdpool.yaml
+++ b/hack/dev-rook-rbdpool.yaml
@@ -11,5 +11,5 @@ spec:
     enabled: true
     mode: image
     snapshotSchedules:
-      - interval: 5m
+      - interval: 2m
         startTime: 14:00:00-05:00

--- a/hack/ocm-minikube.sh
+++ b/hack/ocm-minikube.sh
@@ -8,6 +8,9 @@ set -x
 set -e
 trap 'echo exit value: $?;trap - EXIT' EXIT
 
+# pre-requisites
+command -v jq
+
 mkdir -p ${HOME}/.local/bin
 PATH=${HOME}/.local/bin:${PATH}
 
@@ -159,6 +162,8 @@ spoke_add()
 	kubectl --context ${hub_cluster_name} patch managedclusters/${1} -p '{"spec":{"hubAcceptsClient":true}}' --type=merge
 	# Error from server (InternalError): Internal error occurred: failed calling webhook "managedclustermutators.admission.cluster.open-cluster-management.io": the server is currently unable to handle the request
 	set -e
+	date
+	kubectl --context ${hub_cluster_name} patch managedclusters/${1} -p $(jq -cn --arg clname "$1" '{"metadata":{"labels":{"name":$clname}}}') --type=merge
 	date
 	kubectl --context ${hub_cluster_name} wait managedclusters/${1} --for condition=ManagedClusterConditionAvailable
 	date


### PR DESCRIPTION
with their own minikube profile names.

This also lines up with the ocm-ramen-samples and
cluster names used in that repository.

Additionally reduced mirror snapshot time to 2m
from 5m to ease testing delays.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>