### PR TITLE
minikube-rook-mirror-test.sh: rbd ls -> info

### DIFF
--- a/hack/minikube-rook-mirror-test.sh
+++ b/hack/minikube-rook-mirror-test.sh
@@ -26,6 +26,8 @@ function wait_for_condition() {
     echo "Failed to meet $condition for command $*"
     exit 1
 }
+# shellcheck source=./until_true_or_n.sh disable=1091
+. "$(dirname "$0")"/until_true_or_n.sh
 
 ## Usage
 usage()
@@ -81,7 +83,7 @@ kubectl --context="${PRIMARY_CLUSTER}" -n rook-ceph exec "${CEPH_TOOLBOX_POD}" -
 CEPH_TOOLBOX_POD=$(kubectl --context="${SECONDARY_CLUSTER}" -n rook-ceph get pods -l  app=rook-ceph-tools -o jsonpath='{.items[0].metadata.name}')
 echo CEPH_TOOLBOX_POD on secondary cluster is "$CEPH_TOOLBOX_POD"
 
-wait_for_condition "${RBD_IMAGE_NAME}" kubectl --context="${SECONDARY_CLUSTER}" -n rook-ceph exec "${CEPH_TOOLBOX_POD}" -- rbd ls "${RBD_IMAGE_NAME}" --pool=replicapool
+until_true_or_n 300 kubectl --context="${SECONDARY_CLUSTER}" -n rook-ceph exec "${CEPH_TOOLBOX_POD}" -- rbd info "${RBD_IMAGE_NAME}" --pool=replicapool
 
 kubectl --context="${PRIMARY_CLUSTER}" get volumereplication vr-sample -o yaml
 

--- a/hack/until_true_or_n.sh
+++ b/hack/until_true_or_n.sh
@@ -1,5 +1,4 @@
-#!/bin/sh
-# shellcheck disable=2086
+# shellcheck shell=sh disable=2086
 until_true_or_n()
 {
 	{ case ${-} in *x*) set +x; x='unset -v x; set -x';; esac; } 2>/dev/null


### PR DESCRIPTION
The `rbd ls` command lists all volumes for a pool, but it does not support listing a single given image name.  Sometimes a pool may have more than one volume causing a comparison expecting only one volume to fail, e.g.:
```
++ kubectl --context=cluster1 -n rook-ceph exec rook-ceph-tools-6bc7c4f9fc-h2w2g -- rbd ls csi-vol-6e1b9dd2-ea54-11eb-8cf3-0242ac110011 --pool=replicapool
+ result='csi-vol-6e1b9dd2-ea54-11eb-8cf3-0242ac110011
csi-vol-b9f4f951-e98e-11eb-b651-0242ac11000a
csi-vol-c3a281d9-e99d-11eb-b651-0242ac11000a'
+ [[ csi-vol-6e1b9dd2-ea54-11eb-8cf3-0242ac110011
csi-vol-b9f4f951-e98e-11eb-b651-0242ac11000a
csi-vol-c3a281d9-e99d-11eb-b651-0242ac11000a == \c\s\i\-\v\o\l\-\6\e\1\b\9\d\d\2\-\e\a\5\4\-\1\1\e\b\-\8\c\f\3\-\0\2\4\2\a\c\1\1\0\0\1\1 ]]
```
`rbd info`, in contrast, does support a single image name argument and is therefore used in the secondary cluster context just as it is in the primary, except that it may be run multiple times until either it succeeds or 5 minutes elapse.

`minikube-rook-mirror-test.sh`'s polling routine, `wait_for_condition`, tests for string comparison and expects a zero exit status from its string-outputting command.  `until_true_or_n` is employed instead which tolerates non-zero exit status while it waits for a zero exit status indicating condition satisfied.