### PR TITLE
Add more condition checks to ensure healthy secondary

### DIFF
--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -315,6 +315,8 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 			v.cleanup()
 		})
 	})
+	// TODO: Add tests to move VRG to Secondary
+	// TODO: Add tests to ensure delete as Secondary (check if delete as Primary is tested above)
 })
 
 type vrgTest struct {


### PR DESCRIPTION
VR resources mark their condition as complete if the
volume is marked Secondary.

The resyncing and degraded conditions further tell if
the volume has reestablished replication.

As it stands, deleting VR if only the complete condition
is met, would leave the volume in a potential split-brain
state.

This is fixed by checking for the status of the related
conditions, before calling a volume as a healthy Secondary.

Fixes #176 

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>