### PR TITLE
Avoid overwriting needsStatusUpdate

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -1702,5 +1702,8 @@ func (d *DRPCInstance) setMetricsTimer(
 
 func (d *DRPCInstance) setDRPCCondition(conditions *[]metav1.Condition, condType string,
 	observedGeneration int64, status metav1.ConditionStatus, reason, msg string) {
-	d.needStatusUpdate = SetDRPCStatusCondition(conditions, condType, observedGeneration, status, reason, msg)
+	needStatusUpdate := SetDRPCStatusCondition(conditions, condType, observedGeneration, status, reason, msg)
+	if !d.needStatusUpdate {
+		d.needStatusUpdate = needStatusUpdate
+	}
 }


### PR DESCRIPTION
Ensure previous conditions requiring status
updates are preserved, when a future condition
does not require a status update.

This helps with retaining last known good status
for DRPC "Available" condition, and also prevents
future conditions from overwriting the same.

Was inadvertently introduced in commit 90d1d91e48

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>