### PR TITLE
Add S3 secret distribution to managed clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,6 +258,7 @@ bundle-hub: manifests kustomize operator-sdk ## Generate hub bundle manifests an
 	$(SED_CMD) -e "s,namespaceName: ramen-system,namespaceName: $(OPERATOR_SUGGESTED_NAMESPACE)," -i config/hub/manifests/$(IMAGE_NAME)/ramen_manager_config_append.yaml
 	$(SED_CMD) -e "s,clusterServiceVersionName: ramen-dr-cluster-operator.v0.0.1,clusterServiceVersionName: $(DRCLUSTER_NAME).v$(VERSION)," -i config/hub/manifests/$(IMAGE_NAME)/ramen_manager_config_append.yaml
 	$(SED_CMD) -e "s,deploymentAutomationEnabled: true,deploymentAutomationEnabled: $(AUTO_CONFIGURE_DR_CLUSTER)," -i config/hub/manifests/$(IMAGE_NAME)/ramen_manager_config_append.yaml
+	$(SED_CMD) -e "s,s3SecretDistributionEnabled: true,s3SecretDistributionEnabled: $(AUTO_CONFIGURE_DR_CLUSTER)," -i config/hub/manifests/$(IMAGE_NAME)/ramen_manager_config_append.yaml
 	cat config/hub/manifests/$(IMAGE_NAME)/ramen_manager_config_append.yaml >> config/hub/manager/ramen_manager_config.yaml
 	$(KUSTOMIZE) build --load_restrictor none config/hub/manifests/$(IMAGE_NAME) | $(OSDK) generate bundle -q --package=$(HUB_NAME) --overwrite --output-dir=config/hub/bundle --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	$(OSDK) bundle validate config/hub/bundle

