### PR TITLE
vrg: initialize [Cluster]Data{Ready|Protected} status conditions iff they're uninitialized

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -79,34 +79,45 @@ const (
 // Just when VRG has been picked up for reconciliation when nothing has been
 // figured out yet.
 func setVRGInitialCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
-	setStatusCondition(conditions, metav1.Condition{
-		Type:               VRGConditionTypeDataReady,
-		Reason:             VRGConditionReasonInitializing,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionUnknown,
-		Message:            message,
-	})
-	setStatusCondition(conditions, metav1.Condition{
-		Type:               VRGConditionTypeDataProtected,
-		Reason:             VRGConditionReasonInitializing,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionUnknown,
-		Message:            message,
-	})
-	setStatusCondition(conditions, metav1.Condition{
-		Type:               VRGConditionTypeClusterDataReady,
-		Reason:             VRGConditionReasonInitializing,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionUnknown,
-		Message:            message,
-	})
-	setStatusCondition(conditions, metav1.Condition{
-		Type:               VRGConditionTypeClusterDataProtected,
-		Reason:             VRGConditionReasonInitializing,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionUnknown,
-		Message:            message,
-	})
+	if len(*conditions) > 0 {
+		return
+	}
+
+	time := metav1.NewTime(time.Now())
+	*conditions = []metav1.Condition{
+		{
+			Type:               VRGConditionTypeDataReady,
+			Reason:             VRGConditionReasonInitializing,
+			ObservedGeneration: observedGeneration,
+			Status:             metav1.ConditionUnknown,
+			LastTransitionTime: time,
+			Message:            message,
+		},
+		{
+			Type:               VRGConditionTypeDataProtected,
+			Reason:             VRGConditionReasonInitializing,
+			ObservedGeneration: observedGeneration,
+			Status:             metav1.ConditionUnknown,
+			LastTransitionTime: time,
+			Message:            message,
+		},
+		{
+			Type:               VRGConditionTypeClusterDataReady,
+			Reason:             VRGConditionReasonInitializing,
+			ObservedGeneration: observedGeneration,
+			Status:             metav1.ConditionUnknown,
+			LastTransitionTime: time,
+			Message:            message,
+		},
+		{
+			Type:               VRGConditionTypeClusterDataProtected,
+			Reason:             VRGConditionReasonInitializing,
+			ObservedGeneration: observedGeneration,
+			Status:             metav1.ConditionUnknown,
+			LastTransitionTime: time,
+			Message:            message,
+		},
+	}
 }
 
 // sets conditions when VRG as Secondary is replicating the data with Primary.


### PR DESCRIPTION
Currently they're initialized if vrg.status.protectedPvcs is nil.  This can result in a status condition getting reset.  For example, if clusterDataReady is set before protectedPvcs is, then clusterDataReady is reset on a subsequent reconcile attempt.  It seems to me the status conditions should persist until explicit reset.