### PR TITLE
Parameterize builds

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -14,8 +14,10 @@ on:  # yamllint disable-line rule:truthy
       - '*'
 env:
   GO_VERSION: "1.15"
-  # Use IMAGE_TAG_BASE and IMAGE_TAG Makefile variables to build various images
   IMAGE_TAG_BASE: "quay.io/ramendr/ramen"
+  IMAGE_REGISTRY: "quay.io"
+  IMAGE_REPOSITORY: "ramendr"
+  IMAGE_NAME: "ramen"
   IMAGE_TAG: "sanity"
 defaults:
   run:

--- a/config/dr_cluster/manifests/ramen/kustomization.yaml
+++ b/config/dr_cluster/manifests/ramen/kustomization.yaml
@@ -1,10 +1,10 @@
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
-- bases/ramen_hub.clusterserviceversion.yaml
-- ../default
-- ../samples
-- ../../scorecard
+- ../bases/ramen_dr_cluster.clusterserviceversion.yaml
+- ../../default
+- ../../samples
+- ../../../scorecard
 
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.

--- a/config/hub/manifests/ramen/kustomization.yaml
+++ b/config/hub/manifests/ramen/kustomization.yaml
@@ -1,10 +1,10 @@
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
-- bases/ramen_dr_cluster.clusterserviceversion.yaml
-- ../default
-- ../samples
-- ../../scorecard
+- ../bases/ramen_hub.clusterserviceversion.yaml
+- ../../default
+- ../../samples
+- ../../../scorecard
 
 # [WEBHOOK] To enable webhooks, uncomment all the sections with [WEBHOOK] prefix.
 # Do NOT uncomment sections with prefix [CERTMANAGER], as OLM does not support cert-manager.


### PR DESCRIPTION
This PR aims to make it easy for us to generate the operator manifests and other resources with a different name if required.

