### PR TITLE
Fix VRG restore test which was failing intermittently due to a race

### DIFF
--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -397,6 +397,7 @@ type vrgTest struct {
 	pvcLabels        map[string]string
 	pvcCount         int
 	checkBind        bool
+	vrgFirst         bool
 }
 
 type template struct {
@@ -440,6 +441,7 @@ func newVRGTestCaseBindInfo(pvcCount int, testTemplate *template, checkBind, vrg
 		pvcLabels:        make(map[string]string),
 		pvcCount:         pvcCount,
 		checkBind:        checkBind,
+		vrgFirst:         vrgFirst,
 	}
 
 	By("Creating namespace " + v.namespace)
@@ -453,7 +455,7 @@ func newVRGTestCaseBindInfo(pvcCount int, testTemplate *template, checkBind, vrg
 		v.pvcLabels["environment"] = fmt.Sprintf("dev.AZ1-%v", objectNameSuffix)
 	}
 
-	if vrgFirst {
+	if v.vrgFirst {
 		v.createVRG()
 		v.createPVCandPV(testTemplate.ClaimBindInfo, testTemplate.VolumeBindInfo)
 	} else {

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -367,6 +367,7 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 })
 
 type vrgTest struct {
+	uniqueID         string
 	namespace        string
 	pvNames          []string
 	pvcNames         []string
@@ -427,6 +428,7 @@ func newVRGTestCaseBindInfo(pvcCount int, testTemplate *template, checkBind, vrg
 	objectNameSuffix := newRandomNamespaceSuffix()
 
 	v := vrgTest{
+		uniqueID:         objectNameSuffix,
 		namespace:        fmt.Sprintf("envtest-ns-%v", objectNameSuffix),
 		vrgName:          fmt.Sprintf("vrg-%v", objectNameSuffix),
 		storageClass:     testTemplate.storageClassName,
@@ -446,11 +448,9 @@ func newVRGTestCaseBindInfo(pvcCount int, testTemplate *template, checkBind, vrg
 
 	if vrgFirst {
 		v.createVRG(pvcLabels)
-		v.createPVCandPV(pvcCount, testTemplate.ClaimBindInfo, testTemplate.VolumeBindInfo,
-			objectNameSuffix, pvcLabels)
+		v.createPVCandPV(pvcCount, testTemplate.ClaimBindInfo, testTemplate.VolumeBindInfo, pvcLabels)
 	} else {
-		v.createPVCandPV(pvcCount, testTemplate.ClaimBindInfo, testTemplate.VolumeBindInfo,
-			objectNameSuffix, pvcLabels)
+		v.createPVCandPV(pvcCount, testTemplate.ClaimBindInfo, testTemplate.VolumeBindInfo, pvcLabels)
 		v.createVRG(pvcLabels)
 	}
 
@@ -462,11 +462,11 @@ func newVRGTestCaseBindInfo(pvcCount int, testTemplate *template, checkBind, vrg
 }
 
 func (v *vrgTest) createPVCandPV(pvcCount int, claimBindInfo corev1.PersistentVolumeClaimPhase,
-	volumeBindInfo corev1.PersistentVolumePhase, objectNameSuffix string, pvcLabels map[string]string) {
+	volumeBindInfo corev1.PersistentVolumePhase, pvcLabels map[string]string) {
 	// Create the requested number of PVs and corresponding PVCs
 	for i := 0; i < pvcCount; i++ {
-		pvName := fmt.Sprintf("pv-%v-%02d", objectNameSuffix, i)
-		pvcName := fmt.Sprintf("pvc-%v-%02d", objectNameSuffix, i)
+		pvName := fmt.Sprintf("pv-%v-%02d", v.uniqueID, i)
+		pvcName := fmt.Sprintf("pvc-%v-%02d", v.uniqueID, i)
 
 		// Create PV first and then PVC. This is important to ensure that there
 		// is no race between the unit test and VRG reconciler in modifying PV.

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -39,9 +39,19 @@ var UploadedPVs = make(map[string]interface{})
 var _ = Describe("Test VolumeReplicationGroup", func() {
 	// Test first restore
 	Context("restore test case", func() {
+		restoreTestTemplate := &template{
+			ClaimBindInfo:          corev1.ClaimBound,
+			VolumeBindInfo:         corev1.VolumeBound,
+			schedulingInterval:     "1h",
+			storageClassName:       "manual",
+			replicationClassName:   "test-replicationclass",
+			vrcProvisioner:         "manual.storage.com",
+			scProvisioner:          "manual.storage.com",
+			replicationClassLabels: map[string]string{"protection": "ramen"},
+		}
 		It("populates the S3 store with PVs and starts vrg as primary to check that the PVs are restored", func() {
 			numPVs := 3
-			vtest := newVRGTestCase(0)
+			vtest := newVRGTestCaseBindInfo(0, restoreTestTemplate, true, false)
 			vrgNamespacedName := vtest.namespace + "/" + vtest.vrgName + "/"
 			pvList := generateFakePVs("pv", numPVs)
 			populateS3Store(s3Profiles[0].S3ProfileName, vrgNamespacedName, pvList)
@@ -56,9 +66,19 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 	// check whether VolRep resources are created or not
 	var vrgTestCases []vrgTest
 	Context("in primary state", func() {
+		createTestTemplate := &template{
+			ClaimBindInfo:          corev1.ClaimBound,
+			VolumeBindInfo:         corev1.VolumeBound,
+			schedulingInterval:     "1h",
+			storageClassName:       "manual",
+			replicationClassName:   "test-replicationclass",
+			vrcProvisioner:         "manual.storage.com",
+			scProvisioner:          "manual.storage.com",
+			replicationClassLabels: map[string]string{"protection": "ramen"},
+		}
 		It("sets up PVCs, PVs and VRGs", func() {
 			for c := 0; c < 5; c++ {
-				v := newVRGTestCase(c)
+				v := newVRGTestCaseBindInfo(c, createTestTemplate, true, false)
 				vrgTestCases = append(vrgTestCases, v)
 			}
 		})
@@ -376,24 +396,6 @@ type vrgTest struct {
 	replicationClass string
 	pvcLabels        map[string]string
 	pvcCount         int
-}
-
-// newVRGTestCase creates a new namespace, zero or more PVCs (equal to the
-// input pvcCount), a PV for each PVC, and a VRG in primary state, with
-// label selector that points to the PVCs created.
-func newVRGTestCase(pvcCount int) vrgTest {
-	testTemplate := &template{
-		ClaimBindInfo:          corev1.ClaimBound,
-		VolumeBindInfo:         corev1.VolumeBound,
-		schedulingInterval:     "1h",
-		storageClassName:       "manual",
-		replicationClassName:   "test-replicationclass",
-		vrcProvisioner:         "manual.storage.com",
-		scProvisioner:          "manual.storage.com",
-		replicationClassLabels: map[string]string{"protection": "ramen"},
-	}
-
-	return newVRGTestCaseBindInfo(pvcCount, testTemplate, true, false)
 }
 
 type template struct {

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -51,10 +51,11 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 		}
 		It("populates the S3 store with PVs and starts vrg as primary to check that the PVs are restored", func() {
 			numPVs := 3
-			vtest := newVRGTestCaseCreateAndStart(0, restoreTestTemplate, true, false)
+			vtest := newVRGTestCaseCreate(0, restoreTestTemplate, true, false)
 			vrgNamespacedName := vtest.namespace + "/" + vtest.vrgName + "/"
 			pvList := generateFakePVs("pv", numPVs)
 			populateS3Store(s3Profiles[0].S3ProfileName, vrgNamespacedName, pvList)
+			vtest.VRGTestCaseStart()
 			waitForPVRestore(pvList)
 			// profile name, keyprefix, numPVs
 			// waitForPVRestore(S3ProfileName, numPVs)

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 		}
 		It("populates the S3 store with PVs and starts vrg as primary to check that the PVs are restored", func() {
 			numPVs := 3
-			vtest := newVRGTestCaseBindInfo(0, restoreTestTemplate, true, false)
+			vtest := newVRGTestCaseCreateAndStart(0, restoreTestTemplate, true, false)
 			vrgNamespacedName := vtest.namespace + "/" + vtest.vrgName + "/"
 			pvList := generateFakePVs("pv", numPVs)
 			populateS3Store(s3Profiles[0].S3ProfileName, vrgNamespacedName, pvList)
@@ -78,7 +78,7 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 		}
 		It("sets up PVCs, PVs and VRGs", func() {
 			for c := 0; c < 5; c++ {
-				v := newVRGTestCaseBindInfo(c, createTestTemplate, true, false)
+				v := newVRGTestCaseCreateAndStart(c, createTestTemplate, true, false)
 				vrgTestCases = append(vrgTestCases, v)
 			}
 		})
@@ -131,7 +131,7 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 			for c := 0; c < 5; c++ {
 				// Test the scenario where the pvc is not bound yet
 				// and expect no VRs to be created.
-				v := newVRGTestCaseBindInfo(c, vrgTestTemplate, false, false)
+				v := newVRGTestCaseCreateAndStart(c, vrgTestTemplate, false, false)
 				vrgTests = append(vrgTests, v)
 			}
 		})
@@ -177,7 +177,7 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 	var vrgStatusTests []vrgTest
 	Context("in primary state status check pending to bound", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
-			v := newVRGTestCaseBindInfo(4, vrgTestTemplate, false, false)
+			v := newVRGTestCaseCreateAndStart(4, vrgTestTemplate, false, false)
 			vrgStatusTests = append(vrgStatusTests, v)
 		})
 		It("expect no VR to be created as PVC not bound and check status", func() {
@@ -220,7 +220,7 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 	var vrgStatus2Tests []vrgTest
 	Context("in primary state status check bound", func() {
 		It("sets up PVCs, PVs", func() {
-			v := newVRGTestCaseBindInfo(4, vrgTest2Template, true, true)
+			v := newVRGTestCaseCreateAndStart(4, vrgTest2Template, true, true)
 			vrgStatus2Tests = append(vrgStatus2Tests, v)
 		})
 		It("waits for VRG to create a VR for each PVC bind and checks status", func() {
@@ -255,7 +255,7 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 	var vrgStatus3Tests []vrgTest
 	Context("in primary state status check create VRG first", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
-			v := newVRGTestCaseBindInfo(4, vrgTest3Template, false, true)
+			v := newVRGTestCaseCreateAndStart(4, vrgTest3Template, false, true)
 			vrgStatus3Tests = append(vrgStatus3Tests, v)
 		})
 		It("expect no VR to be created as PVC not bound and check status", func() {
@@ -299,7 +299,7 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 	}
 	Context("schedule test, provisioner does not match", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
-			v := newVRGTestCaseBindInfo(4, vrgScheduleTestTemplate, true, true)
+			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTestTemplate, true, true)
 			vrgScheduleTests = append(vrgScheduleTests, v)
 		})
 		It("expect no VR to be created as PVC not bound and check status", func() {
@@ -332,7 +332,7 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 	}
 	Context("schedule tests schedue does not match", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
-			v := newVRGTestCaseBindInfo(4, vrgScheduleTest2Template, true, true)
+			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest2Template, true, true)
 			vrgSchedule2Tests = append(vrgSchedule2Tests, v)
 		})
 		It("expect no VR to be created as PVC not bound and check status", func() {
@@ -365,7 +365,7 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 	}
 	Context("schedule tests replicationclass does not have labels", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
-			v := newVRGTestCaseBindInfo(4, vrgScheduleTest3Template, true, true)
+			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest3Template, true, true)
 			vrgSchedule3Tests = append(vrgSchedule3Tests, v)
 		})
 		It("expect no VR to be created as VR not created and check status", func() {
@@ -424,13 +424,13 @@ func newRandomNamespaceSuffix() string {
 	return string(randomSuffix)
 }
 
-// newVRGTestCaseBindInfo creates a new namespace, zero or more PVCs (equal
+// newVRGTestCaseCreateAndStart creates a new namespace, zero or more PVCs (equal
 // to the input pvcCount), a PV for each PVC, and a VRG in primary state,
 // with label selector that points to the PVCs created. Each PVC is created
 // with Status.Phase set to ClaimPending instead of ClaimBound. Expectation
 // is that, until pvc is not bound, VolRep resources should not be created
 // by VRG.
-func newVRGTestCaseBindInfo(pvcCount int, testTemplate *template, checkBind, vrgFirst bool) vrgTest {
+func newVRGTestCaseCreateAndStart(pvcCount int, testTemplate *template, checkBind, vrgFirst bool) vrgTest {
 	objectNameSuffix := newRandomNamespaceSuffix()
 
 	v := vrgTest{

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -396,6 +396,7 @@ type vrgTest struct {
 	replicationClass string
 	pvcLabels        map[string]string
 	pvcCount         int
+	checkBind        bool
 }
 
 type template struct {
@@ -438,6 +439,7 @@ func newVRGTestCaseBindInfo(pvcCount int, testTemplate *template, checkBind, vrg
 		replicationClass: testTemplate.replicationClassName,
 		pvcLabels:        make(map[string]string),
 		pvcCount:         pvcCount,
+		checkBind:        checkBind,
 	}
 
 	By("Creating namespace " + v.namespace)
@@ -461,7 +463,7 @@ func newVRGTestCaseBindInfo(pvcCount int, testTemplate *template, checkBind, vrg
 
 	// If checkBind is true, then check whether PVCs and PVs are
 	// bound. Otherwise expect them to not have been bound.
-	v.verifyPVCBindingToPV(checkBind)
+	v.verifyPVCBindingToPV(v.checkBind)
 
 	return v
 }
@@ -796,7 +798,7 @@ func (v *vrgTest) createSC(testTemplate *template) {
 		"failed to create/get StorageClass %s/%s", v.storageClass, v.vrgName)
 }
 
-func (v *vrgTest) verifyPVCBindingToPV(checkBind bool) {
+func (v *vrgTest) verifyPVCBindingToPV(shouldBeBound bool) {
 	By("Waiting for PVC to get bound to PVs for " + v.vrgName)
 
 	for i := 0; i < len(v.pvcNames); i++ {
@@ -805,7 +807,7 @@ func (v *vrgTest) verifyPVCBindingToPV(checkBind bool) {
 		Eventually(func() bool {
 			pvc := v.getPVC(v.pvcNames[i])
 
-			if checkBind == true {
+			if shouldBeBound == true {
 				return pvc.Status.Phase == corev1.ClaimBound
 			}
 

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -375,6 +375,7 @@ type vrgTest struct {
 	storageClass     string
 	replicationClass string
 	pvcLabels        map[string]string
+	pvcCount         int
 }
 
 // newVRGTestCase creates a new namespace, zero or more PVCs (equal to the
@@ -434,6 +435,7 @@ func newVRGTestCaseBindInfo(pvcCount int, testTemplate *template, checkBind, vrg
 		storageClass:     testTemplate.storageClassName,
 		replicationClass: testTemplate.replicationClassName,
 		pvcLabels:        make(map[string]string),
+		pvcCount:         pvcCount,
 	}
 
 	By("Creating namespace " + v.namespace)
@@ -449,9 +451,9 @@ func newVRGTestCaseBindInfo(pvcCount int, testTemplate *template, checkBind, vrg
 
 	if vrgFirst {
 		v.createVRG()
-		v.createPVCandPV(pvcCount, testTemplate.ClaimBindInfo, testTemplate.VolumeBindInfo)
+		v.createPVCandPV(testTemplate.ClaimBindInfo, testTemplate.VolumeBindInfo)
 	} else {
-		v.createPVCandPV(pvcCount, testTemplate.ClaimBindInfo, testTemplate.VolumeBindInfo)
+		v.createPVCandPV(testTemplate.ClaimBindInfo, testTemplate.VolumeBindInfo)
 		v.createVRG()
 	}
 
@@ -462,10 +464,10 @@ func newVRGTestCaseBindInfo(pvcCount int, testTemplate *template, checkBind, vrg
 	return v
 }
 
-func (v *vrgTest) createPVCandPV(pvcCount int, claimBindInfo corev1.PersistentVolumeClaimPhase,
+func (v *vrgTest) createPVCandPV(claimBindInfo corev1.PersistentVolumeClaimPhase,
 	volumeBindInfo corev1.PersistentVolumePhase) {
 	// Create the requested number of PVs and corresponding PVCs
-	for i := 0; i < pvcCount; i++ {
+	for i := 0; i < v.pvcCount; i++ {
 		pvName := fmt.Sprintf("pv-%v-%02d", v.uniqueID, i)
 		pvcName := fmt.Sprintf("pvc-%v-%02d", v.uniqueID, i)
 

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -398,6 +398,7 @@ type vrgTest struct {
 	pvcCount         int
 	checkBind        bool
 	vrgFirst         bool
+	template         *template
 }
 
 type template struct {
@@ -442,12 +443,13 @@ func newVRGTestCaseBindInfo(pvcCount int, testTemplate *template, checkBind, vrg
 		pvcCount:         pvcCount,
 		checkBind:        checkBind,
 		vrgFirst:         vrgFirst,
+		template:         testTemplate,
 	}
 
 	By("Creating namespace " + v.namespace)
 	v.createNamespace()
-	v.createSC(testTemplate)
-	v.createVRC(testTemplate)
+	v.createSC(v.template)
+	v.createVRC(v.template)
 
 	// Setup PVC labels
 	if pvcCount > 0 {
@@ -457,9 +459,9 @@ func newVRGTestCaseBindInfo(pvcCount int, testTemplate *template, checkBind, vrg
 
 	if v.vrgFirst {
 		v.createVRG()
-		v.createPVCandPV(testTemplate.ClaimBindInfo, testTemplate.VolumeBindInfo)
+		v.createPVCandPV(v.template.ClaimBindInfo, v.template.VolumeBindInfo)
 	} else {
-		v.createPVCandPV(testTemplate.ClaimBindInfo, testTemplate.VolumeBindInfo)
+		v.createPVCandPV(v.template.ClaimBindInfo, v.template.VolumeBindInfo)
 		v.createVRG()
 	}
 


### PR DESCRIPTION
This PR also refactors a major chunk of the VRG tests creation as it was needed to prevent the race condition.