### PR TITLE
minikube-rook-setup.sh: vol-rep yamls create -> apply

### DIFF
--- a/hack/minikube-rook-setup.sh
+++ b/hack/minikube-rook-setup.sh
@@ -147,8 +147,8 @@ then
         kubectl apply -f "${ROOK_SRC}/common.yaml" --context="${PROFILE}"
         kubectl apply -f "${ROOK_SRC}/crds.yaml" --context="${PROFILE}"
         # Fetch operator.yaml and enable CSI volume replication
-        kubectl create -f https://raw.githubusercontent.com/csi-addons/volume-replication-operator/v0.1.0/config/crd/bases/replication.storage.openshift.io_volumereplications.yaml --context="${PROFILE}"
-        kubectl create -f https://raw.githubusercontent.com/csi-addons/volume-replication-operator/v0.1.0/config/crd/bases/replication.storage.openshift.io_volumereplicationclasses.yaml --context="${PROFILE}"
+        kubectl apply -f https://raw.githubusercontent.com/csi-addons/volume-replication-operator/v0.1.0/config/crd/bases/replication.storage.openshift.io_volumereplications.yaml --context="${PROFILE}"
+        kubectl apply -f https://raw.githubusercontent.com/csi-addons/volume-replication-operator/v0.1.0/config/crd/bases/replication.storage.openshift.io_volumereplicationclasses.yaml --context="${PROFILE}"
         set -- "$(mktemp --directory)"
         cat <<a >"$1"/kustomization.yaml
 resources:


### PR DESCRIPTION
`hack/ocm-minikube-ramen.sh` was run successfully weeks ago, then again today, without undeployment, and the following error occurred:
```sh
+ kubectl create -f https://raw.githubusercontent.com/csi-addons/volume-replication-operator/v0.1.0/config/crd/bases/replication.storage.openshift.io_volumereplications.yaml --context=cluster1
Error from server (AlreadyExists): error when creating "https://raw.githubusercontent.com/csi-addons/volume-replication-operator/v0.1.0/config/crd/bases/replication.storage.openshift.io_volumereplications.yaml": customresourcedefinitions.apiextensions.k8s.io "volumereplications.replication.storage.openshift.io" already exists
...
exit status: 1
```
I applied this pull request's patch and it proceeded beyond this point.