### PR TITLE
Use golang:1.16 as docker builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
Start usng golang 1.16 to use methods like os.ReadFile() that is not
available in os package of golang:1.15.

Signed-off-by: Veera Deenadhayalan <vdeenadh@redhat.com>