### PR TITLE
clean up current home cluster after failover to another cluster is co…

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -374,8 +374,8 @@ func (d *DRPCInstance) switchToFailoverCluster() (bool, error) {
 		d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), "Completed")
 	d.log.Info("Failover completed", "state", d.getLastDRState())
 
-	// The failover is complete, but we still need to clean up other
-	// secondaries, hence, returning a NOT done
+	// The failover is complete, but we still need to clean up the failed primary.
+	// hence, returning a NOT done
 	return !done, nil
 }
 
@@ -693,27 +693,6 @@ func (d *DRPCInstance) executeRelocation(targetCluster, targetClusterNamespace s
 		return err
 	}
 
-	clusterToSkip := targetCluster
-
-	// Cleaning up the previous VRG primary requires many steps. In this step, we update
-	// the VRG to secondary, and then the subsequent steps, we clean them up.
-	return d.updateOtherVRGsToSecondary(clusterToSkip)
-}
-
-func (d *DRPCInstance) updateOtherVRGsToSecondary(clusterToSkip string) error {
-	for _, drCluster := range d.drPolicy.Spec.DRClusterSet {
-		clusterName := drCluster.Name
-		if clusterToSkip == clusterName {
-			continue
-		}
-
-		err := d.updateVRGStateToSecondary(clusterName)
-		if err != nil {
-			return err
-		}
-	}
-
-	// We need to wait for the MW to go to applied state
 	return nil
 }
 

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -1790,7 +1790,7 @@ func (v *VRGInstance) updateVRGConditions() {
 //    VRG.conditions.Available.Reason = Progressing
 //
 func (v *VRGInstance) updateVRGDataReadyCondition() {
-	vrgReady := true
+	vrgReady := len(v.instance.Status.ProtectedPVCs) != 0
 	vrgProgressing := false
 
 	for _, protectedPVC := range v.instance.Status.ProtectedPVCs {

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -60,7 +60,11 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 			for c := 0; c < len(vrgTestCases); c++ {
 				v := vrgTestCases[c]
 				v.promoteVolReps()
-				v.verifyVRGStatusExpectation(true)
+				if c != 0 {
+					v.verifyVRGStatusExpectation(true)
+				} else {
+					v.verifyVRGStatusExpectation(false)
+				}
 			}
 		})
 		It("cleans up after testing", func() {
@@ -122,7 +126,11 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 			for c := 0; c < len(vrgTests); c++ {
 				v := vrgTests[c]
 				v.promoteVolReps()
-				v.verifyVRGStatusExpectation(true)
+				if c != 0 {
+					v.verifyVRGStatusExpectation(true)
+				} else {
+					v.verifyVRGStatusExpectation(false)
+				}
 			}
 		})
 		It("cleans up after testing", func() {


### PR DESCRIPTION
…mplete

When failing over, DRPC start the failover process and creates a task to cleanup the old primary
in parallel. It is possible that the cleanup task runs before the failover is even started. This
change is to close that window. The cleanup task will only be created when the failover operation
is complete