### PR TITLE
Refactor VRG conditions

### DIFF
--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -105,7 +105,7 @@ type VolumeReplicationGroupStatus struct {
 	// All the protected pvcs
 	ProtectedPVCs ProtectedPVCMap `json:"protectedPVCs,omitempty"`
 
-	// Conditions are the list of conditions and their status.
+	// Conditions are the list of VRG's summary conditions and their status.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// observedGeneration is the last generation change the operator has dealt with

--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -55,7 +55,7 @@ const (
 // 	- Create a VolumeReplication (VR) CR to enable storage level replication
 // 	  of volume data and set the desired replication state (primary, secondary,
 //    etc).
-//  - Take the corresponding PV metadata in Kubernetes etcd and deposit it in
+//  - Take the corresponding PV cluster data in Kubernetes etcd and deposit it in
 //    the S3 store.  The url, access key and access id required to access the
 //    S3 store is specified via environment variables of the VRG operator POD,
 //    which is obtained from a secret resource.

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -42,10 +42,10 @@ spec:
               the given PVC label selector. For each such PVC, the VRG will do the
               following: \t- Create a VolumeReplication (VR) CR to enable storage
               level replication \t  of volume data and set the desired replication
-              state (primary, secondary,    etc).  - Take the corresponding PV metadata
-              in Kubernetes etcd and deposit it in    the S3 store.  The url, access
-              key and access id required to access the    S3 store is specified via
-              environment variables of the VRG operator POD,    which is obtained
+              state (primary, secondary,    etc).  - Take the corresponding PV cluster
+              data in Kubernetes etcd and deposit it in    the S3 store.  The url,
+              access key and access id required to access the    S3 store is specified
+              via environment variables of the VRG operator POD,    which is obtained
               from a secret resource.  - Manage the lifecycle of VR CR and S3 data
               according to CUD operations on    the PVC and the VRG CR."
             properties:
@@ -169,7 +169,8 @@ spec:
               state of cluster
             properties:
               conditions:
-                description: Conditions are the list of conditions and their status.
+                description: Conditions are the list of VRG's summary conditions and
+                  their status.
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1586,7 +1586,7 @@ func (d *DRPCInstance) checkPVsHaveBeenRestored(homeCluster string) (bool, error
 		return false, err
 	}
 
-	clusterDataReady := findCondition(vrg.Status.Conditions, VRGConditionClusterDataReady)
+	clusterDataReady := findCondition(vrg.Status.Conditions, VRGConditionTypeClusterDataReady)
 	if clusterDataReady == nil {
 		d.log.Info("Waiting for PVs to be restored", "cluster", homeCluster)
 

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1586,14 +1586,14 @@ func (d *DRPCInstance) checkPVsHaveBeenRestored(homeCluster string) (bool, error
 		return false, err
 	}
 
-	vrgCondition := findCondition(vrg.Status.Conditions, PVConditionMetadataAvailable)
-	if vrgCondition == nil {
+	clusterDataReady := findCondition(vrg.Status.Conditions, VRGConditionClusterDataReady)
+	if clusterDataReady == nil {
 		d.log.Info("Waiting for PVs to be restored", "cluster", homeCluster)
 
 		return false, nil
 	}
 
-	return vrgCondition.Status == metav1.ConditionTrue && vrgCondition.ObservedGeneration == vrg.Generation, nil
+	return clusterDataReady.Status == metav1.ConditionTrue && clusterDataReady.ObservedGeneration == vrg.Generation, nil
 }
 
 func (d *DRPCInstance) ensureCleanup(clusterToSkip string) error {

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -123,12 +123,12 @@ func updateManagedClusterViewWithVRG(mcvNamespace string,
 		state = rmn.SecondaryState
 	}
 
-	conType := controllers.VRGConditionDataReady
-	reason := controllers.VRGReplicating
+	conType := controllers.VRGConditionTypeDataReady
+	reason := controllers.VRGConditionReasonReplicating
 
 	if addVRGClusterDataReadyCondition {
-		conType = controllers.VRGConditionClusterDataReady
-		reason = controllers.VRGClusterDataRestored
+		conType = controllers.VRGConditionTypeClusterDataReady
+		reason = controllers.VRGConditionReasonClusterDataRestored
 	}
 
 	vrgStatus := rmn.VolumeReplicationGroupStatus{

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -117,7 +117,7 @@ func FakeProgressCallback(drpcName string, state string) {
 
 // create a VRG, then fake ManagedClusterView results
 func updateManagedClusterViewWithVRG(mcvNamespace string,
-	replicationState rmn.ReplicationState, addVRGPVCondition bool) {
+	replicationState rmn.ReplicationState, addVRGClusterDataReadyCondition bool) {
 	state := rmn.PrimaryState
 	if replicationState != rmn.Primary {
 		state = rmn.SecondaryState
@@ -126,9 +126,9 @@ func updateManagedClusterViewWithVRG(mcvNamespace string,
 	conType := controllers.VRGConditionAvailable
 	reason := controllers.VRGReplicating
 
-	if addVRGPVCondition {
-		conType = controllers.PVConditionMetadataAvailable
-		reason = controllers.PVMetadataRestored
+	if addVRGClusterDataReadyCondition {
+		conType = controllers.VRGConditionClusterDataReady
+		reason = controllers.VRGClusterDataRestored
 	}
 
 	vrgStatus := rmn.VolumeReplicationGroupStatus{

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -123,7 +123,7 @@ func updateManagedClusterViewWithVRG(mcvNamespace string,
 		state = rmn.SecondaryState
 	}
 
-	conType := controllers.VRGConditionAvailable
+	conType := controllers.VRGConditionDataReady
 	reason := controllers.VRGReplicating
 
 	if addVRGClusterDataReadyCondition {

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -24,11 +24,11 @@ import (
 
 // VRG condition types
 const (
-	VRGConditionAvailable        = "Available"
+	VRGConditionDataReady        = "DataReady"
 	VRGConditionClusterDataReady = "ClusterDataReady"
 )
 
-// VRGConditionAvailable reasons
+// VRG condition reasons
 const (
 	VRGReplicating = "Replicating"
 	VRGProgressing = "Progressing"
@@ -59,7 +59,14 @@ const (
 // figured out yet.
 func setVRGInitialCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	setStatusCondition(conditions, metav1.Condition{
-		Type:               VRGConditionAvailable,
+		Type:               VRGConditionDataReady,
+		Reason:             "none",
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionUnknown,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               VRGConditionClusterDataReady,
 		Reason:             "none",
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionUnknown,
@@ -67,10 +74,10 @@ func setVRGInitialCondition(conditions *[]metav1.Condition, observedGeneration i
 	})
 }
 
-// sets conditions when VRG is replicating
-func setVRGReplicatingCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+// sets conditions when VRG is data replicating
+func setVRGDataReplicatingCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	setStatusCondition(conditions, metav1.Condition{
-		Type:               VRGConditionAvailable,
+		Type:               VRGConditionDataReady,
 		Reason:             VRGReplicating,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionTrue,
@@ -78,10 +85,10 @@ func setVRGReplicatingCondition(conditions *[]metav1.Condition, observedGenerati
 	})
 }
 
-// sets conditions when VRG is progressing
-func setVRGProgressingCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+// sets conditions when VRG data is progressing
+func setVRGDataProgressingCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	setStatusCondition(conditions, metav1.Condition{
-		Type:               VRGConditionAvailable,
+		Type:               VRGConditionDataReady,
 		Reason:             VRGProgressing,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
@@ -90,9 +97,9 @@ func setVRGProgressingCondition(conditions *[]metav1.Condition, observedGenerati
 }
 
 // sets conditions when VRG sees failures in data sync
-func setVRGErrorCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+func setVRGDataErrorCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	setStatusCondition(conditions, metav1.Condition{
-		Type:               VRGConditionAvailable,
+		Type:               VRGConditionDataReady,
 		Reason:             VRGError,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -24,24 +24,18 @@ import (
 
 // VRG condition types
 const (
-	VRGConditionAvailable = "Available"
+	VRGConditionAvailable        = "Available"
+	VRGConditionClusterDataReady = "ClusterDataReady"
 )
 
-// Protected PVC condition types
-const (
-	PVCConditionAvailable = "Available"
-)
-
-const (
-	PVConditionMetadataAvailable = "MetadataAvailable"
-)
-
+// VRGConditionAvailable reasons
 const (
 	VRGReplicating = "Replicating"
 	VRGProgressing = "Progressing"
 	VRGError       = "Error"
 )
 
+// PVCConditionAvailable reasons
 const (
 	PVCReplicating  = "Replicating"
 	PVCProgressing  = "Progressing"
@@ -49,10 +43,16 @@ const (
 	PVCErrorUnknown = "UnknownError"
 )
 
+// PVC condition types
 const (
-	PVMetadataRestored    = "Restored"
-	PVMetadataProgressing = "Progressing"
-	PVMetadataError       = "Error"
+	PVCConditionAvailable = "Available"
+)
+
+// VRGConditionClusterDataReady reasons
+const (
+	VRGClusterDataRestored    = "Restored"
+	VRGClusterDataProgressing = "Progressing"
+	VRGClusterDataError       = "Error"
 )
 
 // Just when VRG has been picked up for reconciliation when nothing has been
@@ -150,33 +150,33 @@ func setPVCErrorUnknownCondition(conditions *[]metav1.Condition, observedGenerat
 	})
 }
 
-// sets conditions when PV meatadata is restored
-func setPVMetadataAvailableCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+// sets conditions when PV cluster data is restored
+func setVRGClusterDataReadyCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	setStatusCondition(conditions, metav1.Condition{
-		Type:               PVConditionMetadataAvailable,
-		Reason:             PVMetadataRestored,
+		Type:               VRGConditionClusterDataReady,
+		Reason:             VRGClusterDataRestored,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionTrue,
 		Message:            message,
 	})
 }
 
-// sets conditions when PV metadata is being restored
-func setPVMetadataProgressingCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+// sets conditions when PV cluster data is being restored
+func setVRGClusterDataProgressingCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	setStatusCondition(conditions, metav1.Condition{
-		Type:               PVConditionMetadataAvailable,
-		Reason:             PVMetadataProgressing,
+		Type:               VRGConditionClusterDataReady,
+		Reason:             VRGClusterDataProgressing,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
 		Message:            message,
 	})
 }
 
-// sets conditions when PV metadata failed to restore
-func setPVMetadataErrorCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+// sets conditions when PV cluster data failed to restore
+func setVRGClusterDataErrorCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	setStatusCondition(conditions, metav1.Condition{
-		Type:               PVConditionMetadataAvailable,
-		Reason:             PVMetadataError,
+		Type:               VRGConditionClusterDataReady,
+		Reason:             VRGClusterDataError,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
 		Message:            message,

--- a/controllers/util/events.go
+++ b/controllers/util/events.go
@@ -50,7 +50,7 @@ const (
 	// EventReasonProtectPVCFailed is used when VRG fails to protect PVC
 	EventReasonProtectPVCFailed = "ProtectPVCFailed"
 
-	// EventReasonPVUploadFailed is used when VRG fails to upload PV metadata
+	// EventReasonPVUploadFailed is used when VRG fails to upload PV cluster data
 	EventReasonPVUploadFailed = "PVUploadFailed"
 
 	// EventReasonPrimarySuccess is an event generated when VRG is successfully

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -738,13 +738,13 @@ func (v *vrgTest) getVRG(vrgName string) *ramendrv1alpha1.VolumeReplicationGroup
 func (v *vrgTest) verifyVRGStatusExpectation(expectedStatus bool) {
 	Eventually(func() bool {
 		vrg := v.getVRG(v.vrgName)
-		vrgAvailableCondition := checkConditions(vrg.Status.Conditions, vrgController.VRGConditionDataReady)
+		dataReadyCondition := checkConditions(vrg.Status.Conditions, vrgController.VRGConditionTypeDataReady)
 
 		if expectedStatus == true {
-			return vrgAvailableCondition.Status == metav1.ConditionTrue
+			return dataReadyCondition.Status == metav1.ConditionTrue
 		}
 
-		return vrgAvailableCondition.Status != metav1.ConditionTrue
+		return dataReadyCondition.Status != metav1.ConditionTrue
 	}, vrgtimeout, vrginterval).Should(BeTrue(),
 		"while waiting for VRG TRUE condition %s/%s", v.vrgName, v.namespace)
 }
@@ -935,10 +935,10 @@ func (v *vrgTest) waitForVolRepPromotion(vrNamespacedName types.NamespacedName, 
 		// as of now name of VolumeReplication resource created by the VolumeReplicationGroup
 		// is same as the pvc that it replicates. When that changes this has to be changed to
 		// use the right name to get the appropriate protected PVC condition from VRG status.
-		pvcAvailableCondition := checkConditions(vrg.Status.ProtectedPVCs[updatedVolRep.Name].Conditions,
-			vrgController.PVCConditionAvailable)
+		dataReadyCondition := checkConditions(vrg.Status.ProtectedPVCs[updatedVolRep.Name].Conditions,
+			vrgController.VRGConditionTypeDataReady)
 
-		return pvcAvailableCondition.Status == metav1.ConditionTrue
+		return dataReadyCondition.Status == metav1.ConditionTrue
 	}, vrgtimeout, vrginterval).Should(BeTrue(),
 		"while waiting for protected pvc condition %s/%s", updatedVolRep.Namespace, updatedVolRep.Name)
 

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -738,7 +738,7 @@ func (v *vrgTest) getVRG(vrgName string) *ramendrv1alpha1.VolumeReplicationGroup
 func (v *vrgTest) verifyVRGStatusExpectation(expectedStatus bool) {
 	Eventually(func() bool {
 		vrg := v.getVRG(v.vrgName)
-		vrgAvailableCondition := checkConditions(vrg.Status.Conditions, vrgController.VRGConditionAvailable)
+		vrgAvailableCondition := checkConditions(vrg.Status.Conditions, vrgController.VRGConditionDataReady)
 
 		if expectedStatus == true {
 			return vrgAvailableCondition.Status == metav1.ConditionTrue

--- a/docs/install.md
+++ b/docs/install.md
@@ -22,7 +22,7 @@ Ramen also works as part of the [OCM managed clusters] to orchestrate,
 
 - [VolumeReplication](https://github.com/csi-addons/volume-replication-operator/blob/main/api/v1alpha1/volumereplication_types.go)
   resources for all PVCs of an application
-- Preserving metadata regarding each PVC that is replicated
+- Preserving cluster data regarding each PVC that is replicated
 
 VolumeReplication resources require storage providers to support
 [CSI extensions](https://github.com/csi-addons/spec) that enable managing
@@ -39,11 +39,11 @@ kubernetes cluster to manage VRG resources.
 
 ### S3 store
 
-Ramen preserves metadata related to VolumeReplication resources in an S3
+Ramen preserves cluster data related to PV resources in an S3
 compatible object store. An S3 store endpoint is hence required as part of the
 setup.
 
-Ramen specifically stores PV metadata for a replicated PVC, to restore the same
+Ramen specifically stores PV cluster data for a replicated PVC, to restore the same
 across peer cluster prior to deploying the PVCs of the application, to ensure
 proper binding of the PVC resources to the replicated storage end points.
 


### PR DESCRIPTION
Contains three commits:

- Rename VRG condition MetadataAvailable to ClusterDataReady
- Rename VRG condition Available to DataReady
- Refactor VRG conditions to use the same code to update the VRG summary level as well as PVC level conditions.

For ease of PR review, the new ClusterDataProtected VRG condition will be submitted as a separate PR.