### PR TITLE
drpolicy: make schedulingInterval optional

### DIFF
--- a/api/v1alpha1/drpolicy_types.go
+++ b/api/v1alpha1/drpolicy_types.go
@@ -71,7 +71,7 @@ type DRPolicySpec struct {
 	// minutes, 'h' means hours and 'd' stands for days.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^\d+[mhd]$`
-	SchedulingInterval string `json:"schedulingInterval"`
+	SchedulingInterval string `json:"schedulingInterval,omitempty"`
 
 	// Label selector to identify all the VolumeReplicationClasses.
 	// This selector is assumed to be the same for all subscriptions that

--- a/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
@@ -138,7 +138,6 @@ spec:
                 type: string
             required:
             - drClusterSet
-            - schedulingInterval
             type: object
           status:
             description: 'DRPolicyStatus defines the observed state of DRPolicy INSERT


### PR DESCRIPTION
The scheduling interval isn't required for Metro/Sync DR and should be
optional in the drpolicy.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>