### PR TITLE
ocm-minikube-ramen.sh: add failover and relocate commands

### DIFF
--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -4,14 +4,16 @@ set -x
 set -e
 ramen_hack_directory_path_name=$(dirname $0)
 . $ramen_hack_directory_path_name/exit_stack.sh
+. $ramen_hack_directory_path_name/true_if_exit_status_and_stderr.sh
+exit_stack_push unset -f true_if_exit_status_and_stderr
 . $ramen_hack_directory_path_name/until_true_or_n.sh
 exit_stack_push unset -f until_true_or_n
 exit_stack_push unset -v ramen_hack_directory_path_name
-rook_ceph_deploy()
+rook_ceph_deploy_spoke()
 {
 	PROFILE=$1 $ramen_hack_directory_path_name/minikube-rook-setup.sh create
 }
-exit_stack_push unset -f rook_ceph_deploy
+exit_stack_push unset -f rook_ceph_deploy_spoke
 rook_ceph_mirrors_deploy()
 {
 	PRIMARY_CLUSTER=$1 SECONDARY_CLUSTER=$2 $ramen_hack_directory_path_name/minikube-rook-mirror-setup.sh
@@ -20,19 +22,26 @@ rook_ceph_mirrors_deploy()
 	PRIMARY_CLUSTER=$2 SECONDARY_CLUSTER=$1 $ramen_hack_directory_path_name/minikube-rook-mirror-test.sh
 }
 exit_stack_push unset -f rook_ceph_mirrors_deploy
-rook_ceph_undeploy()
+rook_ceph_undeploy_spoke()
 {
 	PROFILE=$1 $ramen_hack_directory_path_name/minikube-rook-setup.sh delete
 }
-exit_stack_push unset -f rook_ceph_undeploy
+exit_stack_push unset -f rook_ceph_undeploy_spoke
 minio_deploy()
 {
-	kubectl --context $1 apply -f $ramen_hack_directory_path_name/minio-deployment.yaml
+	for cluster_name in $spoke_cluster_names; do
+		kubectl --context $cluster_name apply -f $ramen_hack_directory_path_name/minio-deployment.yaml
+		date
+		kubectl --context $cluster_name -n minio wait deployments/minio --for condition=available --timeout 60s
+		date
+	done; unset -v cluster_name
 }
 exit_stack_push unset -f minio_deploy
 minio_undeploy()
 {
-	kubectl --context $1 delete -f $ramen_hack_directory_path_name/minio-deployment.yaml
+	for cluster_name in $spoke_cluster_names; do
+		kubectl --context $cluster_name delete -f $ramen_hack_directory_path_name/minio-deployment.yaml
+	done; unset -v cluster_name
 }
 exit_stack_push unset -f minio_undeploy
 ramen_image_directory_name=${ramen_image_directory_name-localhost}
@@ -45,7 +54,7 @@ ramen_build()
 	${ramen_hack_directory_path_name}/docker-uninstall.sh ${HOME}/.local/bin
 	. ${ramen_hack_directory_path_name}/podman-docker-install.sh
 	. ${ramen_hack_directory_path_name}/go-install.sh; go_install ${HOME}/.local; unset -f go_install
-	make -C ${1} docker-build IMG=${ramen_image_name_colon_tag}
+	make -C $ramen_directory_path_name docker-build IMG=$ramen_image_name_colon_tag
 	ramen_archive
 }
 exit_stack_push unset -f ramen_build
@@ -70,7 +79,7 @@ kube_context_set_undo()
 	exit_stack_pop
 }
 exit_stack_push unset -f kube_context_set_undo
