### PR TITLE
ocm-minikube.sh: specify subscription operator image tag matching manifests

### DIFF
--- a/hack/github-url.sh
+++ b/hack/github-url.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+github_url_file()
+{
+        echo https://raw.githubusercontent.com/"$1"/"$3"/"$2"
+}
+github_url_directory()
+{
+        echo https://github.com/"$1"/"$2"?ref="$3"
+}
+github_url_unset()
+{
+	unset -f github_url_file
+	unset -f github_url_directory
+	unset -f github_url_unset
+}


### PR DESCRIPTION
            - replace subscription operator repository cloning with manifest file urls
            - fix helmrepo channel example by specifying cluster to deploy to
            - define routines to deploy and undeploy subscription operator on all clusters
            - define routine to create hub kubeconfig file
            - define github-url.sh containing routines to construct file and directory urls

Note: this is based on pull request #322 which at the time of writing was not yet merged into main.