### PR TITLE
controllers: skip the s3 validation for the failed cluster

### DIFF
--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -239,6 +239,11 @@ func validateS3Profiles(ctx context.Context, apiReader client.Reader,
 	objectStoreGetter ObjectStoreGetter, drpolicy *ramen.DRPolicy, listKeyPrefix string, log logr.Logger) (string, error) {
 	for i := range drpolicy.Spec.DRClusterSet {
 		cluster := &drpolicy.Spec.DRClusterSet[i]
+		if cluster.ClusterFence == ramen.ClusterFenceStateFenced ||
+			cluster.ClusterFence == ramen.ClusterFenceStateManuallyFenced {
+			continue
+		}
+
 		if reason, err := s3ProfileValidate(ctx, apiReader, objectStoreGetter,
 			cluster.S3ProfileName, listKeyPrefix, log); err != nil {
 			return reason, err


### PR DESCRIPTION
It is possible that the s3 stores used for a site are cohosted and
aren't available when the site/cluster is unavailable.

It is safe to skip the validation all s3 stores listed under a
DRCluster, even if there aren't cohosted because they won't be used to
upload or restore cluster data until the site/cluster is operational
again.

The condition to skip the validation is currently Metro/Sync specific.
In the future, we may want to add a similar logic for the Regional/Async
mode.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>