### PR TITLE
Preserve subscription deployment yaml

### DIFF
--- a/hack/minikube-rook-setup.sh
+++ b/hack/minikube-rook-setup.sh
@@ -43,7 +43,7 @@ function wait_for_ssh() {
 }
 
 function wait_for_condition() {
-    local count=61
+    local count=121
     local condition=${1}
     local result
     shift

--- a/hack/ocm-minikube.sh
+++ b/hack/ocm-minikube.sh
@@ -317,10 +317,14 @@ ocm_subscription_operator_deploy_spoke_nonhub()
 	ocm_subscription_operator_deploy_spoke $1
 	kubectl config use-context ${1}
 	ocm_subscription_operator_checkout
+	mkdir -p multicloud-operators-subscription/munge-manifests
+	cp multicloud-operators-subscription/deploy/managed/operator.yaml multicloud-operators-subscription/munge-manifests/operator.yaml
 	MANAGED_CLUSTER_NAME=${1}\
 	HUB_KUBECONFIG=${HUB_KUBECONFIG}\
 	USE_VENDORIZED_BUILD_HARNESS=faked\
 	make -C multicloud-operators-subscription deploy-community-managed
+	cp multicloud-operators-subscription/munge-manifests/operator.yaml multicloud-operators-subscription/deploy/managed/operator.yaml
+	# deploy/managed/operator.yaml is changed and will not be updated
 	ocm_subscription_operator_checkout_undo
 	date
 	kubectl --context ${1} -n multicluster-operators wait deployments --all --for condition=available --timeout 1m


### PR DESCRIPTION
In the e2e scripts, the command to make deploy an mc,
overwrites the existing deployment file with cluster
name. In the case the scripts are run again, this creates
a mc (managedcluster) subscription on the hub as cluster1
or on a non-cluster1 cluster as cluster1.

This is fixed simply by saving the deploy yaml and restoring
it post the deployment.

Also increased the timeout to wait for rook, which most
often fails to finish in the current time, and also causes
to re-run deployment (which caused the initial problem).

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>