### PR TITLE
Requeue if VRG as primary fails

### DIFF
--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -866,6 +866,10 @@ func (v *VRGInstance) reconcileVRsAsPrimary() bool {
 		if _, err := v.processVRAsPrimary(pvcNamespacedName, log); err != nil {
 			log.Info("Requeuing due to failure in getting or creating VolumeReplication resource for PersistentVolumeClaim",
 				"errorValue", err)
+
+			requeue = true
+
+			continue
 		}
 
 		// Protect the PVC's PV object stored in etcd by uploading it to S3


### PR DESCRIPTION
This was removed recently due to code shuffling
and caused an issue where VRG was not being
reconciled if a VolumeReplicationClass was not found
for the appropriate schedule and later corrected.

As there is no watch/trigger for VRClass as such
and it is expected that we requeue when we hit such
errors, correcting the same adding the requeue back.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>