### PR TITLE
S3 upload optimization

### DIFF
--- a/controllers/s3utils.go
+++ b/controllers/s3utils.go
@@ -131,8 +131,8 @@ func (s3ObjectStoreGetter) objectStore(ctx context.Context,
 	callerTag string) (objectStorer, error) {
 	s3StoreProfile, err := getRamenConfigS3StoreProfile(s3ProfileName)
 	if err != nil {
-		return nil, fmt.Errorf("error %w in profile %s; caller %s",
-			err, s3ProfileName, callerTag)
+		return nil, fmt.Errorf("failed to get profile %s for caller %s, %w",
+			s3ProfileName, callerTag, err)
 	}
 
 	// Use cached connection, if one exists
@@ -143,7 +143,7 @@ func (s3ObjectStoreGetter) objectStore(ctx context.Context,
 
 	accessID, secretAccessKey, err := getS3Secret(ctx, r, s3StoreProfile.S3SecretRef)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get secret %v; caller %s, %w",
+		return nil, fmt.Errorf("failed to get secret %v for caller %s, %w",
 			s3StoreProfile.S3SecretRef, callerTag, err)
 	}
 
@@ -159,7 +159,7 @@ func (s3ObjectStoreGetter) objectStore(ctx context.Context,
 		S3ForcePathStyle: aws.Bool(true),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new session for %s; caller %s, %w",
+		return nil, fmt.Errorf("failed to create new session for %s for caller %s, %w",
 			s3Endpoint, callerTag, err)
 	}
 

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -55,8 +55,7 @@ const (
 	VRGConditionReasonErrorUnknown        = "UnknownError"
 	VRGConditionReasonUploading           = "Uploading"
 	VRGConditionReasonUploaded            = "Uploaded"
-	VRGConditionReasonUploadFailed        = "UploadFailed"
-	VRGConditionReasonMissingS3Profile    = "MissingS3Profile"
+	VRGConditionReasonUploadError         = "UploadError"
 )
 
 // Just when VRG has been picked up for reconciliation when nothing has been
@@ -191,7 +190,7 @@ func setVRGClusterDataProtectingCondition(conditions *[]metav1.Condition, observ
 func setVRGClusterDataUnprotectedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	setStatusCondition(conditions, metav1.Condition{
 		Type:               VRGConditionTypeClusterDataProtected,
-		Reason:             VRGConditionReasonUploadFailed,
+		Reason:             VRGConditionReasonUploadError,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
 		Message:            message,


### PR DESCRIPTION
Skip uploading a PV 's cluster state if it was uploaded previously to `all` s3 stores in the VRG spec `AND` if VRG's spec hasn't changed (detected via generation number) since last upload (to handle s3 profile changes).

Upload action will be triggered if the ClusterDataProtected condition of a PVC is reset.  This will be done in a future PR when PVC size has increased.