### PR TITLE
DrCluster configure from hub

### DIFF
--- a/api/v1alpha1/ramenconfig_types.go
+++ b/api/v1alpha1/ramenconfig_types.go
@@ -104,31 +104,31 @@ type RamenConfig struct {
 
 	// MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run.
 	// Defaults to 1.
-	MaxConcurrentReconciles int
+	MaxConcurrentReconciles int `json:",omitempty"`
 
 	// dr-cluster operator deployment/undeployment automation configuration
 	DrClusterOperator struct {
 		// dr-cluster operator deployment/undeployment automation enabled
-		DeploymentAutomationEnabled bool `json:"deploymentAutomationEnabled"`
+		DeploymentAutomationEnabled bool `json:"deploymentAutomationEnabled,omitempty"`
 
 		// channel name
-		ChannelName string `json:"channelName"`
+		ChannelName string `json:"channelName,omitempty"`
 
 		// package name
-		PackageName string `json:"packageName"`
+		PackageName string `json:"packageName,omitempty"`
 
 		// namespace name
-		NamespaceName string `json:"namespaceName"`
+		NamespaceName string `json:"namespaceName,omitempty"`
 
 		// catalog source name
-		CatalogSourceName string `json:"catalogSourceName"`
+		CatalogSourceName string `json:"catalogSourceName,omitempty"`
 
 		// catalog source namespace name
-		CatalogSourceNamespaceName string `json:"catalogSourceNamespaceName"`
+		CatalogSourceNamespaceName string `json:"catalogSourceNamespaceName,omitempty"`
 
 		// cluster service version name
-		ClusterServiceVersionName string `json:"clusterServiceVersionName"`
-	} `json:"drClusterOperator"`
+		ClusterServiceVersionName string `json:"clusterServiceVersionName,omitempty"`
+	} `json:"drClusterOperator,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
This pull request:
- applies `RamenConfig` from hub to each cluster in a `DRPolicy` with the following modifications:
  - `RamenControllerType` is set to `DRCluster`
  - `LeaderElection.ResourceName` is set to `dr-cluster.ramendr.openshift.io`
  - remaining `LeaderElection` values are set to zero values if not specified because [its fields](https://pkg.go.dev/k8s.io/component-base/config/v1alpha1#LeaderElectionConfiguration) are not tagged `json:,omitempty` , e.g.:
  ```
      leaseDuration: 0s
      renewDeadline: 0s
      resourceLock: ""
      resourceName: dr-cluster.ramendr.openshift.io
      resourceNamespace: ""
      retryPeriod: 0s
  ```
- removes drcluster config map deployment from end-to-end test
- updates drcluster config map if drpolicy including it changes
- closes issue #102
- is dependent on pull request #346 which has not yet been merged

This pull request **does not**:
- update drcluster config map when it changes on hub
- distribute only the s3 profiles needed for a given drcluster
- distribute s3 profile secrets to drclusters