### PR TITLE
Add RBAC role for accessing PlacementDecision resource

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -48,8 +48,13 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
 
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
       - name: GolangCI Lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.37.1
 

--- a/config/hub/rbac/role.yaml
+++ b/config/hub/rbac/role.yaml
@@ -43,7 +43,37 @@ rules:
 - apiGroups:
   - apps.open-cluster-management.io
   resources:
+  - placementrules/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.open-cluster-management.io
+  resources:
   - placementrules/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - placementdecisions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - placementdecisions/status
   verbs:
   - get
   - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,6 +35,16 @@ rules:
 - apiGroups:
   - apps.open-cluster-management.io
   resources:
+  - placementrules/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps.open-cluster-management.io
+  resources:
   - placementrules/status
   verbs:
   - get
@@ -48,6 +58,26 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - placementdecisions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - placementdecisions/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -448,10 +448,13 @@ func (r *DRPlacementControlReconciler) SetupWithManager(mgr ctrl.Manager) error 
 // +kubebuilder:rbac:groups=ramendr.openshift.io,resources=drpolicies,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps.open-cluster-management.io,resources=placementrules,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps.open-cluster-management.io,resources=placementrules/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps.open-cluster-management.io,resources=placementrules/finalizers,verbs=get;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=view.open-cluster-management.io,resources=managedclusterviews,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;create;patch;update
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placementdecisions,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placementdecisions/status,verbs=get;update;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
This commit fixes https://bugzilla.redhat.com/show_bug.cgi?id=2071494.
The PlacmentRule has been changed and now generates a placementDecision in the same namespace.
The subscription watches the PlacementDecision changes and deploy the application to the
managed clusters accordingly. The PlacementRule controller needs to be granted access to the
PlacementDecision resource.