### PR TITLE
Specify S3 bucket name to use for a given DRPolicy (and VRG)

### DIFF
--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -86,7 +86,7 @@ type VolumeReplicationGroupSpec struct {
 
 	// List of unique S3 profiles in RamenConfig that should be used to store
 	// and forward PV related cluster state to peer DR clusters.
-	S3ProfileList []string `json:"s3ProfileName,omitempty"`
+	S3ProfileList []string `json:"s3ProfileName"`
 }
 
 type ProtectedPVC struct {

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -162,6 +162,7 @@ spec:
             required:
             - pvcSelector
             - replicationState
+            - s3ProfileName
             - schedulingInterval
             type: object
           status:

--- a/controllers/ramenconfig.go
+++ b/controllers/ramenconfig.go
@@ -134,6 +134,14 @@ func getRamenConfigS3StoreProfile(profileName string) (
 		return s3StoreProfile, err
 	}
 
+	s3Bucket := s3StoreProfile.S3Bucket
+	if s3Bucket == "" {
+		err = fmt.Errorf("s3 bucket has not been configured in s3 profile %s",
+			profileName)
+
+		return s3StoreProfile, err
+	}
+
 	return s3StoreProfile, nil
 }
 

--- a/controllers/s3utils_test.go
+++ b/controllers/s3utils_test.go
@@ -51,35 +51,36 @@ type fakeObjectStorer struct{}
 func (fakeObjectStorer) CreateBucket(bucket string) error { return nil }
 func (fakeObjectStorer) DeleteBucket(bucket string) error { return nil }
 func (fakeObjectStorer) PurgeBucket(bucket string) error  { return nil }
-func (fakeObjectStorer) UploadPV(bucket string, pvKeySuffix string, pv corev1.PersistentVolume) error {
+func (fakeObjectStorer) UploadPV(pvKeyPrefix, pvKeySuffix string, pv corev1.PersistentVolume) error {
 	return nil
 }
 
-func (fakeObjectStorer) UploadTypedObject(bucket string, keySuffix string, uploadContent interface{}) error {
+func (fakeObjectStorer) UploadTypedObject(pvKeyPrefix, keySuffix string, uploadContent interface{}) error {
 	return nil
 }
 
-func (fakeObjectStorer) UploadObject(bucket string, key string, uploadContent interface{}) error {
+func (fakeObjectStorer) UploadObject(key string, uploadContent interface{}) error {
 	return nil
 }
 
-func (fakeObjectStorer) VerifyPVUpload(bucket string, pvKeySuffix string, verifyPV corev1.PersistentVolume) error {
+func (fakeObjectStorer) VerifyPVUpload(pvKeyPrefix, pvKeySuffix string,
+	verifyPV corev1.PersistentVolume) error {
 	return nil
 }
 
-func (fakeObjectStorer) DownloadPVs(bucket string) ([]corev1.PersistentVolume, error) {
+func (fakeObjectStorer) DownloadPVs(pvKeyPrefix string) ([]corev1.PersistentVolume, error) {
 	return []corev1.PersistentVolume{}, nil
 }
 
-func (fakeObjectStorer) DownloadTypedObjects(bucket string, objectType reflect.Type) (interface{}, error) {
+func (fakeObjectStorer) DownloadTypedObjects(keyPrefix string, objectType reflect.Type) (interface{}, error) {
 	return nil, nil
 }
 
-func (fakeObjectStorer) ListKeys(bucket string, keyPrefix string) ([]string, error) {
+func (fakeObjectStorer) ListKeys(keyPrefix string) ([]string, error) {
 	return []string{}, nil
 }
 
-func (fakeObjectStorer) DownloadObject(bucket string, key string, downloadContent interface{}) error {
+func (fakeObjectStorer) DownloadObject(key string, downloadContent interface{}) error {
 	return nil
 }
-func (fakeObjectStorer) DeleteObject(bucket, keyPrefix string) error { return nil }
+func (fakeObjectStorer) DeleteObjects(keyPrefix string) error { return nil }

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -1036,7 +1036,7 @@ type FakePVDownloader struct{}
 
 func (s FakePVDownloader) DownloadPVs(ctx context.Context, r client.Reader,
 	objStoreGetter vrgController.ObjectStoreGetter, s3Profile, callerTag string,
-	s3Bucket string) ([]corev1.PersistentVolume, error) {
+	keyPrefix string) ([]corev1.PersistentVolume, error) {
 	capacity := corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")}
 	accessModes := []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
 	hostPathType := corev1.HostPathDirectoryOrCreate

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -95,6 +95,7 @@ EOF
 
 	s3StoreProfiles:
 	- s3ProfileName: $s3_store_profile_name
+	  s3BucketName: $s3_store_profile_name
 	  s3CompatibleEndpoint: $(minikube --profile=$s3_store_cluster_name -n minio service --url minio)
 	  s3Region: us-east-1
 	  s3SecretRef:


### PR DESCRIPTION
Specify the S3 bucket name to use for each S3Profile in RamenConfig

When protecting cluster data in S3 store, instead of auto-creating a
    bucket name at the given S3 endpoint, use the S3 bucket name that is
    specified for each S3Profile in RamenConfig.  Store the cluster data
    in the S3 bucket using an S3 key that is prefixed with the VRG's
    namespace-qualified name, to result in this key format:
```
KeyPrefix: <vrgNamespace>/<vrgName>/
KeyInfix:  <objectType>/
KeySuffix: <objectName>
```
In particular, store the PV cluster data with the following key:
```
<vrgNamespace>/<vrgName>/<v1.PersistentVolume>/<pvName>
```
When the VRG is deleted, even as primary, just cleanup the cluster data
    that belongs to that VRG but do not delete the bucket.

When configuring the VRG, make the S3ProfileList a required field.