### PR TITLE
Simplify the s3 store usage in the tests

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -189,7 +189,7 @@ var _ = BeforeSuite(func() {
 		Client:         k8sManager.GetClient(),
 		APIReader:      k8sManager.GetAPIReader(),
 		Log:            ctrl.Log.WithName("controllers").WithName("VolumeReplicationGroup"),
-		ObjStoreGetter: ramencontrollers.S3ObjectStoreGetter(),
+		ObjStoreGetter: fakeObjectStoreGetter{},
 		PVDownloader:   FakePVDownloader{},
 		PVUploader:     FakePVUploader{},
 		PVDeleter:      FakePVDeleter{},

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -32,6 +32,9 @@ type Empty struct{}
 var UploadedPVs = map[string]Empty{}
 
 var _ = Describe("Test VolumeReplicationGroup", func() {
+	Specify("s3 profiles and secret", func() {
+		s3ProfilesSetup()
+	})
 	// Test first restore
 	Context("restore test case", func() {
 		It("sets vrg for restore", func() {
@@ -352,6 +355,9 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 	})
 	// TODO: Add tests to move VRG to Secondary
 	// TODO: Add tests to ensure delete as Secondary (check if delete as Primary is tested above)
+	Specify("delete s3 profiles and secret", func() {
+		s3ProfilesDelete()
+	})
 })
 
 type vrgTest struct {


### PR DESCRIPTION
This PR has two commits:
1. We make sure that the FakeObjectStoreGetter interface is used everywhere in the tests.
2. The tests require S3 store to be setup and deleted at the start and the end. Instead of using global variables, we introduce helper functions to create and delete s3 stores.