### PR TITLE
drpc: set vrg.spec.sync

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -926,6 +926,7 @@ func (d *DRPCInstance) generateVRG() rmn.VolumeReplicationGroup {
 			PVCSelector:      d.instance.Spec.PVCSelector,
 			ReplicationState: rmn.Primary,
 			S3Profiles:       rmnutil.S3UploadProfileList(*d.drPolicy),
+			Sync:             rmn.VRGSyncSpec{Mode: rmn.SyncModeDisabled},
 		},
 	}
 


### PR DESCRIPTION
busybox-sample application failed to deploy because its vrg manifest was missing new `spec.sync` field:

```sh
status:
  conditions:
  - lastTransitionTime: "2022-01-28T23:56:47Z"
    message: 1 of 1 resources are not available
    observedGeneration: 1
    reason: ResourcesNotAvailable
    status: "False"
    type: Available
  - lastTransitionTime: "2022-01-28T23:56:47Z"
    message: Failed to apply manifest work
    observedGeneration: 1
    reason: AppliedManifestWorkFailed
    status: "False"
    type: Applied
  resourceStatus:
    manifests:
    - conditions:
      - lastTransitionTime: "2022-01-28T23:56:47Z"
        message: 'Failed to apply manifest: VolumeReplicationGroup.ramendr.openshift.io
          "busybox-drpc" is invalid: spec.sync.mode: Unsupported value: "": supported
          values: "Enabled", "Disabled"'
        reason: AppliedManifestFailed
        status: "False"
        type: Applied
      - lastTransitionTime: "2022-01-28T23:56:47Z"
        message: Resource is not available
        reason: ResourceNotAvailable
        status: "False"
        type: Available
      resourceMeta:
        group: ramendr.openshift.io
        kind: VolumeReplicationGroup
        name: busybox-drpc
        namespace: busybox-sample
        ordinal: 0
        resource: volumereplicationgroups
        version: v1alpha1
```

I expect this will be fixed soon with the sync support, but here is a fix for now.