### PR TITLE
Timing of deleting the MW can interfere with the expectation

### DIFF
--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -707,7 +707,6 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				updateManagedClusterViewWithVRG(mcvEast, rmn.Secondary)
 				updateManagedClusterViewWithVRG(mcvWest, rmn.Secondary)
 
-				updateManifestWorkStatus(WestManagedCluster, "vrg", ocmworkv1.WorkApplied)
 				updateManifestWorkStatus(EastManagedCluster, "pv", ocmworkv1.WorkApplied)
 				updateManifestWorkStatus(EastManagedCluster, "vrg", ocmworkv1.WorkApplied)
 
@@ -782,7 +781,6 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				updateManagedClusterViewWithVRG(mcvEast, rmn.Secondary)
 				updateManagedClusterViewWithVRG(mcvWest, rmn.Secondary)
 
-				updateManifestWorkStatus(WestManagedCluster, "vrg", ocmworkv1.WorkApplied)
 				updateManifestWorkStatus(EastManagedCluster, "pv", ocmworkv1.WorkApplied)
 				updateManifestWorkStatus(EastManagedCluster, "vrg", ocmworkv1.WorkApplied)
 


### PR DESCRIPTION
We can't tell exactly when the MW is deleted.  If we delete the MW that belongs to the prev home cluster, we
might end up waiting until it expectation times out.