### PR TITLE
fix MCV deletion contention in unit test

### DIFF
--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -261,6 +261,9 @@ func updateManagedClusterViewStatusAsNotFound(mcv *fndv2.ManagedClusterView) {
 
 	Eventually(func() bool {
 		err := k8sClient.Get(context.TODO(), mcvLookupKey, mcvLatest)
+		if errors.IsNotFound(err) {
+			return true
+		}
 
 		return err == nil && len(mcvLatest.Status.Conditions) > 0 &&
 			mcvLatest.Status.Conditions[0].Reason == fndv2.ReasonGetResourceFailed


### PR DESCRIPTION
DRPC will delete MCV once the request is complete. The unit test failed because
while we were waiting for the MCV object to change status, it was deleted by
the DRPC and we didn't handle a not found error