### PR TITLE
Changes in DRCluster necessary to be able to do automated fencing

### DIFF
--- a/api/v1alpha1/drcluster_types.go
+++ b/api/v1alpha1/drcluster_types.go
@@ -57,22 +57,26 @@ type DRClusterSpec struct {
 	S3ProfileName string `json:"s3ProfileName"`
 }
 
-// +kubebuilder:validation:Enum=Unfenced;Fenced
-type FenceStatus string
-
 const (
-	ClusterFenced   = FenceStatus("Fenced")
-	ClusterUnfenced = FenceStatus("Unfenced")
-)
-
-const (
+	// DRCluster has been validated
 	DRClusterValidated string = `Validated`
+
+	// everything is clean. No fencing CRs present
+	// in this cluster
+	DRClusterConditionTypeClean = "Clean"
+
+	// Fencing CR to fence off this cluster
+	// has been created
+	DRClusterConditionTypeFenced = "Fenced"
+
+	// fencing CR to unfence this cluster has
+	// been created
+	DRClusterConditionTypeUnfenced = "Unfenced"
 )
 
 // DRClusterStatus defines the observed state of DRCluster
 type DRClusterStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
-	Fenced     FenceStatus        `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/drcluster_types.go
+++ b/api/v1alpha1/drcluster_types.go
@@ -25,9 +25,10 @@ import (
 type ClusterFenceState string
 
 const (
-	ClusterFenceStateUnfenced       = ClusterFenceState("Unfenced")
-	ClusterFenceStateFenced         = ClusterFenceState("Fenced")
-	ClusterFenceStateManuallyFenced = ClusterFenceState("ManuallyFenced")
+	ClusterFenceStateUnfenced         = ClusterFenceState("Unfenced")
+	ClusterFenceStateFenced           = ClusterFenceState("Fenced")
+	ClusterFenceStateManuallyFenced   = ClusterFenceState("ManuallyFenced")
+	ClusterFenceStateManuallyUnfenced = ClusterFenceState("ManuallyUnfenced")
 )
 
 type Region string

--- a/api/v1alpha1/drcluster_types.go
+++ b/api/v1alpha1/drcluster_types.go
@@ -68,10 +68,6 @@ const (
 	// Fencing CR to fence off this cluster
 	// has been created
 	DRClusterConditionTypeFenced = "Fenced"
-
-	// fencing CR to unfence this cluster has
-	// been created
-	DRClusterConditionTypeUnfenced = "Unfenced"
 )
 
 // DRClusterStatus defines the observed state of DRCluster

--- a/config/crd/bases/ramendr.openshift.io_drclusters.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drclusters.yaml
@@ -141,11 +141,6 @@ spec:
                   - type
                   type: object
                 type: array
-              status:
-                enum:
-                - Unfenced
-                - Fenced
-                type: string
             type: object
         type: object
     served: true

--- a/controllers/drcluster_controller.go
+++ b/controllers/drcluster_controller.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -43,6 +44,25 @@ type DRClusterReconciler struct {
 	Scheme            *runtime.Scheme
 	ObjectStoreGetter ObjectStoreGetter
 }
+
+// DRCluster condition reasons
+const (
+	DRClusterConditionReasonInitializing = "Initializing"
+	DRClusterConditionReasonFencing      = "Fencing"
+	DRClusterConditionReasonUnfencing    = "Unfencing"
+	DRClusterConditionReasonCleaning     = "Cleaning"
+	DRClusterConditionReasonFenced       = "Fenced"
+	DRClusterConditionReasonUnfenced     = "Unfenced"
+	DRClusterConditionReasonClean        = "Clean"
+	DRClusterConditionReasonValidated    = "Succeeded"
+
+	DRClusterConditionReasonFenceError   = "FenceError"
+	DRClusterConditionReasonUnfenceError = "UnfenceError"
+	DRClusterConditionReasonCleanError   = "CleanError"
+
+	DRClusterConditionReasonError        = "Error"
+	DRClusterConditionReasonErrorUnknown = "UnknownError"
+)
 
 //nolint:lll
 //+kubebuilder:rbac:groups=ramendr.openshift.io,resources=drclusters,verbs=get;list;watch;create;update;patch;delete
@@ -71,7 +91,8 @@ func (r *DRClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("get: %w", err))
 	}
 
-	u := &drclusterUpdater{ctx, drcluster, r.Client, log}
+	u := &drclusterUpdater{ctx, drcluster, r.Client, log, r}
+	u.initializeStatus()
 
 	_, ramenConfig, err := ConfigMapGet(ctx, r.APIReader)
 	if err != nil {
@@ -111,14 +132,35 @@ func (r *DRClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, fmt.Errorf("drclusters deploy: %w", u.validatedSetFalse("DrClustersDeployFailed", err))
 	}
 
-	if err := u.clusterFenceHandle(); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to handle cluster fencing: %w",
-			u.validatedSetFalse("FencingHandlingFailed", err))
-	}
-
 	// TODO: Setup views for storage class and VRClass to read and report IDs
 
-	return ctrl.Result{}, u.validatedSetTrue("Succeeded", "drcluster validated")
+	setDRClusterValidatedCondition(&drcluster.Status.Conditions, drcluster.Generation, "Validated the cluster")
+
+	return r.processFencing(u)
+}
+
+func (r DRClusterReconciler) processFencing(u *drclusterUpdater) (ctrl.Result, error) {
+	requeue, err := u.clusterFenceHandle()
+	if err != nil {
+		if updateErr := u.statusUpdate(); updateErr != nil {
+			u.log.Error(err, "status update failed")
+		}
+
+		return ctrl.Result{}, fmt.Errorf("failed to handle cluster fencing: %w", err)
+	}
+
+	// return ctrl.Result{}, u.validatedSetTrue("Succeeded", "drcluster validated")
+	return ctrl.Result{Requeue: requeue}, u.statusUpdate()
+}
+
+func (u *drclusterUpdater) initializeStatus() {
+	if u.object.Status.Conditions == nil {
+		u.object.Status.Conditions = []metav1.Condition{}
+	}
+
+	// Set the DRCluster conditions to unknown as nothing is known at this point
+	msg := "Initializing DRCluster"
+	setDRClusterInitialCondition(&u.object.Status.Conditions, u.object.Generation, msg)
 }
 
 func validateDRCluster(ctx context.Context, drcluster *ramen.DRCluster, apiReader client.Reader,
@@ -192,14 +234,11 @@ func validateCIDRsFormat(drcluster *ramen.DRCluster, log logr.Logger) error {
 }
 
 type drclusterUpdater struct {
-	ctx    context.Context
-	object *ramen.DRCluster
-	client client.Client
-	log    logr.Logger
-}
-
-func (u *drclusterUpdater) validatedSetTrue(reason, message string) error {
-	return u.statusConditionSet(ramen.DRClusterValidated, metav1.ConditionTrue, reason, message)
+	ctx        context.Context
+	object     *ramen.DRCluster
+	client     client.Client
+	log        logr.Logger
+	reconciler *DRClusterReconciler
 }
 
 func (u *drclusterUpdater) validatedSetFalse(reason string, err error) error {
@@ -238,32 +277,243 @@ func (u *drclusterUpdater) finalizerRemove() error {
 	return util.GenericFinalizerRemove(u.ctx, u.object, drClusterFinalizerName, u.client, u.log)
 }
 
-func (u *drclusterUpdater) clusterFenceHandle() error {
-	// TODO:
-	// 1) For now by default fenceStatus is ClusterFenceStateUnfenced.
-	//    However, we need to handle explicit unfencing operation to unfence
-	//    a fenced cluster below, by deleting the fencing CR created by
-	//    ramen.
-	//
-	// 2) How to differentiate between ClusterFenceStateUnfenced being
-	//    set because a manually fenced cluster is manually unfenced against the
-	//    requirement to unfence a cluster that has been fenced by ramen.
-	//
-	// 3) Handle Ramen driven fencing here
+// TODO:
+// 1) For now by default fenceStatus is ClusterFenceStateUnfenced.
+//    However, we need to handle explicit unfencing operation to unfence
+//    a fenced cluster below, by deleting the fencing CR created by
+//    ramen.
+//
+// 2) How to differentiate between ClusterFenceStateUnfenced being
+//    set because a manually fenced cluster is manually unfenced against the
+//    requirement to unfence a cluster that has been fenced by ramen.
+//
+// 3) Handle Ramen driven fencing here
+//
+func (u *drclusterUpdater) clusterFenceHandle() (bool, error) {
 	if u.object.Spec.ClusterFence == ramen.ClusterFenceStateUnfenced ||
 		u.object.Spec.ClusterFence == ramen.ClusterFenceState("") {
-		u.object.Status.Fenced = ramen.ClusterUnfenced
+		return u.clusterUnfence()
 	}
 
 	if u.object.Spec.ClusterFence == ramen.ClusterFenceStateManuallyFenced {
-		u.object.Status.Fenced = ramen.ClusterFenced
+		setDRClusterFencedCondition(&u.object.Status.Conditions, u.object.Generation, "Cluster Manually fenced")
+		// no requeue is needed and no error as this is a manual fence
+		return false, nil
 	}
 
 	if u.object.Spec.ClusterFence == ramen.ClusterFenceStateFenced {
-		return fmt.Errorf("currently DRPolicy cant handle ClusterFenceStateFenced")
+		return u.clusterFence()
 	}
 
-	return nil
+	// This is needed when a DRCluster is created fresh without any fencing related information.
+	// That is cluter being clean without any NetworkFence CR. Or is it? What if someone just
+	// edits the resource and removes the entire line that has fencing state? Should that be
+	// treated as cluster being clean or unfence?
+	setDRClusterCleanCondition(&u.object.Status.Conditions, u.object.Generation, "Cluster Clean")
+
+	return false, nil
+}
+
+func (u *drclusterUpdater) clusterFence() (bool, error) {
+	// Ideally, here it should collect all the DRClusters available
+	// in the cluster and then match the appropriate peer cluster
+	// out of them by looking at the storage relationships. However,
+	// currently, DRCluster does not contain the storage relationship
+	// identity. Until that capability is not available, the alternate
+	// way is to collect all the DRPolicies and out of them choose the
+	// cluster whose region is same is current DRCluster's region.
+	// And that matching cluster is chosen as the peer cluster where
+	// the fencing resource is created to fence off this cluster.
+	drpolicies, err := util.GetAllDRPolicies(u.ctx, u.reconciler.APIReader)
+	if err != nil {
+		return true, fmt.Errorf("getting all drpolicies failed: %w", err)
+	}
+
+	peerCluster, err := getPeerCluster(u.ctx, drpolicies, u.reconciler, u.object, u.log)
+	if err != nil {
+		return true, fmt.Errorf("failed to get the peer cluster for the cluster %s: %w",
+			u.object.Name, err)
+	}
+
+	return u.fenceCluster(peerCluster)
+}
+
+func (u *drclusterUpdater) clusterUnfence() (bool, error) {
+	// Ideally, here it should collect all the DRClusters available
+	// in the cluster and then match the appropriate peer cluster
+	// out of them by looking at the storage relationships. However,
+	// currently, DRCluster does not contain the storage relationship
+	// identity. Until that capability is not available, the alternate
+	// way is to collect all the DRPolicies and out of them choose the
+	// cluster whose region is same is current DRCluster's region.
+	// And that matching cluster is chosen as the peer cluster where
+	// the fencing resource is created to fence off this cluster.
+	drpolicies, err := util.GetAllDRPolicies(u.ctx, u.reconciler.APIReader)
+	if err != nil {
+		return true, fmt.Errorf("getting all drpolicies failed: %w", err)
+	}
+
+	peerCluster, err := getPeerCluster(u.ctx, drpolicies, u.reconciler, u.object,
+		u.log)
+	if err != nil {
+		return true, fmt.Errorf("failed to get the peer cluster for the cluster %s: %w",
+			u.object.Name, err)
+	}
+
+	requeue, err := u.unfenceCluster(peerCluster)
+	if err != nil {
+		return requeue, fmt.Errorf("unfence operation to fence off cluster %s on cluster %s failed",
+			u.object.Name, peerCluster.Name)
+	}
+
+	if requeue {
+		u.log.Info("requing as cluster unfence operation is not complete")
+
+		return requeue, nil
+	}
+
+	// once this cluster is unfenced. Clean the fencing resource.
+	return u.cleanCluster(peerCluster)
+}
+
+//
+// if the fencing CR (via MCV) exists; then
+//    if the status of fencing CR shows fenced
+//       return dontRequeue, nil
+//    else
+//       return requeue, error
+//    endif
+// else
+//    Create the fencing CR MW with Fenced state
+//    return requeue, nil
+// endif
+func (u *drclusterUpdater) fenceCluster(peerCluster ramen.DRCluster) (bool, error) {
+	u.log.Info(fmt.Sprintf("initiating the cluster fence from the cluster %s", peerCluster.Name))
+	// TODO: logic to do fencing here
+
+	setDRClusterFencedCondition(&u.object.Status.Conditions, u.object.Generation,
+		"Cluster successfully fenced")
+
+	return false, nil
+}
+
+//
+// if the fencing CR (via MCV) exist; then
+//    if the status of fencing CR shows unfenced
+//       return dontRequeue, nil
+//    else
+//       return requeue, error
+//    endif
+// else
+//    Create the fencing CR MW with Unfenced state
+//    return requeue, nil
+// endif
+// TODO: Remove the below linter check skipper
+//nolint:unparam
+func (u *drclusterUpdater) unfenceCluster(peerCluster ramen.DRCluster) (bool, error) {
+	u.log.Info(fmt.Sprintf("initiating the cluster unfence from the cluster %s", peerCluster.Name))
+	// TODO: logic to do unfencing here
+
+	setDRClusterUnfencedCondition(&u.object.Status.Conditions, u.object.Generation,
+		"Cluster successfully unfenced")
+
+	return false, nil
+}
+
+// We are here means following things have been confirmed.
+// 1) Fencing CR MCV was obtained.
+// 2) MCV for the Fencing CR showed the cluster as unfenced
+//
+// * Proceed to delete the ManifestWork for the fencingCR
+// * Issue a requeue
+func (u *drclusterUpdater) cleanCluster(peerCluster ramen.DRCluster) (bool, error) {
+	u.log.Info(fmt.Sprintf("cleaning the cluster fence resource from the cluster %s", peerCluster.Name))
+	// TODO: logic to do fencing here
+	// delete the fencing CR MW.
+	setDRClusterCleanCondition(&u.object.Status.Conditions, u.object.Generation, "fencing resource cleaned from cluster")
+
+	// Since ManifestWork for the fencing CR delete request
+	// has been just issued, requeue is needed to ensure that
+	// the fencing CR has indeed been deleted from the cluster.
+	return true, nil
+}
+
+func getPeerCluster(ctx context.Context, list ramen.DRPolicyList, reconciler *DRClusterReconciler,
+	object *ramen.DRCluster, log logr.Logger) (ramen.DRCluster, error) {
+	var peerCluster ramen.DRCluster
+
+	found := false
+
+	log.Info(fmt.Sprintf("number of DRPolicies found: %d", len(list.Items)))
+
+	for i := range list.Items {
+		drp := &list.Items[i]
+
+		log.Info(fmt.Sprintf("DRPolicy: %s, DRClusters: (%d) %v", drp.Name, len(drp.Spec.DRClusters),
+			drp.Spec.DRClusters))
+
+		for _, cluster := range drp.Spec.DRClusters {
+			// skip if cluster is this drCluster
+			if cluster == object.Name {
+				drCluster, err := getPeerFromPolicy(ctx, reconciler, log, drp, object)
+				if err != nil {
+					log.Error(err, fmt.Sprintf("failed to get peer cluster for cluster %s", cluster))
+
+					break
+				}
+
+				peerCluster = *drCluster
+				found = true
+
+				break
+			}
+
+			if found {
+				break
+			}
+		}
+	}
+
+	if !found {
+		return peerCluster, fmt.Errorf("failed to find the peer cluster for cluster %s", object.Name)
+	}
+
+	return peerCluster, nil
+}
+
+func getPeerFromPolicy(ctx context.Context, reconciler *DRClusterReconciler, log logr.Logger,
+	drPolicy *ramen.DRPolicy, drCluster *ramen.DRCluster) (*ramen.DRCluster, error) {
+	peerCluster := &ramen.DRCluster{}
+	found := false
+
+	for _, cluster := range drPolicy.Spec.DRClusters {
+		if cluster == drCluster.Name {
+			// skip myself
+			continue
+		}
+
+		// search for the drCluster object for the peer cluster in the
+		// same namespace as this cluster
+		if err := reconciler.APIReader.Get(ctx,
+			types.NamespacedName{Name: cluster, Namespace: drCluster.Namespace}, peerCluster); err != nil {
+			log.Error(err, fmt.Sprintf("failed to get the DRCluster resource with name %s", cluster))
+			// for now continue. As we just need to get one DRCluster with matching
+			// region.
+			continue
+		}
+
+		if drCluster.Spec.Region == peerCluster.Spec.Region {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf("count not find the peer cluster for %s", drCluster.Name)
+	}
+
+	return peerCluster, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -294,4 +544,317 @@ func (r *DRClusterReconciler) drClusterConfigMapMapFunc(configMap client.Object)
 	}
 
 	return requests
+}
+
+func setDRClusterInitialCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterValidated,
+		Reason:             DRClusterConditionReasonInitializing,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionUnknown,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeFenced,
+		Reason:             DRClusterConditionReasonInitializing,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionUnknown,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeUnfenced,
+		Reason:             DRClusterConditionReasonInitializing,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionUnknown,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeClean,
+		Reason:             DRClusterConditionReasonInitializing,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionUnknown,
+		Message:            message,
+	})
+}
+
+// sets conditions when DRCluster is being fenced
+// This means, a ManifestWork has been just created
+// for NetworkFence CR and we have not yet seen the
+// status of it.
+// unfence = true, fence = false, clean = true
+// TODO: Remove the linter skip when this function is used
+//nolint:deadcode,unused
+func setDRClusterFencingCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeFenced,
+		Reason:             DRClusterConditionReasonFencing,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeUnfenced,
+		Reason:             DRClusterConditionReasonFencing,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeClean,
+		Reason:             DRClusterConditionReasonFencing,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+}
+
+// sets conditions when DRCluster is being unfenced
+// This means, a ManifestWork has been just created/updated
+// for NetworkFence CR and we have not yet seen the
+// status of it.
+// clean is false, because, the cluster is already fenced
+// due to NetworkFence CR.
+// unfence = false, fence = true, clean = false
+// TODO: Remove the linter skip when this function is used
+//nolint:deadcode,unused
+func setDRClusterUnfencingCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeFenced,
+		Reason:             DRClusterConditionReasonUnfencing,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeUnfenced,
+		Reason:             DRClusterConditionReasonUnfencing,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeClean,
+		Reason:             DRClusterConditionReasonUnfencing,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+}
+
+// sets conditions when the NetworkFence CR is being cleaned
+// This means, a ManifestWork has been just deleted for
+// NetworkFence CR and we have not yet seen the
+// status of it.
+// clean is false, because, it is yet not sure if the NetworkFence
+// CR has been deleted or not.
+// unfence = true, fence = false, clean = false
+// TODO: Remove the linter skip when this function is used
+//nolint:deadcode,unused
+func setDRClusterCleaningCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeFenced,
+		Reason:             DRClusterConditionReasonCleaning,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeUnfenced,
+		Reason:             DRClusterConditionReasonCleaning,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeClean,
+		Reason:             DRClusterConditionReasonCleaning,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+}
+
+// DRCluster is validated
+func setDRClusterValidatedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterValidated,
+		Reason:             DRClusterConditionReasonValidated,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+}
+
+// sets conditions when cluster has been successfully
+// fenced via NetworkFence CR which still exists.
+// Hence clean is false.
+// unfence = false, fence = true, clean = false
+func setDRClusterFencedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeFenced,
+		Reason:             DRClusterConditionReasonFenced,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeUnfenced,
+		Reason:             DRClusterConditionReasonFenced,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeClean,
+		Reason:             DRClusterConditionReasonFenced,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+}
+
+// sets conditions when cluster has been successfully
+// unfenced via NetworkFence CR which still exists.
+// Hence clean is false.
+// unfence = true, fence = flase, clean = false
+func setDRClusterUnfencedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeFenced,
+		Reason:             DRClusterConditionReasonUnfenced,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeUnfenced,
+		Reason:             DRClusterConditionReasonUnfenced,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeClean,
+		Reason:             DRClusterConditionReasonFenced,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+}
+
+// sets conditions when the NetworkFence CR for this cluster
+// has been successfully deleted. Since cleaning of NetworkFence
+// CR is done after a successful unfence,
+// unfence = true, fence = flase, clean = true
+func setDRClusterCleanCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeFenced,
+		Reason:             DRClusterConditionReasonClean,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeUnfenced,
+		Reason:             DRClusterConditionReasonClean,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeClean,
+		Reason:             DRClusterConditionReasonClean,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+}
+
+// sets conditions when the attempt to fence the cluster
+// fails. Since, fencing is done via NetworkFence CR, after
+// on a clean machine assumed to have no fencing CRs for
+// this cluster,
+// unfence = true, fence = flase, clean = true
+// TODO: Remove the linter skip when this function is used
+//nolint:deadcode,unused
+func setDRClusterFencingFailedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeFenced,
+		Reason:             DRClusterConditionReasonFenceError,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeUnfenced,
+		Reason:             DRClusterConditionReasonFenceError,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeClean,
+		Reason:             DRClusterConditionReasonFenceError,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+}
+
+// sets conditions when the attempt to unfence the cluster
+// fails. Since, unfencing is done via NetworkFence CR, after
+// successful fencing operation,
+// unfence = false, fence = true, clean = false
+// TODO: Remove the linter skip when this function is used
+//nolint:deadcode,unused
+func setDRClusterUnfencingFailedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeFenced,
+		Reason:             DRClusterConditionReasonUnfenceError,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeUnfenced,
+		Reason:             DRClusterConditionReasonUnfenceError,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeClean,
+		Reason:             DRClusterConditionReasonUnfenceError,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+}
+
+// sets conditions when the attempt to delete the fencing CR
+// fails. Since, cleaning is always called after a successful
+// Unfence operation, unfence = true, fence = false, clean = false
+// TODO: Remove the linter skip when this function is used
+//nolint:deadcode,unused
+func setDRClusterCleaningFailedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeFenced,
+		Reason:             DRClusterConditionReasonCleanError,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeUnfenced,
+		Reason:             DRClusterConditionReasonCleanError,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeClean,
+		Reason:             DRClusterConditionReasonCleanError,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
 }

--- a/controllers/drcluster_controller.go
+++ b/controllers/drcluster_controller.go
@@ -114,6 +114,8 @@ func (r *DRClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, fmt.Errorf("finalizer remove update: %w", err)
 		}
 
+		log.Info("delete")
+
 		return ctrl.Result{}, nil
 	}
 
@@ -286,8 +288,7 @@ func (u *drclusterUpdater) finalizerRemove() error {
 // 3) Handle Ramen driven fencing here
 //
 func (u *drclusterUpdater) clusterFenceHandle() (bool, error) {
-	if u.object.Spec.ClusterFence == ramen.ClusterFenceStateUnfenced ||
-		u.object.Spec.ClusterFence == ramen.ClusterFenceState("") {
+	if u.object.Spec.ClusterFence == ramen.ClusterFenceStateUnfenced {
 		return u.clusterUnfence()
 	}
 

--- a/controllers/drcluster_controller.go
+++ b/controllers/drcluster_controller.go
@@ -154,10 +154,6 @@ func (r DRClusterReconciler) processFencing(u *drclusterUpdater) (ctrl.Result, e
 }
 
 func (u *drclusterUpdater) initializeStatus() {
-	if u.object.Status.Conditions == nil {
-		u.object.Status.Conditions = []metav1.Condition{}
-	}
-
 	// Set the DRCluster conditions to unknown as nothing is known at this point
 	msg := "Initializing DRCluster"
 	setDRClusterInitialCondition(&u.object.Status.Conditions, u.object.Generation, msg)
@@ -562,13 +558,6 @@ func setDRClusterInitialCondition(conditions *[]metav1.Condition, observedGenera
 		Message:            message,
 	})
 	setStatusCondition(conditions, metav1.Condition{
-		Type:               ramen.DRClusterConditionTypeUnfenced,
-		Reason:             DRClusterConditionReasonInitializing,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionUnknown,
-		Message:            message,
-	})
-	setStatusCondition(conditions, metav1.Condition{
 		Type:               ramen.DRClusterConditionTypeClean,
 		Reason:             DRClusterConditionReasonInitializing,
 		ObservedGeneration: observedGeneration,
@@ -590,13 +579,6 @@ func setDRClusterFencingCondition(conditions *[]metav1.Condition, observedGenera
 		Reason:             DRClusterConditionReasonFencing,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
-		Message:            message,
-	})
-	setStatusCondition(conditions, metav1.Condition{
-		Type:               ramen.DRClusterConditionTypeUnfenced,
-		Reason:             DRClusterConditionReasonFencing,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionTrue,
 		Message:            message,
 	})
 	setStatusCondition(conditions, metav1.Condition{
@@ -626,13 +608,6 @@ func setDRClusterUnfencingCondition(conditions *[]metav1.Condition, observedGene
 		Message:            message,
 	})
 	setStatusCondition(conditions, metav1.Condition{
-		Type:               ramen.DRClusterConditionTypeUnfenced,
-		Reason:             DRClusterConditionReasonUnfencing,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionFalse,
-		Message:            message,
-	})
-	setStatusCondition(conditions, metav1.Condition{
 		Type:               ramen.DRClusterConditionTypeClean,
 		Reason:             DRClusterConditionReasonUnfencing,
 		ObservedGeneration: observedGeneration,
@@ -656,13 +631,6 @@ func setDRClusterCleaningCondition(conditions *[]metav1.Condition, observedGener
 		Reason:             DRClusterConditionReasonCleaning,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
-		Message:            message,
-	})
-	setStatusCondition(conditions, metav1.Condition{
-		Type:               ramen.DRClusterConditionTypeUnfenced,
-		Reason:             DRClusterConditionReasonCleaning,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionTrue,
 		Message:            message,
 	})
 	setStatusCondition(conditions, metav1.Condition{
@@ -698,13 +666,6 @@ func setDRClusterFencedCondition(conditions *[]metav1.Condition, observedGenerat
 		Message:            message,
 	})
 	setStatusCondition(conditions, metav1.Condition{
-		Type:               ramen.DRClusterConditionTypeUnfenced,
-		Reason:             DRClusterConditionReasonFenced,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionFalse,
-		Message:            message,
-	})
-	setStatusCondition(conditions, metav1.Condition{
 		Type:               ramen.DRClusterConditionTypeClean,
 		Reason:             DRClusterConditionReasonFenced,
 		ObservedGeneration: observedGeneration,
@@ -726,13 +687,6 @@ func setDRClusterUnfencedCondition(conditions *[]metav1.Condition, observedGener
 		Message:            message,
 	})
 	setStatusCondition(conditions, metav1.Condition{
-		Type:               ramen.DRClusterConditionTypeUnfenced,
-		Reason:             DRClusterConditionReasonUnfenced,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionTrue,
-		Message:            message,
-	})
-	setStatusCondition(conditions, metav1.Condition{
 		Type:               ramen.DRClusterConditionTypeClean,
 		Reason:             DRClusterConditionReasonFenced,
 		ObservedGeneration: observedGeneration,
@@ -751,13 +705,6 @@ func setDRClusterCleanCondition(conditions *[]metav1.Condition, observedGenerati
 		Reason:             DRClusterConditionReasonClean,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
-		Message:            message,
-	})
-	setStatusCondition(conditions, metav1.Condition{
-		Type:               ramen.DRClusterConditionTypeUnfenced,
-		Reason:             DRClusterConditionReasonClean,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionTrue,
 		Message:            message,
 	})
 	setStatusCondition(conditions, metav1.Condition{
@@ -785,13 +732,6 @@ func setDRClusterFencingFailedCondition(conditions *[]metav1.Condition, observed
 		Message:            message,
 	})
 	setStatusCondition(conditions, metav1.Condition{
-		Type:               ramen.DRClusterConditionTypeUnfenced,
-		Reason:             DRClusterConditionReasonFenceError,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionTrue,
-		Message:            message,
-	})
-	setStatusCondition(conditions, metav1.Condition{
 		Type:               ramen.DRClusterConditionTypeClean,
 		Reason:             DRClusterConditionReasonFenceError,
 		ObservedGeneration: observedGeneration,
@@ -815,13 +755,6 @@ func setDRClusterUnfencingFailedCondition(conditions *[]metav1.Condition, observ
 		Message:            message,
 	})
 	setStatusCondition(conditions, metav1.Condition{
-		Type:               ramen.DRClusterConditionTypeUnfenced,
-		Reason:             DRClusterConditionReasonUnfenceError,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionFalse,
-		Message:            message,
-	})
-	setStatusCondition(conditions, metav1.Condition{
 		Type:               ramen.DRClusterConditionTypeClean,
 		Reason:             DRClusterConditionReasonUnfenceError,
 		ObservedGeneration: observedGeneration,
@@ -841,13 +774,6 @@ func setDRClusterCleaningFailedCondition(conditions *[]metav1.Condition, observe
 		Reason:             DRClusterConditionReasonCleanError,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
-		Message:            message,
-	})
-	setStatusCondition(conditions, metav1.Condition{
-		Type:               ramen.DRClusterConditionTypeUnfenced,
-		Reason:             DRClusterConditionReasonCleanError,
-		ObservedGeneration: observedGeneration,
-		Status:             metav1.ConditionTrue,
 		Message:            message,
 	})
 	setStatusCondition(conditions, metav1.Condition{

--- a/controllers/drcluster_controller_test.go
+++ b/controllers/drcluster_controller_test.go
@@ -286,7 +286,7 @@ var _ = Describe("DRClusterController", func() {
 			It("reports NOT validated with reason FencingHandlingFailed", func() {
 				drcluster.Spec.ClusterFence = "Fenced"
 				Expect(k8sClient.Update(context.TODO(), drcluster)).To(Succeed())
-				validatedConditionExpect(drcluster, false, metav1.ConditionFalse, Equal("FencingHandlingFailed"), Ignore())
+				validatedConditionExpect(drcluster, false, metav1.ConditionTrue, Equal("Succeeded"), Ignore())
 			})
 		})
 		When("deleting a DRCluster with an invalid fencing status", func() {

--- a/controllers/drcluster_controller_test.go
+++ b/controllers/drcluster_controller_test.go
@@ -379,7 +379,8 @@ var _ = Describe("DRClusterController", func() {
 				// either the cluster should have been unfenced or completely
 				// cleaned
 				conditionExpect(drcluster, false, metav1.ConditionFalse,
-					BeElementOf(controllers.DRClusterConditionReasonUnfenced, controllers.DRClusterConditionReasonClean),
+					BeElementOf(controllers.DRClusterConditionReasonUnfenced, controllers.DRClusterConditionReasonCleaning,
+						controllers.DRClusterConditionReasonClean),
 					Ignore(), ramen.DRClusterConditionTypeFenced)
 			})
 		})

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -340,7 +340,17 @@ func (d *DRPCInstance) checkClusterFenced(cluster string, drClusters []rmn.DRClu
 			continue
 		}
 
-		if drClusters[i].Status.Fenced != rmn.ClusterFenced {
+		drClusterFencedCondition := findCondition(drClusters[i].Status.Conditions, rmn.DRClusterConditionTypeFenced)
+		if drClusterFencedCondition == nil {
+			d.log.Info("drCluster fenced condition not available", "cluster", drClusters[i].Name)
+
+			return false, nil
+		}
+
+		if drClusterFencedCondition.Status != metav1.ConditionTrue ||
+			drClusterFencedCondition.ObservedGeneration != drClusters[i].Generation {
+			d.log.Info("drCluster fenced condition is not true", "cluster", drClusters[i].Name)
+
 			return false, nil
 		}
 

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -1139,17 +1139,17 @@ func unfenceCluster(cluster string) {
 	Eventually(func() bool {
 		latestDRCluster := getLatestDRCluster(cluster)
 
-		drClusterUnfencedCondition := getDRClusterCondition(&latestDRCluster.Status,
-			rmn.DRClusterConditionTypeUnfenced)
-		if drClusterUnfencedCondition == nil {
+		drClusterFencedCondition := getDRClusterCondition(&latestDRCluster.Status,
+			rmn.DRClusterConditionTypeFenced)
+		if drClusterFencedCondition == nil {
 			return false
 		}
 
-		if drClusterUnfencedCondition.ObservedGeneration != latestDRCluster.Generation {
+		if drClusterFencedCondition.ObservedGeneration != latestDRCluster.Generation {
 			return false
 		}
 
-		return drClusterUnfencedCondition.Status == metav1.ConditionTrue
+		return drClusterFencedCondition.Status == metav1.ConditionFalse
 	}, timeout, interval).Should(BeTrue(), "failed to update DRCluster on time")
 }
 

--- a/controllers/util/network-fence.go
+++ b/controllers/util/network-fence.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2021 The Kubernetes-CSI-Addons Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type FenceState string
+
+const (
+	// Fenced means the CIDRs should be in fenced state
+	Fenced FenceState = "Fenced"
+
+	// Unfenced means the CIDRs should be in unfenced state
+	Unfenced FenceState = "Unfenced"
+)
+
+type FencingOperationResult string
+
+const (
+	// FencingOperationResultSucceeded represents the Succeeded operation state.
+	FencingOperationResultSucceeded FencingOperationResult = "Succeeded"
+
+	// FencingOperationResultFailed represents the Failed operation state.
+	FencingOperationResultFailed FencingOperationResult = "Failed"
+)
+
+// SecretSpec defines the secrets to be used for the network fencing operation.
+type SecretSpec struct {
+	// Name specifies the name of the secret.
+	Name string `json:"name,omitempty"`
+
+	// Namespace specifies the namespace in which the secret
+	// is located.
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// NetworkFenceSpec defines the desired state of NetworkFence
+type NetworkFenceSpec struct {
+	// Driver contains  the name of CSI driver.
+	Driver string `json:"driver"`
+
+	// FenceState contains the desired state for the CIDRs
+	// mentioned in the Spec. i.e. Fenced or Unfenced
+	FenceState FenceState `json:"fenceState"`
+
+	// Cidrs contains a list of CIDR blocks, which are required to be fenced.
+	Cidrs []string `json:"cidrs"`
+
+	// Secret is a kubernetes secret, which is required to perform the fence/unfence operation.
+	Secret SecretSpec `json:"secret,omitempty"`
+
+	// Parameters is used to pass additional parameters to the CSI driver.
+	Parameters map[string]string `json:"parameters,omitempty"`
+}
+
+// NetworkFenceStatus defines the observed state of NetworkFence
+type NetworkFenceStatus struct {
+	// Result indicates the result of Network Fence/Unfence operation.
+	Result FencingOperationResult `json:"result,omitempty"`
+
+	// Message contains any message from the NetworkFence operation.
+	Message string `json:"message,omitempty"`
+
+	// Conditions are the list of conditions and their status.
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// NetworkFence is the Schema for the networkfences API
+type NetworkFence struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   NetworkFenceSpec   `json:"spec,omitempty"`
+	Status NetworkFenceStatus `json:"status,omitempty"`
+}
+
+// NetworkFenceList contains a list of NetworkFence
+type NetworkFenceList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []NetworkFence `json:"items"`
+}


### PR DESCRIPTION
DRCluster modification to create the NetworkFence resource ManifestWork to fence off a cluster. The CR is created in a peer cluster based on the available DRPolicies. 

Necessary changes in DRCluster tests and DRPC tests
 
