### PR TITLE
Add workaround for occasional ocm-controller deployment failure

### DIFF
--- a/hack/ocm-minikube.sh
+++ b/hack/ocm-minikube.sh
@@ -235,6 +235,13 @@ ocm_foundation_operator_deploy_hub()
 	ocm_foundation_operator_kubectl_hub apply
 	kubectl --context $hub_cluster_name delete apiservices v1.clusterview.open-cluster-management.io v1alpha1.clusterview.open-cluster-management.io v1beta1.proxy.open-cluster-management.io
 	kubectl --context $hub_cluster_name -n open-cluster-management delete deployments/ocm-proxyserver services/ocm-proxyserver
+	# Start of ocm-controller failure workaround for the issue where the
+	# controller crashes due to improper rolers and missing CRD issues.
+	kubectl --context $hub_cluster_name -n open-cluster-management scale deployments/ocm-controller --replicas=0
+	sleep 1
+	kubectl --context $hub_cluster_name -n open-cluster-management scale deployments/ocm-controller --replicas=1
+	# End of ocm-controller failure workaround for the issue where the
+	# controller crashes due to improper rolers and missing CRD issues.
 	kubectl --context $hub_cluster_name -n open-cluster-management wait deployments/ocm-controller --for condition=available
 }
 exit_stack_push unset -f ocm_foundation_operator_deploy_hub


### PR DESCRIPTION
On some occasions, ocm-controller fails to come up with the following
errors:
- Failed to watch *v1alpha1.PlacementDecision: failed to list
  *v1alpha1.PlacementDecision:
  placementdecisions.cluster.open-cluster-management.io is forbidden:
  User "system:serviceaccount:open-cluster-management:foundation-hub-sa" cannot
  list resource "placementdecisions" in API group
  "cluster.open-cluster-management.io" at the cluster scope

- Controller-runtime manager exited non-zero, failed to wait for
  imageregistry-controller caches to sync: no matches for kind
  "ManagedClusterImageRegistry" in version
  "imageregistry.open-cluster-management.io/v1alpha1"
  failed to wait for imageregistry-controller caches to sync: no matches
  for kind "ManagedClusterImageRegistry" in version
  "imageregistry.open-cluster-management.io/v1alpha1"

Scale down and scale up the ocm-controller appears to work around the
unknown root cause.

Signed-off-by: Veera Deenadhayalan <vdeenadh@redhat.com>