-ramen_deploy()
+ramen_deploy_hub_or_spoke()
 {
 	minikube -p ${2} image load ${ramen_image_name_colon_tag}
 	kube_context_set ${2}
@@ -78,26 +87,33 @@ ramen_deploy()
 	kube_context_set_undo
 	kubectl --context ${2} -n ramen-system wait deployments --all --for condition=available --timeout 60s
 	# Add s3 profile to ramen config
-	cat <<EOF | kubectl --context ${2} apply -f -
-apiVersion: v1
-kind: Secret
-metadata:
-  name: s3secret
-  namespace: ramen-system
-stringData:
-  AWS_ACCESS_KEY_ID: "minio"
-  AWS_SECRET_ACCESS_KEY: "minio123"
-EOF
+	cat <<-EOF | kubectl --context $2 apply -f -
+	apiVersion: v1
+	kind: Secret
+	metadata:
+	  name: s3secret
+	  namespace: ramen-system
+	stringData:
+	  AWS_ACCESS_KEY_ID: "minio"
+	  AWS_SECRET_ACCESS_KEY: "minio123"
+	EOF
 	ramen_config_map_name=ramen-${3}-operator-config
 	until_true_or_n 90 kubectl --context ${2} -n ramen-system get configmap ${ramen_config_map_name}
 	cp ${1}/config/${3}/manager/ramen_manager_config.yaml /tmp/ramen_manager_config.yaml
-	cat <<-EOF >> /tmp/ramen_manager_config.yaml
-
+	set -- $1 $2 $3 $spoke_cluster_names
+	cat <<-EOF >>/tmp/ramen_manager_config.yaml
 	s3StoreProfiles:
-	- s3ProfileName: $s3_store_profile_name
-	  s3BucketName: $s3_store_profile_name
-	  s3CompatibleEndpoint: $(minikube --profile=$s3_store_cluster_name -n minio service --url minio)
+	- s3ProfileName: minio-on-$4
+	  s3BucketName: ramen
+	  s3CompatibleEndpoint: $(minikube --profile $4 -n minio service --url minio)
 	  s3Region: us-east-1
+	  s3SecretRef:
+	    name: s3secret
+	    namespace: ramen-system
+	- s3ProfileName: minio-on-$5
+	  s3BucketName: ramen
+	  s3CompatibleEndpoint: $(minikube --profile $5 -n minio service --url minio)
+	  s3Region: us-west-1
 	  s3SecretRef:
 	    name: s3secret
 	    namespace: ramen-system
@@ -109,18 +125,18 @@ EOF
 		kubectl --context ${2} -n ramen-system replace -f -
 	unset -v ramen_config_map_name
 }
-exit_stack_push unset -f ramen_deploy
+exit_stack_push unset -f ramen_deploy_hub_or_spoke
 ramen_deploy_hub()
 {
-	ramen_deploy $1 $2 hub
+	ramen_deploy_hub_or_spoke $1 $2 hub
 }
 exit_stack_push unset -f ramen_deploy_hub
 ramen_deploy_spoke()
 {
-	ramen_deploy $1 $2 dr-cluster
+	ramen_deploy_hub_or_spoke $1 $2 dr-cluster
 }
 exit_stack_push unset -f ramen_deploy_spoke
-ramen_undeploy()
+ramen_undeploy_hub_or_spoke()
 {
 	kube_context_set ${2}
 	make -C $1 undeploy-$3
@@ -134,31 +150,32 @@ ramen_undeploy()
 	# Makefile:149: recipe for target 'undeploy-hub' failed
 	# make: *** [undeploy-hub] Error 1
 	kube_context_set_undo
-	minikube -p $2 ssh docker image rm $ramen_image_name_colon_tag
+	minikube -p $2 ssh -- docker image rm $ramen_image_name_colon_tag
 	# Error: No such image: $ramen_image_name_colon_tag
 	# ssh: Process exited with status 1
 }
-exit_stack_push unset -f ramen_undeploy
+exit_stack_push unset -f ramen_undeploy_hub_or_spoke
 ramen_undeploy_hub()
 {
-	ramen_undeploy $1 $2 hub
+	ramen_undeploy_hub_or_spoke $1 $2 hub
 }
 exit_stack_push unset -f ramen_undeploy_hub
 ramen_undeploy_spoke()
 {
-	ramen_undeploy $1 $2 dr-cluster
+	ramen_undeploy_hub_or_spoke $1 $2 dr-cluster
 }
 exit_stack_push unset -f ramen_undeploy_spoke
 ocm_ramen_samples_git_ref=${ocm_ramen_samples_git_ref-main}
 ocm_ramen_samples_git_path=${ocm_ramen_samples_git_path-ramendr}
 exit_stack_push unset -v ocm_ramen_samples_git_ref
