### PR TITLE
Switch to Go 1.15

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -13,7 +13,7 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - '*'
 env:
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.15"
   # Use IMAGE_TAG_BASE and IMAGE_TAG Makefile variables to build various images
   IMAGE_TAG_BASE: "quay.io/ramendr/ramen"
   IMAGE_TAG: "sanity"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM golang:1.15 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/controllers/ramenconfig.go
+++ b/controllers/ramenconfig.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"io/ioutil"
 	"os"
 
 	"github.com/ghodss/yaml"
@@ -71,7 +72,7 @@ func LoadRamenConfig(configFile string, log logr.Logger) (
 
 	log.Info("loading Ramen config file ", "name", configFile)
 
-	fileContents, err := os.ReadFile(configFile)
+	fileContents, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		log.Error(err, "unable to load the config file")
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ramendr/ramen
 
-go 1.16
+go 1.15
 
 require (
 	github.com/aws/aws-sdk-go v1.38.3


### PR DESCRIPTION
Go 1.15 is a better match than Go 1.16 for some of the build environments. Hence, revert commits e3977ca & 5492012.

Signed-off-by: Veera Deenadhayalan <vdeenadh@redhat.com>