### PR TITLE
Increase the memory resources for the operator

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,9 +52,9 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 300Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 200Mi
       serviceAccountName: operator
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Changing it to 300Mi limit and 200Mi request. This is just a guess and
we might have to revisit after collecting more data.

Fixes: #256 

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>