### PR TITLE
ocm-minikube.sh: ocm-proxyserver delete

### DIFF
--- a/hack/ocm-minikube.sh
+++ b/hack/ocm-minikube.sh
@@ -234,6 +234,8 @@ exit_stack_push unset -f ocm_foundation_operator_kubectl_spoke
 ocm_foundation_operator_deploy_hub()
 {
 	ocm_foundation_operator_kubectl_hub apply
+	kubectl --context $hub_cluster_name delete apiservices v1.clusterview.open-cluster-management.io v1alpha1.clusterview.open-cluster-management.io v1beta1.proxy.open-cluster-management.io
+	kubectl --context $hub_cluster_name -n open-cluster-management delete deployments/ocm-proxyserver services/ocm-proxyserver
 	kubectl --context $hub_cluster_name -n open-cluster-management wait deployments/ocm-controller --for condition=available
 }
 exit_stack_push unset -f ocm_foundation_operator_deploy_hub


### PR DESCRIPTION
Problem: ocm foundation operator's `ocm-proxyserver` fails to deploy resulting in inability to delete namespaces
Solution: it seems ramen does not require `ocm-proxyserver` so it is therefore removed
```
$ kubectl --context hub apply -k https://github.com/open-cluster-management/multicloud-operators-foundation/deploy/foundation
/hub?ref=b5df50deb87618e8c6057637705e94a58b5a19da
customresourcedefinition.apiextensions.k8s.io/baremetalassets.inventory.open-cluster-management.io created
customresourcedefinition.apiextensions.k8s.io/managedclusteractions.action.open-cluster-management.io created
customresourcedefinition.apiextensions.k8s.io/managedclusterinfos.internal.open-cluster-management.io created
customresourcedefinition.apiextensions.k8s.io/managedclusterviews.view.open-cluster-management.io created
Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
customresourcedefinition.apiextensions.k8s.io/clusterclaims.hive.openshift.io created
customresourcedefinition.apiextensions.k8s.io/clusterdeployments.hive.openshift.io created
customresourcedefinition.apiextensions.k8s.io/clusterpools.hive.openshift.io created
customresourcedefinition.apiextensions.k8s.io/clustersyncs.hiveinternal.openshift.io created
customresourcedefinition.apiextensions.k8s.io/syncsets.hive.openshift.io created
serviceaccount/foundation-hub-sa created
clusterrole.rbac.authorization.k8s.io/foundation-hub created
clusterrolebinding.rbac.authorization.k8s.io/foundation-hub created
service/ocm-proxyserver created
deployment.apps/ocm-controller created
deployment.apps/ocm-proxyserver created
apiservice.apiregistration.k8s.io/v1.clusterview.open-cluster-management.io created
apiservice.apiregistration.k8s.io/v1alpha1.clusterview.open-cluster-management.io created
apiservice.apiregistration.k8s.io/v1beta1.proxy.open-cluster-management.io created


$ kubectl --context hub -n open-cluster-management get deployments/ocm-proxyserver
NAME              READY   UP-TO-DATE   AVAILABLE   AGE
ocm-proxyserver   0/1     1            0           2m9s

$ kubectl --context hub -n open-cluster-management get pods
NAME                               READY   STATUS              RESTARTS   AGE
cluster-manager-659658cbd-v7cz9    1/1     Running             0          30h
klusterlet-5c9d6c5476-9srwd        1/1     Running             0          30h
ocm-controller-7c7fd888c8-kgdwr    1/1     Running             0          3m4s
ocm-proxyserver-55cc69bf5c-f9xk9   0/1     ContainerCreating   0          3m4s

$ kubectl --context hub -n open-cluster-management describe pods/ocm-proxyserver-55cc69bf5c-f9xk9
Events:
  Type     Reason       Age                  From               Message
  ----     ------       ----                 ----               -------
  Normal   Scheduled    3m25s                default-scheduler  Successfully assigned open-cluster-management/ocm-proxyserver-55cc69bf5c-f9xk9 to hub
  Warning  FailedMount  82s                  kubelet            Unable to attach or mount volumes: unmounted volumes=[apiservice-certs], unattached volumes=[klusterlet-certs apiservice-certs foundation-hub-sa-token-rkrp4]: timed out waiting for the condition
  Warning  FailedMount  77s (x9 over 3m25s)  kubelet            MountVolume.SetUp failed for volume "apiservice-certs" : secret "ocm-proxyserver" not found

$ kubectl --context hub api-resources >/dev/null
error: unable to retrieve the complete list of server APIs: clusterview.open-cluster-management.io/v1: the server is currently unable to handle the request, clusterview.open-cluster-management.io/v1alpha1: the server is currently unable to handle the request, proxy.open-cluster-management.io/v1beta1: the server is currently unable to handle the request

bhatfiel@eyewall2:~/ramen/hack$ kubectl --context hub get apiservices v1.clusterview.open-cluster-management.io v1alpha1.clusterview.open-cluster-management.io v1beta1.proxy.open-cluster-management.io
NAME                                              SERVICE                                   AVAILABLE                  AGE
v1.clusterview.open-cluster-management.io         open-cluster-management/ocm-proxyserver   False (MissingEndpoints)   6m36s
v1alpha1.clusterview.open-cluster-management.io   open-cluster-management/ocm-proxyserver   False (MissingEndpoints)   6m36s
v1beta1.proxy.open-cluster-management.io          open-cluster-management/ocm-proxyserver   False (MissingEndpoints)   6m36s

$ kubectl --context hub describe apiservices v1.clusterview.open-cluster-management.io
Status:
  Conditions:
    Last Transition Time:  2021-07-22T00:54:45Z
    Message:               endpoints for service/ocm-proxyserver in "open-cluster-management" have no addresses with port name "secure"
    Reason:                MissingEndpoints
    Status:                False
    Type:                  Available

$ kubectl --context hub create ns foo
namespace/foo created

$ kubectl --context hub delete ns foo
namespace "foo" deleted
^Z
[1]+  Stopped                 kubectl --context hub delete ns foo
$ bg
[1]+ kubectl --context hub delete ns foo &

$ kubectl --context hub get ns foo
NAME   STATUS        AGE
foo    Terminating   2m26s

$ kubectl --context hub get ns foo -oyaml
status:
  conditions:
  - lastTransitionTime: "2021-07-22T01:05:47Z"
    message: 'Discovery failed for some groups, 3 failing: unable to retrieve the
      complete list of server APIs: clusterview.open-cluster-management.io/v1: the
      server is currently unable to handle the request, clusterview.open-cluster-management.io/v1alpha1:
      the server is currently unable to handle the request, proxy.open-cluster-management.io/v1beta1:
      the server is currently unable to handle the request'
    reason: DiscoveryFailed
    status: "True"
    type: NamespaceDeletionDiscoveryFailure

$ kubectl delete --context hub apiservices v1.clusterview.open-cluster-management.io v1alpha1.clusterview.open-cluster-manage
ment.io v1beta1.proxy.open-cluster-management.io
apiservice.apiregistration.k8s.io "v1.clusterview.open-cluster-management.io" deleted
apiservice.apiregistration.k8s.io "v1alpha1.clusterview.open-cluster-management.io" deleted
apiservice.apiregistration.k8s.io "v1beta1.proxy.open-cluster-management.io" deleted

$ kubectl --context hub get ns foo -oyaml
Error from server (NotFound): namespaces "foo" not found
[1]+  Done                    kubectl --context hub delete ns foo
```