-application_sample_deploy()
+ramen_samples_channel_and_drpolicy_deploy()
 {
-	set -- /tmp/$USER/ocm-ramen-samples/subscriptions $spoke_cluster_names
+	set -- ocm-ramen-samples/subscriptions
+	set -- /tmp/$USER/$1 $1 $spoke_cluster_names
 	mkdir -p $1
 	cat <<-a >$1/kustomization.yaml
 	resources:
-	  - https://github.com/$ocm_ramen_samples_git_path/ocm-ramen-samples/subscriptions?ref=$ocm_ramen_samples_git_ref
+	  - https://github.com/$ocm_ramen_samples_git_path/$2?ref=$ocm_ramen_samples_git_ref
 	patchesJson6902:
 	  - target:
 	      group: ramendr.openshift.io
@@ -169,19 +186,49 @@ application_sample_deploy()
 	      - op: replace
 	        path: /spec/drClusterSet
 	        value:
-	          - name: $2
-	            s3ProfileName: $s3_store_profile_name
 	          - name: $3
-	            s3ProfileName: $s3_store_profile_name
+	            s3ProfileName: minio-on-$3
+	          - name: $4
+	            s3ProfileName: minio-on-$4
 	a
 	kubectl --context $hub_cluster_name apply -k $1
-	set --
-	kubectl --context ${hub_cluster_name} -n ramen-samples get channels/ramen-gitops
-	kubectl --context $hub_cluster_name apply -k https://github.com/$ocm_ramen_samples_git_path/ocm-ramen-samples/subscriptions/busybox?ref=$ocm_ramen_samples_git_ref
-	kubectl --context ${hub_cluster_name} -n busybox-sample get placementrules/busybox-placement
+	kubectl --context $hub_cluster_name -n ramen-samples get channels/ramen-gitops
+}
+exit_stack_push unset -f ramen_samples_channel_and_drpolicy_deploy
+ramen_samples_channel_and_drpolicy_undeploy()
+{
+	date
+	kubectl --context $hub_cluster_name delete -k https://github.com/$ocm_ramen_samples_git_path/ocm-ramen-samples/subscriptions?ref=$ocm_ramen_samples_git_ref
+	date
+}
+exit_stack_push unset -f ramen_samples_channel_and_drpolicy_undeploy
+application_sample_place()
+{
+	set -- $1 "$2" $3 $4 "$5" $6 ocm-ramen-samples subscriptions/busybox
+	set -- $1 "$2" $3 https://$4/$ocm_ramen_samples_git_path/$7$5/$8$6 /tmp/$USER/$7/$8
+	mkdir -p $5
+	cat <<-a >$5/kustomization.yaml
+	resources:
+	  - $4
+	namespace: busybox-sample
+	patchesJson6902:
+	  - target:
+	      group: ramendr.openshift.io
+	      version: v1alpha1
+	      kind: DRPlacementControl
+	      name: busybox-drpc
+	    patch: |-
+	      - op: add
+	        path: /spec/action
+	        value: $2
+	      - op: add
+	        path: /spec/$3Cluster
+	        value: $1
+	a
+	kubectl create namespace busybox-sample --dry-run=client -o yaml | kubectl --context $1 apply -f -
+	kubectl --context $hub_cluster_name apply -k $5
 	until_true_or_n 90 eval test \"\$\(kubectl --context ${hub_cluster_name} -n busybox-sample get subscriptions/busybox-sub -ojsonpath='{.status.phase}'\)\" = Propagated
-	until_true_or_n 1 eval test -n \"\$\(kubectl --context ${hub_cluster_name} -n busybox-sample get placementrules/busybox-placement -ojsonpath='{.status.decisions[].clusterName}'\)\"
-	set -- $(kubectl --context ${hub_cluster_name} -n busybox-sample get placementrules/busybox-placement -ojsonpath='{.status.decisions[].clusterName}')
+	until_true_or_n 30 eval test \"\$\(kubectl --context $hub_cluster_name -n busybox-sample get placementrules/busybox-placement -ojsonpath='{.status.decisions[].clusterName}'\)\" = $1
 	if test ${1} = ${hub_cluster_name}; then
 		subscription_name_suffix=-local
 	else
@@ -195,57 +242,91 @@ application_sample_deploy()
 	until_true_or_n 90 kubectl --context ${1} -n busybox-sample get volumereplicationgroups/busybox-drpc
 	date
 }
