### PR TITLE
tests: reduce the poll interval for Eventually and Consistently

### DIFF
--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -53,7 +53,7 @@ const (
 	DRPolicyName          = "my-dr-peers"
 
 	timeout       = time.Second * 10
-	interval      = time.Millisecond * 250
+	interval      = time.Millisecond * 10
 	updateRetries = 2 // replace this with 5 when done testing.  It takes a long time for the test to complete
 )
 

--- a/controllers/drpolicy_controller_test.go
+++ b/controllers/drpolicy_controller_test.go
@@ -34,8 +34,8 @@ var _ = Describe("DrpolicyController", func() {
 				g.Expect(util.ClusterRolesList(context.TODO(), k8sClient, &clusterNames)).To(Succeed())
 				g.Expect(clusterNames.UnsortedList()).To(ConsistOf(clusterNamesCurrent.UnsortedList()))
 			},
-			10,
-			0.25,
+			timeout,
+			interval,
 		).Should(Succeed())
 	}
 	validatedConditionExpect := func(drpolicy *ramen.DRPolicy, status metav1.ConditionStatus,
@@ -65,8 +65,8 @@ var _ = Describe("DrpolicyController", func() {
 					},
 				))
 			},
-			5,
-			0.25,
+			timeout,
+			interval,
 		).Should(Succeed())
 	}
 	drpolicyCreate := func(drpolicy *ramen.DRPolicy) {
@@ -84,7 +84,7 @@ var _ = Describe("DrpolicyController", func() {
 		Expect(k8sClient.Delete(context.TODO(), drpolicy)).To(Succeed())
 		Eventually(func() bool {
 			return errors.IsNotFound(apiReader.Get(context.TODO(), types.NamespacedName{Name: drpolicy.Name}, drpolicy))
-		}, 10, 0.25).Should(BeTrue())
+		}, timeout, interval).Should(BeTrue())
 	}
 	namespaceDeleteAndConfirm := func(namespaceName string) {
 		// TODO: debug namespace delete not finalized
@@ -99,7 +99,7 @@ var _ = Describe("DrpolicyController", func() {
 			fmt.Println(string(s))
 
 			return errors.IsNotFound(err)
-		}, 30, 15).Should(BeTrue())
+		}, timeout*3, interval).Should(BeTrue())
 	}
 	drpolicyDelete := func(drpolicy *ramen.DRPolicy, clusterNamesExpected sets.String) {
 		drpolicyDeleteAndConfirm(drpolicy)
@@ -112,7 +112,7 @@ var _ = Describe("DrpolicyController", func() {
 				manifestWork := &workv1.ManifestWork{}
 
 				return errors.IsNotFound(apiReader.Get(context.TODO(), manifestWorkName, manifestWork))
-			}, 10, 0.25).Should(BeTrue())
+			}, timeout, interval).Should(BeTrue())
 			namespaceDeleteAndConfirm(clusterName)
 			*clusterNamesCurrent = clusterNamesCurrent.Delete(clusterName)
 		}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	vrgtimeout  = time.Second * 222
-	vrginterval = time.Millisecond * 1315
+	vrginterval = time.Millisecond * 10
 )
 
 type Empty struct{}


### PR DESCRIPTION
It should be perfectly acceptable to poll every 10ms without exerting
too much cpu load on the test systems. This seems to make the tests run
in less than 1/3rd time than before.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>