### PR TITLE
VolumeReplicationGroup: Dont filter pvc creation events

### DIFF
--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -93,20 +93,7 @@ func pvcPredicateFunc() predicate.Funcs {
 
 			log.Info("Create event for PersistentVolumeClaim")
 
-			pvc, ok := e.Object.DeepCopyObject().(*corev1.PersistentVolumeClaim)
-			if !ok {
-				log.Info("Failed to deep copy PersistentVolumeClaim")
-
-				return false
-			}
-
-			if pvc.Status.Phase == corev1.ClaimBound {
-				return true
-			}
-
-			log.Info("pvc which got created is not bound yet. Dont requeue")
-
-			return false
+			return true
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			log := ctrl.Log.WithName("pvcmap").WithName("VolumeReplicationGroup")


### PR DESCRIPTION
Filtering the pvc creation events leads to different behavior when
the order pvc creation and VRG creation is not same, which is
updated differently in VRG status.

Signed-off-by: Raghavendra M <raghavendra@redhat.com>