+exit_stack_push unset -f application_sample_place
+application_sample_undeploy_wait_and_namespace_undeploy()
+{
+	date
+	true_if_exit_status_and_stderr 1 'error: no matching resources found' \
+	kubectl --context ${1} -n busybox-sample wait pods/busybox --for delete --timeout 2m
+	date
+	true_if_exit_status_and_stderr 1 'error: no matching resources found' \
+	kubectl --context ${1} -n busybox-sample wait volumereplicationgroups/busybox-drpc --for delete
+	date
+	true_if_exit_status_and_stderr 1 'error: no matching resources found' \
+	kubectl --context $1 -n busybox-sample wait persistentvolumeclaims/busybox-pvc --for delete
+	date
+	kubectl --context $1 delete $2 namespace/busybox-sample
+	date
+}
+exit_stack_push unset -f application_sample_undeploy_wait_and_namespace_undeploy
+application_sample_deploy()
+{
+	ramen_samples_channel_and_drpolicy_deploy
+	set -- $spoke_cluster_names
+	application_sample_place $1 '' preferred github.com '' \?ref=$ocm_ramen_samples_git_ref
+}
 exit_stack_push unset -f application_sample_deploy
+application_sample_failover()
+{
+	set -- $spoke_cluster_names
+	application_sample_place $2 Failover failover raw.githubusercontent.com /$ocm_ramen_samples_git_ref /drpc.yaml
+	application_sample_undeploy_wait_and_namespace_undeploy $1
+}
+exit_stack_push unset -f application_sample_failover
+application_sample_relocate()
+{
+	set -- $spoke_cluster_names
+	application_sample_place $1 Relocate preferred raw.githubusercontent.com /$ocm_ramen_samples_git_ref /drpc.yaml
+	application_sample_undeploy_wait_and_namespace_undeploy $2
+}
+exit_stack_push unset -f application_sample_relocate
 application_sample_undeploy()
 {
 	set -- $(kubectl --context ${hub_cluster_name} -n busybox-sample get placementrules/busybox-placement -ojsonpath='{.status.decisions[].clusterName}')
-	kubectl --context ${1} delete persistentvolumes $(kubectl --context ${1} -n busybox-sample get persistentvolumeclaims/busybox-pvc -ojsonpath='{.spec.volumeName}') --wait=false
 	kubectl --context $hub_cluster_name delete -k https://github.com/$ocm_ramen_samples_git_path/ocm-ramen-samples/subscriptions/busybox?ref=$ocm_ramen_samples_git_ref
-	date
-	set +e
-	kubectl --context ${1} -n busybox-sample wait pods/busybox --for delete --timeout 2m
-	# error: no matching resources found
-	set -e
-	date
-	set +e
-	kubectl --context ${1} -n busybox-sample wait volumereplicationgroups/busybox-drpc --for delete
-	# error: no matching resources found
-	set -e
-	date
-	kubectl --context $hub_cluster_name delete -k https://github.com/$ocm_ramen_samples_git_path/ocm-ramen-samples/subscriptions?ref=$ocm_ramen_samples_git_ref
-	date
+	application_sample_undeploy_wait_and_namespace_undeploy $1
+	ramen_samples_channel_and_drpolicy_undeploy
 }
 exit_stack_push unset -f application_sample_undeploy
 ramen_directory_path_name=${ramen_hack_directory_path_name}/..
 exit_stack_push unset -v ramen_directory_path_name
 hub_cluster_name=${hub_cluster_name:-hub}
 exit_stack_push unset -v hub_cluster_name
-spoke_cluster_names=${spoke_cluster_names:-${hub_cluster_name}\ cluster1}
+spoke_cluster_names=${spoke_cluster_names:-cluster1\ $hub_cluster_name}
 exit_stack_push unset -v spoke_cluster_names