--- a/api/v1alpha1/ramenconfig_types.go
+++ b/api/v1alpha1/ramenconfig_types.go
@@ -111,6 +111,9 @@ type RamenConfig struct {
 		// dr-cluster operator deployment/undeployment automation enabled
 		DeploymentAutomationEnabled bool `json:"deploymentAutomationEnabled,omitempty"`
 
+		// Enable s3 secret distribution and management across dr-clusters
+		S3SecretDistributionEnabled bool `json:"s3SecretDistributionEnabled,omitempty"`
+
 		// channel name
 		ChannelName string `json:"channelName,omitempty"`
 

--- a/config/dr-cluster/manager/ramen_manager_config.yaml
+++ b/config/dr-cluster/manager/ramen_manager_config.yaml
@@ -9,4 +9,4 @@ webhook:
 leaderElection:
   leaderElect: true
   resourceName: dr-cluster.ramendr.openshift.io
-ramenControllerType: "dr-cluster"
+ramenControllerType: dr-cluster

--- a/config/hub/manager/ramen_manager_config.yaml
+++ b/config/hub/manager/ramen_manager_config.yaml
@@ -9,4 +9,4 @@ webhook:
 leaderElection:
   leaderElect: true
   resourceName: hub.ramendr.openshift.io
-ramenControllerType: "dr-hub"
+ramenControllerType: dr-hub

--- a/config/hub/manifests/ramen/ramen_manager_config_append.yaml
+++ b/config/hub/manifests/ramen/ramen_manager_config_append.yaml
@@ -1,5 +1,6 @@
 drClusterOperator:
   deploymentAutomationEnabled: true
+  s3SecretDistributionEnabled: true
   channelName: alpha
   packageName: ramen-dr-cluster-operator
   namespaceName: ramen-system

--- a/config/hub/rbac/role.yaml
+++ b/config/hub/rbac/role.yaml
@@ -57,6 +57,20 @@ rules:
   - list
   - watch
 - apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - placementbindings
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policies
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - ramendr.openshift.io
   resources:
   - drplacementcontrols
@@ -146,3 +160,22 @@ rules:
   - secrets
   verbs:
   - get
+  - update
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - placementbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policies
+  verbs:
+  - create
+  - delete
+  - get
+  - update

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -79,6 +79,20 @@ rules:
   - update
   - watch
 - apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - placementbindings
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policies
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - ramendr.openshift.io
   resources:
   - drplacementcontrols
@@ -223,3 +237,22 @@ rules:
   - secrets
   verbs:
   - get
+  - update
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - placementbindings
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+- apiGroups:
+  - policy.open-cluster-management.io
+  resources:
+  - policies
+  verbs:
+  - create
+  - delete
+  - get
+  - update

--- a/config/samples/ramendr_v1alpha1_ramenconfig.yaml
+++ b/config/samples/ramendr_v1alpha1_ramenconfig.yaml
@@ -24,6 +24,7 @@ s3StoreProfiles:
       namespace: default
 drClusterOperator:
   deploymentAutomationEnabled: true
+  s3SecretDistributionEnabled: true
   channelName: alpha
   packageName: ramen-dr-cluster-operator
   namespaceName: ramen-system

--- a/controllers/drclusters.go
+++ b/controllers/drclusters.go
@@ -189,7 +189,11 @@ func drClusterSecretsDeploy(
 	}
 
 	for _, secretName := range drPolicySecrets.List() {
-		if err := secretsUtil.AddSecretToCluster(secretName, clusterName, NamespaceName()); err != nil {
+		if err := secretsUtil.AddSecretToCluster(
+			secretName,
+			clusterName,
+			NamespaceName(),
+			drClusterOperatorNamespaceNameOrDefault(rmnCfg)); err != nil {
 			return fmt.Errorf("drcluster '%v' secret add '%v': %w", clusterName, secretName, err)
 		}
 	}

--- a/controllers/drclusters.go
+++ b/controllers/drclusters.go
@@ -169,6 +169,11 @@ func drClusterSecretsDeploy(
 	drpolicy *rmn.DRPolicy,
 	secretsUtil *util.SecretsUtil,
 	rmnCfg *rmn.RamenConfig) error {
+	if !rmnCfg.DrClusterOperator.DeploymentAutomationEnabled ||
+		!rmnCfg.DrClusterOperator.S3SecretDistributionEnabled {
+		return nil
+	}
+
 	for _, secretName := range drPolicySecretNames(drpolicy, rmnCfg).List() {
 		if err := secretsUtil.AddSecretToCluster(secretName, clusterName, NamespaceName()); err != nil {
 			return fmt.Errorf("drcluster '%v' secret add '%v': %w", clusterName, secretName, err)
@@ -305,6 +310,11 @@ func drClustersUndeploySecrets(
 	drpolicies rmn.DRPolicyList,
 	secretsUtil *util.SecretsUtil,
 	ramenConfig *rmn.RamenConfig) error {
+	if !ramenConfig.DrClusterOperator.DeploymentAutomationEnabled ||
+		!ramenConfig.DrClusterOperator.S3SecretDistributionEnabled {
+		return nil
+	}
+
 	mustHaveS3Secrets := map[string]sets.String{}
 
 	// Determine S3 secrets that must continue to exist per cluster in the policy being deleted

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -60,6 +60,11 @@ const ReasonValidationFailed = "ValidationFailed"
 // +kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=list;watch
+// +kubebuilder:rbac:groups="policy.open-cluster-management.io",resources=placementbindings,verbs=list;watch
+// +kubebuilder:rbac:groups="policy.open-cluster-management.io",resources=policies,verbs=list;watch
+// +kubebuilder:rbac:groups="",namespace=system,resources=secrets,verbs=get;update
+// +kubebuilder:rbac:groups="policy.open-cluster-management.io",namespace=system,resources=placementbindings,verbs=get;create;update;delete
+// +kubebuilder:rbac:groups="policy.open-cluster-management.io",namespace=system,resources=policies,verbs=get;create;update;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -94,7 +94,7 @@ func (r *DRPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if !drpolicy.ObjectMeta.DeletionTimestamp.IsZero() {
 		log.Info("delete")
 
-		if err := drClustersUndeploy(drpolicy, &manifestWorkUtil); err != nil {
+		if err := drClustersUndeploy(drpolicy, &manifestWorkUtil, ramenConfig); err != nil {
 			return ctrl.Result{}, fmt.Errorf("drclusters undeploy: %w", err)
 		}
 

--- a/controllers/util/secrets_util.go
+++ b/controllers/util/secrets_util.go
@@ -143,11 +143,16 @@ func newPolicy(name, namespace string, object runtime.RawExtension) *gppv1.Polic
 	}
 }
 
+func (sutil *SecretsUtil) generatePolicyResourceNames(
+	s3Secret string) (policyName, plBindingName, plRuleName, configPolicyName string) {
+	return fmt.Sprintf(secretResourceNameFormat, secretPolicyBaseName, s3Secret),
+		fmt.Sprintf(secretResourceNameFormat, secretPlBindingBaseName, s3Secret),
+		fmt.Sprintf(secretResourceNameFormat, secretPlRuleBaseName, s3Secret),
+		fmt.Sprintf(secretResourceNameFormat, secretConfigPolicyBaseName, s3Secret)
+}
+
 func (sutil *SecretsUtil) createPolicyResources(s3Secret, cluster, namespace string) error {
-	policyName := fmt.Sprintf(secretResourceNameFormat, secretPolicyBaseName, s3Secret)
-	plBindingName := fmt.Sprintf(secretResourceNameFormat, secretPlBindingBaseName, s3Secret)
-	plRuleName := fmt.Sprintf(secretResourceNameFormat, secretPlRuleBaseName, s3Secret)
-	configPolicyName := fmt.Sprintf(secretResourceNameFormat, secretConfigPolicyBaseName, s3Secret)
+	policyName, plBindingName, plRuleName, configPolicyName := sutil.generatePolicyResourceNames(s3Secret)
 
 	// Create a PlacementBinding for the Policy object and the placement rule
 	subjects := []gppv1.Subject{
@@ -191,17 +196,61 @@ func (sutil *SecretsUtil) createPolicyResources(s3Secret, cluster, namespace str
 	return nil
 }
 
-func (sutil *SecretsUtil) updatePlacementRule(plRule *plrv1.PlacementRule, cluster string, add bool) error {
-	found := false
+func (sutil *SecretsUtil) deletePolicyResources(s3Secret, namespace string) error {
+	policyName, plBindingName, plRuleName, _ := sutil.generatePolicyResourceNames(s3Secret)
+
+	plRuleBindingObject := &gppv1.PlacementBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      plBindingName,
+			Namespace: namespace,
+		},
+	}
+	if err := sutil.Client.Delete(sutil.Ctx, plRuleBindingObject); !errors.IsNotFound(err) {
+		sutil.Log.Error(err, "unable to delete placement binding", "secret", s3Secret)
+
+		return errorswrapper.Wrap(err, fmt.Sprintf("unable to delete placement binding (secret: %s)", s3Secret))
+	}
+
+	policyObject := &gppv1.Policy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policyName,
+			Namespace: namespace,
+		},
+	}
+	if err := sutil.Client.Delete(sutil.Ctx, policyObject); !errors.IsNotFound(err) {
+		sutil.Log.Error(err, "unable to delete policy", "secret", s3Secret)
+
+		return errorswrapper.Wrap(err, fmt.Sprintf("unable to delete policy (secret: %s)", s3Secret))
+	}
+
+	plRuleObject := &plrv1.PlacementRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      plRuleName,
+			Namespace: namespace,
+		},
+	}
+	if err := sutil.Client.Delete(sutil.Ctx, plRuleObject); !errors.IsNotFound(err) {
+		sutil.Log.Error(err, "unable to delete placement rule", "secret", s3Secret)
+
+		return errorswrapper.Wrap(err, fmt.Sprintf("unable to delete placement rule (secret: %s)",
+			s3Secret))
+	}
+
+	return nil
+}
+
+func inspectClusters(
+	clusters []plrv1.GenericClusterReference,
+	cluster string,
+	add bool) (bool, []plrv1.GenericClusterReference) {
+	found := true
 	survivors := []plrv1.GenericClusterReference{}
 
 	// Check if cluster is already part of placement rule
-	for _, plCluster := range plRule.Spec.Clusters {
+	for _, plCluster := range clusters {
 		if plCluster.Name == cluster {
-			found = true
-
 			if add {
-				break
+				return found, clusters
 			}
 
 			continue
@@ -209,6 +258,15 @@ func (sutil *SecretsUtil) updatePlacementRule(plRule *plrv1.PlacementRule, clust
 		// Build a potential surviving cluster list
 		survivors = append(survivors, plCluster)
 	}
+
+	return !found, survivors
+}
+
+func (sutil *SecretsUtil) updatePlacementRule(
+	plRule *plrv1.PlacementRule,
+	s3Secret, cluster, namespace string,
+	add bool) error {
+	found, survivors := inspectClusters(plRule.Spec.Clusters, cluster, add)
 
 	switch add {
 	case true:
@@ -218,6 +276,10 @@ func (sutil *SecretsUtil) updatePlacementRule(plRule *plrv1.PlacementRule, clust
 
 		plRule.Spec.Clusters = append(plRule.Spec.Clusters, plrv1.GenericClusterReference{Name: cluster})
 	case false:
+		if len(survivors) == 0 {
+			return sutil.deletePolicyResources(s3Secret, namespace)
+		}
+
 		if !found {
 			return nil
 		}
@@ -236,10 +298,36 @@ func (sutil *SecretsUtil) updatePlacementRule(plRule *plrv1.PlacementRule, clust
 	return nil
 }
 
+func (sutil *SecretsUtil) ensureS3SecretResources(s3Secret, namespace string) (bool, error) {
+	found := true
+
+	secret := corev1.Secret{}
+	if err := sutil.Client.Get(sutil.Ctx,
+		types.NamespacedName{Namespace: namespace, Name: s3Secret},
+		&secret); err != nil {
+		if !errors.IsNotFound(err) {
+			return !found, errorswrapper.Wrap(err, "failed to get secret object")
+		}
+
+		// Cleanup policy for missing secret
+		return !found, sutil.deletePolicyResources(s3Secret, namespace)
+	}
+
+	return found, nil
+}
+
 func (sutil *SecretsUtil) AddSecretToCluster(s3Secret, clusterName, namespace string) error {
 	sutil.Log.Info("Add Secret", "cluster", clusterName, "s3Secret", s3Secret)
 
-	// TODO: Proceed if secret is found, else error and reconcile later
+	found, err := sutil.ensureS3SecretResources(s3Secret, namespace)
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		return fmt.Errorf("failed to find secret (secret: %s, cluster: %s)", s3Secret, clusterName)
+	}
+
 	plRule := &plrv1.PlacementRule{}
 	plRuleName := types.NamespacedName{
 		Namespace: namespace,
@@ -247,7 +335,7 @@ func (sutil *SecretsUtil) AddSecretToCluster(s3Secret, clusterName, namespace st
 	}
 
 	// Fetch secret placement rule, create if not found
-	err := sutil.Client.Get(sutil.Ctx, plRuleName, plRule)
+	err = sutil.Client.Get(sutil.Ctx, plRuleName, plRule)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return errorswrapper.Wrap(err, "failed to get placementRule object")
@@ -256,11 +344,20 @@ func (sutil *SecretsUtil) AddSecretToCluster(s3Secret, clusterName, namespace st
 		return sutil.createPolicyResources(s3Secret, clusterName, namespace)
 	}
 
-	return sutil.updatePlacementRule(plRule, clusterName, true)
+	return sutil.updatePlacementRule(plRule, s3Secret, clusterName, namespace, true)
 }
 
 func (sutil *SecretsUtil) RemoveSecretFromCluster(s3Secret, clusterName, namespace string) error {
 	sutil.Log.Info("Delete Secret", "cluster", clusterName, "s3Secret", s3Secret)
+
+	found, err := sutil.ensureS3SecretResources(s3Secret, namespace)
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		return nil
+	}
 
 	plRule := &plrv1.PlacementRule{}
 	plRuleName := types.NamespacedName{
@@ -269,7 +366,7 @@ func (sutil *SecretsUtil) RemoveSecretFromCluster(s3Secret, clusterName, namespa
 	}
 
 	// Fetch secret placement rule, success if not found
-	err := sutil.Client.Get(sutil.Ctx, plRuleName, plRule)
+	err = sutil.Client.Get(sutil.Ctx, plRuleName, plRule)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return errorswrapper.Wrap(err, "failed to get placementRule object")
@@ -278,5 +375,5 @@ func (sutil *SecretsUtil) RemoveSecretFromCluster(s3Secret, clusterName, namespa
 		return nil
 	}
 
-	return sutil.updatePlacementRule(plRule, clusterName, false)
+	return sutil.updatePlacementRule(plRule, s3Secret, clusterName, namespace, false)
 }

--- a/controllers/util/secrets_util.go
+++ b/controllers/util/secrets_util.go
@@ -1,0 +1,282 @@
+/*
+Copyright 2022 The RamenDR authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	errorswrapper "github.com/pkg/errors"
+	cpcv1 "github.com/stolostron/config-policy-controller/api/v1"
+	gppv1 "github.com/stolostron/governance-policy-propagator/api/v1"
+	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	secretResourcesBaseName    = "ramen-secret"
+	secretPolicyBaseName       = secretResourcesBaseName + "-policy"
+	secretPlRuleBaseName       = secretResourcesBaseName + "-plrule"
+	secretPlBindingBaseName    = secretResourcesBaseName + "-plbinding"
+	secretConfigPolicyBaseName = secretResourcesBaseName + "-config-policy"
+
+	secretResourceNameFormat string = "%s-%s"
+)
+
+type SecretsUtil struct {
+	client.Client
+	Ctx context.Context
+	Log logr.Logger
+}
+
+func newPlacementRuleBinding(
+	name, namespace, placementRuleName string,
+	subjects []gppv1.Subject) *gppv1.PlacementBinding {
+	return &gppv1.PlacementBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		PlacementRef: gppv1.PlacementSubject{
+			APIGroup: plrv1.Resource("PlacementRule").Group,
+			Kind:     plrv1.Resource("PlacementRule").Resource,
+			Name:     placementRuleName,
+		},
+		Subjects: subjects,
+	}
+}
+
+func newPlacementRule(name string, namespace string,
+	clusters []string) *plrv1.PlacementRule {
+	plRuleClusters := []plrv1.GenericClusterReference{}
+	for _, clusterRef := range clusters {
+		plRuleClusters = append(plRuleClusters, plrv1.GenericClusterReference{
+			Name: clusterRef,
+		})
+	}
+
+	return &plrv1.PlacementRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: plrv1.PlacementRuleSpec{
+			GenericPlacementFields: plrv1.GenericPlacementFields{
+				Clusters: plRuleClusters,
+			},
+		},
+	}
+}
+
+func newS3ConfigurationSecret(s3SecretRef corev1.SecretReference) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      s3SecretRef.Name,
+			Namespace: s3SecretRef.Namespace,
+		},
+		Data: map[string][]byte{
+			"AWS_ACCESS_KEY_ID": []byte("'{{ fromSecret " +
+				"\"" + s3SecretRef.Namespace + "\"" +
+				"\"" + s3SecretRef.Name + "\"" +
+				"\"AWS_ACCESS_KEY_ID\" }}'"),
+			"AWS_SECRET_ACCESS_KEY": []byte("'{{ fromSecret " +
+				"\"" + s3SecretRef.Namespace + "\"" +
+				"\"" + s3SecretRef.Name + "\"" +
+				"\"AWS_SECRET_ACCESS_KEY\" }}'"),
+		},
+	}
+}
+
+func newConfigurationPolicy(name string, object runtime.RawExtension) *cpcv1.ConfigurationPolicy {
+	return &cpcv1.ConfigurationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: cpcv1.ConfigurationPolicySpec{
+			RemediationAction: cpcv1.Enforce,
+			Severity:          "high",
+			ObjectTemplates: []*cpcv1.ObjectTemplate{
+				{
+					ComplianceType:   cpcv1.MustHave,
+					ObjectDefinition: object,
+				},
+			},
+		},
+	}
+}
+
+func newPolicy(name, namespace string, object runtime.RawExtension) *gppv1.Policy {
+	return &gppv1.Policy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: gppv1.PolicySpec{
+			RemediationAction: gppv1.Enforce,
+			Disabled:          false,
+			PolicyTemplates: []*gppv1.PolicyTemplate{
+				{
+					ObjectDefinition: object,
+				},
+			},
+		},
+	}
+}
+
+func (sutil *SecretsUtil) createPolicyResources(s3Secret, cluster, namespace string) error {
+	policyName := fmt.Sprintf(secretResourceNameFormat, secretPolicyBaseName, s3Secret)
+	plBindingName := fmt.Sprintf(secretResourceNameFormat, secretPlBindingBaseName, s3Secret)
+	plRuleName := fmt.Sprintf(secretResourceNameFormat, secretPlRuleBaseName, s3Secret)
+	configPolicyName := fmt.Sprintf(secretResourceNameFormat, secretConfigPolicyBaseName, s3Secret)
+
+	// Create a PlacementBinding for the Policy object and the placement rule
+	subjects := []gppv1.Subject{
+		{
+			Name:     policyName,
+			APIGroup: gppv1.SchemeGroupVersion.WithResource("Policy").GroupResource().Group,
+			Kind:     gppv1.SchemeGroupVersion.WithResource("Policy").GroupResource().Resource,
+		},
+	}
+
+	plRuleBindingObject := newPlacementRuleBinding(plBindingName, namespace, plRuleName, subjects)
+	if err := sutil.Client.Create(sutil.Ctx, plRuleBindingObject); !errors.IsAlreadyExists(err) {
+		sutil.Log.Error(err, "unable to create placement binding", "secret", s3Secret, "cluster", cluster)
+
+		return errorswrapper.Wrap(err, fmt.Sprintf("unable to create placement binding (secret: %s, cluster: %s)",
+			s3Secret, cluster))
+	}
+
+	// Create a Policy object for the secret
+	s3SecretRef := corev1.SecretReference{Name: s3Secret, Namespace: namespace}
+	secretObject := newS3ConfigurationSecret(s3SecretRef)
+	configObject := newConfigurationPolicy(configPolicyName, runtime.RawExtension{Object: secretObject})
+
+	policyObject := newPolicy(policyName, namespace, runtime.RawExtension{Object: configObject})
+	if err := sutil.Client.Create(sutil.Ctx, policyObject); !errors.IsAlreadyExists(err) {
+		sutil.Log.Error(err, "unable to create policy", "secret", s3Secret, "cluster", cluster)
+
+		return errorswrapper.Wrap(err, fmt.Sprintf("unable to create policy (secret: %s, cluster: %s)",
+			s3Secret, cluster))
+	}
+
+	// Create a PlacementRule, including cluster
+	plRuleObject := newPlacementRule(plRuleName, namespace, []string{cluster})
+	if err := sutil.Client.Create(sutil.Ctx, plRuleObject); !errors.IsAlreadyExists(err) {
+		sutil.Log.Error(err, "unable to create placement rule", "secret", s3Secret, "cluster", cluster)
+
+		return errorswrapper.Wrap(err, fmt.Sprintf("unable to create placement rule (secret: %s, cluster: %s)",
+			s3Secret, cluster))
+	}
+
+	return nil
+}
+
+func (sutil *SecretsUtil) updatePlacementRule(plRule *plrv1.PlacementRule, cluster string, add bool) error {
+	found := false
+	survivors := []plrv1.GenericClusterReference{}
+
+	// Check if cluster is already part of placement rule
+	for _, plCluster := range plRule.Spec.Clusters {
+		if plCluster.Name == cluster {
+			found = true
+
+			if add {
+				break
+			}
+
+			continue
+		}
+		// Build a potential surviving cluster list
+		survivors = append(survivors, plCluster)
+	}
+
+	switch add {
+	case true:
+		if found {
+			return nil
+		}
+
+		plRule.Spec.Clusters = append(plRule.Spec.Clusters, plrv1.GenericClusterReference{Name: cluster})
+	case false:
+		if !found {
+			return nil
+		}
+
+		plRule.Spec.Clusters = survivors
+	}
+
+	err := sutil.Client.Update(sutil.Ctx, plRule)
+	if err != nil {
+		sutil.Log.Error(err, "unable to update placement rule", "placementRule", plRule.Name, "cluster", cluster)
+
+		return errorswrapper.Wrap(err, fmt.Sprintf("unable to update placement rule (placementRule: %s, cluster: %s)",
+			plRule.Name, cluster))
+	}
+
+	return nil
+}
+
+func (sutil *SecretsUtil) AddSecretToCluster(s3Secret, clusterName, namespace string) error {
+	sutil.Log.Info("Add Secret", "cluster", clusterName, "s3Secret", s3Secret)
+
+	// TODO: Proceed if secret is found, else error and reconcile later
+	plRule := &plrv1.PlacementRule{}
+	plRuleName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      fmt.Sprintf(secretResourceNameFormat, secretPlRuleBaseName, s3Secret),
+	}
+
+	// Fetch secret placement rule, create if not found
+	err := sutil.Client.Get(sutil.Ctx, plRuleName, plRule)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return errorswrapper.Wrap(err, "failed to get placementRule object")
+		}
+
+		return sutil.createPolicyResources(s3Secret, clusterName, namespace)
+	}
+
+	return sutil.updatePlacementRule(plRule, clusterName, true)
+}
+
+func (sutil *SecretsUtil) RemoveSecretFromCluster(s3Secret, clusterName, namespace string) error {
+	sutil.Log.Info("Delete Secret", "cluster", clusterName, "s3Secret", s3Secret)
+
+	plRule := &plrv1.PlacementRule{}
+	plRuleName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      fmt.Sprintf(secretResourceNameFormat, secretPlRuleBaseName, s3Secret),
+	}
+
+	// Fetch secret placement rule, success if not found
+	err := sutil.Client.Get(sutil.Ctx, plRuleName, plRule)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return errorswrapper.Wrap(err, "failed to get placementRule object")
+		}
+
+		return nil
+	}
+
+	return sutil.updatePlacementRule(plRule, clusterName, false)
+}

--- a/controllers/util/secrets_util_test.go
+++ b/controllers/util/secrets_util_test.go
@@ -1,0 +1,411 @@
+/*
+Copyright 2022 The RamenDR authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util_test
+
+import (
+	"context"
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/ramendr/ramen/controllers/util"
+	gppv1 "github.com/stolostron/governance-policy-propagator/api/v1"
+	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Secrets_Util", func() {
+	const (
+		secretsCount  = 2
+		clustersCount = 2
+	)
+
+	var (
+		secretNames                           = [secretsCount]string{"secreta", "secretb"}
+		clusterNames                          = [clustersCount]string{"clusterEast", "clusterWest"}
+		policyName, plBindingName, plRuleName [secretsCount]string
+		secrets                               [secretsCount]*corev1.Secret
+		tstNamespace                          = "default"
+	)
+
+	BeforeEach(func() {
+		for idx := range secretNames {
+			policyName[idx], plBindingName[idx], plRuleName[idx], _ = util.GeneratePolicyResourceNames(secretNames[idx])
+			secrets[idx] = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretNames[idx],
+					Namespace: tstNamespace,
+				},
+				StringData: map[string]string{
+					"AWS_ACCESS_KEY_ID":     "id",
+					"AWS_SECRET_ACCESS_KEY": "key",
+				},
+			}
+		}
+	})
+
+	plRuleAbsent := func(plRuleName, namespace string) bool {
+		plRule := &plrv1.PlacementRule{}
+
+		return errors.IsNotFound(k8sClient.Get(context.TODO(),
+			types.NamespacedName{Name: plRuleName, Namespace: namespace},
+			plRule))
+	}
+
+	plRuleContains := func(plRuleName, namespace string, clusters []string) bool {
+		plRule := &plrv1.PlacementRule{}
+		if err := k8sClient.Get(
+			context.TODO(),
+			types.NamespacedName{Name: plRuleName, Namespace: namespace},
+			plRule); err != nil {
+			return false
+		}
+
+		for _, cluster := range clusters {
+			found := false
+			for _, specCluster := range plRule.Spec.Clusters {
+				if specCluster.Name == cluster {
+					found = true
+
+					break
+				}
+			}
+
+			if !found {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	policyContains := func(policyName, namespace string, expectedTrigger int) bool {
+		policyObject := &gppv1.Policy{}
+		if err := k8sClient.Get(
+			context.TODO(),
+			types.NamespacedName{Name: policyName, Namespace: namespace},
+			policyObject); err != nil {
+			return false
+		}
+
+		for annotation, value := range policyObject.Annotations {
+			if annotation == util.PolicyTriggerAnnotation {
+				triggerValue, err := strconv.Atoi(value)
+				if err != nil || triggerValue != expectedTrigger {
+					return false
+				}
+
+				return true
+			}
+		}
+
+		return false
+	}
+
+	finalizerPresent := func(secretName string) bool {
+		secret := &corev1.Secret{}
+		if err := k8sClient.Get(
+			context.TODO(),
+			types.NamespacedName{
+				Name:      secretName,
+				Namespace: tstNamespace,
+			},
+			secret); err != nil {
+			return false
+		}
+		for _, finalizer := range secret.Finalizers {
+			if finalizer == util.SecretPolicyFinalizer {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	finalizerAbsent := func(secretName string) bool {
+		secret := &corev1.Secret{}
+		if err := k8sClient.Get(context.TODO(),
+			types.NamespacedName{
+				Name:      secretName,
+				Namespace: tstNamespace,
+			},
+			secret); err != nil {
+			return false
+		}
+		for _, finalizer := range secret.Finalizers {
+			if finalizer == util.SecretPolicyFinalizer {
+				return false
+			}
+		}
+
+		return true
+	}
+
+	updateSecret := func(secret *corev1.Secret, value string) bool {
+		secretFetched := &corev1.Secret{}
+		if err := k8sClient.Get(
+			context.TODO(),
+			types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace},
+			secretFetched); err != nil {
+			return false
+		}
+
+		secretFetched.StringData = map[string]string{
+			"AWS_ACCESS_KEY_ID":     value,
+			"AWS_SECRET_ACCESS_KEY": value,
+		}
+
+		return k8sClient.Update(context.TODO(), secretFetched) == nil
+	}
+
+	secretAbsent := func(secretName string) bool {
+		secret := &corev1.Secret{}
+
+		return errors.IsNotFound(k8sClient.Get(
+			context.TODO(),
+			types.NamespacedName{
+				Name:      secretName,
+				Namespace: tstNamespace,
+			}, secret))
+	}
+
+	Context("AddSecretToCluster", func() {
+		When("Secret is missing", func() {
+			It("Returns an error", func() {
+				Expect(secretsUtil.AddSecretToCluster(
+					secretNames[0],
+					clusterNames[0],
+					tstNamespace)).Should(HaveOccurred())
+			})
+			It("Does not create an associated secret policy", func() {
+				Expect(plRuleAbsent(plRuleName[0], tstNamespace)).Should(BeTrue())
+			})
+		})
+		When("Secret is present", func() {
+			Specify("Create the secret", func() {
+				Expect(k8sClient.Create(context.TODO(), secrets[0])).To(Succeed())
+			})
+			It("Returns success", func() {
+				Expect(secretsUtil.AddSecretToCluster(
+					secretNames[0],
+					clusterNames[0],
+					tstNamespace)).To(Succeed())
+			})
+			It("Protects the secret with a finalizer", func() {
+				Expect(finalizerPresent(secretNames[0])).Should(BeTrue())
+			})
+			It("Creates a associated policy for the secret including the cluster", func() {
+				Expect(plRuleContains(plRuleName[0], tstNamespace, clusterNames[:1])).Should(BeTrue())
+				Expect(policyContains(policyName[0], tstNamespace, 0)).Should(BeTrue())
+			})
+		})
+		When("Secret is removed", func() {
+			Specify("Delete the secret", func() {
+				Expect(k8sClient.Delete(context.TODO(), secrets[0])).To(Succeed())
+			})
+			It("Returns an error", func() {
+				Expect(secretsUtil.AddSecretToCluster(
+					secretNames[0],
+					clusterNames[0],
+					tstNamespace)).Should(HaveOccurred())
+			})
+			It("No longer protects the secret with a finalizer", func() {
+				By("Ensuring secret is deleted")
+				Eventually(secretAbsent(secretNames[0]), timeout, interval).Should(BeTrue())
+			})
+			It("Cleans up the associated policy for the secret", func() {
+				Expect(plRuleAbsent(plRuleName[0], tstNamespace)).Should(BeTrue())
+			})
+		})
+		When("Secret is recreated", func() {
+			Specify("Create the secret", func() {
+				Expect(k8sClient.Create(context.TODO(), secrets[0])).To(Succeed())
+			})
+			It("Returns success", func() {
+				Expect(secretsUtil.AddSecretToCluster(
+					secretNames[0],
+					clusterNames[0],
+					tstNamespace)).To(Succeed())
+			})
+			It("Protects the secret with a finalizer", func() {
+				Expect(finalizerPresent(secretNames[0])).Should(BeTrue())
+			})
+			It("Creates a associated policy for the secret including the cluster", func() {
+				Expect(plRuleContains(plRuleName[0], tstNamespace, clusterNames[:1])).Should(BeTrue())
+				Expect(policyContains(policyName[0], tstNamespace, 0)).Should(BeTrue())
+			})
+		})
+		When("Secret is updated", func() {
+			Specify("Update the secret", func() {
+				Expect(updateSecret(secrets[0], "update1")).Should(BeTrue())
+			})
+			It("Returns success", func() {
+				Expect(secretsUtil.AddSecretToCluster(
+					secretNames[0],
+					clusterNames[0],
+					tstNamespace)).To(Succeed())
+			})
+			It("Protects the secret with a finalizer", func() {
+				Expect(finalizerPresent(secretNames[0])).Should(BeTrue())
+			})
+			It("Creates a associated policy for the secret including the cluster", func() {
+				Expect(plRuleContains(plRuleName[0], tstNamespace, clusterNames[:1])).Should(BeTrue())
+				Expect(policyContains(policyName[0], tstNamespace, 1)).Should(BeTrue())
+			})
+		})
+		When("Another cluster is added to the secret", func() {
+			It("Returns success", func() {
+				Expect(secretsUtil.AddSecretToCluster(
+					secretNames[0],
+					clusterNames[1],
+					tstNamespace)).To(Succeed())
+			})
+			It("Protects the secret with a finalizer", func() {
+				Expect(finalizerPresent(secretNames[0])).Should(BeTrue())
+			})
+			It("Creates a associated policy for the secret including the cluster", func() {
+				Expect(plRuleContains(plRuleName[0], tstNamespace, clusterNames[0:])).Should(BeTrue())
+				Expect(policyContains(policyName[0], tstNamespace, 2)).Should(BeTrue())
+			})
+		})
+		// Second policy
+		When("A cluster is added to another secret", func() {
+			Specify("Create the secret", func() {
+				Expect(k8sClient.Create(context.TODO(), secrets[1])).To(Succeed())
+			})
+			It("Returns success", func() {
+				Expect(secretsUtil.AddSecretToCluster(
+					secretNames[1],
+					clusterNames[0],
+					tstNamespace)).To(Succeed())
+			})
+			It("Protects the secret with a finalizer", func() {
+				Expect(finalizerPresent(secretNames[1])).Should(BeTrue())
+			})
+			It("Creates a associated policy for the secret including the cluster", func() {
+				Expect(plRuleContains(plRuleName[1], tstNamespace, clusterNames[:1])).Should(BeTrue())
+				Expect(policyContains(policyName[1], tstNamespace, 0)).Should(BeTrue())
+			})
+			It("Retains the associated policy with the older secret", func() {
+				Expect(plRuleContains(plRuleName[0], tstNamespace, clusterNames[0:])).Should(BeTrue())
+				Expect(policyContains(policyName[0], tstNamespace, 2)).Should(BeTrue())
+			})
+		})
+	})
+	Context("Removing secrets from clusters", func() {
+		When("A cluster is removed from an updated secret with multiple cluster associations", func() {
+			Specify("Update the secret", func() {
+				Expect(updateSecret(secrets[0], "update2")).Should(BeTrue())
+			})
+			It("Returns success", func() {
+				Expect(secretsUtil.RemoveSecretFromCluster(
+					secretNames[0],
+					clusterNames[0],
+					tstNamespace)).To(Succeed())
+			})
+			It("Continues protecting the secret with a finalizer", func() {
+				Expect(finalizerPresent(secretNames[0])).Should(BeTrue())
+			})
+			It("Updates the associated policy for the secret excuding the cluster", func() {
+				Expect(plRuleContains(plRuleName[0], tstNamespace, clusterNames[1:2])).Should(BeTrue())
+				Expect(policyContains(policyName[0], tstNamespace, 3)).Should(BeTrue())
+			})
+		})
+		When("A cluster is removed again from a secret with multiple cluster associations", func() {
+			It("Returns success", func() {
+				Expect(secretsUtil.RemoveSecretFromCluster(
+					secretNames[0],
+					clusterNames[0],
+					tstNamespace)).To(Succeed())
+			})
+			It("Continues protecting the secret with a finalizer", func() {
+				Expect(finalizerPresent(secretNames[0])).Should(BeTrue())
+			})
+			It("Updates the associated policy for the secret excuding the cluster", func() {
+				Expect(plRuleContains(plRuleName[0], tstNamespace, clusterNames[1:2])).Should(BeTrue())
+				Expect(policyContains(policyName[0], tstNamespace, 4)).Should(BeTrue())
+			})
+		})
+		When("The last cluster is removed from the secret", func() {
+			It("Returns success", func() {
+				Expect(secretsUtil.RemoveSecretFromCluster(
+					secretNames[0],
+					clusterNames[1],
+					tstNamespace)).To(Succeed())
+			})
+			It("No longer protects the secret with a finalizer", func() {
+				Expect(finalizerAbsent(secretNames[0])).To(BeTrue())
+			})
+			It("Cleans up the associated policy for the secret", func() {
+				Expect(plRuleAbsent(plRuleName[0], tstNamespace)).Should(BeTrue())
+			})
+		})
+		When("The last cluster is removed again from the secret", func() {
+			It("Returns success", func() {
+				Expect(secretsUtil.RemoveSecretFromCluster(
+					secretNames[0],
+					clusterNames[1],
+					tstNamespace)).To(Succeed())
+			})
+			It("No longer protects the secret with a finalizer", func() {
+				Expect(finalizerAbsent(secretNames[0])).To(BeTrue())
+			})
+			It("Cleans up the associated policy for the secret", func() {
+				Expect(plRuleAbsent(plRuleName[0], tstNamespace)).Should(BeTrue())
+			})
+			It("Does not block deletion of the secret", func() {
+				By("Delete the secret")
+				Expect(k8sClient.Delete(context.TODO(), secrets[0])).To(Succeed())
+				By("Ensuring secret is deleted")
+				Eventually(secretAbsent(secretNames[0]), timeout, interval).Should(BeTrue())
+			})
+		})
+		When("A cluster from a non-existent secret is removed", func() {
+			It("Returns success", func() {
+				Expect(secretsUtil.RemoveSecretFromCluster(
+					secretNames[0]+"-missing",
+					clusterNames[1],
+					tstNamespace)).To(Succeed())
+			})
+			It("Does not create the associated policy for the secret", func() {
+				Expect(plRuleAbsent(plRuleName[0]+"-missing", tstNamespace)).Should(BeTrue())
+			})
+		})
+		// Second policy
+		When("A secret is deleted and a unassociated cluster is removed", func() {
+			Specify("Delete the secret", func() {
+				Expect(k8sClient.Delete(context.TODO(), secrets[1])).To(Succeed())
+			})
+			It("Returns success", func() {
+				Expect(secretsUtil.RemoveSecretFromCluster(
+					secretNames[1],
+					clusterNames[1],
+					tstNamespace)).To(Succeed())
+			})
+			It("No longer protects the secret with a finalizer", func() {
+				By("Ensuring secret is deleted")
+				Eventually(secretAbsent(secretNames[1]), timeout, interval).Should(BeTrue())
+			})
+			It("Cleans up the associated policy for the secret", func() {
+				Expect(plRuleAbsent(plRuleName[1], tstNamespace)).Should(BeTrue())
+			})
+		})
+	})
+})

--- a/controllers/util/secrets_util_test.go
+++ b/controllers/util/secrets_util_test.go
@@ -192,6 +192,7 @@ var _ = Describe("Secrets_Util", func() {
 				Expect(secretsUtil.AddSecretToCluster(
 					secretNames[0],
 					clusterNames[0],
+					tstNamespace,
 					tstNamespace)).Should(HaveOccurred())
 			})
 			It("Does not create an associated secret policy", func() {
@@ -206,6 +207,7 @@ var _ = Describe("Secrets_Util", func() {
 				Expect(secretsUtil.AddSecretToCluster(
 					secretNames[0],
 					clusterNames[0],
+					tstNamespace,
 					tstNamespace)).To(Succeed())
 			})
 			It("Protects the secret with a finalizer", func() {
@@ -224,6 +226,7 @@ var _ = Describe("Secrets_Util", func() {
 				Expect(secretsUtil.AddSecretToCluster(
 					secretNames[0],
 					clusterNames[0],
+					tstNamespace,
 					tstNamespace)).Should(HaveOccurred())
 			})
 			It("No longer protects the secret with a finalizer", func() {
@@ -242,6 +245,7 @@ var _ = Describe("Secrets_Util", func() {
 				Expect(secretsUtil.AddSecretToCluster(
 					secretNames[0],
 					clusterNames[0],
+					tstNamespace,
 					tstNamespace)).To(Succeed())
 			})
 			It("Protects the secret with a finalizer", func() {
@@ -260,6 +264,7 @@ var _ = Describe("Secrets_Util", func() {
 				Expect(secretsUtil.AddSecretToCluster(
 					secretNames[0],
 					clusterNames[0],
+					tstNamespace,
 					tstNamespace)).To(Succeed())
 			})
 			It("Protects the secret with a finalizer", func() {
@@ -275,6 +280,7 @@ var _ = Describe("Secrets_Util", func() {
 				Expect(secretsUtil.AddSecretToCluster(
 					secretNames[0],
 					clusterNames[1],
+					tstNamespace,
 					tstNamespace)).To(Succeed())
 			})
 			It("Protects the secret with a finalizer", func() {
@@ -294,6 +300,7 @@ var _ = Describe("Secrets_Util", func() {
 				Expect(secretsUtil.AddSecretToCluster(
 					secretNames[1],
 					clusterNames[0],
+					tstNamespace,
 					tstNamespace)).To(Succeed())
 			})
 			It("Protects the secret with a finalizer", func() {

--- a/controllers/util/util_suite_test.go
+++ b/controllers/util/util_suite_test.go
@@ -1,13 +1,88 @@
 package util_test
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/ramendr/ramen/controllers/util"
+	cpcv1 "github.com/stolostron/config-policy-controller/api/v1"
+	gppv1 "github.com/stolostron/governance-policy-propagator/api/v1"
+	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+const (
+	timeout  = time.Second * 10
+	interval = time.Millisecond * 10
+)
+
+var (
+	cfg         *rest.Config
+	k8sClient   client.Client
+	testEnv     *envtest.Environment
+	secretsUtil util.SecretsUtil
 )
 
 func TestUtil(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Util Suite")
 }
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	By("Setting up KUBEBUILDER_ASSETS for envtest")
+	if _, set := os.LookupEnv("KUBEBUILDER_ASSETS"); !set {
+		Expect(os.Setenv("KUBEBUILDER_ASSETS", "../../testbin/bin")).To(Succeed())
+	}
+
+	By("Bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+			filepath.Join("..", "..", "hack", "test"),
+		},
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	By("Setting up required schemes in envtest")
+	err = plrv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = cpcv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = gppv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Creating a k8s client")
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	secretsUtil = util.SecretsUtil{
+		Client: k8sClient,
+		Ctx:    context.TODO(),
+		Log:    ctrl.Log.WithName("secrets_util"),
+	}
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -477,6 +477,7 @@ ramen_config_deploy_hub_or_spoke()
 	    namespace: ramen-system
 	drClusterOperator:
 	  deploymentAutomationEnabled: true
+	  s3SecretDistributionEnabled: true
 	EOF
 	ramen_config_replace_hub_or_spoke $1 $2 $3
 }
@@ -588,7 +589,7 @@ ramen_samples_channel_and_drpolicy_deploy()
 		until_true_or_n 300 kubectl --context $cluster_name get namespaces/ramen-system
 		ramen_catalog_deploy_cluster $cluster_name
 		until_true_or_n 300 kubectl --context $cluster_name -n ramen-system wait deployments ramen-dr-cluster-operator --for condition=available --timeout 0
-		ramen_s3_secret_deploy_cluster $cluster_name # TODO remove once automated
+		#ramen_s3_secret_deploy_cluster $cluster_name # TODO remove once automated
 	done; unset -v cluster_name
 	kubectl --context $hub_cluster_name -n ramen-samples get channels/ramen-gitops
 }

--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ import (
 
 	volrep "github.com/csi-addons/volume-replication-operator/api/v1alpha1"
 	ocmworkv1 "github.com/open-cluster-management/api/work/v1"
+	cpcv1 "github.com/stolostron/config-policy-controller/api/v1"
+	gppv1 "github.com/stolostron/governance-policy-propagator/api/v1"
 	viewv1beta1 "github.com/stolostron/multicloud-operators-foundation/pkg/apis/view/v1beta1"
 	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
 	uberzap "go.uber.org/zap"
@@ -89,6 +91,8 @@ func newManager() (ctrl.Manager, error) {
 		utilruntime.Must(plrv1.AddToScheme(scheme))
 		utilruntime.Must(ocmworkv1.AddToScheme(scheme))
 		utilruntime.Must(viewv1beta1.AddToScheme(scheme))
+		utilruntime.Must(cpcv1.AddToScheme(scheme))
+		utilruntime.Must(gppv1.AddToScheme(scheme))
 	} else {
 		utilruntime.Must(volrep.AddToScheme(scheme))
 	}


### PR DESCRIPTION
- Distribute secrets using OCM policies
- One policy per secret
- Each policy has a placement rule that has a list of clusters the policy applies to
- A managed cluster is added to the policy placement if there is any surviving DRPolicy that points to the secret
- A managed cluster is removed from the policy placement iff there are no DRPolicies containing the cluster and pointing to the secret

Address subsequently:
- Update DRPolicy status once a secret is delivered to the respective clusters (unsure if policy status allows
extrapolating this information, retained for tracking)
- Handle changes to drcluster operator namespace changes in ramen config
- Update to use secrets instead of localSecrets once we understand how to based on OCM changes
- Use secret resourceVersion to detect updates and trigger policy updates instead of monotonic increasing counter as the trigger
- Split managers such that listing is namespace scoped for resources that we are interested at that scope (we now add RBAC for list/watch at a cluster level for secrets, configmaps, etc.)
- Add a common routine to deploy poicy artifacts in e2e scripts

Fixes #359 

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>