### PR TITLE
ocm-minikube.sh: fix foundation operator deployment

### DIFF
--- a/hack/ocm-minikube.sh
+++ b/hack/ocm-minikube.sh
@@ -195,39 +195,34 @@ ocm_registration_operator_undeploy_spoke()
 	set -e
 	ocm_registration_operator_checkout_undo
 }
-ocm_foundation_operator_kustomization_directory()
+ocm_foundation_operator_git_ref=${ocm_foundation_operator_git_ref:-dc43ec703e62594e3942c7f06d38d1897550ffea}
+exit_stack_push unset -v ocm_foundation_operator_git_ref
+ocm_foundation_operator_image_tag=${ocm_foundation_operator_image_name:-2.4.0\-$ocm_foundation_operator_git_ref}
+exit_stack_push unset -v ocm_foundation_operator_image_tag
+ocm_foundation_operator_kubectl()
 {
-	echo https://github.com/open-cluster-management/multicloud-operators-foundation/deploy/foundation/$1?ref=b5df50deb87618e8c6057637705e94a58b5a19da
+	set -- foundation/$1 $2 $3 $4
+	set -- $1 /tmp/$USER/open-cluster-management/$1/$2 $3 $4
+	mkdir -p $2
+	cat <<-a >$2/kustomization.yaml
+	resources:
+	  - https://github.com/open-cluster-management/multicloud-operators-foundation/deploy/$1?ref=$ocm_foundation_operator_git_ref
+	namespace: $4
+	images:
+	  - name: quay.io/open-cluster-management/multicloud-manager
+	    newTag: $ocm_foundation_operator_image_tag
+	a
+	kubectl --context $hub_cluster_name $3 -k $2
 }
-exit_stack_push unset -f ocm_foundation_operator_kustomization_directory
+exit_stack_push unset -f ocm_foundation_operator_kubectl
 ocm_foundation_operator_kubectl_hub()
 {
-	kubectl --context $hub_cluster_name $1 -k $(ocm_foundation_operator_kustomization_directory hub)
+	ocm_foundation_operator_kubectl hub $hub_cluster_name $1
 }
 exit_stack_push unset -f ocm_foundation_operator_kubectl_hub
 ocm_foundation_operator_kubectl_spoke()
 {
-	set -- $1 $2 /tmp/$USER/open-cluster-management/foundation/klusterlet/$1
-	mkdir -p $3
-	cat <<-a >$3/kustomization.yaml
-	resources:
-	  - $(ocm_foundation_operator_kustomization_directory klusterlet)
-	namespace: $1
-	patchesJson6902:
-	  - target:
-	      group: work.open-cluster-management.io
-	      version: v1
-	      kind: ManifestWork
-	      name: klusterlet-addon-workmgr
-	    patch: |-
-	      - op: test
-	        path: /spec/workload/manifests/4/spec/template/spec/containers/0/args/2
-	        value: --cluster-name=cluster1
-	      - op: replace
-	        path: /spec/workload/manifests/4/spec/template/spec/containers/0/args/2
-	        value: --cluster-name=$1
-	a
-	kubectl --context $hub_cluster_name $2 -k $3
+	ocm_foundation_operator_kubectl klusterlet $1 $2 $1
 }
 exit_stack_push unset -f ocm_foundation_operator_kubectl_spoke
 ocm_foundation_operator_deploy_hub()
@@ -240,7 +235,14 @@ ocm_foundation_operator_deploy_hub()
 exit_stack_push unset -f ocm_foundation_operator_deploy_hub
 ocm_foundation_operator_undeploy_hub()
 {
+	set +e
 	ocm_foundation_operator_kubectl_hub delete
+	# Error from server (NotFound): error when deleting "/tmp/$USER/open-cluster-management/foundation/hub/hub": services "ocm-proxyserver" not found
+	# Error from server (NotFound): error when deleting "/tmp/$USER/open-cluster-management/foundation/hub/hub": deployments.apps "ocm-proxyserver" not found
+	# Error from server (NotFound): error when deleting "/tmp/$USER/open-cluster-management/foundation/hub/hub": apiservices.apiregistration.k8s.io "v1.clusterview.open-cluster-management.io" not found
+	# Error from server (NotFound): error when deleting "/tmp/$USER/open-cluster-management/foundation/hub/hub": apiservices.apiregistration.k8s.io "v1alpha1.clusterview.open-cluster-management.io" not found
+	# Error from server (NotFound): error when deleting "/tmp/$USER/open-cluster-management/foundation/hub/hub": apiservices.apiregistration.k8s.io "v1beta1.proxy.open-cluster-management.io" not found
+	set -e
 	set +e
 	kubectl --context $hub_cluster_name -n open-cluster-management wait deployments/ocm-controller --for delete
 	# error: no matching resources found


### PR DESCRIPTION
The end-to-end deployment script, `ocm-minikube.sh`, fixes open cluster management's foundation operator deployment manifests at certain commit, `b5df50deb87618e8c6057637705e94a58b5a19da`, but not its image.  This results in a new image trying to reference a new custom resource definition that is not deployed because it is not included in an old manifest:

```
$ kubectl --context hub -n open-cluster-management logs pods/ocm-controller-7c7fd888c8-27khn
E0915 03:14:29.282273       1 server.go:211] Controller-runtime manager exited non-zero, failed to wait for imageregistry-controller caches to sync: no matches for kind "ManagedClusterImageRegistry" in version "imageregistry.open-cluster-management.io/v1alpha1"
failed to wait for imageregistry-controller caches to sync: no matches for kind "ManagedClusterImageRegistry" in version "imageregistry.open-cluster-management.io/v1alpha1"
```

and `ocm-controller` to fail:
```
$ kubectl --context hub -n open-cluster-management get pods
NAME                              READY   STATUS    RESTARTS   AGE
ocm-controller-7c7fd888c8-27khn   1/1     Running   4          2m50s
```

This pull request uses a container image matching the fixed manifests.