### PR TITLE
backup and restore pvc alongside pv

### DIFF
--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -19,6 +19,7 @@ rules:
   resources:
   - persistentvolumeclaims
   verbs:
+  - create
   - get
   - list
   - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -62,6 +62,7 @@ rules:
   resources:
   - persistentvolumeclaims
   verbs:
+  - create
   - get
   - list
   - patch

--- a/controllers/s3utils_test.go
+++ b/controllers/s3utils_test.go
@@ -77,7 +77,11 @@ type fakeObjectStorer struct{}
 func (fakeObjectStorer) CreateBucket(bucket string) error { return nil }
 func (fakeObjectStorer) DeleteBucket(bucket string) error { return nil }
 func (fakeObjectStorer) PurgeBucket(bucket string) error  { return nil }
-func (fakeObjectStorer) UploadPV(pvKeyPrefix, pvKeySuffix string, pv corev1.PersistentVolume) error {
+func (fakeObjectStorer) UploadPV(pvKeyPrefix, pvKeySuffix string, pv *corev1.PersistentVolume) error {
+	return nil
+}
+
+func (fakeObjectStorer) UploadPVC(pvcKeyPrefix, pvcKeySuffix string, pvc *corev1.PersistentVolumeClaim) error {
 	return nil
 }
 
@@ -94,8 +98,9 @@ func (fakeObjectStorer) VerifyPVUpload(pvKeyPrefix, pvKeySuffix string,
 	return nil
 }
 
-func (fakeObjectStorer) DownloadPVs(pvKeyPrefix string) ([]corev1.PersistentVolume, error) {
-	return []corev1.PersistentVolume{}, nil
+func (fakeObjectStorer) DownloadPVsAndPVCs(pvKeyPrefix string) ([]corev1.PersistentVolume,
+	[]corev1.PersistentVolumeClaim, error) {
+	return []corev1.PersistentVolume{}, []corev1.PersistentVolumeClaim{}, nil
 }
 
 func (fakeObjectStorer) DownloadTypedObjects(keyPrefix string, objectType reflect.Type) (interface{}, error) {


### PR DESCRIPTION
This PR solves the Crunchy DB issue where a new PV/PVC is created with a random name. We backup the PVC as well as the PV and restore both on the other side so that the crunchy DB operator does not create a new PV/PVC but instead it reuses the restored ones.