### PR TITLE
ocm-minikube.sh: registration-operator olm packagemanifests error (#83) fix

### DIFF
--- a/hack/docker-install.sh
+++ b/hack/docker-install.sh
@@ -1,5 +1,4 @@
-#!/bin/sh
-# shellcheck disable=2046,2086
+# shellcheck shell=sh disable=2046,2086
 docker_install()
 {
 	if test -w /var/run/docker.sock; then

--- a/hack/exit_stack.sh
+++ b/hack/exit_stack.sh
@@ -1,0 +1,23 @@
+# shellcheck shell=sh
+trap 'set -- $?; trap - EXIT; eval $exit_stack; echo exit status: $1' EXIT
+trap 'trap - ABRT' ABRT
+trap 'trap - QUIT' QUIT
+trap 'trap - TERM' TERM
+trap 'trap - INT' INT
+trap 'trap - HUP' HUP
+exit_stack_push()
+{
+	exit_stack=$*\;$exit_stack
+} 2>/dev/null
+exit_stack_push unset -v exit_stack
+exit_stack_push unset -f exit_stack_push
+exit_stack_pop()
+{
+	{ set +x; } 2>/dev/null
+	IFS=\; read -r x exit_stack <<-a
+	$exit_stack
+	a
+	eval set -x; $x
+	{ unset -v x; } 2>/dev/null
+}
+exit_stack_push unset -f exit_stack_pop

--- a/hack/git-checkout.sh
+++ b/hack/git-checkout.sh
@@ -1,0 +1,38 @@
+# shellcheck shell=sh disable=2086
+git_checkout()
+{
+        git --git-dir $1/.git --work-tree $1 checkout $2
+}
+git_checkout_undo()
+{
+        git_checkout $1 -
+}
+git_clone_and_checkout()
+{
+        set +e
+        git clone $1/$2
+        # fatal: destination path '$2' already exists and is not an empty directory.
+        set -e
+        git --git-dir $2/.git fetch $1/$2 $3
+        git_checkout $2 $4
+}
+git_branch_delete()
+{
+        set +e
+        git --git-dir $1/.git branch --delete $3 $2
+        # error: branch '<branchname>' not found.
+        set -e
+}
+git_branch_delete_force()
+{
+	git_branch_delete $1 $2 --force
+}
+git_checkout_unset()
+{
+	unset -f git_checkout_unset
+	unset -f git_branch_delete_force
+	unset -f git_branch_delete
+	unset -f git_clone_and_checkout
+	unset -f git_checkout_undo
+	unset -f git_checkout
+}

--- a/hack/go-install.sh
+++ b/hack/go-install.sh
@@ -1,5 +1,4 @@
-#!/bin/sh
-# shellcheck disable=2046,2086
+# shellcheck shell=sh disable=2046,2086
 go_install()
 {
 	if ! command -v go

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -2,32 +2,9 @@
 # shellcheck disable=1090,2046,2086
 set -x
 set -e
-trap 'set -- ${?}; trap - EXIT; eval ${exit_stack}; echo exit status: ${1}' EXIT
-trap 'trap - ABRT' ABRT
-trap 'trap - QUIT' QUIT
-trap 'trap - TERM' TERM
-trap 'trap - INT' INT
-trap 'trap - HUP' HUP
-exit_stack_push()
-{
-	{ set +x; } 2>/dev/null
-	exit_stack=${*}\;${exit_stack}
-	set -x
-}
-exit_stack_push unset -v exit_stack
-exit_stack_push unset -f exit_stack_push
-exit_stack_pop()
-{
-	{ set +x; } 2>/dev/null
-	IFS=\; read -r x exit_stack <<-a
-	${exit_stack}
-	a
-	eval set -x; ${x}
-	{ set +x; } 2>/dev/null
-	unset -v x
-	set -x
-}
-exit_stack_push unset -f exit_stack_pop
+ramen_hack_directory_path_name=$(dirname $0)
+. $ramen_hack_directory_path_name/exit_stack.sh
+exit_stack_push unset -v ramen_hack_directory_path_name
 rook_ceph_deploy()
 {
 	PROFILE=${2} ${1}/minikube-rook-setup.sh create
@@ -234,8 +211,6 @@ application_sample_undeploy()
 	ramen_samples_branch_checkout_undo
 }
 exit_stack_push unset -f application_sample_undeploy
-ramen_hack_directory_path_name=$(dirname ${0})
-exit_stack_push unset -v ramen_hack_directory_path_name
 ramen_directory_path_name=${ramen_hack_directory_path_name}/..
 exit_stack_push unset -v ramen_directory_path_name
 hub_cluster_name=${hub_cluster_name:-hub}

--- a/hack/shell_option_store_restore.sh
+++ b/hack/shell_option_store_restore.sh
@@ -1,0 +1,41 @@
+# shellcheck shell=sh disable=2086
+shell_option_store()
+{
+	case $- in
+		*$2*)
+		eval $1=set\\ -$2
+		;;
+	*)
+		eval $1=set\\ +$2
+		;;
+	esac
+} 2>/dev/null
+shell_option_disable()
+{
+	case $- in
+	*$2*)
+		set +$2
+		eval $1=set\\ -$2
+		;;
+	*)
+		unset -v $1
+		;;
+	esac
+} 2>/dev/null
+shell_option_enable()
+{
+	case $- in
+	*$2*)
+		unset -v $1
+		;;
+	*)
+		set -$2
+		eval $1=set\\ +$2
+		;;
+	esac
+} 2>/dev/null
+shell_option_restore()
+{
+	eval \$$1
+	unset -v $1
+} 2>/dev/null


### PR DESCRIPTION
	- hub olm namespace deployments wait remove
	- open-cluster-management checkout commits instead of branches:
		- registration-operator c723e19
		- subscription-operator c48c559
		- application-samples 65853af
	- open-cluster-management checkouts undo after use
	- github.com/ShyamsundarR/ocm-minikube depnendencies remove:
		- registration-operator diff apply inline instead of fetching from github
		- subscription-operator diff apply remove because it was merged into main in commit 313bdbe
		- application-samples diff apply inline instead of fetching from github
	- modules define
		- git checkout
		- exit_stack
		- shell option store/restore
	- execute permission remove from scripts only executable in current environment
		- shebang replace with shellcheck shell directive

Signed-off-by: bhatfiel <bhatfiel@redhat.com>