### PR TITLE
Update bundle name with "-operator" suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,12 @@ IMAGE_NAME ?= ramen
 IMAGE_TAG ?= latest
 IMAGE_TAG_BASE = $(IMAGE_REGISTRY)/$(IMAGE_REPOSITORY)/$(IMAGE_NAME)
 
-HUB_NAME ?= $(IMAGE_NAME)-hub
+HUB_NAME ?= $(IMAGE_NAME)-hub-operator
 ifeq (dr,$(findstring dr,$(IMAGE_NAME)))
-	DRCLUSTER_NAME = $(IMAGE_NAME)-cluster
+	DRCLUSTER_NAME = $(IMAGE_NAME)-cluster-operator
 	BUNDLE_IMG_DRCLUSTER = $(IMAGE_TAG_BASE)-cluster-operator-bundle:$(IMAGE_TAG)
 else
-	DRCLUSTER_NAME = $(IMAGE_NAME)-dr-cluster
+	DRCLUSTER_NAME = $(IMAGE_NAME)-dr-cluster-operator
 	BUNDLE_IMG_DRCLUSTER = $(IMAGE_TAG_BASE)-dr-cluster-operator-bundle:$(IMAGE_TAG)
 endif
 

--- a/config/dr-cluster/manifests/bases/ramen_dr_cluster.clusterserviceversion.yaml
+++ b/config/dr-cluster/manifests/bases/ramen_dr_cluster.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-  name: ramen-dr-cluster.v0.0.0
+  name: ramen-dr-cluster-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/config/hub/manifests/bases/ramen_hub.clusterserviceversion.yaml
+++ b/config/hub/manifests/bases/ramen_hub.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-  name: ramen-hub.v0.0.0
+  name: ramen-hub-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/config/olm-install/dr-cluster/kustomization.yaml
+++ b/config/olm-install/dr-cluster/kustomization.yaml
@@ -18,7 +18,7 @@ patches:
       value: alpha
     - op: replace
       path: /spec/startingCSV
-      value: ramen-dr-cluster.v0.0.1
+      value: ramen-dr-cluster-operator.v0.0.1
   target:
     kind: Subscription
     name: ramen-dr-cluster-subscription

--- a/config/olm-install/dr-cluster/ramen-dr-cluster-subscription.yaml
+++ b/config/olm-install/dr-cluster/ramen-dr-cluster-subscription.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   channel: "alpha"
   installPlanApproval: Automatic
-  name: ramen-dr-cluster
+  name: ramen-dr-cluster-operator
   source: ramen-catalog
   sourceNamespace: ramen-system
-  startingCSV: ramen-dr-cluster.v0.0.1
+  startingCSV: ramen-dr-cluster-operator.v0.0.1

--- a/config/olm-install/hub/kustomization.yaml
+++ b/config/olm-install/hub/kustomization.yaml
@@ -18,7 +18,7 @@ patches:
       value: alpha
     - op: replace
       path: /spec/startingCSV
-      value: ramen-hub.v0.0.1
+      value: ramen-hub-operator.v0.0.1
   target:
     kind: Subscription
     name: ramen-hub-subscription

--- a/config/olm-install/hub/ramen-hub-subscription.yaml
+++ b/config/olm-install/hub/ramen-hub-subscription.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   channel: "alpha"
   installPlanApproval: Automatic
-  name: ramen-hub
+  name: ramen-hub-operator
   source: ramen-catalog
   sourceNamespace: ramen-system
-  startingCSV: ramen-hub.v0.0.1
+  startingCSV: ramen-hub-operator.v0.0.1


### PR DESCRIPTION
The CSV file name and the bundle name was missing the `-operator` suffix.

This PR fixes the same, to align with other operators.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>