### PR TITLE
drpc: set vrg.spec.sync.mode to disabled if drpolicy does not support it

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -950,15 +950,15 @@ func (d *DRPCInstance) generateVRGSpecAsync() rmn.VRGAsyncSpec {
 }
 
 func (d *DRPCInstance) generateVRGSpecSync() rmn.VRGSyncSpec {
-	spec := rmn.VRGSyncSpec{}
-
 	if supports, _ := dRPolicySupportsMetro(d.drPolicy); supports {
-		spec = rmn.VRGSyncSpec{
+		return rmn.VRGSyncSpec{
 			Mode: rmn.SyncModeEnabled,
 		}
 	}
 
-	return spec
+	return rmn.VRGSyncSpec{
+		Mode: rmn.SyncModeDisabled,
+	}
 }
 
 func dRPolicySupportsRegional(drpolicy *rmn.DRPolicy) bool {


### PR DESCRIPTION
End-to-end test failed initial deployment of busybox-sample application because vrg failed to manifest with the following error in the hub manifest work object:

```sh
    - conditions:
      - lastTransitionTime: "2022-02-10T17:55:57Z"
        message: 'Failed to apply manifest: VolumeReplicationGroup.ramendr.openshift.io
          "busybox-drpc" is invalid: spec.sync.mode: Unsupported value: "": supported
          values: "Enabled", "Disabled"'
        reason: AppliedManifestFailed
        status: "False"
        type: Applied
      - lastTransitionTime: "2022-02-10T17:55:57Z"
        message: Resource is not available
        reason: ResourceNotAvailable
        status: "False"
        type: Available
```