### PR TITLE
run pre-commit.sh with make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,9 @@ else ifneq ($(GOLANGCI_VERSION),$(GOLANGCI_INSTALLED_VER))
 endif
 
 .PHONY: lint
-lint: golangci-bin ## Run configured golangci-lint linters against the code.
-	testbin/golangci-lint run ./...
+lint: golangci-bin ## Run configured golangci-lint and pre-commit.sh linters against the code.
+	testbin/golangci-lint run ./... 
+	hack/pre-commit.sh
 
 # Run tests
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin

--- a/hack/minikube-rook-setup.sh
+++ b/hack/minikube-rook-setup.sh
@@ -121,7 +121,7 @@ pool_target_path_set_unqualified()
 	)"
 }
 case $pool_target_path in
-$IMAGE_DIR)
+"$IMAGE_DIR")
 	;;
 ?*)
 	pool_target_path_set

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck disable=1090,2046,2086
+# shellcheck disable=1090,2046,2086,1091
 set -x
 set -e
 ramen_hack_directory_path_name=$(dirname $0)

--- a/hack/true_if_exit_status_and_stderr.sh
+++ b/hack/true_if_exit_status_and_stderr.sh
@@ -11,7 +11,7 @@ true_if_exit_status_and_stderr()
 	tee_pid=$!
 	case $- in *e*) e=-e; set +e;; *) e= ; esac
 	"$@" 2>$stderr_pipe_name1
-	set $e -- $?
+	set "$e" -- $?
 	unset -v e
 	stderr=$(cat $stderr_pipe_name2)
 	wait $tee_pid


### PR DESCRIPTION
- Adding `pre-commit.sh` to run while running `make lint` 
this prevents failing github lint checks when the PRs are raised.

- Few shell files were failing on validating with `shellcheck`. added the fixes for these 