### PR TITLE
drpolicy controller define

### DIFF
--- a/config/hub/rbac/role.yaml
+++ b/config/hub/rbac/role.yaml
@@ -89,6 +89,20 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ramendr.openshift.io
+  resources:
+  - drpolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ramendr.openshift.io
+  resources:
+  - drpolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - view.open-cluster-management.io
   resources:
   - managedclusterviews

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -121,6 +121,20 @@ rules:
 - apiGroups:
   - ramendr.openshift.io
   resources:
+  - drpolicies/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ramendr.openshift.io
+  resources:
+  - drpolicies/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ramendr.openshift.io
+  resources:
   - volumereplicationgroups
   verbs:
   - create

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2021 The RamenDR authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	ramen "github.com/ramendr/ramen/api/v1alpha1"
+	"github.com/ramendr/ramen/controllers/util"
+)
+
+// DRPolicyReconciler reconciles a DRPolicy object
+type DRPolicyReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+//+kubebuilder:rbac:groups=ramendr.openshift.io,resources=drpolicies,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=ramendr.openshift.io,resources=drpolicies/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=ramendr.openshift.io,resources=drpolicies/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the DRPolicy object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile
+func (r *DRPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.Log.WithName("controllers").WithName("drpolicy").WithValues("name", req.NamespacedName.Name)
+	log.Info("reconcile enter")
+
+	defer log.Info("reconcile exit")
+
+	drpolicy := &ramen.DRPolicy{}
+	if err := r.Client.Get(ctx, req.NamespacedName, drpolicy); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("get: %w", err))
+	}
+
+	manifestWorkUtil := util.MWUtil{Client: r.Client, Ctx: ctx, Log: log, InstName: "", InstNamespace: ""}
+
+	switch drpolicy.ObjectMeta.DeletionTimestamp.IsZero() {
+	case true:
+		log.Info("create/update")
+
+		if err := finalizerAdd(ctx, drpolicy, r.Client, log); err != nil {
+			return ctrl.Result{}, fmt.Errorf("finalizer add update: %w", err)
+		}
+
+		if err := manifestWorkUtil.ClusterRolesCreate(drpolicy); err != nil {
+			return ctrl.Result{}, fmt.Errorf("cluster roles create: %w", err)
+		}
+	default:
+		log.Info("delete")
+
+		if err := manifestWorkUtil.ClusterRolesDelete(drpolicy); err != nil {
+			return ctrl.Result{}, fmt.Errorf("cluster roles delete: %w", err)
+		}
+
+		if err := finalizerRemove(ctx, drpolicy, r.Client, log); err != nil {
+			return ctrl.Result{}, fmt.Errorf("finalizer remove update: %w", err)
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+const finalizerName = "drpolicies.ramendr.openshift.io/ramen"
+
+func finalizerAdd(ctx context.Context, drpolicy *ramen.DRPolicy, client client.Client, log logr.Logger) error {
+	finalizerCount := len(drpolicy.ObjectMeta.Finalizers)
+	controllerutil.AddFinalizer(drpolicy, finalizerName)
+
+	if len(drpolicy.ObjectMeta.Finalizers) != finalizerCount {
+		log.Info("finalizer add")
+
+		return client.Update(ctx, drpolicy)
+	}
+
+	return nil
+}
+
+func finalizerRemove(ctx context.Context, drpolicy *ramen.DRPolicy, client client.Client, log logr.Logger) error {
+	finalizerCount := len(drpolicy.ObjectMeta.Finalizers)
+	controllerutil.RemoveFinalizer(drpolicy, finalizerName)
+
+	if len(drpolicy.ObjectMeta.Finalizers) != finalizerCount {
+		log.Info("finalizer remove")
+
+		return client.Update(ctx, drpolicy)
+	}
+
+	return nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *DRPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&ramen.DRPolicy{}).
+		Complete(r)
+}

--- a/controllers/drpolicy_controller_test.go
+++ b/controllers/drpolicy_controller_test.go
@@ -1,0 +1,107 @@
+package controllers_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	ramen "github.com/ramendr/ramen/api/v1alpha1"
+	"github.com/ramendr/ramen/controllers/util"
+)
+
+var _ = Describe("DrpolicyController", func() {
+	clusterNamesCurrent := &sets.String{}
+	clusterNames := func(drpolicy *ramen.DRPolicy) sets.String {
+		return sets.NewString(util.DrpolicyClusterNames(drpolicy)...)
+	}
+	clusterRolesExpect := func() {
+		Eventually(
+			func(g Gomega) {
+				clusterNames := sets.String{}
+				g.Expect(util.ClusterRolesList(context.TODO(), k8sClient, &clusterNames)).To(Succeed())
+				fmt.Fprintf(
+					GinkgoWriter,
+					"expect: %v\nactual: %v\n",
+					*clusterNamesCurrent,
+					clusterNames,
+				)
+				g.Expect(clusterNamesCurrent.Equal(clusterNames)).To(BeTrue())
+			},
+			10,
+			0.25,
+		).Should(Succeed())
+	}
+	drpolicyCreate := func(drpolicy *ramen.DRPolicy) {
+		for _, clusterName := range clusterNames(drpolicy).Difference(*clusterNamesCurrent).UnsortedList() {
+			Expect(k8sClient.Create(
+				context.TODO(),
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterName}},
+			)).To(Succeed())
+			*clusterNamesCurrent = clusterNamesCurrent.Insert(clusterName)
+		}
+		Expect(k8sClient.Create(context.TODO(), drpolicy)).To(Succeed())
+		clusterRolesExpect()
+	}
+	drpolicyDelete := func(drpolicy *ramen.DRPolicy, clusterNamesExpected sets.String) {
+		Expect(k8sClient.Delete(context.TODO(), drpolicy)).To(Succeed())
+		for _, clusterName := range clusterNamesCurrent.Difference(clusterNamesExpected).UnsortedList() {
+			Expect(k8sClient.Delete(
+				context.TODO(),
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterName}},
+			)).To(Succeed())
+			*clusterNamesCurrent = clusterNamesCurrent.Delete(clusterName)
+		}
+		clusterRolesExpect()
+	}
+	clusters := [...]ramen.ManagedCluster{
+		{Name: "cluster-a", S3ProfileName: ""},
+		{Name: "cluster-b", S3ProfileName: ""},
+		{Name: "cluster-c", S3ProfileName: ""},
+	}
+	drpolicies := [...]ramen.DRPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "drpolicy0"},
+			Spec:       ramen.DRPolicySpec{DRClusterSet: clusters[0:2]},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "drpolicy1"},
+			Spec:       ramen.DRPolicySpec{DRClusterSet: clusters[1:3]},
+		},
+	}
+	clusterNamesNone := sets.String{}
+	When("a 1st drpolicy is created", func() {
+		It("should create a cluster roles manifest work for each cluster specified in a 1st drpolicy", func() {
+			drpolicyCreate(&drpolicies[0])
+		})
+	})
+	When("TODO a 1st drpolicy is updated to add some clusters and remove some other clusters", func() {
+		It("should create a cluster roles manifest work for each cluster added and "+
+			"delete a cluster roles manifest work for each cluster removed", func() {
+		})
+	})
+	When("a 2nd drpolicy is created specifying some clusters in a 1st drpolicy and some not", func() {
+		It("should create a cluster roles manifest work for each cluster specified in a 2nd drpolicy but not a 1st drpolicy",
+			func() {
+				drpolicyCreate(&drpolicies[1])
+			},
+		)
+	})
+	When("a 1st drpolicy is deleted", func() {
+		It("should delete a cluster roles manifest work for each cluster specified in a 1st drpolicy but not a 2nd drpolicy",
+			func() {
+				drpolicyDelete(&drpolicies[0], clusterNames(&drpolicies[1]))
+			},
+		)
+	})
+	When("a 2nd drpolicy is deleted", func() {
+		It("should delete a cluster roles manifest work for each cluster specified in a 2nd drpolicy", func() {
+			drpolicyDelete(&drpolicies[1], clusterNamesNone)
+		})
+	})
+})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -104,6 +104,11 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
+	Expect((&ramencontrollers.DRPolicyReconciler{
+		Client: k8sManager.GetClient(),
+		Scheme: k8sManager.GetScheme(),
+	}).SetupWithManager(k8sManager)).To(Succeed())
+
 	err = (&ramencontrollers.VolumeReplicationGroupReconciler{
 		Client:         k8sManager.GetClient(),
 		Log:            ctrl.Log.WithName("controllers").WithName("VolumeReplicationGroup"),

--- a/controllers/util/drpolicy_util.go
+++ b/controllers/util/drpolicy_util.go
@@ -20,6 +20,15 @@ import (
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
 )
 
+func DrpolicyClusterNames(drpolicy *rmn.DRPolicy) []string {
+	clusterNames := make([]string, len(drpolicy.Spec.DRClusterSet))
+	for i := range drpolicy.Spec.DRClusterSet {
+		clusterNames[i] = drpolicy.Spec.DRClusterSet[i].Name
+	}
+
+	return clusterNames
+}
+
 // Return a list of unique S3 profiles to upload the relevant cluster state of
 // the given home cluster
 func s3UploadProfileList(drPolicy rmn.DRPolicy, homeCluster string) (s3ProfileList []string) {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v0.4.0
 	github.com/onsi/ginkgo v1.16.4
-	github.com/onsi/gomega v1.14.0
+	github.com/onsi/gomega v1.15.0
 	github.com/open-cluster-management/api v0.0.0-20210527013639-a6845f2ebcb1
 	github.com/open-cluster-management/multicloud-operators-foundation v0.0.0-20210722145122-534b4232f1c9
 	github.com/open-cluster-management/multicloud-operators-placementrule v1.2.2-2-20201130-98cfd.0.20210722134723-73b5f55a3813

--- a/go.sum
+++ b/go.sum
@@ -1435,8 +1435,8 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
-github.com/onsi/gomega v1.14.0 h1:ep6kpPVwmr/nTbklSx2nrLNSIO62DoYAhnPNIMhK8gI=
-github.com/onsi/gomega v1.14.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
+github.com/onsi/gomega v1.15.0 h1:WjP/FQ/sk43MRmnEcT+MlDw2TFvkrXlprrPST/IudjU=
+github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+tEHG0=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/open-cluster-management/addon-framework v0.0.0-20210621074027-a81f712c10c2/go.mod h1:mcpd6pc0j/L+WLFwV2MXHVMr+86ri2iUdTK2M8RHJ7U=
 github.com/open-cluster-management/api v0.0.0-20200903203421-64b667f5455c/go.mod h1:F1hDJHtWuV7BAUtfL4XRS9GZjUpksleLgEcisNXvQEw=

--- a/main.go
+++ b/main.go
@@ -105,6 +105,14 @@ func newManager() (ctrl.Manager, error) {
 
 func setupReconcilers(mgr ctrl.Manager) {
 	if controllerType == ramendrv1alpha1.DRHub {
+		if err := (&controllers.DRPolicyReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "DRPolicy")
+			os.Exit(1)
+		}
+
 		drpcReconciler := (&controllers.DRPlacementControlReconciler{
 			Client:   mgr.GetClient(),
 			Log:      ctrl.Log.WithName("controllers").WithName("DRPlacementControl"),


### PR DESCRIPTION
	- vrg and pv cluster roles manifestworks unify
	- drpolicy create/update:
		- finalizer add if absent
		- cluster roles manifestwork create, if absent, for each cluster in drpolicy
	- drpolicy delete:
		- cluster roles manifestwork delete for each cluster not in any other drpolicy
		- finalizer remove if present
	- ginkgo version increase from 1.16.1 to 1.16.4
	- gomega version increase from 1.11.0 to 1.15.0

Signed-off-by: bhatfiel <bhatfiel@redhat.com>