### PR TITLE
Update to operator SDK 1.11.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ ifeq (,$(shell which operator-sdk 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OSDK)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OSDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.8.0/operator-sdk_$${OS}_$${ARCH} ;\
+	curl -sSLo $(OSDK) https://github.com/operator-framework/operator-sdk/releases/download/v1.11.0/operator-sdk_$${OS}_$${ARCH} ;\
 	chmod +x $(OSDK) ;\
 	}
 else


### PR DESCRIPTION
- This is to address not generating and using a
servie account, which was bundled by default with
the previous versions

This commit does not address other related moves
to 1.11.0 version of the operator-sdk, specifcally
items in https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.11.0/

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>