### PR TITLE
check ClusterData protected condition before relocation

### DIFF
--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -204,10 +204,10 @@ func getVRGFromManifestWork(managedCluster string) (*rmn.VolumeReplicationGroup,
 
 	// Always report conditions as a success?
 	vrg.Status.Conditions = append(vrg.Status.Conditions, metav1.Condition{
-		Type:               controllers.VRGConditionTypeClusterDataReady,
-		Reason:             controllers.VRGConditionReasonClusterDataRestored,
+		Type:               controllers.VRGConditionTypeClusterDataProtected,
+		Reason:             controllers.VRGConditionReasonUploaded,
 		Status:             metav1.ConditionTrue,
-		Message:            "Testing VRG",
+		Message:            "Cluster data protected",
 		LastTransitionTime: metav1.Now(),
 		ObservedGeneration: vrg.Generation,
 	})


### PR DESCRIPTION
Use ClusterDataProtected condition to figure out whether to proceed with the relocation.
It indicates whether all PV related cluster data for an App (Managed by an instance of DRPC)
has been protected (uploaded to the S3 store(s)) or not.