### PR TITLE
ocm-minikube-ramen.sh: vrg manifest work delete remove

### DIFF
--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -194,10 +194,6 @@ application_sample_undeploy()
 	# error: no matching resources found
 	set -e
 	date
-	# TODO drplacementcontrols finalizer delete volumereplicationgroup manifest work instead
-	kubectl --context ${1} -n busybox-sample get volumereplicationgroups/busybox-drpc
-	kubectl --context ${hub_cluster_name} -n ${1} delete manifestworks/busybox-drpc-busybox-sample-vrg-mw
-	date
 	set +e
 	kubectl --context ${1} -n busybox-sample wait volumereplicationgroups/busybox-drpc --for delete
 	# error: no matching resources found


### PR DESCRIPTION
It seems volumereplicationgroup is now being deleted by ramen, so e2e no longer needs to.