### PR TITLE
vrg: make sync and async fields pointers

### DIFF
--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -48,32 +48,6 @@ const (
 	UnknownState State = "Unknown"
 )
 
-// AsyncMode which will be either Enabled or Disabled
-// +kubebuilder:validation:Enum=Enabled;Disabled
-type AsyncMode string
-
-// SyncMode which will be either Enabled or Disabled
-// +kubebuilder:validation:Enum=Enabled;Disabled
-type SyncMode string
-
-// These are the valid values for AsyncMode
-const (
-	// AsyncMode enabled for DR
-	AsyncModeEnabled = AsyncMode("Enabled")
-
-	// AsyncMode disabled for DR
-	AsyncModeDisabled = AsyncMode("Disabled")
-)
-
-// These are the valid values for SyncMode
-const (
-	// AsyncMode enabled for DR
-	SyncModeEnabled = SyncMode("Enabled")
-
-	// AsyncMode disabled for DR
-	SyncModeDisabled = SyncMode("Disabled")
-)
-
 // VRGAsyncSpec has the parameters associated with RegionalDR
 type VRGAsyncSpec struct {
 	// Label selector to identify the VolumeReplicationClass resources
@@ -95,16 +69,10 @@ type VRGAsyncSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern=`^\d+[mhd]$`
 	SchedulingInterval string `json:"schedulingInterval"`
-
-	// Mode determines if AsyncDR is enabled or not
-	Mode AsyncMode `json:"mode"`
 }
 
 // VRGSyncSpec has the parameters associated with MetroDR
-type VRGSyncSpec struct {
-	// Mode determines if SyncDR is enabled or not
-	Mode SyncMode `json:"mode"`
-}
+type VRGSyncSpec struct{}
 
 // VolSyncReplicationDestinationSpec defines the configuration for the VolSync
 // protected PVC to be used by the destination cluster (Secondary)
@@ -175,8 +143,10 @@ type VolumeReplicationGroupSpec struct {
 	// and forward PV related cluster state to peer DR clusters.
 	S3Profiles []string `json:"s3Profiles"`
 
-	Async VRGAsyncSpec `json:"async,omitempty"`
-	Sync  VRGSyncSpec  `json:"sync,omitempty"`
+	// +optional
+	Async *VRGAsyncSpec `json:"async,omitempty"`
+	// +optional
+	Sync *VRGSyncSpec `json:"sync,omitempty"`
 
 	// volsync defines the configuration when using VolSync plugin for replication.
 	//+optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -627,8 +627,16 @@ func (in *VolumeReplicationGroupSpec) DeepCopyInto(out *VolumeReplicationGroupSp
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	in.Async.DeepCopyInto(&out.Async)
-	out.Sync = in.Sync
+	if in.Async != nil {
+		in, out := &in.Async, &out.Async
+		*out = new(VRGAsyncSpec)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Sync != nil {
+		in, out := &in.Sync, &out.Sync
+		*out = new(VRGSyncSpec)
+		**out = **in
+	}
 	in.VolSync.DeepCopyInto(&out.VolSync)
 }
 

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -64,12 +64,6 @@ spec:
               async:
                 description: VRGAsyncSpec has the parameters associated with RegionalDR
                 properties:
-                  mode:
-                    description: Mode determines if AsyncDR is enabled or not
-                    enum:
-                    - Enabled
-                    - Disabled
-                    type: string
                   replicationClassSelector:
                     description: Label selector to identify the VolumeReplicationClass
                       resources that are scanned to select an appropriate VolumeReplicationClass
@@ -170,7 +164,6 @@ spec:
                         type: object
                     type: object
                 required:
-                - mode
                 - schedulingInterval
                 type: object
               prepareForFinalSync:
@@ -241,15 +234,6 @@ spec:
                 type: array
               sync:
                 description: VRGSyncSpec has the parameters associated with MetroDR
-                properties:
-                  mode:
-                    description: Mode determines if SyncDR is enabled or not
-                    enum:
-                    - Enabled
-                    - Disabled
-                    type: string
-                required:
-                - mode
                 type: object
               volSync:
                 description: volsync defines the configuration when using VolSync

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -1211,32 +1211,24 @@ func (d *DRPCInstance) generateVRG(repState rmn.ReplicationState) rmn.VolumeRepl
 	return vrg
 }
 
