### PR TITLE
drpolicy test: use gomega ConsistOf for cluster sets compare

### DIFF
--- a/controllers/drpolicy_controller_test.go
+++ b/controllers/drpolicy_controller_test.go
@@ -2,7 +2,6 @@ package controllers_test
 
 import (
 	"context"
-	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -25,13 +24,7 @@ var _ = Describe("DrpolicyController", func() {
 			func(g Gomega) {
 				clusterNames := sets.String{}
 				g.Expect(util.ClusterRolesList(context.TODO(), k8sClient, &clusterNames)).To(Succeed())
-				fmt.Fprintf(
-					GinkgoWriter,
-					"expect: %v\nactual: %v\n",
-					*clusterNamesCurrent,
-					clusterNames,
-				)
-				g.Expect(clusterNamesCurrent.Equal(clusterNames)).To(BeTrue())
+				g.Expect(clusterNames.UnsortedList()).To(ConsistOf(clusterNamesCurrent.UnsortedList()))
 			},
 			10,
 			0.25,


### PR DESCRIPTION
drpolicy test uses `sets.String.Equal` to compare cluster sets, but when the comparison fails, the failure summary excludes the contents of the sets.  The sets contents are output in the subsequent logs, which may not be captured.  This change removes the log output and compares cluster sets using gomega's `ConsistOf` which contains set data in the failure summary, e.g.:
```
• Failure [10.011 seconds]
DrpolicyController
/c/f/ramen/controllers/drpolicy_controller_test.go:18
  when a 2nd drpolicy is created specifying some clusters in a 1st drpolicy and some not
  /c/f/ramen/controllers/drpolicy_controller_test.go:88
    should create a cluster roles manifest work for each cluster specified in a 2nd drpolicy but not a 1st drpolicy [It]
    /c/f/ramen/controllers/drpolicy_controller_test.go:89

    Timed out after 10.001s.
    Expected success, but got an error:
        <*errors.errorString | 0xc0002a3870>: {
            s: "Assertion in callback at /c/f/ramen/controllers/drpolicy_controller_test.go:34 failed:\nExpected\n    <[]string | len:3, cap:3>: [\"cluster-a\", \"cluster-b\", \"cluster-c\"]\nto consist of\n    <[]string | len:4, cap:4>: [\"cluster-b\", \"cluster-a\", \"asdf\", \"cluster-c\"]\nthe missing elements were\n    <[]string | len:1, cap:1>: [\"asdf\"]",
        }
        Assertion in callback at /c/f/ramen/controllers/drpolicy_controller_test.go:34 failed:
        Expected
            <[]string | len:3, cap:3>: ["cluster-a", "cluster-b", "cluster-c"]
        to consist of
            <[]string | len:4, cap:4>: ["cluster-b", "cluster-a", "asdf", "cluster-c"]
        the missing elements were
            <[]string | len:1, cap:1>: ["asdf"]

    /c/f/ramen/controllers/drpolicy_controller_test.go:38
```
    