-cluster_names=$hub_cluster_name
-for cluster_name in ${spoke_cluster_names}; do
-	if test $cluster_name != $hub_cluster_name; then
-		cluster_names=$cluster_names\ $cluster_name
-	fi
-done; unset -v cluster_name
-exit_stack_push unset -v cluster_names
-rook_ceph_deploy_all()
+rook_ceph_deploy()
 {
 	# volumes required: mirror sources, mirror targets, minio backend
-	for cluster_name in $cluster_names; do
-		rook_ceph_deploy $cluster_name
+	for cluster_name in $spoke_cluster_names; do
+		rook_ceph_deploy_spoke $cluster_name
 	done; unset -v cluster_name
 	rook_ceph_mirrors_deploy $spoke_cluster_names
 }
-exit_stack_push unset -v rook_ceph_deploy_all
-rook_ceph_undeploy_all()
+exit_stack_push unset -f rook_ceph_deploy
+rook_ceph_undeploy()
 {
-	for cluster_name in $cluster_names; do
-		rook_ceph_undeploy $cluster_name
+	for cluster_name in $spoke_cluster_names; do
+		rook_ceph_undeploy_spoke $cluster_name
 	done; unset -v cluster_name
 }
-exit_stack_push unset -v rook_ceph_undeploy_all
-ramen_deploy_all()
+exit_stack_push unset -f rook_ceph_undeploy
+rook_ceph_csi_image_canary_deploy()
+{
+	for cluster_name in $spoke_cluster_names; do
+		minikube -p $cluster_name ssh -- docker image pull quay.io/cephcsi/cephcsi:canary
+		kubectl --context $cluster_name -n rook-ceph rollout restart deploy/csi-rbdplugin-provisioner
+	done; unset -v cluster_name
+}
+exit_stack_push unset -f rook_ceph_csi_image_canary_deploy
+rook_ceph_volume_replication_image_latest_deploy()
+{
+	for cluster_name in $spoke_cluster_names; do
+		minikube -p $cluster_name ssh -- docker image pull quay.io/csiaddons/volumereplication-operator:latest
+		kubectl --context $cluster_name -n rook-ceph rollout restart deploy/csi-rbdplugin-provisioner
+	done; unset -v cluster_name
+}
+exit_stack_push unset -f rook_ceph_volume_replication_image_latest_deploy
+ramen_deploy()
 {
 	. ${ramen_hack_directory_path_name}/go-install.sh; go_install ${HOME}/.local; unset -f go_install
 	ramen_deploy_hub $ramen_directory_path_name $hub_cluster_name
@@ -253,8 +334,8 @@ ramen_deploy_all()
 		ramen_deploy_spoke $ramen_directory_path_name $cluster_name
 	done; unset -v cluster_name
 }
-exit_stack_push unset -v ramen_deploy_all
-ramen_undeploy_all()
+exit_stack_push unset -f ramen_deploy
+ramen_undeploy()
 {
 	. ${ramen_hack_directory_path_name}/go-install.sh; go_install ${HOME}/.local; unset -f go_install
 	for cluster_name in $spoke_cluster_names; do
@@ -264,55 +345,29 @@ ramen_undeploy_all()
 	ramen_undeploy_hub $ramen_directory_path_name $hub_cluster_name
 	set -e
 }
-exit_stack_push unset -v ramen_undeploy_all
-s3_store_cluster_name=$hub_cluster_name
-s3_store_profile_name=minio-on-$s3_store_cluster_name
-exit_stack_push unset -v s3_store_profile_name s3_store_cluster_name
-exit_stack_push unset -v command
+exit_stack_push unset -f ramen_undeploy
+deploy()
+{
+	hub_cluster_name=$hub_cluster_name spoke_cluster_names=$spoke_cluster_names $ramen_hack_directory_path_name/ocm-minikube.sh
+	rook_ceph_deploy
+	minio_deploy
 # ENV variable to skip building ramen
 #   - deploy will expect pre-loaded local docker image named
 #     ${ramen_image_directory_name}/${ramen_image_name}:${ramen_image_tag}
-skip_ramen_build=${skip_ramen_build:-false}
+	if test "${skip_ramen_build:-false}" = false; then
+		ramen_build
+	fi
+	ramen_deploy
+}
+exit_stack_push unset -f deploy
+undeploy()
+{
+	ramen_undeploy
+	minio_undeploy
+	rook_ceph_undeploy
+}
+exit_stack_push unset -f undeploy
+exit_stack_push unset -v command
 for command in "${@:-deploy}"; do
