### PR TITLE
pass the right err on failure

### DIFF
--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -497,7 +497,9 @@ func (v *VRGInstance) fetchAndRestorePV() (bool, error) {
 	)
 
 	for _, s3ProfileName := range v.instance.Spec.S3Profiles {
-		pvList, err := v.fetchPVClusterDataFromS3Store(s3ProfileName)
+		var pvList []corev1.PersistentVolume
+
+		pvList, err = v.fetchPVClusterDataFromS3Store(s3ProfileName)
 		if err != nil {
 			v.log.Error(err, fmt.Sprintf("error fetching PV cluster data from S3 profile %s", s3ProfileName))
 


### PR DESCRIPTION
Error seen earlier:
```
"errorValue": "failed to restorePVs using profile list ([fakeS3Profile]): !(%w) nil"}
```

Now
```
"errorValue": "failed to restorePVs using profile list ([fakeS3Profile]): failed to restore all PVs. Total 1. Restored 0"}
```

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>