### PR TITLE
fixes and refactoring

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -60,6 +60,7 @@ const (
 func setVRGInitialCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	setStatusCondition(conditions, metav1.Condition{
 		Type:               VRGConditionAvailable,
+		Reason:             "none",
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionUnknown,
 		Message:            message,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -109,6 +109,7 @@ var _ = BeforeSuite(func() {
 		Log:            ctrl.Log.WithName("controllers").WithName("VolumeReplicationGroup"),
 		ObjStoreGetter: ramencontrollers.S3ObjectStoreGetter(),
 		PVDownloader:   FakePVDownloader{},
+		PVUploader:     FakePVUploader{},
 		Scheme:         k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/main.go
+++ b/main.go
@@ -124,6 +124,7 @@ func setupReconcilers(mgr ctrl.Manager) {
 		Log:            ctrl.Log.WithName("controllers").WithName("VolumeReplicationGroup"),
 		ObjStoreGetter: controllers.S3ObjectStoreGetter(),
 		PVDownloader:   controllers.ObjectStorePVDownloader{},
+		PVUploader:     controllers.ObjectStorePVUploader{},
 		Scheme:         mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VolumeReplicationGroup")


### PR DESCRIPTION
- Add metrics for initial deployment
- Add ObservedGeneration when checking if PVs have been restored
- Add PVUploader for unit test (this has not been tested)
- Add the Required field "Reason" to the setVRGInitialCondition
- Refactor PV Restore and add annotation to help determine the PVs restored by Ramen as opposed to PVs that are not.