### PR TITLE
Delete VR before PVC deletion

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -126,11 +126,23 @@ var (
 			Buckets: prometheus.ExponentialBuckets(1.0, 2.0, 12), // start=1.0, factor=2.0, buckets=12
 		}),
 	)
+
+	deployTime = newTimerWrapper(
+		prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "ramen_initial_deploy_time",
+			Help: "Duration of the last initial deploy time",
+		}),
+		prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "ramen_initial_deploy_histogram",
+			Help:    "Histogram of all initial deploymet timers (seconds)",
+			Buckets: prometheus.ExponentialBuckets(1.0, 2.0, 12), // start=1.0, factor=2.0, buckets=12
+		}),
+	)
 )
 
 func init() {
 	// register custom metrics with the global Prometheus registry
-	metrics.Registry.MustRegister(failbackTime.gauge, failoverTime.gauge, relocateTime.gauge)
+	metrics.Registry.MustRegister(failbackTime.gauge, failoverTime.gauge, relocateTime.gauge, deployTime.gauge)
 }
 
 var WaitForPVRestoreToComplete = errorswrapper.New("Waiting for PV restore to complete")
@@ -795,6 +807,7 @@ func (d *DRPCInstance) runInitialDeployment() (bool, error) {
 
 	// Make sure we record the state that we are deploying
 	d.setDRState(rmn.Deploying)
+	setMetricsTimerFromDRState(rmn.Deploying, timerStart)
 
 	// Create VRG first, to leverage user PlacementRule decision to skip placement and move to cleanup
 	err := d.createVRGManifestWork(homeCluster)
@@ -816,11 +829,11 @@ func (d *DRPCInstance) runInitialDeployment() (bool, error) {
 	d.advanceToNextDRState()
 
 	d.log.Info(fmt.Sprintf("DRPC (%+v)", d.instance))
+	setMetricsTimerFromDRState(rmn.Deployed, timerStop)
 
 	return done, nil
 }
 
-//nolint:exhaustive
 func setMetricsTimerFromDRState(stateDR rmn.DRState, stateTimer timerState) {
 	switch stateDR {
 	case rmn.FailingOver:
@@ -829,8 +842,8 @@ func setMetricsTimerFromDRState(stateDR rmn.DRState, stateTimer timerState) {
 		setMetricsTimer(&failbackTime, stateTimer, stateDR)
 	case rmn.Relocating:
 		setMetricsTimer(&relocateTime, stateTimer, stateDR)
-	// case rmn.Deploying:
-	// TODO: setMetricsTimer(&deployTime, stateTimer, stateDR)
+	case rmn.Deploying:
+		setMetricsTimer(&deployTime, stateTimer, stateDR)
 	case rmn.FailedBack:
 		fallthrough
 	case rmn.FailedOver:
@@ -1024,7 +1037,7 @@ func (d *DRPCInstance) switchToPreferredCluster(drState rmn.DRState) (bool, erro
 	d.setDRState(drState)
 	setMetricsTimerFromDRState(drState, timerStart)
 
-	// During failback/relocate, the preferredCluster is does not contain a VRG or the VRG is already
+	// During failback/relocate, the preferredCluster does not contain a VRG or the VRG is already
 	// secondary. We need to skip checking if the VRG for it is secondary to avoid messing up with the
 	// order of execution (it could be refactored better to avoid this complexity). IOW, if we first update
 	// VRG in all clusters to secondaries, then we call runPlacementTask. If runPlacementTask does not complete
@@ -1396,7 +1409,7 @@ func (d *DRPCInstance) checkPVsHaveBeenRestored(homeCluster string) (bool, error
 		return false, nil
 	}
 
-	return vrgCondition.Status == metav1.ConditionTrue, nil
+	return vrgCondition.Status == metav1.ConditionTrue && vrgCondition.ObservedGeneration == vrg.Generation, nil
 }
 
 func (d *DRPCInstance) ensureCleanup(clusterToSkip string) error {
@@ -1415,7 +1428,7 @@ func (d *DRPCInstance) ensureCleanup(clusterToSkip string) error {
 	if condition.Reason == rmn.ReasonSuccess &&
 		condition.Status == metav1.ConditionTrue &&
 		condition.ObservedGeneration == d.instance.Generation {
-		d.log.Info("Condition values tallied, cleaup is considered complete")
+		d.log.Info("Condition values tallied, cleanup is considered complete")
 
 		return nil
 	}

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -60,6 +60,7 @@ const (
 func setVRGInitialCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	setStatusCondition(conditions, metav1.Condition{
 		Type:               VRGConditionAvailable,
+		Reason:             "none",
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionUnknown,
 		Message:            message,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -115,6 +115,7 @@ var _ = BeforeSuite(func() {
 		ObjStoreGetter: ramencontrollers.S3ObjectStoreGetter(),
 		PVDownloader:   FakePVDownloader{},
 		PVUploader:     FakePVUploader{},
+		PVDeleter:      FakePVDeleter{},
 		Scheme:         k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -114,6 +114,7 @@ var _ = BeforeSuite(func() {
 		Log:            ctrl.Log.WithName("controllers").WithName("VolumeReplicationGroup"),
 		ObjStoreGetter: ramencontrollers.S3ObjectStoreGetter(),
 		PVDownloader:   FakePVDownloader{},
+		PVUploader:     FakePVUploader{},
 		Scheme:         k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -56,6 +56,13 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 				v.waitForVRCountToMatch(expectedVRCount)
 			}
 		})
+		It("waits for VRG to status to match", func() {
+			for c := 0; c < len(vrgTestCases); c++ {
+				v := vrgTestCases[c]
+				v.promoteVolReps()
+				v.verifyVRGStatusExpectation(true)
+			}
+		})
 		It("cleans up after testing", func() {
 			for c := 0; c < len(vrgTestCases); c++ {
 				v := vrgTestCases[c]
@@ -109,6 +116,13 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 				v := vrgTests[c]
 				expectedVRCount := len(v.pvcNames)
 				v.waitForVRCountToMatch(expectedVRCount)
+			}
+		})
+		It("waits for VRG to status to match", func() {
+			for c := 0; c < len(vrgTests); c++ {
+				v := vrgTests[c]
+				v.promoteVolReps()
+				v.verifyVRGStatusExpectation(true)
 			}
 		})
 		It("cleans up after testing", func() {
@@ -1043,12 +1057,9 @@ func (s FakePVUploader) UploadPV(v interface{}, s3ProfileName string, pvc *corev
 
 type FakePVDeleter struct{}
 
-func (s FakePVDeleter) DeletePV(v interface{}, s3ProfileName string, pvc *corev1.PersistentVolumeClaim) error {
-	_, ok := UploadedPVs[pvc.Spec.VolumeName]
-	if ok {
-		delete(UploadedPVs, pvc.Spec.VolumeName)
-	} else {
-		Fail(fmt.Sprintf("PV %s not found", pvc.Spec.VolumeName))
+func (s FakePVDeleter) DeletePVs(v interface{}, s3ProfileName string) error {
+	for key := range UploadedPVs {
+		delete(UploadedPVs, key)
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -132,6 +132,7 @@ func setupReconcilers(mgr ctrl.Manager) {
 		Log:            ctrl.Log.WithName("controllers").WithName("VolumeReplicationGroup"),
 		ObjStoreGetter: controllers.S3ObjectStoreGetter(),
 		PVDownloader:   controllers.ObjectStorePVDownloader{},
+		PVUploader:     controllers.ObjectStorePVUploader{},
 		Scheme:         mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VolumeReplicationGroup")

--- a/main.go
+++ b/main.go
@@ -133,6 +133,7 @@ func setupReconcilers(mgr ctrl.Manager) {
 		ObjStoreGetter: controllers.S3ObjectStoreGetter(),
 		PVDownloader:   controllers.ObjectStorePVDownloader{},
 		PVUploader:     controllers.ObjectStorePVUploader{},
+		PVDeleter:      controllers.ObjectStorePVDeleter{},
 		Scheme:         mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VolumeReplicationGroup")


### PR DESCRIPTION
We had a leak in VR if the reconcile was
interrupted, this is fixed by deleting the VR before
marking the PVC as no longer protected.

This helps with finalizer updates, when there are races
to finalize VRG due to PVC events, and the state fails
in between.

We also ensure VR is in the desired state before deleting
the same, and finalizing the VRG, to leave the system in
an overall desired and consistent state.

Also, corrects S3 object deletion to delete all PVs inside the
PVC bucket.

Fixes #52

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>