### PR TITLE
require namespace before VRG creation #240

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -727,9 +727,16 @@ func (d *DRPCInstance) cleanupSecondaries(skipCluster string) (bool, error) {
 			return false, nil
 		}
 
-		mcvName := BuildManagedClusterViewName(d.instance.Name, d.instance.Namespace, "vrg")
+		mcvNameVRG := BuildManagedClusterViewName(d.instance.Name, d.instance.Namespace, rmnutil.MWTypeVRG)
 		// MW is deleted, VRG is deleted, so we no longer need MCV for the VRG
-		err = d.reconciler.deleteManagedClusterView(clusterName, mcvName)
+		err = d.reconciler.deleteManagedClusterView(clusterName, mcvNameVRG)
+		if err != nil {
+			return false, err
+		}
+
+		mcvNameNS := BuildManagedClusterViewName(d.instance.Name, d.instance.Namespace, rmnutil.MWTypeNS)
+		// MCV for Namespace is no longer needed
+		err = d.reconciler.deleteManagedClusterView(clusterName, mcvNameNS)
 		if err != nil {
 			return false, err
 		}
@@ -785,6 +792,14 @@ func (d *DRPCInstance) updateUserPlacementRuleStatus(status plrv1.PlacementRuleS
 }
 
 func (d *DRPCInstance) createVRGManifestWork(homeCluster string) error {
+	// TODO: check if VRG MW here as a less expensive way to validate if Namespace exists
+	err := d.ensureNamespaceExistsOnManagedCluster(homeCluster)
+	if err != nil {
+		return fmt.Errorf("createVRGManifestWork couldn't ensure namespace '%s' on cluster %s exists",
+			d.instance.Namespace, homeCluster)
+	}
+
+	// create VRG ManifestWork
 	d.log.Info("Creating VRG ManifestWork",
 		"Last State:", d.getLastDRState(), "cluster", homeCluster)
 
@@ -795,6 +810,33 @@ func (d *DRPCInstance) createVRGManifestWork(homeCluster string) error {
 		d.log.Error(err, "failed to create or update VolumeReplicationGroup manifest")
 
 		return fmt.Errorf("failed to create or update VolumeReplicationGroup manifest in namespace %s (%w)", homeCluster, err)
+	}
+
+	return nil
+}
+
+func (d *DRPCInstance) ensureNamespaceExistsOnManagedCluster(homeCluster string) error {
+	// verify namespace exists on target cluster
+	namespaceExists, err := d.namespaceExistsOnManagedCluster(homeCluster)
+
+	d.log.Info(fmt.Sprintf("createVRGManifestWork: namespace '%s' exists on cluster %s: %t",
+		d.instance.Namespace, homeCluster, namespaceExists))
+
+	if !namespaceExists { // attempt to create it
+		err := d.mwu.CreateOrUpdateNamespaceManifest(d.instance.Name, d.instance.Namespace, homeCluster)
+		if err != nil {
+			return fmt.Errorf("failed to create namespace '%s' on cluster %s: %w", d.instance.Namespace, homeCluster, err)
+		}
+
+		d.log.Info(fmt.Sprintf("Created Namespace '%s' on cluster %s", d.instance.Namespace, homeCluster))
+
+		return nil // created namespace
+	}
+
+	// namespace exists already
+	if err != nil {
+		return fmt.Errorf("failed to verify if namespace '%s' on cluster %s exists: %w",
+			d.instance.Namespace, homeCluster, err)
 	}
 
 	return nil
@@ -875,6 +917,26 @@ func (d *DRPCInstance) updateCondition(condition *metav1.Condition, idx int, rea
 	condition.ObservedGeneration = d.instance.Generation
 	d.instance.Status.Conditions[idx] = *condition
 	d.needStatusUpdate = true
+}
+
+func (d *DRPCInstance) namespaceExistsOnManagedCluster(cluster string) (bool, error) {
+	exists := true
+
+	// create ManagedClusterView to check if namespace exists
+	_, err := d.reconciler.MCVGetter.GetNamespaceFromManagedCluster(d.instance.Name, cluster, d.instance.Namespace)
+	if err != nil {
+		if errors.IsNotFound(err) { // successfully detected that Namespace is not found by ManagedClusterView
+			d.log.Info(fmt.Sprintf("Namespace '%s' not found on cluster %s", d.instance.Namespace, cluster))
+
+			return !exists, nil
+		}
+
+		d.log.Error(err, "failed get Namespace from ManagedCluster")
+
+		return !exists, errorswrapper.Wrap(err, "failed to get Namespace from managedcluster")
+	}
+
+	return exists, nil // namespace exists and looks good to use
 }
 
 func (d *DRPCInstance) ensureVRGManifestWorkOnClusterDeleted(clusterName string) (bool, error) {

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -28,6 +28,7 @@ import (
 	viewv1beta1 "github.com/open-cluster-management/multicloud-operators-foundation/pkg/apis/view/v1beta1"
 	plrv1 "github.com/open-cluster-management/multicloud-operators-placementrule/pkg/apis/apps/v1"
 	errorswrapper "github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -178,6 +179,8 @@ type ProgressCallback func(string, string)
 type ManagedClusterViewGetter interface {
 	GetVRGFromManagedCluster(
 		resourceName, resourceNamespace, managedCluster string) (*rmn.VolumeReplicationGroup, error)
+
+	GetNamespaceFromManagedCluster(resourceName, resourceNamespace, managedCluster string) (*corev1.Namespace, error)
 }
 
 type ManagedClusterViewGetterImpl struct {
@@ -208,6 +211,28 @@ func (m ManagedClusterViewGetterImpl) GetVRGFromManagedCluster(
 	err := m.getManagedClusterResource(mcvMeta, mcvViewscope, vrg, logger)
 
 	return vrg, err
+}
+
+func (m ManagedClusterViewGetterImpl) GetNamespaceFromManagedCluster(
+	resourceName, managedCluster, namespaceString string) (*corev1.Namespace, error) {
+	logger := ctrl.Log.WithName("MCV").WithValues("resouceName", resourceName)
+
+	// get Namespace and verify status through ManagedClusterView
+	mcvMeta := metav1.ObjectMeta{
+		Name:      BuildManagedClusterViewName(resourceName, namespaceString, rmnutil.MWTypeNS),
+		Namespace: managedCluster,
+	}
+
+	mcvViewscope := viewv1beta1.ViewScope{
+		Resource: "Namespace",
+		Name:     namespaceString,
+	}
+
+	namespace := &corev1.Namespace{}
+
+	err := m.getManagedClusterResource(mcvMeta, mcvViewscope, namespace, logger)
+
+	return namespace, err
 }
 
 /*
@@ -674,8 +699,15 @@ func (r *DRPlacementControlReconciler) finalizeDRPC(ctx context.Context, drpc *r
 			return fmt.Errorf("%w", err)
 		}
 
-		mcvName := BuildManagedClusterViewName(drpc.Name, drpc.Namespace, "vrg")
+		mcvName := BuildManagedClusterViewName(drpc.Name, drpc.Namespace, rmnutil.MWTypeVRG)
 		// Delete MCV for the VRG
+		err = r.deleteManagedClusterView(clustersToClean[idx], mcvName)
+		if err != nil {
+			return err
+		}
+
+		mcvName = BuildManagedClusterViewName(drpc.Name, drpc.Namespace, rmnutil.MWTypeNS)
+		// Delete MCV for Namespace
 		err = r.deleteManagedClusterView(clustersToClean[idx], mcvName)
 		if err != nil {
 			return err

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	errorswrapper "github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -129,6 +130,16 @@ func getFunctionNameAtIndex(idx int) string {
 	result := strings.Split(data, ".")
 
 	return result[len(result)-1]
+}
+
+func (f FakeMCVGetter) GetNamespaceFromManagedCluster(
+	resourceName, managedCluster, namespaceString string) (*corev1.Namespace, error) {
+	appNamespaceLookupKey := types.NamespacedName{Name: namespaceString}
+	appNamespaceObj := &corev1.Namespace{}
+
+	err := k8sClient.Get(context.TODO(), appNamespaceLookupKey, appNamespaceObj)
+
+	return appNamespaceObj, errorswrapper.Wrap(err, "failed to get Namespace from managedcluster")
 }
 
 func (f FakeMCVGetter) GetVRGFromManagedCluster(


### PR DESCRIPTION
- if a workload is used for a non-existent namespace on a managed cluster, create it first

Signed-off-by: Travis Janssen <travis.janssen@ibm.com>

---
**Known issue**: the logic for verifying that a namespace exists on a managed cluster is housed in `drplacementcontrol.go::createVRGManifestWork()`, but if the namespace doesn't exist and none of the resources exist when Ramen initializes, `drplacementcontrol_controller.go::getVRGsFromManagedClusters()` executes first, which will result in Reconcile errors. However, this runs a few times then creates the namespace and those errors are resolved. I couldn't figure out how to generalize this functionality in a way that didn't require the DRPC instance or mwu_util instance and fixed the errors at start. On my test machine, this executed so quickly that I had to search for the errors, but it's probably worth fixing later.

--- 
**How to easily reproduce the error this patch fixes:**
1. Obtain a clean environment (meaning no minikube instances, no virsh osd pools), then run the following commands:
2. `$ bash ramen/hack/ocm-minikube-ramen.sh`
3. `$ bash ramen/hack/ocm-minikube-ramen.sh application_sample_deploy`
4. `$ kubectl delete namespace busybox-sample --context=cluster1`
5. `$ kubectl config use-context hub`
6. `$ make generate; make maniefsts; make; make install; make run-hub`

You should notice that since the `busybox-sample` namespace doesn't exist on cluster1, that VRG creation will fail. 