### PR TITLE
drpolicy controller watch for config map and secrets updates

### DIFF
--- a/config/hub/rbac/role.yaml
+++ b/config/hub/rbac/role.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -6,6 +5,20 @@ metadata:
   creationTimestamp: null
   name: operator-role
 rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,6 +35,10 @@ spec:
         env:
           - name: PORT
             value: "9289"
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         securityContext:
           allowPrivilegeEscalation: false
         livenessProbe:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,20 @@ metadata:
   name: operator-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - apps.open-cluster-management.io
   resources:
   - placementrules

--- a/controllers/drclusters.go
+++ b/controllers/drclusters.go
@@ -22,8 +22,12 @@ import (
 	"sync"
 
 	ocmworkv1 "github.com/open-cluster-management/api/work/v1"
+	operatorsv1 "github.com/operator-framework/api/pkg/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/controllers/util"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -44,23 +48,112 @@ func DrClustersDeployedSet(ctx context.Context, client client.Client, clusterNam
 	return nil
 }
 
+var olmClusterRole = &rbacv1.ClusterRole{
+	TypeMeta:   metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+	ObjectMeta: metav1.ObjectMeta{Name: "open-cluster-management:klusterlet-work-sa:agent:olm-edit"},
+	Rules: []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{"operators.coreos.com"},
+			Resources: []string{"operatorgroups"},
+			Verbs:     []string{"create", "get", "list", "update", "delete"},
+		},
+	},
+}
+
+func olmRoleBinding(namespaceName string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{Kind: "RoleBinding", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "open-cluster-management:klusterlet-work-sa:agent:olm-edit",
+			Namespace: namespaceName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "klusterlet-work-sa",
+				Namespace: "open-cluster-management-agent",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "open-cluster-management:klusterlet-work-sa:agent:olm-edit",
+		},
+	}
+}
+
+func operatorGroup(namespaceName string) *operatorsv1.OperatorGroup {
+	return &operatorsv1.OperatorGroup{
+		TypeMeta:   metav1.TypeMeta{Kind: "OperatorGroup", APIVersion: "operators.coreos.com/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "ramen-operator-group", Namespace: namespaceName},
+	}
+}
+
+func subscription(
+	namespaceName string,
+	channelName string,
+	packageName string,
+	catalogSourceName string,
+	catalogSourceNamespaceName string,
+	clusterServiceVersionName string,
+) *operatorsv1alpha1.Subscription {
+	return &operatorsv1alpha1.Subscription{
+		TypeMeta:   metav1.TypeMeta{Kind: "Subscription", APIVersion: "operators.coreos.com/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "ramen-dr-cluster-subscription", Namespace: namespaceName},
+		Spec: &operatorsv1alpha1.SubscriptionSpec{
+			CatalogSource:          catalogSourceName,
+			CatalogSourceNamespace: catalogSourceNamespaceName,
+			Package:                packageName,
+			Channel:                channelName,
+			StartingCSV:            clusterServiceVersionName,
+			InstallPlanApproval:    "Automatic",
+		},
+	}
+}
+
 var drClustersMutex sync.Mutex
 
-func drClustersDeploy(drpolicy *rmn.DRPolicy, mwu *util.MWUtil, ramenConfig *rmn.RamenConfig) error {
+func drClustersDeploy(drpolicy *rmn.DRPolicy, mwu *util.MWUtil, hubOperatorRamenConfig *rmn.RamenConfig) error {
+	objects := []interface{}{}
+
+	if hubOperatorRamenConfig.DrClusterOperator.DeploymentAutomationEnabled {
+		drClusterOperatorRamenConfig := *hubOperatorRamenConfig
+		ramenConfig := &drClusterOperatorRamenConfig
+		drClusterOperatorNamespaceName := drClusterOperatorNamespaceNameOrDefault(ramenConfig)
+		ramenConfig.LeaderElection.ResourceName = drClusterLeaderElectionResourceName
+		ramenConfig.RamenControllerType = rmn.DRCluster
+
+		drClusterOperatorConfigMap, err := ConfigMapNew(
+			drClusterOperatorNamespaceName,
+			drClusterOperatorConfigMapName,
+			ramenConfig,
+		)
+		if err != nil {
+			return err
+		}
+
+		objects = append(objects,
+			util.Namespace(drClusterOperatorNamespaceName),
+			olmClusterRole,
+			olmRoleBinding(drClusterOperatorNamespaceName),
+			operatorGroup(drClusterOperatorNamespaceName),
+			subscription(
+				drClusterOperatorNamespaceName,
+				drClusterOperatorChannelNameOrDefault(ramenConfig),
+				drClusterOperatorPackageNameOrDefault(ramenConfig),
+				drClusterOperatorCatalogSourceNameOrDefault(ramenConfig),
+				drClusterOperatorCatalogSourceNamespaceNameOrDefault(ramenConfig),
+				drClusterOperatorClusterServiceVersionNameOrDefault(ramenConfig),
+			),
+			drClusterOperatorConfigMap,
+		)
+	}
+
 	drClustersMutex.Lock()
 	defer drClustersMutex.Unlock()
 
 	for _, clusterName := range util.DrpolicyClusterNames(drpolicy) {
-		if err := mwu.CreateOrUpdateDrClusterManifestWork(
-			clusterName,
-			ramenConfig,
-			drClusterOperatorChannelNameOrDefault(ramenConfig),
-			drClusterOperatorPackageNameOrDefault(ramenConfig),
-			drClusterOperatorNamespaceNameOrDefault(ramenConfig),
-			drClusterOperatorCatalogSourceNameOrDefault(ramenConfig),
-			drClusterOperatorCatalogSourceNamespaceNameOrDefault(ramenConfig),
-			drClusterOperatorClusterServiceVersionNameOrDefault(ramenConfig),
-		); err != nil {
+		if err := mwu.CreateOrUpdateDrClusterManifestWork(clusterName, objects...); err != nil {
 			return fmt.Errorf("drcluster '%v' manifest work create or update: %w", clusterName, err)
 		}
 	}

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -109,6 +109,24 @@ var (
 
 	schedulingInterval = "1h"
 
+	s3Secret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "s3secret"},
+		StringData: map[string]string{
+			"AWS_ACCESS_KEY_ID":     awsAccessKeyIDSucc,
+			"AWS_SECRET_ACCESS_KEY": "",
+		},
+	}
+
+	s3Profiles = []rmn.S3StoreProfile{
+		{
+			S3ProfileName:        "fakeS3Profile",
+			S3Bucket:             bucketNameSucc,
+			S3CompatibleEndpoint: "http://192.168.39.223:30000",
+			S3Region:             "us-east-1",
+			S3SecretRef:          corev1.SecretReference{Name: s3Secret.Name},
+		},
+	}
+
 	asyncDRPolicy = &rmn.DRPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: AsyncDRPolicyName,
@@ -117,12 +135,12 @@ var (
 			DRClusterSet: []rmn.ManagedCluster{
 				{
 					Name:          East1ManagedCluster,
-					S3ProfileName: "fakeS3Profile",
+					S3ProfileName: s3Profiles[0].S3ProfileName,
 					Region:        "east",
 				},
 				{
 					Name:          West1ManagedCluster,
-					S3ProfileName: "fakeS3Profile",
+					S3ProfileName: s3Profiles[0].S3ProfileName,
 					Region:        "west",
 				},
 			},
@@ -138,12 +156,12 @@ var (
 			DRClusterSet: []rmn.ManagedCluster{
 				{
 					Name:          East1ManagedCluster,
-					S3ProfileName: "fakeS3Profile",
+					S3ProfileName: s3Profiles[0].S3ProfileName,
 					Region:        "east",
 				},
 				{
 					Name:          East2ManagedCluster,
-					S3ProfileName: "fakeS3Profile",
+					S3ProfileName: s3Profiles[0].S3ProfileName,
 					Region:        "east",
 				},
 			},
@@ -151,6 +169,24 @@ var (
 		},
 	}
 )
+
+func s3SecretNamespaceSet() {
+	s3Secret.Namespace = configMap.Namespace
+
+	for i := range s3Profiles {
+		s3Profiles[i].S3SecretRef.Namespace = s3Secret.Namespace
+	}
+}
+
+func s3SecretAndProfilesCreate() {
+	Expect(k8sClient.Create(context.TODO(), s3Secret)).To(Succeed())
+	Expect(s3ProfilesStore(context.TODO(), apiReader, k8sClient, s3Profiles)).To(Succeed())
+}
+
+func s3SecretAndProfilesDelete() {
+	Expect(s3ProfilesStore(context.TODO(), apiReader, k8sClient, []rmn.S3StoreProfile{})).To(Succeed())
+	Expect(k8sClient.Delete(context.TODO(), s3Secret)).To(Succeed())
+}
 
 var drstate string
 
@@ -210,7 +246,7 @@ func (f FakeMCVGetter) GetVRGFromManagedCluster(
 			PVCSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"appclass": "gold"},
 			},
-			S3Profiles: []string{"fakeS3Profile"},
+			S3Profiles: []string{s3Profiles[0].S3ProfileName},
 		},
 		Status: vrgStatus,
 	}
@@ -1091,6 +1127,10 @@ func verifyFailoverToSecondary(userPlacementRule *plrv1.PlacementRule, fromClust
 
 // +kubebuilder:docs-gen:collapse=Imports
 var _ = Describe("DRPlacementControl Reconciler", func() {
+	Specify("s3 profiles and secret", func() {
+		s3SecretNamespaceSet()
+		s3SecretAndProfilesCreate()
+	})
 	Context("DRPlacementControl Reconciler Async DR", func() {
 		userPlacementRule := &plrv1.PlacementRule{}
 		drpc := &rmn.DRPlacementControl{}
@@ -1289,5 +1329,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				deleteDRPolicySync()
 			})
 		})
+	})
+	Specify("s3 profiles and secret delete", func() {
+		s3SecretAndProfilesDelete()
 	})
 })

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -180,11 +180,11 @@ func s3SecretNamespaceSet() {
 
 func s3SecretAndProfilesCreate() {
 	Expect(k8sClient.Create(context.TODO(), s3Secret)).To(Succeed())
-	Expect(s3ProfilesStore(context.TODO(), apiReader, k8sClient, s3Profiles)).To(Succeed())
+	s3ProfilesStore(s3Profiles)
 }
 
 func s3SecretAndProfilesDelete() {
-	Expect(s3ProfilesStore(context.TODO(), apiReader, k8sClient, []rmn.S3StoreProfile{})).To(Succeed())
+	s3ProfilesStore([]rmn.S3StoreProfile{})
 	Expect(k8sClient.Delete(context.TODO(), s3Secret)).To(Succeed())
 }
 

--- a/controllers/predicates.go
+++ b/controllers/predicates.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The RamenDR authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+type createOrDeleteOrResourceVersionUpdatePredicate struct{}
+
+func (createOrDeleteOrResourceVersionUpdatePredicate) Create(e event.CreateEvent) bool {
+	return true
+}
+
+func (createOrDeleteOrResourceVersionUpdatePredicate) Delete(e event.DeleteEvent) bool {
+	return true
+}
+
+func (createOrDeleteOrResourceVersionUpdatePredicate) Update(e event.UpdateEvent) bool {
+	return predicate.ResourceVersionChangedPredicate{}.Update(e)
+}
+
+func (createOrDeleteOrResourceVersionUpdatePredicate) Generic(e event.GenericEvent) bool {
+	return false
+}

--- a/controllers/ramenconfig.go
+++ b/controllers/ramenconfig.go
@@ -35,26 +35,23 @@ import (
 )
 
 const (
-	NamespaceNameDefault                               = "ramen-system"
-	hubName                                            = "hub"
-	drClusterName                                      = "dr-cluster"
-	operatorNamePrefix                                 = "ramen-"
-	operatorNameSuffix                                 = "-operator"
-	hubOperatorNameDefault                             = operatorNamePrefix + hubName + operatorNameSuffix
-	drClusterOperatorNameDefault                       = operatorNamePrefix + drClusterName + operatorNameSuffix
-	configMapNameSuffix                                = "-config"
-	HubOperatorConfigMapName                           = hubOperatorNameDefault + configMapNameSuffix
-	drClusterOperatorConfigMapName                     = drClusterOperatorNameDefault + configMapNameSuffix
-	leaderElectionResourceNameSuffix                   = ".ramendr.openshift.io"
-	HubLeaderElectionResourceName                      = hubName + leaderElectionResourceNameSuffix
-	drClusterLeaderElectionResourceName                = drClusterName + leaderElectionResourceNameSuffix
-	ConfigMapRamenConfigKeyName                        = "ramen_manager_config.yaml"
-	drClusterOperatorPackageNameDefault                = drClusterOperatorNameDefault
-	drClusterOperatorChannelNameDefault                = "alpha"
-	drClusterOperatorNamespaceNameDefault              = NamespaceNameDefault
-	drClusterOperatorCatalogSourceNameDefault          = "ramen-catalog"
-	drClusterOperatorCatalogSourceNamespaceNameDefault = drClusterOperatorNamespaceNameDefault
-	drClusterOperatorClusterServiceVersionNameDefault  = drClusterOperatorPackageNameDefault + ".v0.0.1"
+	hubName                                           = "hub"
+	drClusterName                                     = "dr-cluster"
+	operatorNamePrefix                                = "ramen-"
+	operatorNameSuffix                                = "-operator"
+	hubOperatorNameDefault                            = operatorNamePrefix + hubName + operatorNameSuffix
+	drClusterOperatorNameDefault                      = operatorNamePrefix + drClusterName + operatorNameSuffix
+	configMapNameSuffix                               = "-config"
+	HubOperatorConfigMapName                          = hubOperatorNameDefault + configMapNameSuffix
+	drClusterOperatorConfigMapName                    = drClusterOperatorNameDefault + configMapNameSuffix
+	leaderElectionResourceNameSuffix                  = ".ramendr.openshift.io"
+	HubLeaderElectionResourceName                     = hubName + leaderElectionResourceNameSuffix
+	drClusterLeaderElectionResourceName               = drClusterName + leaderElectionResourceNameSuffix
+	ConfigMapRamenConfigKeyName                       = "ramen_manager_config.yaml"
+	drClusterOperatorPackageNameDefault               = drClusterOperatorNameDefault
+	drClusterOperatorChannelNameDefault               = "alpha"
+	drClusterOperatorCatalogSourceNameDefault         = "ramen-catalog"
+	drClusterOperatorClusterServiceVersionNameDefault = drClusterOperatorPackageNameDefault + ".v0.0.1"
 )
 
 var cachedRamenConfigFileName string
@@ -264,7 +261,7 @@ func drClusterOperatorPackageNameOrDefault(ramenConfig *ramendrv1alpha1.RamenCon
 
 func drClusterOperatorNamespaceNameOrDefault(ramenConfig *ramendrv1alpha1.RamenConfig) string {
 	if ramenConfig.DrClusterOperator.NamespaceName == "" {
-		return drClusterOperatorNamespaceNameDefault
+		return NamespaceName()
 	}
 
 	return ramenConfig.DrClusterOperator.NamespaceName
@@ -280,7 +277,7 @@ func drClusterOperatorCatalogSourceNameOrDefault(ramenConfig *ramendrv1alpha1.Ra
 
 func drClusterOperatorCatalogSourceNamespaceNameOrDefault(ramenConfig *ramendrv1alpha1.RamenConfig) string {
 	if ramenConfig.DrClusterOperator.CatalogSourceNamespaceName == "" {
-		return drClusterOperatorCatalogSourceNamespaceNameDefault
+		return NamespaceName()
 	}
 
 	return ramenConfig.DrClusterOperator.CatalogSourceNamespaceName

--- a/controllers/ramenconfig.go
+++ b/controllers/ramenconfig.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -25,8 +26,35 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/go-logr/logr"
 	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	NamespaceNameDefault                               = "ramen-system"
+	hubName                                            = "hub"
+	drClusterName                                      = "dr-cluster"
+	operatorNamePrefix                                 = "ramen-"
+	operatorNameSuffix                                 = "-operator"
+	hubOperatorNameDefault                             = operatorNamePrefix + hubName + operatorNameSuffix
+	drClusterOperatorNameDefault                       = operatorNamePrefix + drClusterName + operatorNameSuffix
+	configMapNameSuffix                                = "-config"
+	HubOperatorConfigMapName                           = hubOperatorNameDefault + configMapNameSuffix
+	drClusterOperatorConfigMapName                     = drClusterOperatorNameDefault + configMapNameSuffix
+	leaderElectionResourceNameSuffix                   = ".ramendr.openshift.io"
+	HubLeaderElectionResourceName                      = hubName + leaderElectionResourceNameSuffix
+	drClusterLeaderElectionResourceName                = drClusterName + leaderElectionResourceNameSuffix
+	ConfigMapRamenConfigKeyName                        = "ramen_manager_config.yaml"
+	drClusterOperatorPackageNameDefault                = drClusterOperatorNameDefault
+	drClusterOperatorChannelNameDefault                = "alpha"
+	drClusterOperatorNamespaceNameDefault              = NamespaceNameDefault
+	drClusterOperatorCatalogSourceNameDefault          = "ramen-catalog"
+	drClusterOperatorCatalogSourceNamespaceNameDefault = drClusterOperatorNamespaceNameDefault
+	drClusterOperatorClusterServiceVersionNameDefault  = drClusterOperatorPackageNameDefault + ".v0.0.1"
 )
 
 var cachedRamenConfigFileName string
@@ -65,7 +93,7 @@ func LoadControllerConfig(configFile string, scheme *runtime.Scheme,
 // RamenConfig file for every S3 store profile access turns out to be more
 // expensive, we may need to enhance this logic to load it only when
 // RamenConfig has changed.
-func ReadRamenConfig(log logr.Logger) (ramenConfig ramendrv1alpha1.RamenConfig, err error) {
+func ReadRamenConfigFile(log logr.Logger) (ramenConfig ramendrv1alpha1.RamenConfig, err error) {
 	if cachedRamenConfigFileName == "" {
 		err = fmt.Errorf("config file not specified")
 
@@ -93,61 +121,72 @@ func ReadRamenConfig(log logr.Logger) (ramenConfig ramendrv1alpha1.RamenConfig, 
 	return
 }
 
-func getRamenConfigS3StoreProfile(profileName string, log logr.Logger) (
+func GetRamenConfigS3StoreProfile(ctx context.Context, apiReader client.Reader, profileName string) (
 	s3StoreProfile ramendrv1alpha1.S3StoreProfile, err error) {
-	ramenConfig, err := ReadRamenConfig(log)
+	_, ramenConfig, err := ConfigMapGet(ctx, apiReader)
 	if err != nil {
 		return s3StoreProfile, err
 	}
 
-	profileExists := false
+	s3StoreProfilePointer := RamenConfigS3StoreProfilePointerGet(ramenConfig, profileName)
 
-	for _, s3Profile := range ramenConfig.S3StoreProfiles {
-		if s3Profile.S3ProfileName == profileName {
-			s3StoreProfile = s3Profile
-			profileExists = true
-
-			break // found profile
-		}
-	}
-
-	if !profileExists {
+	if s3StoreProfilePointer == nil {
 		err = fmt.Errorf("s3 profile %s not found in RamenConfig", profileName)
 
 		return s3StoreProfile, err
 	}
 
+	s3StoreProfile = *s3StoreProfilePointer
+
+	err = s3StoreProfileFormatCheck(&s3StoreProfile)
+
+	return
+}
+
+func RamenConfigS3StoreProfilePointerGet(ramenConfig *ramendrv1alpha1.RamenConfig, profileName string,
+) *ramendrv1alpha1.S3StoreProfile {
+	for i := range ramenConfig.S3StoreProfiles {
+		s3Profile := &ramenConfig.S3StoreProfiles[i]
+		if s3Profile.S3ProfileName == profileName {
+			return s3Profile
+		}
+	}
+
+	return nil
+}
+
+func s3StoreProfileFormatCheck(s3StoreProfile *ramendrv1alpha1.S3StoreProfile) (err error) {
 	s3Endpoint := s3StoreProfile.S3CompatibleEndpoint
 	if s3Endpoint == "" {
 		err = fmt.Errorf("s3 endpoint has not been configured in s3 profile %s",
-			profileName)
+			s3StoreProfile.S3ProfileName)
 
-		return s3StoreProfile, err
+		return err
 	}
 
 	_, err = url.ParseRequestURI(s3Endpoint)
 	if err != nil {
 		err = fmt.Errorf("invalid s3 endpoint <%s> in "+
-			"profile %s, reason: %w", s3Endpoint, profileName, err)
+			"profile %s, reason: %w", s3Endpoint, s3StoreProfile.S3ProfileName, err)
 
-		return s3StoreProfile, err
+		return err
 	}
 
 	s3Bucket := s3StoreProfile.S3Bucket
 	if s3Bucket == "" {
 		err = fmt.Errorf("s3 bucket has not been configured in s3 profile %s",
-			profileName)
+			s3StoreProfile.S3ProfileName)
 
-		return s3StoreProfile, err
+		return err
 	}
 
-	return s3StoreProfile, nil
+	return nil
 }
 
 func getMaxConcurrentReconciles(log logr.Logger) int {
 	const defaultMaxConcurrentReconciles = 1
 
-	ramenConfig, err := ReadRamenConfig(log)
+	ramenConfig, err := ReadRamenConfigFile(log)
 	if err != nil {
 		return defaultMaxConcurrentReconciles
 	}
@@ -159,14 +198,53 @@ func getMaxConcurrentReconciles(log logr.Logger) int {
 	return ramenConfig.MaxConcurrentReconciles
 }
 
-const (
-	drClusterOperatorChannelNameDefault                = "alpha"
-	drClusterOperatorPackageNameDefault                = "ramen-dr-cluster-operator"
-	drClusterOperatorNamespaceNameDefault              = "ramen-system"
-	drClusterOperatorCatalogSourceNameDefault          = "ramen-catalog"
-	drClusterOperatorCatalogSourceNamespaceNameDefault = drClusterOperatorNamespaceNameDefault
-	drClusterOperatorClusterServiceVersionNameDefault  = drClusterOperatorPackageNameDefault + ".v0.0.1"
-)
+func ConfigMapNew(
+	namespaceName string,
+	name string,
+	ramenConfig *ramendrv1alpha1.RamenConfig,
+) (*corev1.ConfigMap, error) {
+	ramenConfigYaml, err := yaml.Marshal(ramenConfig)
+	if err != nil {
+		return nil, fmt.Errorf("config map yaml marshal %w", err)
+	}
+
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespaceName,
+		},
+		Data: map[string]string{
+			ConfigMapRamenConfigKeyName: string(ramenConfigYaml),
+		},
+	}, nil
+}
+
+func ConfigMapGet(
+	ctx context.Context,
+	apiReader client.Reader,
+) (configMap *corev1.ConfigMap, ramenConfig *ramendrv1alpha1.RamenConfig, err error) {
+	configMap = &corev1.ConfigMap{}
+	if err = apiReader.Get(
+		ctx,
+		types.NamespacedName{
+			Namespace: NamespaceName(),
+			Name:      HubOperatorConfigMapName,
+		},
+		configMap,
+	); err != nil {
+		return
+	}
+
+	ramenConfig = &ramendrv1alpha1.RamenConfig{}
+	err = yaml.Unmarshal([]byte(configMap.Data[ConfigMapRamenConfigKeyName]), ramenConfig)
+
+	return
+}
+
+func NamespaceName() string {
+	return os.Getenv("POD_NAMESPACE")
+}
 
 func drClusterOperatorChannelNameOrDefault(ramenConfig *ramendrv1alpha1.RamenConfig) string {
 	if ramenConfig.DrClusterOperator.ChannelName == "" {

--- a/controllers/ramenconfig_test.go
+++ b/controllers/ramenconfig_test.go
@@ -18,43 +18,24 @@ package controllers_test
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ghodss/yaml"
+	. "github.com/onsi/gomega"
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/controllers"
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func configMapUpdate(
-	ctx context.Context,
-	client client.Client,
-	configMap *corev1.ConfigMap,
-	ramenConfig *ramen.RamenConfig,
-) error {
+func configMapUpdate() {
 	ramenConfigYaml, err := yaml.Marshal(ramenConfig)
-	if err != nil {
-		return fmt.Errorf("config map yaml marshal %w", err)
-	}
+	Expect(err).To(Succeed())
 
 	configMap.Data[controllers.ConfigMapRamenConfigKeyName] = string(ramenConfigYaml)
 
-	return client.Update(ctx, configMap)
+	Expect(k8sClient.Update(context.TODO(), configMap)).To(Succeed())
 }
 
-func s3ProfilesStore(
-	ctx context.Context,
-	apiReader client.Reader,
-	client client.Client,
-	s3Profiles []ramen.S3StoreProfile,
-) error {
-	configMap, ramenConfig, err := controllers.ConfigMapGet(ctx, apiReader)
-	if err != nil {
-		return fmt.Errorf("config map get %w", err)
-	}
-
+func s3ProfilesStore(s3Profiles []ramen.S3StoreProfile) {
 	ramenConfig.S3StoreProfiles = s3Profiles
 
-	return configMapUpdate(ctx, client, configMap, ramenConfig)
+	configMapUpdate()
 }

--- a/controllers/s3utils.go
+++ b/controllers/s3utils.go
@@ -127,13 +127,13 @@ type s3ObjectStoreGetter struct{}
 func (s3ObjectStoreGetter) ObjectStore(ctx context.Context,
 	r client.Reader, s3ProfileName string,
 	callerTag string, log logr.Logger) (ObjectStorer, error) {
-	s3StoreProfile, err := getRamenConfigS3StoreProfile(s3ProfileName, log)
+	s3StoreProfile, err := GetRamenConfigS3StoreProfile(ctx, r, s3ProfileName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get profile %s for caller %s, %w",
 			s3ProfileName, callerTag, err)
 	}
 
-	accessID, secretAccessKey, err := getS3Secret(ctx, r, s3StoreProfile.S3SecretRef)
+	accessID, secretAccessKey, err := GetS3Secret(ctx, r, s3StoreProfile.S3SecretRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get secret %v for caller %s, %w",
 			s3StoreProfile.S3SecretRef, callerTag, err)
@@ -179,7 +179,7 @@ func (s3ObjectStoreGetter) ObjectStore(ctx context.Context,
 	return s3Conn, nil
 }
 
-func getS3Secret(ctx context.Context, r client.Reader,
+func GetS3Secret(ctx context.Context, r client.Reader,
 	secretRef corev1.SecretReference) (
 	s3AccessID, s3SecretAccessKey []byte, err error) {
 	secret := corev1.Secret{}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -55,11 +55,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	cfg       *rest.Config
-	apiReader client.Reader
-	k8sClient client.Client
-	testEnv   *envtest.Environment
-	configMap *corev1.ConfigMap
+	cfg         *rest.Config
+	apiReader   client.Reader
+	k8sClient   client.Client
+	testEnv     *envtest.Environment
+	configMap   *corev1.ConfigMap
+	ramenConfig *ramendrv1alpha1.RamenConfig
 )
 
 func TestAPIs(t *testing.T) {
@@ -140,7 +141,7 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).NotTo(BeNil())
 
 	createOperatorNamespace(ramenNamespace)
-	ramenConfig := &ramendrv1alpha1.RamenConfig{
+	ramenConfig = &ramendrv1alpha1.RamenConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "RamenConfig",
 			APIVersion: ramendrv1alpha1.GroupVersion.String(),


### PR DESCRIPTION
	- permit list and watch of secrets and config maps at cluster scope
	- set environment variable POD_NAMESPACE to pod's namespace name
	- move dr cluster object routines to drclusters.go from util/mw_util.go
	- unit tests:
		- create and delete a config map
		- define s3 profiles and secrets for drpolicy and drplacement control unit tests
		- test re-reconcile of a valid drpolicy on config map and secret updates

closes #319