### PR TITLE
Improve test times

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -69,7 +69,7 @@ jobs:
         run: make docker-build
 
       - name: Run unit tests
-        run: make test
+        run: GO_TEST_GINKGO_ARGS="" make test
 
       - name: Export image
         run: docker save -o /tmp/ramen-operator.tar ${IMAGE_TAG_BASE}-operator:${IMAGE_TAG}

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,8 @@ ifeq ($(GOHOSTOS),darwin)
 	endif
 endif
 
+GO_TEST_GINKGO_ARGS ?= -test.v -ginkgo.v -ginkgo.failFast
+
 all: build
 
 ##@ General
@@ -134,7 +136,7 @@ setup-envtest:
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR)
 
 test: generate manifests setup-envtest ## Run tests.
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out $(GO_TEST_GINKGO_ARGS)
 
 ##@ Build
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -21,7 +21,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -61,6 +63,7 @@ var (
 	testEnv     *envtest.Environment
 	configMap   *corev1.ConfigMap
 	ramenConfig *ramendrv1alpha1.RamenConfig
+	testLog     logr.Logger
 )
 
 func TestAPIs(t *testing.T) {
@@ -86,10 +89,13 @@ func createOperatorNamespace(ramenNamespace string) {
 }
 
 var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	testLog = ctrl.Log.WithName("tester")
+	testLog.Info("Starting the controller test suite", "time", time.Now())
+
 	// default controller type to DRHub
 	ramencontrollers.ControllerType = ramendrv1alpha1.DRHub
 
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	if _, set := os.LookupEnv("KUBEBUILDER_ASSETS"); !set {
 		Expect(os.Setenv("KUBEBUILDER_ASSETS", "../testbin/bin")).To(Succeed())
 	}

--- a/controllers/util/util_suite_test.go
+++ b/controllers/util/util_suite_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/ramendr/ramen/controllers/util"
@@ -32,6 +33,7 @@ var (
 	k8sClient   client.Client
 	testEnv     *envtest.Environment
 	secretsUtil util.SecretsUtil
+	testLog     logr.Logger
 )
 
 func TestUtil(t *testing.T) {
@@ -41,6 +43,9 @@ func TestUtil(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	testLog = ctrl.Log.WithName("tester")
+	testLog.Info("Starting the utils test suite", "time", time.Now())
+
 	By("Setting up KUBEBUILDER_ASSETS for envtest")
 	if _, set := os.LookupEnv("KUBEBUILDER_ASSETS"); !set {
 		Expect(os.Setenv("KUBEBUILDER_ASSETS", "../../testbin/bin")).To(Succeed())

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	vrgtimeout  = time.Second * 222
+	vrgtimeout  = time.Second * 10
 	vrginterval = time.Millisecond * 10
 )
 


### PR DESCRIPTION
This PR has three commits.
* One is to reduce the timeout in the VRG tests.
* The second is to make go test and ginkgo fail on first error for all invocations. The github workflow yaml has been modified to retain the old behavior in the CI.
* The third commit adds a logger `testLog` that can be used anywhere in the unit/integration tests to log additional info.