### PR TITLE
Sync mode fixes for VRG deletion in primary and secondary mode

### DIFF
--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -644,6 +644,21 @@ func (v *VRGInstance) restorePVClusterData(pvList []corev1.PersistentVolume) err
 	return nil
 }
 
+func (v *VRGInstance) updateExistingPVForSync(pv *corev1.PersistentVolume) error {
+	// In case of sync mode, the pv is never deleted as part of the
+	// failover/relocate process. Hence, the restore may not be
+	// required and the annotation for restore can be missing for
+	// the sync mode.
+	v.cleanupPVForRestore(pv)
+	v.addPVRestoreAnnotation(pv)
+
+	if err := v.reconciler.Update(v.ctx, pv); err != nil {
+		return fmt.Errorf("failed to cleanup existing PV for sync DR PV: %v, err: %w", pv.Name, err)
+	}
+
+	return nil
+}
+
 func (v *VRGInstance) validatePVExistence(pv *corev1.PersistentVolume) error {
 	existingPV := &corev1.PersistentVolume{}
 
@@ -652,16 +667,27 @@ func (v *VRGInstance) validatePVExistence(pv *corev1.PersistentVolume) error {
 		return fmt.Errorf("failed to get existing PV (%w)", err)
 	}
 
-	if existingPV.ObjectMeta.Annotations == nil ||
-		existingPV.ObjectMeta.Annotations[PVRestoreAnnotation] == "" {
-		return fmt.Errorf("found PV object not restored by Ramen for PV %s", existingPV.Name)
+	if existingPV.ObjectMeta.Annotations != nil &&
+		existingPV.ObjectMeta.Annotations[PVRestoreAnnotation] == "True" {
+		// Should we check and see if PV in being deleted? Should we just treat it as exists
+		// and then we don't care if deletion takes place later, which is what we do now?
+		v.log.Info("PV exists and managed by Ramen", "PV", existingPV)
+
+		return nil
 	}
 
-	// Should we check and see if PV in being deleted? Should we just treat it as exists
-	// and then we don't care if deletion takes place later, which is what we do now?
-	v.log.Info("PV exists and managed by Ramen", "PV", existingPV)
+	// Right now, we can only have either Sync mode or Async mode. In case of
+	// sync mode, the pv is never deleted as part of the failover/relocate
+	// process. Hence, the restore is not required and the annotation for
+	// restore can be missing for the sync mode. Skip the check for the
+	// annotation in this case.
+	if v.instance.Spec.Sync.Mode == ramendrv1alpha1.SyncModeEnabled {
+		v.log.Info("PV exists, will update for sync", "PV", existingPV)
 
-	return nil
+		return v.updateExistingPVForSync(existingPV)
+	}
+
+	return fmt.Errorf("found PV object not restored by Ramen for PV %s", existingPV.Name)
 }
 
 // cleanupPVForRestore cleans up required PV fields, to ensure restore succeeds to a new cluster, and

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -1280,9 +1280,17 @@ func (v *VRGInstance) preparePVCForVRDeletion(pvc *corev1.PersistentVolumeClaim,
 		return nil
 	}
 
-	// Change PV `reclaimPolicy` back to stored state
-	if err := v.undoPVRetentionForPVC(*pvc, log); err != nil {
-		return err
+	// For Async mode, we want to change the retention policy back to delete
+	// and remove the annotation.
+	// For Sync mode, we don't want to set the retention policy to delete as
+	// both the primary and the secondary VRG map to the same volume. The only
+	// state where a delete retention policy is required for the sync mode is
+	// when the VRG is primary.
+	if !(v.instance.Spec.ReplicationState == ramendrv1alpha1.Secondary &&
+		v.instance.Spec.Sync.Mode == ramendrv1alpha1.SyncModeEnabled) {
+		if err := v.undoPVRetentionForPVC(*pvc, log); err != nil {
+			return err
+		}
 	}
 
 	// TODO: Delete the PV from the backing store? But when is it safe to do so?


### PR DESCRIPTION
This PR has three commits, which do the following:

* Update the PVC conditions only inside the leaf functions of VRG which are ProcessAsPrimary and ProcessAsSecondary. This way the code flow for both sync and async modes is the same.
* In sync mode, the PV should not be allowed to be deleted when the VRG is deleted as secondary.
* As the PV is left behind when the VRG is deleted as secondary, when the VRG is created again, it needs to remove the claim refs on the existing PV and place the restore annotation on it.




Signed-off-by: Raghavendra M <raghavendra@redhat.com>
Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>