### PR TITLE
add Deployment match and template and Service selector labels containing operator name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.8)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/config/dr-cluster/default/kustomization.yaml
+++ b/config/dr-cluster/default/kustomization.yaml
@@ -12,6 +12,26 @@ namePrefix: ramen-dr-cluster-
 #commonLabels:
 #  someName: someValue
 
+transformers:
+- |-
+  apiVersion: builtin
+  kind: LabelTransformer
+  metadata:
+    name: temporary
+  labels:
+    app: ramen-dr-cluster
+  fieldSpecs:
+  - kind: Deployment
+    path: metadata/labels
+  - kind: Deployment
+    path: spec/selector/matchLabels
+  - kind: Deployment
+    path: spec/template/metadata/labels
+  - kind: Service
+    path: metadata/labels
+  - kind: Service
+    path: spec/selector
+
 bases:
 - ../crd
 - ../rbac

--- a/config/hub/default/kustomization.yaml
+++ b/config/hub/default/kustomization.yaml
@@ -12,6 +12,26 @@ namePrefix: ramen-hub-
 #commonLabels:
 #  someName: someValue
 
+transformers:
+- |-
+  apiVersion: builtin
+  kind: LabelTransformer
+  metadata:
+    name: temporary
+  labels:
+    app: ramen-hub
+  fieldSpecs:
+  - kind: Deployment
+    path: metadata/labels
+  - kind: Deployment
+    path: spec/selector/matchLabels
+  - kind: Deployment
+    path: spec/template/metadata/labels
+  - kind: Service
+    path: metadata/labels
+  - kind: Service
+    path: spec/selector
+
 bases:
 - ../crd
 - ../rbac


### PR DESCRIPTION
kubebuilder applies the same label `control-plane: controller-manager` to both ramen's `hub` and `dr-cluster` operators in many places including:
```
Deployment.spec/selector/matchLabels 
Deployment.spec/template/metadata/labels
Service.spec/selector
```

When ramen's `hub` and `dr-cluster` operators are deployed to the same cluster each operator's `pods` belong to each operator's `deployments` and each operator's `endpoints` belong to each operator's `services`.

This pull request adds an `app=ramen-hub` or `app=ramen-dr-cluster` label, depending on the controller deployed, to the 3 places above so that each `pod` belongs to only one `deployment` and each `endpoint` belongs to only one `service`.

It uses kustomize's inline transformer support, introduced in version 3.8.8:
		- https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv3.8.8
		- https://github.com/kubernetes-sigs/kustomize/releases/tag/api%2Fv0.6.6

Since `kustomize`'s version query method may not output a version, e.g.:
```sh
$ ~/ramen/bin/kustomize version
{Version:unknown GitCommit:$Format:%H$ BuildDate:1970-01-01T00:00:00Z GoOs:linux GoArch:amd64}
```
and the existing version installed, `3.8.7`, lacks inline transformer support, the minimum version including it, `3.8.8`, is unconditionally installed on `hub` and `dr-cluster` `make deploy`.

Unit test:
- 2-cluster configuration: a hub that is also a dr-cluster and a non-hub dr-cluster
- confirmed expected relationships based on labels:
```sh
$ kubectl --context hub -nramen-system describe svc
Name:              ramen-dr-cluster-operator-metrics-service
Namespace:         ramen-system
Labels:            control-plane=controller-manager
Annotations:       <none>
Selector:          app=ramen-dr-cluster,control-plane=controller-manager
Type:              ClusterIP
IP Families:       <none>
IP:                10.106.62.130
IPs:               10.106.62.130
Port:              https  9289/TCP
TargetPort:        9289/TCP
Endpoints:         172.17.0.22:9289
Session Affinity:  None
Events:            <none>

Name:              ramen-hub-operator-metrics-service
Namespace:         ramen-system
Labels:            control-plane=controller-manager
Annotations:       <none>
Selector:          app=ramen-hub,control-plane=controller-manager
Type:              ClusterIP
IP Families:       <none>
IP:                10.111.30.125
IPs:               10.111.30.125
Port:              https  9289/TCP
TargetPort:        9289/TCP
Endpoints:         172.17.0.21:9289
Session Affinity:  None
Events:            <none>
```

