### PR TITLE
vrg_controller_test.go: dereference data ready condition pointer iff it is not nil

### DIFF
--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -874,16 +874,18 @@ func (v *vrgTest) verifyVRGStatusExpectation(expectedStatus bool) {
 	Eventually(func() bool {
 		vrg := v.getVRG(v.vrgName)
 		dataReadyCondition := checkConditions(vrg.Status.Conditions, vrgController.VRGConditionTypeDataReady)
+		if dataReadyCondition == nil {
+			return false
+		}
 
 		if expectedStatus == true {
 			// reasons for success can be different for Primary and
 			// secondary. Validate that as well.
-			if vrg.Spec.ReplicationState == ramendrv1alpha1.Primary {
+			switch vrg.Spec.ReplicationState {
+			case ramendrv1alpha1.Primary:
 				return dataReadyCondition.Status == metav1.ConditionTrue && dataReadyCondition.Reason ==
 					vrgController.VRGConditionReasonReady
-			}
-
-			if vrg.Spec.ReplicationState == ramendrv1alpha1.Secondary {
+			case ramendrv1alpha1.Secondary:
 				return dataReadyCondition.Status == metav1.ConditionTrue && dataReadyCondition.Reason ==
 					vrgController.VRGConditionReasonReplicating
 			}


### PR DESCRIPTION
Problem exposed by injecting a delay in PV object restore routine exceeding `Eventually`'s 10 ms poll interval:

```diff
--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -20,6 +20,7 @@ import (
        "context"
        "fmt"
        "reflect"
+       "time"

        "github.com/go-logr/logr"

@@ -524,6 +525,8 @@ func (v *VRGInstance) fetchAndRestorePV() (bool, error) {
                        continue
                }

+               time.Sleep(11 * time.Millisecond)
+
                msg := "Restored PV cluster data"
                setVRGClusterDataReadyCondition(&v.instance.Status.Conditions, v.instance.Generation, msg)
```

https://github.com/hatfieldbrian/ramen/commit/5ebf978b995e7fa87ae0be951bba8fcb497ddc02#diff-428a43c23cf418d4022f864ffab5269355b5e7521d3fb9e5f7bdf6b202b184d8L520-L532

```
------------------------------
Test VolumeReplicationGroup schedule tests schedue does not match
  waits for VRG to status to match
  /home/bhatfiel/ramen/controllers/volumereplicationgroup_controller_test.go:311
2022-04-08T06:56:51.689-0700    INFO    pvcmap.VolumeReplicationGroup   Found VolumeReplicationGroup with matching labels       {"pvc": "envtest-ns-p/pvc-p-03", "vrg": "vrg-p", "labeled": "appclass=platinum,environment=dev.AZ1-p"}

•! Panic [0.000 seconds]
Test VolumeReplicationGroup
/home/bhatfiel/ramen/controllers/volumereplicationgroup_controller_test.go:34
  schedule tests schedue does not match
  /home/bhatfiel/ramen/controllers/volumereplicationgroup_controller_test.go:301
    waits for VRG to status to match [It]
    /home/bhatfiel/ramen/controllers/volumereplicationgroup_controller_test.go:311

    Test Panicked
    runtime error: invalid memory address or nil pointer dereference
    /home/bhatfiel/.local/go/src/runtime/panic.go:221

    Full Stack Trace
    github.com/ramendr/ramen/controllers_test.(*vrgTest).verifyVRGStatusExpectation.func1()
        /home/bhatfiel/ramen/controllers/volumereplicationgroup_controller_test.go:772 +0x14b
    reflect.Value.call({0x1823780, 0xc000111f38, 0xc0011bdb80}, {0x1b1f025, 0x4}, {0xc000848f60, 0x0, 0x203000})
        /home/bhatfiel/.local/go/src/reflect/value.go:543 +0x814
    reflect.Value.Call({0x1823780, 0xc000111f38, 0x3b}, {0xc000848f60, 0x0, 0x0})
        /home/bhatfiel/.local/go/src/reflect/value.go:339 +0xc5
    github.com/onsi/gomega/internal.NewAsyncAssertion.func1()
        /home/bhatfiel/go/pkg/mod/github.com/onsi/gomega@v1.15.0/internal/async_assertion.go:48 +0xb1
    github.com/onsi/gomega/internal.(*AsyncAssertion).pollActual(0x1e9a100)
        /home/bhatfiel/go/pkg/mod/github.com/onsi/gomega@v1.15.0/internal/async_assertion.go:117 +0x35
    github.com/onsi/gomega/internal.(*AsyncAssertion).match(0xc0011bdb30, {0x1e379e0, 0x2d9ad50}, 0x1, {0xc0008fef60, 0x3, 0x3})
        /home/bhatfiel/go/pkg/mod/github.com/onsi/gomega@v1.15.0/internal/async_assertion.go:147 +0xa5
    github.com/onsi/gomega/internal.(*AsyncAssertion).Should(0xc0011bdb30, {0x1e379e0, 0x2d9ad50}, {0xc0008fef60, 0x3, 0x3})
        /home/bhatfiel/go/pkg/mod/github.com/onsi/gomega@v1.15.0/internal/async_assertion.go:92 +0x6b
    github.com/ramendr/ramen/controllers_test.(*vrgTest).verifyVRGStatusExpectation(0xc000bbb9d0, 0x0)
        /home/bhatfiel/ramen/controllers/volumereplicationgroup_controller_test.go:773 +0x18e
    github.com/ramendr/ramen/controllers_test.glob..func5.8.3()
        /home/bhatfiel/ramen/controllers/volumereplicationgroup_controller_test.go:313 +0x85
    github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0x4)
        /home/bhatfiel/go/pkg/mod/github.com/onsi/ginkgo@v1.16.4/internal/leafnodes/runner.go:113 +0xba
    github.com/onsi/ginkgo/internal/leafnodes.(*runner).run(0x57)
        /home/bhatfiel/go/pkg/mod/github.com/onsi/ginkgo@v1.16.4/internal/leafnodes/runner.go:64 +0x125
    github.com/onsi/ginkgo/internal/leafnodes.(*ItNode).Run(0xc0001024e0)
        /home/bhatfiel/go/pkg/mod/github.com/onsi/ginkgo@v1.16.4/internal/leafnodes/it_node.go:26 +0x7b
    github.com/onsi/ginkgo/internal/spec.(*Spec).runSample(0xc0000324b0, 0xc000849a08, {0x1e17d00, 0xc0003ec7c0})
        /home/bhatfiel/go/pkg/mod/github.com/onsi/ginkgo@v1.16.4/internal/spec/spec.go:215 +0x2a9
    github.com/onsi/ginkgo/internal/spec.(*Spec).Run(0xc0000324b0, {0x1e17d00, 0xc0003ec7c0})
        /home/bhatfiel/go/pkg/mod/github.com/onsi/ginkgo@v1.16.4/internal/spec/spec.go:138 +0xe7
    github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpec(0xc0009c6160, 0xc0000324b0)
        /home/bhatfiel/go/pkg/mod/github.com/onsi/ginkgo@v1.16.4/internal/specrunner/spec_runner.go:200 +0xe5
    github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpecs(0xc0009c6160)
        /home/bhatfiel/go/pkg/mod/github.com/onsi/ginkgo@v1.16.4/internal/specrunner/spec_runner.go:170 +0x1a5
    github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).Run(0xc0009c6160)
        /home/bhatfiel/go/pkg/mod/github.com/onsi/ginkgo@v1.16.4/internal/specrunner/spec_runner.go:66 +0xc5
    github.com/onsi/ginkgo/internal/suite.(*Suite).Run(0xc00046cee0, {0x7fdd9c6ffc28, 0xc000602680}, {0x1b304ab, 0x10}, {0xc00037cec0, 0x2, 0x2}, {0x1e65b38, 0xc0003ec7c0}, ...)
        /home/bhatfiel/go/pkg/mod/github.com/onsi/ginkgo@v1.16.4/internal/suite/suite.go:79 +0x4d2
    github.com/onsi/ginkgo.runSpecsWithCustomReporters({0x1e19a40, 0xc000602680}, {0x1b304ab, 0x10}, {0xc00037cea0, 0x2, 0x1b3f459})
        /home/bhatfiel/go/pkg/mod/github.com/onsi/ginkgo@v1.16.4/ginkgo_dsl.go:238 +0x185
    github.com/onsi/ginkgo.RunSpecsWithDefaultAndCustomReporters({0x1e19a40, 0xc000602680}, {0x1b304ab, 0x10}, {0xc000511750, 0x1, 0x1})
        /home/bhatfiel/go/pkg/mod/github.com/onsi/ginkgo@v1.16.4/ginkgo_dsl.go:221 +0x1be
    github.com/ramendr/ramen/controllers_test.TestAPIs(0x407c59)
        /home/bhatfiel/ramen/controllers/suite_test.go:72 +0xbc
    testing.tRunner(0xc000602680, 0x1c06328)
        /home/bhatfiel/.local/go/src/testing/testing.go:1259 +0x102
    created by testing.(*T).Run
        /home/bhatfiel/.local/go/src/testing/testing.go:1306 +0x35a
------------------------------
```