### PR TITLE
dr-cluster-operator: use APIReader to get s3 secret

### DIFF
--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -8,13 +8,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - secrets
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - events
   verbs:
   - create
@@ -110,5 +103,3 @@ rules:
   - secrets
   verbs:
   - get
-  - list
-  - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,13 +7,6 @@ metadata:
   name: operator-role
 rules:
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - list
-  - watch
-- apiGroups:
   - apps.open-cluster-management.io
   resources:
   - placementrules
@@ -216,5 +209,3 @@ rules:
   - secrets
   verbs:
   - get
-  - list
-  - watch


### PR DESCRIPTION
Ramen's dr-cluster-operator accesses a secret to read and write an s3 store.   Secret access is restricted to a namespace with a `rolebinding` bound to a `role`.  However, when a secret is retrieved using a manager's caching client without list and watch access an error is logged:

```
E0916 22:41:25.119050       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.21.3/tools/cache/reflector.go:167: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:ramen-system:ramen-dr-cluster-operator" cannot list resource "secrets" in API group "" at the cluster scope
```

If `secret` `list` and `watch` permissions are granted at cluster scope, the error is not logged; however, this is considered too permissive.

This pull request:
- uses manager's non-caching `APIReader` instead of its default caching `Client` to `get` s3 `secrets`
- removes `secret` `list` and `watch` permission at cluster and namespace scopes, but leaves `get` permission at namespace scope.

Fixes #239

Unit test:
- hub and two other managed clusters
- initial deployment and failover
- confirmed `persistentvolume` object uploads and downloads were successful which require s3 secret access
- confirmed absence of `list/watch` failure logs