```sh
$ kubectl --context hub -nramen-system describe pod
Name:         ramen-dr-cluster-operator-bdd4cc95d-9g77c
Namespace:    ramen-system
Priority:     0
Node:         hub/192.168.39.117
Start Time:   Tue, 21 Sep 2021 22:36:11 -0700
Labels:       app=ramen-dr-cluster
              control-plane=controller-manager
              pod-template-hash=bdd4cc95d
Annotations:  <none>
Status:       Running
IP:           172.17.0.22
IPs:
  IP:           172.17.0.22
Controlled By:  ReplicaSet/ramen-dr-cluster-operator-bdd4cc95d

Name:         ramen-hub-operator-f77bb964-7pshb
Namespace:    ramen-system
Priority:     0
Node:         hub/192.168.39.117
Start Time:   Tue, 21 Sep 2021 22:35:02 -0700
Labels:       app=ramen-hub
              control-plane=controller-manager
              pod-template-hash=f77bb964
Annotations:  <none>
Status:       Running
IP:           172.17.0.21
IPs:
  IP:           172.17.0.21
Controlled By:  ReplicaSet/ramen-hub-operator-f77bb964
```

```sh
$ kubectl --context hub -n ramen-system logs deploy/ramen-hub-operator manager
2021-09-22T04:38:28.678Z        INFO    setup   controllers/ramenconfig.go:43   loading Ramen configuration from        {"file": "/config/ramen_manager_config.yaml"}
I0922 04:38:29.871126       1 request.go:668] Waited for 1.000857644s due to client-side throttling, not priority and fairness, request: GET:https://10.96.0.1:443/apis/action.open-cluster-management.io/v1beta1?timeout=32s
2021-09-22T04:38:30.479Z        INFO    controller-runtime.metrics      metrics/listener.go:44  metrics server is starting to listen    {"addr": "127.0.0.1:9289"}
time="2021-09-22T04:38:30Z" level=info msg="loading Ramen config file name/config/ramen_manager_config.yaml" source="ramenconfig.go:76"
2021-09-22T04:38:30.571Z        INFO    setup   workspace/main.go:167   starting manager
I0922 04:38:30.572411       1 leaderelection.go:243] attempting to acquire leader lease ramen-system/hub.ramendr.openshift.io...
2021-09-22T04:38:30.572Z        INFO    controller-runtime.manager      manager/manager.go:297  starting metrics server {"path": "/metrics"}
I0922 04:38:30.587911       1 leaderelection.go:253] successfully acquired lease ramen-system/hub.ramendr.openshift.io
2021-09-22T04:38:30.588Z        DEBUG   controller-runtime.manager.events       record/event.go:308     Normal  {"object": {"kind":"ConfigMap","namespace":"ramen-system","name":"hub.ramendr.openshift.io","uid":"428d4168-a5ae-4e07-a477-3252136f9b8f","apiVersion":"v1","resourceVersion":"152206"}, "reason": "LeaderElection", "message": "ramen-hub-operator-f77bb964-dg2ms_e56ddb58-afb9-470f-8f7e-f3a6dee486da became leader"}
2021-09-22T04:38:30.588Z        DEBUG   controller-runtime.manager.events       record/event.go:308     Normal  {"object": {"kind":"Lease","namespace":"ramen-system","name":"hub.ramendr.openshift.io","uid":"c3a5857c-d695-4c18-9b2d-054b3475d04f","apiVersion":"coordination.k8s.io/v1","resourceVersion":"152207"}, "reason": "LeaderElection", "message": "ramen-hub-operator-f77bb964-dg2ms_e56ddb58-afb9-470f-8f7e-f3a6dee486da became leader"}
2021-09-22T04:38:30.589Z        INFO    controller-runtime.manager.controller.drplacementcontrol        controller/controller.go:221    Starting EventSource  {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPlacementControl", "source": "kind source: /, Kind="}
2021-09-22T04:38:30.589Z        INFO    controller-runtime.manager.controller.drplacementcontrol        controller/controller.go:221    Starting EventSource  {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPlacementControl", "source": "kind source: /, Kind="}
2021-09-22T04:38:30.589Z        INFO    controller-runtime.manager.controller.drplacementcontrol        controller/controller.go:221    Starting EventSource  {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPlacementControl", "source": "kind source: /, Kind="}
2021-09-22T04:38:30.589Z        INFO    controller-runtime.manager.controller.drplacementcontrol        controller/controller.go:221    Starting Controller   {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPlacementControl"}
2021-09-22T04:38:30.590Z        INFO    controller-runtime.manager.controller.drpolicy  controller/controller.go:221    Starting EventSource {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "source": "kind source: /, Kind="}
2021-09-22T04:38:30.590Z        INFO    controller-runtime.manager.controller.drpolicy  controller/controller.go:221    Starting Controller  {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy"}
2021-09-22T04:38:30.771Z        INFO    controllers/drplacementcontrol_controller.go:424        Filtering ManifestWork (addon-work-manager-deploy/hub)
2021-09-22T04:38:30.771Z        INFO    controllers/drplacementcontrol_controller.go:424        Filtering ManifestWork (addon-work-manager-deploy/cluster1)
2021-09-22T04:38:30.871Z        INFO    controller-runtime.manager.controller.drpolicy  controller/controller.go:221    Starting workers     {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "worker count": 1}
2021-09-22T04:38:30.871Z        INFO    controller-runtime.manager.controller.drplacementcontrol        controller/controller.go:221    Starting workers      {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPlacementControl", "worker count": 1}

$ kubectl --context hub -n ramen-system logs deploy/ramen-dr-cluster-operator manager
2021-09-22T04:39:26.381Z        INFO    setup   controllers/ramenconfig.go:43   loading Ramen configuration from        {"file": "/config/ramen_manager_config.yaml"}
I0922 04:39:27.531058       1 request.go:668] Waited for 1.045176214s due to client-side throttling, not priority and fairness, request: GET:https://10.96.0.1:443/apis/addon.open-cluster-management.io/v1alpha1?timeout=32s
2021-09-22T04:39:27.989Z        INFO    controller-runtime.metrics      metrics/listener.go:44  metrics server is starting to listen    {"addr": "127.0.0.1:9289"}
2021-09-22T04:39:27.989Z        INFO    controllers.VolumeReplicationGroup      workspace/main.go:141   Adding VolumeReplicationGroup controller
time="2021-09-22T04:39:27Z" level=info msg="loading Ramen config file name/config/ramen_manager_config.yaml" source="ramenconfig.go:76"
2021-09-22T04:39:27.990Z        INFO    setup   workspace/main.go:167   starting manager
I0922 04:39:27.990648       1 leaderelection.go:243] attempting to acquire leader lease ramen-system/dr-cluster.ramendr.openshift.io...
2021-09-22T04:39:27.990Z        INFO    controller-runtime.manager      manager/manager.go:297  starting metrics server {"path": "/metrics"}
I0922 04:39:28.090358       1 leaderelection.go:253] successfully acquired lease ramen-system/dr-cluster.ramendr.openshift.io
2021-09-22T04:39:28.090Z        DEBUG   controller-runtime.manager.events       record/event.go:308     Normal  {"object": {"kind":"ConfigMap","namespace":"ramen-system","name":"dr-cluster.ramendr.openshift.io","uid":"483192d6-a767-4b2f-9f6c-6bdb1e8846a7","apiVersion":"v1","resourceVersion":"152877"}, "reason": "LeaderElection", "message": "ramen-dr-cluster-operator-bdd4cc95d-l2gn9_0e515d2f-a0c0-4ec3-9a92-bdfe0a0d818c became leader"}
2021-09-22T04:39:28.090Z        DEBUG   controller-runtime.manager.events       record/event.go:308     Normal  {"object": {"kind":"Lease","namespace":"ramen-system","name":"dr-cluster.ramendr.openshift.io","uid":"c3ea5c3a-4e51-4215-a577-e373c1962794","apiVersion":"coordination.k8s.io/v1","resourceVersion":"152878"}, "reason": "LeaderElection", "message": "ramen-dr-cluster-operator-bdd4cc95d-l2gn9_0e515d2f-a0c0-4ec3-9a92-bdfe0a0d818c became leader"}
2021-09-22T04:39:28.090Z        INFO    controller-runtime.manager.controller.volumereplicationgroup    controller/controller.go:221    Starting EventSource  {"reconciler group": "ramendr.openshift.io", "reconciler kind": "VolumeReplicationGroup", "source": "kind source: /, Kind="}
2021-09-22T04:39:28.090Z        INFO    controller-runtime.manager.controller.volumereplicationgroup    controller/controller.go:221    Starting EventSource  {"reconciler group": "ramendr.openshift.io", "reconciler kind": "VolumeReplicationGroup", "source": "kind source: /, Kind="}
2021-09-22T04:39:28.090Z        INFO    controller-runtime.manager.controller.volumereplicationgroup    controller/controller.go:221    Starting EventSource  {"reconciler group": "ramendr.openshift.io", "reconciler kind": "VolumeReplicationGroup", "source": "kind source: /, Kind="}
2021-09-22T04:39:28.090Z        INFO    controller-runtime.manager.controller.volumereplicationgroup    controller/controller.go:221    Starting Controller   {"reconciler group": "ramendr.openshift.io", "reconciler kind": "VolumeReplicationGroup"}
2021-09-22T04:39:28.272Z        INFO    pvcmap.VolumeReplicationGroup   predicate/predicate.go:71       Create event for PersistentVolumeClaim
2021-09-22T04:39:28.272Z        INFO    controller-runtime.manager.controller.volumereplicationgroup    controller/controller.go:221    Starting workers      {"reconciler group": "ramendr.openshift.io", "reconciler kind": "VolumeReplicationGroup", "worker count": 1}
2021-09-22T04:39:28.273Z        INFO    pvcmap.VolumeReplicationGroup   predicate/predicate.go:71       Create event for PersistentVolumeClaim
```

Fixes #277