### PR TITLE
validate drpolicy's s3 buckets and cluster roles exist on each reconcile attempt

### DIFF
--- a/controllers/drpolicy_controller_test.go
+++ b/controllers/drpolicy_controller_test.go
@@ -57,7 +57,7 @@ var _ = Describe("DrpolicyController", func() {
 						ramen.DRPolicyValidated: MatchAllFields(Fields{
 							`Type`:               Ignore(),
 							`Status`:             Equal(status),
-							`ObservedGeneration`: Ignore(),
+							`ObservedGeneration`: Equal(drpolicy.Generation),
 							`LastTransitionTime`: Ignore(),
 							`Reason`:             Ignore(),
 							`Message`:            messageMatcher,
@@ -249,6 +249,20 @@ var _ = Describe("DrpolicyController", func() {
 			drpolicy.Spec.DRClusterSet[1].S3ProfileName = s3ProfileNameConnectSucc
 			Expect(k8sClient.Update(context.TODO(), drpolicy)).To(Succeed())
 			validatedConditionExpect(drpolicy, metav1.ConditionTrue, Ignore())
+		})
+	})
+	When("a previously valid drpolicy is updated containing a different s3 profile that connects successfully", func() {
+		It("should update its validated status condition's observed generation", func() {
+			drpolicy.Spec.DRClusterSet[0].S3ProfileName = s3ProfileNameConnectSucc2
+			Expect(k8sClient.Update(context.TODO(), drpolicy)).To(Succeed())
+			validatedConditionExpect(drpolicy, metav1.ConditionTrue, Ignore())
+		})
+	})
+	When("a previously valid drpolicy is updated containing an s3 profile connects unsuccessfully", func() {
+		It("should update its validated status condition's status to false", func() {
+			drpolicy.Spec.DRClusterSet[0].S3ProfileName = s3ProfileNameConnectFail
+			Expect(k8sClient.Update(context.TODO(), drpolicy)).To(Succeed())
+			validatedConditionExpect(drpolicy, metav1.ConditionFalse, HavePrefix(s3ProfileNameConnectFail+": "))
 		})
 	})
 	Specify(`drpolicy delete`, func() {

--- a/controllers/s3utils_test.go
+++ b/controllers/s3utils_test.go
@@ -30,6 +30,7 @@ type fakeObjectStoreGetter struct{}
 
 const (
 	s3ProfileNameConnectSucc  = "fakeS3Profile"
+	s3ProfileNameConnectSucc2 = s3ProfileNameConnectSucc + "1"
 	s3ProfileNameConnectFail  = s3ProfileNameConnectSucc + "ConnectFail"
 	s3ProfileNameConnectFail2 = s3ProfileNameConnectFail + "2"
 )

--- a/controllers/s3utils_test.go
+++ b/controllers/s3utils_test.go
@@ -29,8 +29,9 @@ import (
 type fakeObjectStoreGetter struct{}
 
 const (
-	s3ProfileNameConnectSucc = `fakeS3Profile`
-	s3ProfileNameConnectFail = s3ProfileNameConnectSucc + `ConnectFail`
+	s3ProfileNameConnectSucc  = "fakeS3Profile"
+	s3ProfileNameConnectFail  = s3ProfileNameConnectSucc + "ConnectFail"
+	s3ProfileNameConnectFail2 = s3ProfileNameConnectFail + "2"
 )
 
 func (fakeObjectStoreGetter) ObjectStore(
@@ -39,7 +40,10 @@ func (fakeObjectStoreGetter) ObjectStore(
 	s3ProfileName string,
 	callerTag string,
 ) (controllers.ObjectStorer, error) {
-	if s3ProfileName == s3ProfileNameConnectFail {
+	switch s3ProfileName {
+	case s3ProfileNameConnectFail:
+		fallthrough
+	case s3ProfileNameConnectFail2:
 		return fakeObjectStorer{}, errors.New(`object store connection failed`)
 	}
 

--- a/controllers/util/drpolicy_util.go
+++ b/controllers/util/drpolicy_util.go
@@ -34,12 +34,8 @@ func DrpolicyClusterNames(drpolicy *rmn.DRPolicy) []string {
 	return clusterNames
 }
 
-func DrpolicyValidatedConditionGet(drpolicy *rmn.DRPolicy) *metav1.Condition {
-	return meta.FindStatusCondition(drpolicy.Status.Conditions, rmn.DRPolicyValidated)
-}
-
 func DrpolicyValidated(drpolicy *rmn.DRPolicy) error {
-	if condition := DrpolicyValidatedConditionGet(drpolicy); condition != nil {
+	if condition := meta.FindStatusCondition(drpolicy.Status.Conditions, rmn.DRPolicyValidated); condition != nil {
 		if condition.Status != metav1.ConditionTrue {
 			return errors.New(condition.Message)
 		}


### PR DESCRIPTION
- for each drpolicy reconciliation attempt,
  - validate:
    - each s3 store's bucket exists
    - drpolicy's finalizer exists
    - each cluster's cluster roles manifest work exists
  - update validated status condition if its status, reason, or message differs
    - closes #318 