### PR TITLE
Allow relocation after vrg is available

### DIFF
--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -22,17 +22,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// DRAction which will be either a failover or failback action
-// +kubebuilder:validation:Enum=Failover;Failback;Relocate
+// DRAction which will be either a Failover or Relocate action
+// +kubebuilder:validation:Enum=Failover;Relocate
 type DRAction string
 
 // These are the valid values for DRAction
 const (
 	// Failover, restore PVs to the TargetCluster
 	ActionFailover = DRAction("Failover")
-
-	// Failback, restore PVs to the PreferredCluster
-	ActionFailback = DRAction("Failback")
 
 	// Relocate, restore PVs to the designated TargetCluster.  PreferredCluster will change
 	// to be the TargetCluster.
@@ -59,7 +56,7 @@ type DRPlacementControlSpec struct {
 	// need DR protection. It will be passed in to the VRG when it is created
 	PVCSelector metav1.LabelSelector `json:"pvcSelector"`
 
-	// Action is either failover or failback operation
+	// Action is either Failover or Relocate operation
 	Action DRAction `json:"action,omitempty"`
 }
 
@@ -85,14 +82,6 @@ const (
 	// FailedOver, state recorded in the DRPC status when the failover
 	// process has completed
 	FailedOver = DRState("FailedOver")
-
-	// FailingBack, state recorded in the DRPC status when the failback
-	// is initiated but has not been completed yet
-	FailingBack = DRState("FailingBack")
-
-	// FailedBack, state recorded in the DRPC status when the failback
-	// process has completed
-	FailedBack = DRState("FailedBack")
 
 	// Relocating, state recorded in the DRPC status to indicate that the
 	// relocation is in progress

--- a/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
@@ -40,10 +40,9 @@ spec:
             description: DRPlacementControlSpec defines the desired state of DRPlacementControl
             properties:
               action:
-                description: Action is either failover or failback operation
+                description: Action is either Failover or Relocate operation
                 enum:
                 - Failover
-                - Failback
                 - Relocate
                 type: string
               drPolicyRef:

--- a/controllers/drpolicy_controller_test.go
+++ b/controllers/drpolicy_controller_test.go
@@ -5,13 +5,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
+	ramen "github.com/ramendr/ramen/api/v1alpha1"
+	"github.com/ramendr/ramen/controllers/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-
-	ramen "github.com/ramendr/ramen/api/v1alpha1"
-	"github.com/ramendr/ramen/controllers/util"
 )
 
 var _ = Describe("DrpolicyController", func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -111,6 +111,7 @@ var _ = BeforeSuite(func() {
 
 	err = (&ramencontrollers.VolumeReplicationGroupReconciler{
 		Client:         k8sManager.GetClient(),
+		APIReader:      k8sManager.GetAPIReader(),
 		Log:            ctrl.Log.WithName("controllers").WithName("VolumeReplicationGroup"),
 		ObjStoreGetter: ramencontrollers.S3ObjectStoreGetter(),
 		PVDownloader:   FakePVDownloader{},
@@ -122,6 +123,7 @@ var _ = BeforeSuite(func() {
 
 	drpcReconciler := (&ramencontrollers.DRPlacementControlReconciler{
 		Client:    k8sManager.GetClient(),
+		APIReader: k8sManager.GetAPIReader(),
 		Log:       ctrl.Log.WithName("controllers").WithName("DRPlacementControl"),
 		MCVGetter: FakeMCVGetter{},
 		Scheme:    k8sManager.GetScheme(),

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -121,10 +121,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	drpcReconciler := (&ramencontrollers.DRPlacementControlReconciler{
-		Client:   k8sManager.GetClient(),
-		Log:      ctrl.Log.WithName("controllers").WithName("DRPlacementControl"),
-		Scheme:   k8sManager.GetScheme(),
-		Callback: FakeProgressCallback,
+		Client:    k8sManager.GetClient(),
+		Log:       ctrl.Log.WithName("controllers").WithName("DRPlacementControl"),
+		MCVGetter: FakeMCVGetter{},
+		Scheme:    k8sManager.GetScheme(),
+		Callback:  FakeProgressCallback,
 	})
 	err = drpcReconciler.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/controllers/util/events.go
+++ b/controllers/util/events.go
@@ -89,13 +89,6 @@ const (
 	// failover
 	EventReasonFailoverSuccess = "DRPCFailoverSuccess"
 
-	// EventsReasonFailingBack is an event generated when DRPC starts failing back
-	EventReasonFailingBack = "DRPCFailingBack"
-
-	// EventReasonFailbackSuccess is an event generated when DRPC does a successful
-	// failback
-	EventReasonFailbackSuccess = "DRPCFailbackSuccess"
-
 	// EventReasonRelocating is an event generated when DRPC starts relocating
 	EventReasonRelocating = "DRPCRelocating"
 

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -63,6 +63,7 @@ type PVDeleter interface {
 // VolumeReplicationGroupReconciler reconciles a VolumeReplicationGroup object
 type VolumeReplicationGroupReconciler struct {
 	client.Client
+	APIReader      client.Reader
 	Log            logr.Logger
 	PVDownloader   PVDownloader
 	PVUploader     PVUploader
@@ -287,7 +288,7 @@ func (r *VolumeReplicationGroupReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	// Fetch the VolumeReplicationGroup instance
-	if err := r.Get(ctx, req.NamespacedName, v.instance); err != nil {
+	if err := r.APIReader.Get(ctx, req.NamespacedName, v.instance); err != nil {
 		if errors.IsNotFound(err) {
 			log.Info("Resource not found")
 

--- a/main.go
+++ b/main.go
@@ -115,6 +115,7 @@ func setupReconcilers(mgr ctrl.Manager) {
 
 		drpcReconciler := (&controllers.DRPlacementControlReconciler{
 			Client:    mgr.GetClient(),
+			APIReader: mgr.GetAPIReader(),
 			Log:       ctrl.Log.WithName("controllers").WithName("DRPlacementControl"),
 			MCVGetter: controllers.ManagedClusterViewGetterImpl{Client: mgr.GetClient()},
 			Scheme:    mgr.GetScheme(),
@@ -130,6 +131,7 @@ func setupReconcilers(mgr ctrl.Manager) {
 
 	if err := (&controllers.VolumeReplicationGroupReconciler{
 		Client:         mgr.GetClient(),
+		APIReader:      mgr.GetAPIReader(),
 		Log:            ctrl.Log.WithName("controllers").WithName("VolumeReplicationGroup"),
 		ObjStoreGetter: controllers.S3ObjectStoreGetter(),
 		PVDownloader:   controllers.ObjectStorePVDownloader{},

--- a/main.go
+++ b/main.go
@@ -114,10 +114,11 @@ func setupReconcilers(mgr ctrl.Manager) {
 		}
 
 		drpcReconciler := (&controllers.DRPlacementControlReconciler{
-			Client:   mgr.GetClient(),
-			Log:      ctrl.Log.WithName("controllers").WithName("DRPlacementControl"),
-			Scheme:   mgr.GetScheme(),
-			Callback: func(string, string) {},
+			Client:    mgr.GetClient(),
+			Log:       ctrl.Log.WithName("controllers").WithName("DRPlacementControl"),
+			MCVGetter: controllers.ManagedClusterViewGetterImpl{Client: mgr.GetClient()},
+			Scheme:    mgr.GetScheme(),
+			Callback:  func(string, string) {},
 		})
 		if err := drpcReconciler.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "DRPlacementControl")


### PR DESCRIPTION
In this WIP PR, I have added the following:
1. Use API Reader to read DRPC/VRG objects in the reconciler function
2. allow relocation only after vrg reports vrg available and cluster data available
3. Add MCV fake getter to control unit tests
4. Removed failback code 

@vdeenadh I have added `VRGConditionClusterDataAvailable` in the status.go file but nowhere else in the VRG.  Just so that I can code against it.