-func (d *DRPCInstance) generateVRGSpecAsync() rmn.VRGAsyncSpec {
+func (d *DRPCInstance) generateVRGSpecAsync() *rmn.VRGAsyncSpec {
 	if dRPolicySupportsRegional(d.drPolicy, d.drClusters) {
-		return rmn.VRGAsyncSpec{
+		return &rmn.VRGAsyncSpec{
 			ReplicationClassSelector:    d.drPolicy.Spec.ReplicationClassSelector,
 			VolumeSnapshotClassSelector: d.drPolicy.Spec.VolumeSnapshotClassSelector,
 			SchedulingInterval:          d.drPolicy.Spec.SchedulingInterval,
-			Mode:                        rmn.AsyncModeEnabled,
 		}
 	}
 
-	return rmn.VRGAsyncSpec{
-		SchedulingInterval: "365d", // this is mandatory, spoof it!
-		Mode:               rmn.AsyncModeDisabled,
-	}
+	return nil
 }
 
-func (d *DRPCInstance) generateVRGSpecSync() rmn.VRGSyncSpec {
+func (d *DRPCInstance) generateVRGSpecSync() *rmn.VRGSyncSpec {
 	if supports, _ := dRPolicySupportsMetro(d.drPolicy, d.drClusters); supports {
-		return rmn.VRGSyncSpec{
-			Mode: rmn.SyncModeEnabled,
-		}
+		return &rmn.VRGSyncSpec{}
 	}
 
-	return rmn.VRGSyncSpec{
-		Mode: rmn.SyncModeDisabled,
-	}
+	return nil
 }
 
 func dRPolicySupportsRegional(drpolicy *rmn.DRPolicy, drClusters []rmn.DRCluster) bool {

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -192,8 +192,7 @@ var baseVRG = &rmn.VolumeReplicationGroup{
 	TypeMeta:   metav1.TypeMeta{Kind: "VolumeReplicationGroup", APIVersion: "ramendr.openshift.io/v1alpha1"},
 	ObjectMeta: metav1.ObjectMeta{Name: DRPCName, Namespace: DRPCNamespaceName},
 	Spec: rmn.VolumeReplicationGroupSpec{
-		Async: rmn.VRGAsyncSpec{
-			Mode:               rmn.AsyncModeEnabled,
+		Async: &rmn.VRGAsyncSpec{
 			SchedulingInterval: schedulingInterval,
 		},
 		ReplicationState: rmn.Primary,

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -72,15 +72,17 @@ var _ = Describe("VolSync Handler - utils", func() {
 })
 
 var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
-	schedulingInterval := "1h"
+	asyncSpec := &ramendrv1alpha1.VRGAsyncSpec{
+		SchedulingInterval:          "1h",
+		VolumeSnapshotClassSelector: metav1.LabelSelector{},
+	}
 
 	Describe("Get volume snapshot classes", func() {
 		Context("With no label selector", func() {
 			var vsHandler *volsync.VSHandler
 
 			BeforeEach(func() {
-				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil,
-					schedulingInterval, metav1.LabelSelector{})
+				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec)
 			})
 
 			It("GetVolumeSnapshotClasses() should find all volume snapshot classes", func() {
@@ -103,14 +105,13 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 			var vsHandler *volsync.VSHandler
 
 			BeforeEach(func() {
-				vsClassLabelSelector := metav1.LabelSelector{
+				asyncSpec.VolumeSnapshotClassSelector = metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"i-like-ramen": "true",
 					},
 				}
 
-				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil,
-					schedulingInterval, vsClassLabelSelector)
+				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec)
 			})
 
 			It("GetVolumeSnapshotClasses() should find matching volume snapshot classes", func() {
@@ -146,15 +147,14 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 			var vsHandler *volsync.VSHandler
 
 			BeforeEach(func() {
-				vsClassLabelSelector := metav1.LabelSelector{
+				asyncSpec.VolumeSnapshotClassSelector = metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"i-like-ramen": "true",
 						"abc":          "b",
 					},
 				}
 
-				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil,
-					schedulingInterval, vsClassLabelSelector)
+				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec)
 			})
 
 			It("GetVolumeSnapshotClasses() should find matching volume snapshot classes", func() {
@@ -181,7 +181,10 @@ var _ = Describe("VolSync Handler", func() {
 	var owner metav1.Object
 	var vsHandler *volsync.VSHandler
 
-	schedulingInterval := "5m"
+	asyncSpec := &ramendrv1alpha1.VRGAsyncSpec{
+		SchedulingInterval:          "5m",
+		VolumeSnapshotClassSelector: metav1.LabelSelector{},
+	}
 	expectedCronSpecSchedule := "*/5 * * * *"
 
 	BeforeEach(func() {
@@ -207,7 +210,7 @@ var _ = Describe("VolSync Handler", func() {
 		Expect(ownerCm.GetName()).NotTo(BeEmpty())
 		owner = ownerCm
 
-		vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, owner, schedulingInterval, metav1.LabelSelector{})
+		vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, owner, asyncSpec)
 	})
 
 	AfterEach(func() {
@@ -1175,8 +1178,7 @@ var _ = Describe("VolSync Handler", func() {
 			}
 			Expect(k8sClient.Create(ctx, otherOwnerCm)).To(Succeed())
 			Expect(otherOwnerCm.GetName()).NotTo(BeEmpty())
-			otherVSHandler := volsync.NewVSHandler(ctx, k8sClient, logger, otherOwnerCm,
-				schedulingInterval, metav1.LabelSelector{})
+			otherVSHandler := volsync.NewVSHandler(ctx, k8sClient, logger, otherOwnerCm, asyncSpec)
 
 			for i := 0; i < 2; i++ {
 				otherOwnerRdSpec := ramendrv1alpha1.VolSyncReplicationDestinationSpec{
@@ -1365,8 +1367,7 @@ var _ = Describe("VolSync Handler", func() {
 			}
 			Expect(k8sClient.Create(ctx, otherOwnerCm)).To(Succeed())
 			Expect(otherOwnerCm.GetName()).NotTo(BeEmpty())
-			otherVSHandler := volsync.NewVSHandler(ctx, k8sClient, logger, otherOwnerCm,
-				schedulingInterval, metav1.LabelSelector{})
+			otherVSHandler := volsync.NewVSHandler(ctx, k8sClient, logger, otherOwnerCm, asyncSpec)
 
 			for i := 0; i < 2; i++ {
 				otherOwnerRsSpec := ramendrv1alpha1.VolSyncReplicationSourceSpec{

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -454,16 +454,8 @@ func (v *VRGInstance) validateVRGState() error {
 // This needs more thought as this function is making a
 // compulsion that either of sync or async mode should be there.
 func (v *VRGInstance) validateVRGMode() error {
-	async := false
-	sync := false
-
-	if v.instance.Spec.Async.Mode == ramendrv1alpha1.AsyncModeEnabled {
-		async = true
-	}
-
-	if v.instance.Spec.Sync.Mode == ramendrv1alpha1.SyncModeEnabled {
-		sync = true
-	}
+	async := v.instance.Spec.Async != nil
+	sync := v.instance.Spec.Sync != nil
 
 	if !sync && !async {
 		err := fmt.Errorf("neither of sync or async mode is enabled (deleted %v)",

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -308,8 +308,7 @@ func (r *VolumeReplicationGroupReconciler) Reconcile(ctx context.Context, req ct
 			req.NamespacedName, err)
 	}
 
-	v.volSyncHandler = volsync.NewVSHandler(ctx, r.Client, log, v.instance,
-		v.instance.Spec.Async.SchedulingInterval, v.instance.Spec.Async.VolumeSnapshotClassSelector)
+	v.volSyncHandler = volsync.NewVSHandler(ctx, r.Client, log, v.instance, v.instance.Spec.Async)
 
 	if v.instance.Status.ProtectedPVCs == nil {
 		v.instance.Status.ProtectedPVCs = []ramendrv1alpha1.ProtectedPVC{}
@@ -547,6 +546,12 @@ func (v *VRGInstance) updatePVCListForAll() error {
 	pvcList, err := v.listPVCsByPVCSelector()
 	if err != nil {
 		return err
+	}
+
+	v.log.Info(fmt.Sprintf("Found %d PVCs using matching lables %v", len(pvcList.Items), labelSelector.MatchLabels))
+
+	if v.instance.Spec.Async == nil {
+		return nil
 	}
 
 	if !v.vrcUpdated {

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -524,33 +524,17 @@ func (v *VRGInstance) listPVCsByPVCSelector() (*corev1.PersistentVolumeClaimList
 
 // updatePVCList fetches and updates the PVC list to process for the current instance of VRG
 func (v *VRGInstance) updatePVCList() error {
-	if v.instance.Spec.VolSync.Disabled {
-		pvcList, err := v.listPVCsByPVCSelector()
-		if err != nil {
-			return err
-		}
-
-		v.volRepPVCs = make([]corev1.PersistentVolumeClaim, len(pvcList.Items))
-		total := copy(v.volRepPVCs, pvcList.Items)
-
-		v.log.Info("Found PersistentVolumeClaims", "count", total)
-
-		return nil
-	}
-
-	// Processing PVCs for VolSync and VolRep
-	return v.updatePVCListForAll()
-}
-
-func (v *VRGInstance) updatePVCListForAll() error {
 	pvcList, err := v.listPVCsByPVCSelector()
 	if err != nil {
 		return err
 	}
 
-	v.log.Info(fmt.Sprintf("Found %d PVCs using matching lables %v", len(pvcList.Items), labelSelector.MatchLabels))
+	if v.instance.Spec.Async == nil || v.instance.Spec.VolSync.Disabled {
+		v.volRepPVCs = make([]corev1.PersistentVolumeClaim, len(pvcList.Items))
+		total := copy(v.volRepPVCs, pvcList.Items)
 
-	if v.instance.Spec.Async == nil {
+		v.log.Info("Found PersistentVolumeClaims", "count", total)
+
 		return nil
 	}
 

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -709,7 +709,7 @@ func (v *VRGInstance) reconcileMissingVR(pvc *corev1.PersistentVolumeClaim, log 
 		vrMissing = true
 	)
 
-	if v.instance.Spec.Async.Mode != ramendrv1alpha1.AsyncModeEnabled {
+	if v.instance.Spec.Async == nil {
 		return !vrMissing, !requeue
 	}
 

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -321,7 +321,7 @@ func (v *VRGInstance) preparePVCForVRDeletion(pvc *corev1.PersistentVolumeClaim,
 	// when the VRG is primary. Furthermore, we need to clear the PV claimRef
 	// in order for the PV to go to the Available status phase.
 	if v.instance.Spec.ReplicationState == ramendrv1alpha1.Secondary &&
-		v.instance.Spec.Sync.Mode == ramendrv1alpha1.SyncModeEnabled {
+		v.instance.Spec.Sync != nil {
 		if err := v.clearPVClaimRefMembers(pvc); err != nil {
 			return err
 		}
@@ -786,7 +786,7 @@ func (v *VRGInstance) DeletePVs(s3ProfileName string) (err error) {
 //  - a boolean indicating if VR is already at the desired state
 //  - any errors during processing
 func (v *VRGInstance) processVRAsPrimary(vrNamespacedName types.NamespacedName, log logr.Logger) (bool, bool, error) {
-	if v.instance.Spec.Async.Mode == ramendrv1alpha1.AsyncModeEnabled {
+	if v.instance.Spec.Async != nil {
 		return v.createOrUpdateVR(vrNamespacedName, volrep.Primary, log)
 	}
 
@@ -797,7 +797,7 @@ func (v *VRGInstance) processVRAsPrimary(vrNamespacedName types.NamespacedName, 
 	// mode below. As there is no VolRep involved in sync mode, the
 	// availability is always true. Also, the refactor should work for the
 	// condition where both async and sync are enabled at the same time.
-	if v.instance.Spec.Sync.Mode == ramendrv1alpha1.SyncModeEnabled {
+	if v.instance.Spec.Sync != nil {
 		msg := "PVC in the VolumeReplicationGroup is ready for use"
 		v.updatePVCDataReadyCondition(vrNamespacedName.Name, VRGConditionReasonReady, msg)
 		v.updatePVCDataProtectedCondition(vrNamespacedName.Name, VRGConditionReasonReady, msg)
@@ -815,7 +815,7 @@ func (v *VRGInstance) processVRAsPrimary(vrNamespacedName types.NamespacedName, 
 //  - a boolean indicating if VR is already at the desired state
 //  - any errors during processing
 func (v *VRGInstance) processVRAsSecondary(vrNamespacedName types.NamespacedName, log logr.Logger) (bool, bool, error) {
-	if v.instance.Spec.Async.Mode == ramendrv1alpha1.AsyncModeEnabled {
+	if v.instance.Spec.Async != nil {
 		return v.createOrUpdateVR(vrNamespacedName, volrep.Secondary, log)
 	}
 
@@ -826,7 +826,7 @@ func (v *VRGInstance) processVRAsSecondary(vrNamespacedName types.NamespacedName
 	// mode below. As there is no VolRep involved in sync mode, the
 	// availability is always true. Also, the refactor should work for the
 	// condition where both async and sync are enabled at the same time.
-	if v.instance.Spec.Sync.Mode == ramendrv1alpha1.SyncModeEnabled {
+	if v.instance.Spec.Sync != nil {
 		msg := "VolumeReplication resource for the pvc as Secondary is in sync with Primary"
 		v.updatePVCDataReadyCondition(vrNamespacedName.Name, VRGConditionReasonReplicated, msg)
 		v.updatePVCDataProtectedCondition(vrNamespacedName.Name, VRGConditionReasonDataProtected, msg)
@@ -1758,7 +1758,7 @@ func (v *VRGInstance) validatePVExistence(pv *corev1.PersistentVolume) error {
 	// process. Hence, the restore is not required and the annotation for
 	// restore can be missing for the sync mode. Skip the check for the
 	// annotation in this case.
-	if v.instance.Spec.Sync.Mode == ramendrv1alpha1.SyncModeEnabled {
+	if v.instance.Spec.Sync != nil {
 		v.log.Info("PV exists, will update for sync", "PV", existingPV)
 
 		return v.updateExistingPVForSync(existingPV)

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -73,13 +73,6 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 					PVCSelector:      metav1.LabelSelector{},
 					ReplicationState: "invalid",
 					S3Profiles:       []string{},
-					Async: ramendrv1alpha1.VRGAsyncSpec{
-						Mode:               ramendrv1alpha1.AsyncModeDisabled,
-						SchedulingInterval: "0m",
-					},
-					Sync: ramendrv1alpha1.VRGSyncSpec{
-						Mode: ramendrv1alpha1.SyncModeDisabled,
-					},
 				},
 			}
 			Expect(k8sClient.Create(context.TODO(), vrg)).To(Succeed())
@@ -116,7 +109,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	})
 	When("ReplicationState is primary and sync is enabled, but s3 profiles are absent", func() {
 		It("should set ClusterDataReady status=False reason=Error", func() {
-			vrg.Spec.Sync.Mode = ramendrv1alpha1.SyncModeEnabled
+			vrg.Spec.Sync = &ramendrv1alpha1.VRGSyncSpec{}
 			Expect(k8sClient.Update(context.TODO(), vrg)).To(Succeed())
 			var clusterDataReadyCondition *metav1.Condition
 			Eventually(func() metav1.ConditionStatus {
@@ -900,13 +893,9 @@ func (v *vrgTest) createVRG() {
 		Spec: ramendrv1alpha1.VolumeReplicationGroupSpec{
 			PVCSelector:      metav1.LabelSelector{MatchLabels: v.pvcLabels},
 			ReplicationState: "primary",
-			Async: ramendrv1alpha1.VRGAsyncSpec{
-				Mode:                     ramendrv1alpha1.AsyncModeEnabled,
+			Async: &ramendrv1alpha1.VRGAsyncSpec{
 				SchedulingInterval:       schedulingInterval,
 				ReplicationClassSelector: metav1.LabelSelector{MatchLabels: replicationClassLabels},
-			},
-			Sync: ramendrv1alpha1.VRGSyncSpec{
-				Mode: ramendrv1alpha1.SyncModeDisabled,
 			},
 			VolSync: ramendrv1alpha1.VolSyncSpec{
 				Disabled: true,

--- a/controllers/vrg_volsync_test.go
+++ b/controllers/vrg_volsync_test.go
@@ -69,12 +69,8 @@ var _ = Describe("VolumeReplicationGroupVolSyncController", func() {
 					},
 					Spec: ramendrv1alpha1.VolumeReplicationGroupSpec{
 						ReplicationState: ramendrv1alpha1.Primary,
-						Async: ramendrv1alpha1.VRGAsyncSpec{
-							Mode:               ramendrv1alpha1.AsyncModeEnabled,
+						Async: &ramendrv1alpha1.VRGAsyncSpec{
 							SchedulingInterval: "1h",
-						},
-						Sync: ramendrv1alpha1.VRGSyncSpec{
-							Mode: ramendrv1alpha1.SyncModeDisabled,
 						},
 						PVCSelector: metav1.LabelSelector{
 							MatchLabels: testMatchLabels,
@@ -207,12 +203,8 @@ var _ = Describe("VolumeReplicationGroupVolSyncController", func() {
 					},
 					Spec: ramendrv1alpha1.VolumeReplicationGroupSpec{
 						ReplicationState: ramendrv1alpha1.Secondary,
-						Async: ramendrv1alpha1.VRGAsyncSpec{
-							Mode:               ramendrv1alpha1.AsyncModeEnabled,
+						Async: &ramendrv1alpha1.VRGAsyncSpec{
 							SchedulingInterval: "1h",
-						},
-						Sync: ramendrv1alpha1.VRGSyncSpec{
-							Mode: ramendrv1alpha1.SyncModeDisabled,
 						},
 						PVCSelector: metav1.LabelSelector{
 							MatchLabels: testMatchLabels,


### PR DESCRIPTION
If someone were to use VRG in sync mode only, they'd have to specify a dummy async scheduling interval since it is required.  This patch removes that need.

API conventions recommend pointers for optional fields.