### PR TITLE
Add olm-install artifacts

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -14,9 +14,9 @@ on:  # yamllint disable-line rule:truthy
       - '*'
 env:
   GO_VERSION: "1.16"
-  # Uses image name IMG to build image in Makefile
-  IMG: "quay.io/ramendr/ramen-operator:sanity"
-  IMG_NAME: "quay.io/ramendr/ramen-operator"
+  # Use IMAGE_TAG_BASE and IMAGE_TAG Makefile variables to build various images
+  IMAGE_TAG_BASE: "quay.io/ramendr/ramen"
+  IMAGE_TAG: "sanity"
 defaults:
   run:
     shell: bash
@@ -67,7 +67,7 @@ jobs:
         run: make docker-build
 
       - name: Export image
-        run: docker save -o /tmp/ramen-operator.tar ${IMG}
+        run: docker save -o /tmp/ramen-operator.tar ${IMAGE_TAG_BASE}-operator:${IMAGE_TAG}
 
       - name: Save image artifact
         uses: actions/upload-artifact@v2
@@ -129,7 +129,7 @@ jobs:
       - name: Load image artifact
         run: |
           docker load -i /tmp/ramen-operator.tar
-          kind load docker-image "${IMG}" --name ${KIND_CLUSTER_NAME}
+          kind load docker-image ${IMAGE_TAG_BASE}-operator:${IMAGE_TAG} --name ${KIND_CLUSTER_NAME}
 
       - name: Deploy dependent CRDs
         run: |
@@ -186,7 +186,7 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Push to Quay
+      - name: Determine image tag
         run: |
           [[ "${{ github.ref }}" =~ ^refs\/(heads|tags)\/(release-)?(.*) ]]
           echo "heads or tags? ${BASH_REMATCH[1]}"
@@ -203,6 +203,27 @@ jobs:
             TAG="${BASH_REMATCH[3]}"
           fi
           test "${TAG}" = "" && exit 1
-          echo "Tagging as ${IMG_NAME}:${TAG}"
-          docker tag "${IMG}" "${IMG_NAME}:${TAG}"
-          docker push "${IMG_NAME}:${TAG}"
+          echo "Publish image tag ${TAG}"
+          echo "publish_image_tag=${TAG}" >> $GITHUB_ENV
+
+      - name: Push operator image to Quay
+        run: |
+          docker tag "${IMAGE_TAG_BASE}-operator:${IMAGE_TAG}" "${IMAGE_TAG_BASE}-operator:${{ env.publish_image_tag }}"
+          docker push "${IMAGE_TAG_BASE}-operator:${{ env.publish_image_tag }}"
+
+      # TODO: We do not need to build bundles and catalogs each time, fix once we reach alpha
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build and push bundle images to Quay
+        run: |
+          IMAGE_TAG="${{ env.publish_image_tag }}" make bundle-build bundle-push
+
+      - name: Build and push catalog image to Quay
+        run: |
+          IMAGE_TAG="${{ env.publish_image_tag }}" make catalog-build catalog-push"

--- a/config/olm-install/base/catalog-source-kustomizeconfig.yaml
+++ b/config/olm-install/base/catalog-source-kustomizeconfig.yaml
@@ -1,0 +1,4 @@
+---
+images:
+- path: spec/image
+  kind: CatalogSource

--- a/config/olm-install/base/kustomization.yaml
+++ b/config/olm-install/base/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ramen-system
+
+resources:
+- ramen-catalog.yaml
+- ramen-operator-group.yaml
+
+configurations:
+- catalog-source-kustomizeconfig.yaml
+
+# replace catalogsource image
+images:
+- name: ramen-operator-catalog
+  newName: quay.io/ramendr/ramen-operator-catalog
+  newTag: canary

--- a/config/olm-install/base/ramen-catalog.yaml
+++ b/config/olm-install/base/ramen-catalog.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ramen-catalog
+  namespace: ramen-system
+spec:
+  displayName: Ramen Operators
+  image: ramen-operator-catalog:canary
+  sourceType: grpc

--- a/config/olm-install/base/ramen-operator-group.yaml
+++ b/config/olm-install/base/ramen-operator-group.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ramen-system
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: ramen-operator-group
+  namespace: ramen-system

--- a/config/olm-install/dr-cluster/kustomization.yaml
+++ b/config/olm-install/dr-cluster/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ramen-system
+
+bases:
+- ../base
+
+resources:
+- ramen-dr-cluster-subscription.yaml
+
+# patch Subscriptions channel and version
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: alpha
+    - op: replace
+      path: /spec/startingCSV
+      value: ramen-dr-cluster.v0.0.1
+  target:
+    kind: Subscription
+    name: ramen-dr-cluster-subscription

--- a/config/olm-install/dr-cluster/ramen-dr-cluster-subscription.yaml
+++ b/config/olm-install/dr-cluster/ramen-dr-cluster-subscription.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ramen-dr-cluster-subscription
+  namespace: ramen-system
+spec:
+  channel: "alpha"
+  installPlanApproval: Automatic
+  name: ramen-dr-cluster
+  source: ramen-catalog
+  sourceNamespace: ramen-system
+  startingCSV: ramen-dr-cluster.v0.0.1

--- a/config/olm-install/hub/kustomization.yaml
+++ b/config/olm-install/hub/kustomization.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ramen-system
+
+bases:
+- ../base
+
+resources:
+- ramen-hub-subscription.yaml
+
+# patch Subscriptions channel and version
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/channel
+      value: alpha
+    - op: replace
+      path: /spec/startingCSV
+      value: ramen-hub.v0.0.1
+  target:
+    kind: Subscription
+    name: ramen-hub-subscription

--- a/config/olm-install/hub/ramen-hub-subscription.yaml
+++ b/config/olm-install/hub/ramen-hub-subscription.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ramen-hub-subscription
+  namespace: ramen-system
+spec:
+  channel: "alpha"
+  installPlanApproval: Automatic
+  name: ramen-hub
+  source: ramen-catalog
+  sourceNamespace: ramen-system
+  startingCSV: ramen-hub.v0.0.1


### PR DESCRIPTION
- Modified Makefile to separate VERSION of CSV from
  IMAGE_TAG, to name images without versions
- Added YAML and kustomize artifacts to subscribe to
  - ramen-hub
  - ramen-dr-cluster
  - add ramen-operator-catalog as a CatalogSource

Usage pattern would be as follows (once bundles and catalog
are published):
  - Install olm on desired cluster
  - cd config/olm-install/base
    - kustomize edit set image ramen-operator-catalog=quay.io/ramendr/ramen-operator-catalog:canary
    - Or, set catalog image to version of choice
  - Install hub,
    - kubectl apply -f config/olm-install/hub/
  - Install dr-cluster,
    - kubectl apply -f config/olm-install/dr-cluster

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>