-	case ${command} in
-	deploy)
-		hub_cluster_name=${hub_cluster_name} spoke_cluster_names=${spoke_cluster_names}\
-		${ramen_hack_directory_path_name}/ocm-minikube.sh
-		rook_ceph_deploy_all
-		minio_deploy $s3_store_cluster_name
-		if [ "$skip_ramen_build" = false ] ; then
-		    ramen_build ${ramen_directory_path_name}
-		fi
-		ramen_deploy_all
-		;;
-	undeploy)
-		ramen_undeploy_all
-		minio_undeploy $s3_store_cluster_name
-		rook_ceph_undeploy_all
-		;;
-	application_sample_deploy)
-		application_sample_deploy
-		;;
-	application_sample_undeploy)
-		application_sample_undeploy
-		;;
-	ramen_build)
-		ramen_build ${ramen_directory_path_name}
-		;;
-	ramen_deploy)
-		ramen_deploy_all
-		;;
-	ramen_undeploy)
-		ramen_undeploy_all
-		;;
-	rook_ceph_deploy)
-		rook_ceph_deploy_all
-		;;
-	rook_ceph_undeploy)
-		rook_ceph_undeploy_all
-		;;
-	*)
-		echo subcommand unsupported: ${command}
-		;;
-	esac
+	$command
 done

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -105,14 +105,14 @@ ramen_deploy_hub_or_spoke()
 	cat <<-EOF >>/tmp/ramen_manager_config.yaml
 	s3StoreProfiles:
 	- s3ProfileName: minio-on-$3
-	  s3BucketName: ramen
+	  s3Bucket: bucket
 	  s3CompatibleEndpoint: $(minikube --profile $3 -n minio service --url minio)
 	  s3Region: us-east-1
 	  s3SecretRef:
 	    name: s3secret
 	    namespace: ramen-system
 	- s3ProfileName: minio-on-$4
-	  s3BucketName: ramen
+	  s3Bucket: bucket
 	  s3CompatibleEndpoint: $(minikube --profile $4 -n minio service --url minio)
 	  s3Region: us-west-1
 	  s3SecretRef:

--- a/hack/true_if_exit_status_and_stderr.sh
+++ b/hack/true_if_exit_status_and_stderr.sh
@@ -1,0 +1,26 @@
+# shellcheck shell=sh
+true_if_exit_status_and_stderr()
+{
+	exit_status_expected=$1
+	stderr_expected=$2
+	shift 2
+	stderr_pipe_name1=/tmp/$$.err1 stderr_pipe_name2=/tmp/$$.err2
+	rm -f $stderr_pipe_name1 $stderr_pipe_name2
+	mkfifo -m o=rw $stderr_pipe_name1 $stderr_pipe_name2
+	tee $stderr_pipe_name2 <$stderr_pipe_name1 >&2 &
+	tee_pid=$!
+	case $- in *e*) e=-e; set +e;; *) e= ; esac
+	"$@" 2>$stderr_pipe_name1
+	set $e -- $?
+	unset -v e
+	stderr=$(cat $stderr_pipe_name2)
+	wait $tee_pid
+	unset -v tee_pid
+	rm -f $stderr_pipe_name1 $stderr_pipe_name2
+	unset -v stderr_pipe_name1 stderr_pipe_name2
+	if test "$1" -eq "$exit_status_expected" && test "$stderr" = "$stderr_expected"; then
+		set -- 0
+	fi
+	unset -v stderr stderr_expected exit_status_expected
+	return "$1"
+}


### PR DESCRIPTION
This pull request adds new commands to `ocm-minikube-ramen.sh`:
- `application_sample_failover` to the 2nd cluster name in `spoke_cluster_names`
- `application_sample_relocate` to the 1st cluster name in `spoke_cluster_names`
- `ramen_deploy_hub`

Notes:
- `spoke_cluster_names` default value is `cluster1 hub`
- `application_sample_deploy` initially deploys application to the 1st cluster name in `spoke_cluster_names`

Issues encountered in testing:
- #297 
- #300 
- #302

This pull request fixes #334 