### PR TITLE
Ramen fails to restore PVs in the case where multiple s3Profiles are configured

### DIFF
--- a/controllers/util/drpolicy_util.go
+++ b/controllers/util/drpolicy_util.go
@@ -29,36 +29,19 @@ func DrpolicyClusterNames(drpolicy *rmn.DRPolicy) []string {
 	return clusterNames
 }
 
-// Return a list of unique S3 profiles to upload the relevant cluster state of
-// the given home cluster
-func s3UploadProfileList(drPolicy rmn.DRPolicy, homeCluster string) (s3ProfileList []string) {
+// Return a list of unique S3 profiles to upload the relevant cluster state
+func S3UploadProfileList(drPolicy rmn.DRPolicy) (s3ProfileList []string) {
 	for _, drCluster := range drPolicy.Spec.DRClusterSet {
-		if drCluster.Name != homeCluster {
-			// This drCluster is not the home cluster and is hence, a candidate to
-			// upload cluster state to if this S3 profile is not already on the list.
-			found := false
+		found := false
 
-			for _, s3ProfileName := range s3ProfileList {
-				if s3ProfileName == drCluster.S3ProfileName {
-					found = true
-				}
-			}
-
-			if !found {
-				s3ProfileList = append(s3ProfileList, drCluster.S3ProfileName)
+		for _, s3ProfileName := range s3ProfileList {
+			if s3ProfileName == drCluster.S3ProfileName {
+				found = true
 			}
 		}
-	}
 
-	return
-}
-
-// Return the S3 profile to download the relevant cluster state to the given
-// home cluster
-func S3DownloadProfile(drPolicy rmn.DRPolicy, homeCluster string) (s3Profile string) {
-	for _, drCluster := range drPolicy.Spec.DRClusterSet {
-		if drCluster.Name == homeCluster {
-			s3Profile = drCluster.S3ProfileName
+		if !found {
+			s3ProfileList = append(s3ProfileList, drCluster.S3ProfileName)
 		}
 	}
 

--- a/controllers/util/mw_util.go
+++ b/controllers/util/mw_util.go
@@ -122,7 +122,7 @@ func IsManifestInAppliedState(mw *ocmworkv1.ManifestWork) bool {
 func (mwu *MWUtil) CreateOrUpdateVRGManifestWork(
 	name, namespace, homeCluster string,
 	drPolicy *rmn.DRPolicy, pvcSelector metav1.LabelSelector) error {
-	s3ProfileList := s3UploadProfileList(*drPolicy, homeCluster)
+	s3ProfileList := S3UploadProfileList(*drPolicy)
 	schedulingInterval := drPolicy.Spec.SchedulingInterval
 	replClassSelector := drPolicy.Spec.ReplicationClassSelector
 


### PR DESCRIPTION
If multiple s3 profiles are configured, ramen will fail to restore PVs. Here is a use case that shows the problem:
1. Assume we have two clusters and two s3profiles, C1, C2, and P1, P2 respectively.
2. Initial Deploy to C1: we upload to P2 and Download from P2 (download not needed for initial Deploy)
3. Failover to C2, we upload to P1 and download from P1 (problem)
4. Relocate to C1, we upload to P2 and download from P2 (problem)

In both steps 3 and 4, we end up using a profile that does not have PV Cluster data.