### PR TITLE
Check specific conditions for MW and MCV

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1502,22 +1502,20 @@ func (r *DRPlacementControlReconciler) getManagedClusterResource(
 		return errorswrapper.Wrap(err, "getManagedClusterResource failed")
 	}
 
-	// get query results
-	recentConditions := rmnutil.GetMostRecentConditions(mcv.Status.Conditions)
+	r.Log.Info(fmt.Sprintf("MCV condtions: %v", mcv.Status.Conditions))
 
-	r.Log.Info(fmt.Sprintf("MCV recent condtions: %v", recentConditions))
 	// want single recent Condition with correct Type; otherwise: bad path
-	switch len(recentConditions) {
+	switch len(mcv.Status.Conditions) {
 	case 0:
 		err = fmt.Errorf("missing ManagedClusterView conditions")
 	case 1:
 		switch {
-		case recentConditions[0].Type != fndv2.ConditionViewProcessing:
-			err = fmt.Errorf("found invalid condition (%s) in ManagedClusterView", recentConditions[0].Type)
-		case recentConditions[0].Reason == fndv2.ReasonGetResourceFailed:
+		case mcv.Status.Conditions[0].Type != fndv2.ConditionViewProcessing:
+			err = fmt.Errorf("found invalid condition (%s) in ManagedClusterView", mcv.Status.Conditions[0].Type)
+		case mcv.Status.Conditions[0].Reason == fndv2.ReasonGetResourceFailed:
 			err = errors.NewNotFound(schema.GroupResource{}, "requested resource not found in ManagedCluster")
-		case recentConditions[0].Status != metav1.ConditionTrue:
-			err = fmt.Errorf("ManagedClusterView is not ready (reason: %s)", recentConditions[0].Reason)
+		case mcv.Status.Conditions[0].Status != metav1.ConditionTrue:
+			err = fmt.Errorf("ManagedClusterView is not ready (reason: %s)", mcv.Status.Conditions[0].Reason)
 		}
 	default:
 		err = fmt.Errorf("found multiple status conditions with ManagedClusterView")

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -496,6 +496,16 @@ func updateManifestWorkStatus(clusterNamespace, mwType, workType string) {
 			},
 		},
 	}
+	// If work requires `applied`, add `available` as well to ensure a successful check
+	if workType == ocmworkv1.WorkApplied {
+		pvManifestStatus.Conditions = append(pvManifestStatus.Conditions, metav1.Condition{
+			Type:               ocmworkv1.WorkAvailable,
+			LastTransitionTime: metav1.Time{Time: timeMostRecent},
+			Status:             metav1.ConditionTrue,
+			Reason:             "test",
+		})
+	}
+
 	createdManifest.Status = pvManifestStatus
 
 	err := k8sClient.Status().Update(context.TODO(), createdManifest)


### PR DESCRIPTION
Current code looks for duplicate conditions in MW and
MCV status and filters the most current ones.

Conditions typically do not have duplicate entries and
are maintained one per condition type. Also, looking at
MW and MCV reconcilers they do not seem to add muntiple
conditions.

Hence simplyfying the code to address only conditions by
type and not time stamps.

Further addressed checking for both 'applied' and 'available'
condition for MW to be deemed succesfully available on a
managed cluster.

Fixes #173

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>