### PR TITLE
Add auto creation of PV roles to klusterlet

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1088,6 +1088,13 @@ func (d *DRPCInstance) processVRGManifestWork(homeCluster string) error {
 			homeCluster, err)
 	}
 
+	if err := d.mwu.CreateOrUpdatePVRolesManifestWork(homeCluster); err != nil {
+		d.log.Error(err, "failed to create or update PersistentVolume Roles manifest")
+
+		return fmt.Errorf("failed to create or update PersistentVolume Roles manifest in namespace %s (%w)",
+			homeCluster, err)
+	}
+
 	if err := d.mwu.CreateOrUpdateVRGManifestWork(
 		d.instance.Name, d.instance.Namespace,
 		homeCluster, d.instance.Spec.S3Endpoint,

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -641,7 +641,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				updateManifestWorkStatus(EastManagedCluster, "vrg", ocmworkv1.WorkApplied)
 				verifyUserPlacementRuleDecision(userPlacementRule.Name, userPlacementRule.Namespace, EastManagedCluster)
 				verifyDRPCStatusPreferredClusterExpectation(rmn.Initial)
-				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(2)) // MWs for VRG and ROLES
+				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(3)) // MWs for VRG and ROLES
 				waitForCompletion()
 			})
 		})
@@ -663,10 +663,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				verifyUserPlacementRuleDecision(userPlacementRule.Name, userPlacementRule.Namespace, WestManagedCluster)
 				verifyDRPCStatusPreferredClusterExpectation(rmn.FailedOver)
 				verifyVRGManifestWorkCreatedAsPrimary(WestManagedCluster)
-				Expect(getManifestWorkCount(WestManagedCluster)).Should(Equal(3)) // MWs for VRG+ROLES+PVs
+				Expect(getManifestWorkCount(WestManagedCluster)).Should(Equal(4)) // MWs for VRG+ROLES+PVs
 				waitForVRGMWDeletion(EastManagedCluster)
 				updateManagedClusterViewStatusAsNotFound(mcvEast)
-				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(1)) // MW for ROLES only
+				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(2)) // MW for ROLES only
 				waitForCompletion()
 			})
 		})
@@ -684,10 +684,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				setDRPCSpecExpectationTo(drpc, "newS3Endpoint", rmn.ActionFailover, "")
 				verifyUserPlacementRuleDecision(userPlacementRule.Name, userPlacementRule.Namespace, WestManagedCluster)
 				verifyDRPCStatusPreferredClusterExpectation(rmn.FailedOver)
-				Expect(getManifestWorkCount(WestManagedCluster)).Should(Equal(3)) // MWs for VRG+ROLES+PVs
+				Expect(getManifestWorkCount(WestManagedCluster)).Should(Equal(4)) // MWs for VRG+ROLES+PVs
 				waitForVRGMWDeletion(EastManagedCluster)
 				updateManagedClusterViewStatusAsNotFound(mcvEast)
-				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(1)) // MWs for ROLES
+				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(2)) // MWs for ROLES
 				waitForCompletion()
 			})
 		})
@@ -714,10 +714,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				verifyDRPCStatusPreferredClusterExpectation(rmn.FailedBack)
 				verifyVRGManifestWorkCreatedAsPrimary(EastManagedCluster)
 
-				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(3)) // MWs for VRG+ROLES+PVs
+				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(4)) // MWs for VRG+ROLES+PVs
 				waitForVRGMWDeletion(WestManagedCluster)
 				updateManagedClusterViewStatusAsNotFound(mcvWest)
-				Expect(getManifestWorkCount(WestManagedCluster)).Should(Equal(1)) // MWs for ROLES
+				Expect(getManifestWorkCount(WestManagedCluster)).Should(Equal(2)) // MWs for ROLES
 				waitForCompletion()
 			})
 		})
@@ -732,8 +732,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				verifyUserPlacementRuleDecision(userPlacementRule.Name, userPlacementRule.Namespace, EastManagedCluster)
 				verifyDRPCStatusPreferredClusterExpectation(rmn.FailedBack)
 				waitForVRGMWDeletion(WestManagedCluster)
-				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(3)) // MWs for VRG+ROLES+PVs
-				Expect(getManifestWorkCount(WestManagedCluster)).Should(Equal(1)) // MWs for ROLES
+				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(4)) // MWs for VRG+ROLES+PVs
+				Expect(getManifestWorkCount(WestManagedCluster)).Should(Equal(2)) // MWs for ROLES
 				waitForCompletion()
 			})
 		})
@@ -758,10 +758,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				verifyDRPCStatusPreferredClusterExpectation(rmn.FailedOver)
 				verifyVRGManifestWorkCreatedAsPrimary(WestManagedCluster)
 
-				Expect(getManifestWorkCount(WestManagedCluster)).Should(Equal(3)) // MW for VRG+ROLES+PVs
+				Expect(getManifestWorkCount(WestManagedCluster)).Should(Equal(4)) // MW for VRG+ROLES+PVs
 				waitForVRGMWDeletion(EastManagedCluster)
 				updateManagedClusterViewStatusAsNotFound(mcvEast)
-				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(1)) // MWs for ROLES
+				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(2)) // MWs for ROLES
 				waitForCompletion()
 			})
 		})
@@ -788,10 +788,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				verifyDRPCStatusPreferredClusterExpectation(rmn.Relocated)
 				verifyVRGManifestWorkCreatedAsPrimary(EastManagedCluster)
 
-				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(3)) // MWs for VRG+ROLES+PVs
+				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(4)) // MWs for VRG+ROLES+PVs
 				waitForVRGMWDeletion(WestManagedCluster)
 				updateManagedClusterViewStatusAsNotFound(mcvWest)
-				Expect(getManifestWorkCount(WestManagedCluster)).Should(Equal(1)) // MWs for ROLES
+				Expect(getManifestWorkCount(WestManagedCluster)).Should(Equal(2)) // MWs for ROLES
 				waitForCompletion()
 			})
 		})

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -145,7 +145,6 @@ application_sample_deploy()
 	ramen_samples_branch_checkout
 	kubectl --context ${hub_cluster_name} apply -k ocm-ramen-samples/subscriptions
 	kubectl --context ${hub_cluster_name} -n ramen-samples get channels/ramen-gitops
-	kubectl --context ${hub_cluster_name} apply -f ocm-ramen-samples/mw-pv.yaml
 	mkdir -p ocm-ramen-samples/subscriptions/busybox-${USER}
 	cat <<-a >ocm-ramen-samples/subscriptions/busybox-${USER}/kustomization.yaml
 	---
@@ -203,8 +202,6 @@ application_sample_undeploy()
 	kubectl --context ${1} -n busybox-sample wait volumereplicationgroups/busybox-drpc --for delete
 	# error: no matching resources found
 	set -e
-	date
-	kubectl --context ${hub_cluster_name} delete -f ocm-ramen-samples/mw-pv.yaml
 	date
 	kubectl --context ${hub_cluster_name} delete -k ocm-ramen-samples/subscriptions
 	date


### PR DESCRIPTION
This is along the lines of VRG roles for klusterlet,
and follows the same pattern.

These roles would be created and deleted by DRPolicy
reconciler, when available, to ensure on uninstall of
ramen orchestrator controller, the klusterlet is reset
back to its original roles on the managed clusters.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>