### PR TITLE
Add PV roles before restoring PVs

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -811,6 +811,13 @@ func (d *DRPCInstance) updateUserPlRuleAndCreateVRGMW(homeCluster, homeClusterNa
 }
 
 func (d *DRPCInstance) createPVManifestWorkForRestore(newPrimary string) error {
+	if err := d.mwu.CreateOrUpdatePVRolesManifestWork(newPrimary); err != nil {
+		d.log.Error(err, "failed to create or update PersistentVolume Roles manifest")
+
+		return fmt.Errorf("failed to create or update PersistentVolume Roles manifest in namespace %s (%w)",
+			newPrimary, err)
+	}
+
 	pvMWName := d.mwu.BuildManifestWorkName(rmnutil.MWTypePV)
 
 	existAndApplied, err := d.mwu.ManifestExistAndApplied(pvMWName, newPrimary)
@@ -1237,13 +1244,6 @@ func (d *DRPCInstance) processVRGManifestWork(homeCluster string) error {
 		d.log.Error(err, "failed to create or update VolumeReplicationGroup Roles manifest")
 
 		return fmt.Errorf("failed to create or update VolumeReplicationGroup Roles manifest in namespace %s (%w)",
-			homeCluster, err)
-	}
-
-	if err := d.mwu.CreateOrUpdatePVRolesManifestWork(homeCluster); err != nil {
-		d.log.Error(err, "failed to create or update PersistentVolume Roles manifest")
-
-		return fmt.Errorf("failed to create or update PersistentVolume Roles manifest in namespace %s (%w)",
 			homeCluster, err)
 	}
 

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -689,7 +689,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				updateManifestWorkStatus(EastManagedCluster, "vrg", ocmworkv1.WorkApplied)
 				verifyUserPlacementRuleDecision(userPlacementRule.Name, userPlacementRule.Namespace, EastManagedCluster)
 				verifyDRPCStatusPreferredClusterExpectation(rmn.Initial)
-				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(3)) // MWs for VRG and ROLES
+				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(2)) // MWs for VRG and ROLES
 				waitForCompletion()
 			})
 		})
@@ -699,6 +699,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				updateClonedPlacementRuleStatus(userPlacementRule, drpc, WestManagedCluster)
 				setDRPCSpecExpectationTo(drpc, "", rmn.ActionFailover, "")
 				verifyUserPlacementRuleDecisionUnchanged(userPlacementRule.Name, userPlacementRule.Namespace, EastManagedCluster)
+				Expect(getManifestWorkCount(WestManagedCluster)).Should(Equal(2)) // MWs for PV and PV ROLE
 			})
 			It("Should failover to Secondary (WestManagedCluster)", func() {
 				// ----------------------------- FAILOVER TO SECONDARY (WestManagedCluster) --------------------------------------
@@ -720,7 +721,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				updateManagedClusterViewStatusAsNotFound(mcvEast)
 				// tickle the DRPC reconciler, should be removed once we watch for MCV resource updates
 				setDRPCSpecExpectationTo(drpc, "newS3Endpoint-1", rmn.ActionFailover, "")
-				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(2)) // MW for ROLES only
+				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(1)) // MW for VRG ROLE only
 				waitForCompletion()
 			})
 		})
@@ -741,7 +742,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(getManifestWorkCount(WestManagedCluster)).Should(Equal(4)) // MWs for VRG+ROLES+PVs
 				waitForVRGMWDeletion(EastManagedCluster)
 				updateManagedClusterViewStatusAsNotFound(mcvEast)
-				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(2)) // MWs for ROLES
+				Expect(getManifestWorkCount(EastManagedCluster)).Should(Equal(1)) // MWs for VRG ROLE only
 				waitForCompletion()
 			})
 		})


### PR DESCRIPTION
Currently PV roles were created during VRG creation
which happens once PVs are created on the ManagedCluster.

Modified where the PV roles are created and set
tests expectations on MW counts appropriately.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>