### PR TITLE
Update rook in e2e to 1.8

### DIFF
--- a/hack/dev-rook-cluster.yaml
+++ b/hack/dev-rook-cluster.yaml
@@ -1,3 +1,5 @@
+# Copy of:
+#  github.com/rook/rook/blob/release-1.8/deploy/examples/cluster-test.yaml
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -9,18 +11,23 @@ data:
     [global]
     osd_pool_default_size = 1
     mon_warn_on_pool_no_redundancy = false
+    bdev_flock_retry = 20
+    bluefs_buffered_io = false
 ---
 apiVersion: ceph.rook.io/v1
 kind: CephCluster
 metadata:
-  name: rook-ceph
+  name: my-cluster
   namespace: rook-ceph
 spec:
   dataDirHostPath: /var/lib/rook
   cephVersion:
-    image: ceph/ceph:v15
+    image: quay.io/ceph/ceph:v16.2.6
     allowUnsupported: true
   mon:
+    count: 1
+    allowMultiplePerNode: true
+  mgr:
     count: 1
     allowMultiplePerNode: true
   dashboard:
@@ -30,10 +37,24 @@ spec:
   storage:
     useAllNodes: true
     useAllDevices: true
-  network:
-    provider: host
   healthCheck:
     daemonHealth:
       mon:
         interval: 45s
         timeout: 600s
+  disruptionManagement:
+    managePodBudgets: true
+  network:
+    provider: host
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: device-health-metrics
+  namespace: rook-ceph
+spec:
+  name: device_health_metrics
+  failureDomain: host
+  replicated:
+    size: 1
+    requireSafeReplicaSize: false

--- a/hack/dev-rook-rbdpool.yaml
+++ b/hack/dev-rook-rbdpool.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   replicated:
     size: 1
+    requireSafeReplicaSize: false
   mirroring:
     enabled: true
     mode: image

--- a/hack/minikube-rook-setup.sh
+++ b/hack/minikube-rook-setup.sh
@@ -14,7 +14,7 @@ if test -z "${IMAGE_DIR}"; then
 fi
 IMAGE_NAME="osd0"
 
-ROOK_SRC="${ROOK_SRC:-"https://raw.githubusercontent.com/rook/rook/v1.6.5/cluster/examples/kubernetes/ceph/"}"
+ROOK_SRC="${ROOK_SRC:-"https://raw.githubusercontent.com/rook/rook/release-1.8/deploy/examples"}"
 
 ## Usage
 usage()
@@ -149,6 +149,8 @@ set -e
 kubectl apply -f "${ROOK_SRC}/common.yaml" --context="${PROFILE}"
 kubectl apply -f "${ROOK_SRC}/crds.yaml" --context="${PROFILE}"
 # Fetch operator.yaml and enable CSI volume replication
+kubectl create -f https://raw.githubusercontent.com/csi-addons/volume-replication-operator/v0.1.0/config/crd/bases/replication.storage.openshift.io_volumereplications.yaml --context="${PROFILE}"
+kubectl create -f https://raw.githubusercontent.com/csi-addons/volume-replication-operator/v0.1.0/config/crd/bases/replication.storage.openshift.io_volumereplicationclasses.yaml --context="${PROFILE}"
 set -- "$(mktemp --directory)"
 cat <<a >"$1"/kustomization.yaml
 resources:


### PR DESCRIPTION
- 1.8 rook has its examples under 1.8 and
not as 1.8.z as such
- 1.8 does not install mirror CRDs and hence is
included here, as per rook instructions
- Ceph version is bumped to 16.2.6

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>