### PR TITLE
Read secret placement rules from API server

### DIFF
--- a/controllers/drcluster_controller_test.go
+++ b/controllers/drcluster_controller_test.go
@@ -33,60 +33,66 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-var _ = Describe("DRClusterController", func() {
-	conditionExpect := func(drcluster *ramen.DRCluster, disabled bool, status metav1.ConditionStatus,
-		reasonMatcher, messageMatcher gomegaTypes.GomegaMatcher, conditionType string,
-	) {
-		Eventually(
-			func(g Gomega) {
-				g.Expect(apiReader.Get(
-					context.TODO(),
-					types.NamespacedName{Namespace: drcluster.Namespace, Name: drcluster.Name},
-					drcluster,
-				)).To(Succeed())
-				g.Expect(drcluster.Status.Conditions).To(MatchElements(
-					func(element interface{}) string {
-						return element.(metav1.Condition).Type
-					},
-					IgnoreExtras,
-					Elements{
-						conditionType: MatchAllFields(Fields{
-							`Type`:               Ignore(),
-							`Status`:             Equal(status),
-							`ObservedGeneration`: Equal(drcluster.Generation),
-							`LastTransitionTime`: Ignore(),
-							`Reason`:             reasonMatcher,
-							`Message`:            messageMatcher,
-						}),
-					},
-				))
-				// TODO: Validate finaliziers and labels
-				if status == metav1.ConditionFalse {
-					return
-				}
+func drclusterConditionExpect(
+	drcluster *ramen.DRCluster,
+	disabled bool,
+	status metav1.ConditionStatus,
+	reasonMatcher,
+	messageMatcher gomegaTypes.GomegaMatcher,
+	conditionType string,
+) {
+	Eventually(
+		func() []metav1.Condition {
+			Expect(apiReader.Get(context.TODO(), types.NamespacedName{
+				Namespace: drcluster.Namespace,
+				Name:      drcluster.Name,
+			}, drcluster)).To(Succeed())
 
-				expectedCount := 8
-				if disabled {
-					expectedCount = 2
-				}
-				clusterName := drcluster.Name
-				manifestWork := &workv1.ManifestWork{}
-				g.Expect(apiReader.Get(
-					context.TODO(),
-					types.NamespacedName{
-						Name:      util.DrClusterManifestWorkName,
-						Namespace: clusterName,
-					},
-					manifestWork,
-				)).To(Succeed())
-				g.Expect(manifestWork.Spec.Workload.Manifests).To(HaveLen(expectedCount))
-				// TODO: Validate fencing status
-			},
-			timeout,
-			interval,
-		).Should(Succeed())
+			return drcluster.Status.Conditions
+		}, timeout, interval,
+	).Should(MatchElements(
+		func(element interface{}) string {
+			return element.(metav1.Condition).Type
+		},
+		IgnoreExtras,
+		Elements{
+			conditionType: MatchAllFields(Fields{
+				`Type`:               Ignore(),
+				`Status`:             Equal(status),
+				`ObservedGeneration`: Equal(drcluster.Generation),
+				`LastTransitionTime`: Ignore(),
+				`Reason`:             reasonMatcher,
+				`Message`:            messageMatcher,
+			}),
+		},
+	))
+
+	// TODO: Validate finaliziers and labels
+	if status == metav1.ConditionFalse {
+		return
 	}
 
+	expectedCount := 8
+	if disabled {
+		expectedCount = 2
+	}
+
+	Eventually(
+		func(g Gomega) []workv1.Manifest {
+			clusterName := drcluster.Name
+			manifestWork := &workv1.ManifestWork{}
+			g.Expect(apiReader.Get(context.TODO(), types.NamespacedName{
+				Name:      util.DrClusterManifestWorkName,
+				Namespace: clusterName,
+			}, manifestWork)).To(Succeed())
+
+			return manifestWork.Spec.Workload.Manifests
+		}, timeout, interval,
+	).Should(HaveLen(expectedCount))
+	// TODO: Validate fencing status
+}
+
+var _ = Describe("DRClusterController", func() {
 	drclusterDelete := func(drcluster *ramen.DRCluster) {
 		clusterName := drcluster.Name
 		Expect(k8sClient.Delete(context.TODO(), drcluster)).To(Succeed())
@@ -236,7 +242,7 @@ var _ = Describe("DRClusterController", func() {
 				By("creating a new DRCluster with an invalid S3Profile")
 				drcluster.Spec.S3ProfileName = "missing"
 				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionFalse, Equal("s3ConnectionFailed"), Ignore(),
+				drclusterConditionExpect(drcluster, false, metav1.ConditionFalse, Equal("s3ConnectionFailed"), Ignore(),
 					ramen.DRClusterValidated)
 			})
 		})
@@ -245,7 +251,7 @@ var _ = Describe("DRClusterController", func() {
 				By("modifying a DRCluster with an invalid S3Profile that fails listing")
 				drcluster.Spec.S3ProfileName = s3Profiles[4].S3ProfileName
 				Expect(k8sClient.Update(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionFalse, Equal("s3ListFailed"), Ignore(),
+				drclusterConditionExpect(drcluster, false, metav1.ConditionFalse, Equal("s3ListFailed"), Ignore(),
 					ramen.DRClusterValidated)
 			})
 		})
@@ -254,7 +260,7 @@ var _ = Describe("DRClusterController", func() {
 				By("fencing an existing DRCluster with an invalid S3Profile")
 				drcluster.Spec.ClusterFence = ramen.ClusterFenceStateManuallyFenced
 				Expect(k8sClient.Update(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionTrue,
+				drclusterConditionExpect(drcluster, false, metav1.ConditionTrue,
 					Equal(controllers.DRClusterConditionReasonFenced), Ignore(),
 					ramen.DRClusterConditionTypeFenced)
 			})
@@ -265,7 +271,7 @@ var _ = Describe("DRClusterController", func() {
 				drcluster.Spec.S3ProfileName = s3Profiles[0].S3ProfileName
 				drcluster.Spec.ClusterFence = ""
 				Expect(k8sClient.Update(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
+				drclusterConditionExpect(drcluster, false, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
 					ramen.DRClusterValidated)
 			})
 		})
@@ -274,13 +280,13 @@ var _ = Describe("DRClusterController", func() {
 				By("modifying a DRCluster with the new valid S3Profile")
 				drcluster.Spec.S3ProfileName = s3Profiles[5].S3ProfileName
 				Expect(k8sClient.Update(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
+				drclusterConditionExpect(drcluster, false, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
 					ramen.DRClusterValidated)
 				By("changing the S3Profile in ramen config to an invalid value")
 				newS3Profiles := s3Profiles[0:]
 				s3Profiles[5].S3Bucket = bucketNameFail
 				s3ProfilesStore(newS3Profiles)
-				conditionExpect(drcluster, false, metav1.ConditionFalse, Equal("s3ConnectionFailed"), Ignore(),
+				drclusterConditionExpect(drcluster, false, metav1.ConditionFalse, Equal("s3ConnectionFailed"), Ignore(),
 					ramen.DRClusterValidated)
 				// TODO: Ensure when changing S3Profile, dr-cluster's ramen config is updated in MW
 			})
@@ -290,12 +296,12 @@ var _ = Describe("DRClusterController", func() {
 				By("modifying a DRCluster with a valid S3Profile")
 				drcluster.Spec.S3ProfileName = s3Profiles[0].S3ProfileName
 				Expect(k8sClient.Update(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
+				drclusterConditionExpect(drcluster, false, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
 					ramen.DRClusterValidated)
 				By("modifying a DRCluster with an invalid S3Profile that fails listing")
 				drcluster.Spec.S3ProfileName = s3Profiles[4].S3ProfileName
 				Expect(k8sClient.Update(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionFalse, Equal("s3ListFailed"), Ignore(),
+				drclusterConditionExpect(drcluster, false, metav1.ConditionFalse, Equal("s3ListFailed"), Ignore(),
 					ramen.DRClusterValidated)
 			})
 		})
@@ -317,7 +323,7 @@ var _ = Describe("DRClusterController", func() {
 				By("creating a new DRCluster with an invalid CIDR")
 				drcluster.Spec.CIDRs = cidrs[1]
 				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionFalse, Equal("ValidationFailed"), Ignore(),
+				drclusterConditionExpect(drcluster, false, metav1.ConditionFalse, Equal("ValidationFailed"), Ignore(),
 					ramen.DRClusterValidated)
 			})
 		})
@@ -325,7 +331,7 @@ var _ = Describe("DRClusterController", func() {
 			It("reports validated", func() {
 				drcluster.Spec.CIDRs = cidrs[0]
 				Expect(k8sClient.Update(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
+				drclusterConditionExpect(drcluster, false, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
 					ramen.DRClusterValidated)
 			})
 		})
@@ -346,7 +352,7 @@ var _ = Describe("DRClusterController", func() {
 			It("reports validated", func() {
 				By("creating a new DRCluster with an valid CIDR")
 				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
+				drclusterConditionExpect(drcluster, false, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
 					ramen.DRClusterValidated)
 			})
 		})
@@ -354,7 +360,7 @@ var _ = Describe("DRClusterController", func() {
 			It("reports NOT validated with reason ValidationFailed", func() {
 				drcluster.Spec.CIDRs = cidrs[1]
 				Expect(k8sClient.Update(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionFalse,
+				drclusterConditionExpect(drcluster, false, metav1.ConditionFalse,
 					Equal("ValidationFailed"), Ignore(), ramen.DRClusterValidated)
 			})
 		})
@@ -375,7 +381,7 @@ var _ = Describe("DRClusterController", func() {
 			It("reports validated with status fencing as Unfenced", func() {
 				drcluster.Spec.ClusterFence = ""
 				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionFalse,
+				drclusterConditionExpect(drcluster, false, metav1.ConditionFalse,
 					Equal(controllers.DRClusterConditionReasonClean), Ignore(),
 					ramen.DRClusterConditionTypeFenced)
 			})
@@ -389,7 +395,7 @@ var _ = Describe("DRClusterController", func() {
 				// up the fencing resource. So, by the time this check is made,
 				// either the cluster should have been unfenced or completely
 				// cleaned
-				conditionExpect(drcluster, false, metav1.ConditionFalse,
+				drclusterConditionExpect(drcluster, false, metav1.ConditionFalse,
 					BeElementOf(controllers.DRClusterConditionReasonUnfenced, controllers.DRClusterConditionReasonCleaning,
 						controllers.DRClusterConditionReasonClean),
 					Ignore(), ramen.DRClusterConditionTypeFenced)
@@ -399,7 +405,7 @@ var _ = Describe("DRClusterController", func() {
 			It("reports validated with status fencing as Fenced", func() {
 				drcluster.Spec.ClusterFence = "ManuallyFenced"
 				Expect(k8sClient.Update(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionTrue,
+				drclusterConditionExpect(drcluster, false, metav1.ConditionTrue,
 					Equal(controllers.DRClusterConditionReasonFenced), Ignore(),
 					ramen.DRClusterConditionTypeFenced)
 			})
@@ -408,7 +414,7 @@ var _ = Describe("DRClusterController", func() {
 			It("reports NOT validated with reason FencingHandlingFailed", func() {
 				drcluster.Spec.ClusterFence = "Fenced"
 				Expect(k8sClient.Update(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionTrue,
+				drclusterConditionExpect(drcluster, false, metav1.ConditionTrue,
 					Equal(controllers.DRClusterConditionReasonFenced), Ignore(),
 					ramen.DRClusterConditionTypeFenced)
 			})
@@ -431,7 +437,7 @@ var _ = Describe("DRClusterController", func() {
 			It("reports NOT validated with reason DrClustersDeployFailed", func() {
 				drcluster.Name = "drc-missing"
 				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionFalse, Equal("DrClustersDeployFailed"), Ignore(),
+				drclusterConditionExpect(drcluster, false, metav1.ConditionFalse, Equal("DrClustersDeployFailed"), Ignore(),
 					ramen.DRClusterValidated)
 				drclusterDelete(drcluster)
 			})
@@ -440,7 +446,7 @@ var _ = Describe("DRClusterController", func() {
 			It("reports validated", func() {
 				drcluster = drclusters[0].DeepCopy()
 				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
+				drclusterConditionExpect(drcluster, false, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
 					ramen.DRClusterValidated)
 			})
 		})
@@ -462,12 +468,12 @@ var _ = Describe("DRClusterController", func() {
 			It("does NOT create Subscription related manifests", func() {
 				By("creating a valid DRCluster")
 				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
-				conditionExpect(drcluster, false, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
+				drclusterConditionExpect(drcluster, false, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
 					ramen.DRClusterValidated)
 				ramenConfig.DrClusterOperator.DeploymentAutomationEnabled = false
 				ramenConfig.DrClusterOperator.S3SecretDistributionEnabled = false
 				configMapUpdate()
-				conditionExpect(drcluster, true, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
+				drclusterConditionExpect(drcluster, true, metav1.ConditionTrue, Equal("Succeeded"), Ignore(),
 					ramen.DRClusterValidated)
 				ramenConfig.DrClusterOperator.DeploymentAutomationEnabled = true
 				ramenConfig.DrClusterOperator.S3SecretDistributionEnabled = true

--- a/controllers/drcluster_controller_test.go
+++ b/controllers/drcluster_controller_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -161,12 +162,28 @@ var _ = Describe("DRClusterController", func() {
 		}
 	}
 
+	namespaceDeletionConfirm := func(name string) {
+		namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+		Eventually(func() error {
+			return k8sClient.Get(context.TODO(), types.NamespacedName{Name: namespace.Name}, namespace)
+		}, timeout, interval).Should(
+			MatchError(errors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, namespace.Name)),
+			"%v", namespace,
+		)
+	}
+
 	deleteDRClusterNamespaces := func() {
+		if !namespaceDeletionSupported {
+			return
+		}
 		for _, drcluster := range drclusters {
 			Expect(k8sClient.Delete(
 				context.TODO(),
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: drcluster.Name}},
 			)).To(Succeed())
+		}
+		for i := range drclusters {
+			namespaceDeletionConfirm(drclusters[i].Name)
 		}
 	}
 

--- a/controllers/drcluster_controller_test.go
+++ b/controllers/drcluster_controller_test.go
@@ -194,20 +194,14 @@ var _ = Describe("DRClusterController", func() {
 	}
 
 	createOtherDRClusters := func() {
-		for i := range drclusters {
-			if i == 0 {
-				continue
-			}
+		for i := 1; i < len(drclusters); i++ {
 			cluster := drclusters[i].DeepCopy()
 			Expect(k8sClient.Create(context.TODO(), cluster)).To(Succeed())
 		}
 	}
 
 	deleteOtherDRClusters := func() {
-		for i := range drclusters {
-			if i == 0 {
-				continue
-			}
+		for i := 1; i < len(drclusters); i++ {
 			cluster := drclusters[i].DeepCopy()
 			Expect(k8sClient.Delete(context.TODO(), cluster)).To(Succeed())
 		}
@@ -483,10 +477,16 @@ var _ = Describe("DRClusterController", func() {
 		When("deleting a DRCluster with all valid values", func() {
 			It("is successful", func() {
 				drclusterDelete(drcluster)
-				deleteOtherDRClusters()
-				deleteDRClusterNamespaces()
 			})
 		})
+	})
+
+	Specify("Delete other DRClusters", func() {
+		deleteOtherDRClusters()
+	})
+
+	Specify("Delete namespaces named the same as DRClusters", func() {
+		deleteDRClusterNamespaces()
 	})
 
 	Context("DRCluster resource deletion validation", func() {

--- a/controllers/drcluster_controller_test.go
+++ b/controllers/drcluster_controller_test.go
@@ -203,7 +203,7 @@ var _ = Describe("DRClusterController", func() {
 	deleteOtherDRClusters := func() {
 		for i := 1; i < len(drclusters); i++ {
 			cluster := drclusters[i].DeepCopy()
-			Expect(k8sClient.Delete(context.TODO(), cluster)).To(Succeed())
+			drclusterDelete(cluster)
 		}
 	}
 

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -96,7 +96,7 @@ func (r *DRPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, fmt.Errorf("drclusters list: %w", u.validatedSetFalse("drClusterListFailed", err))
 	}
 
-	secretsUtil := &util.SecretsUtil{Client: r.Client, Ctx: ctx, Log: log}
+	secretsUtil := &util.SecretsUtil{Client: r.Client, APIReader: r.APIReader, Ctx: ctx, Log: log}
 	// DRPolicy is marked for deletion
 	if !drpolicy.ObjectMeta.DeletionTimestamp.IsZero() &&
 		controllerutil.ContainsFinalizer(drpolicy, drPolicyFinalizerName) {

--- a/controllers/drpolicy_controller_test.go
+++ b/controllers/drpolicy_controller_test.go
@@ -202,12 +202,20 @@ var _ = Describe("DrpolicyController", func() {
 	Specify("initialize tests", func() {
 		populateDRClusters()
 		for idx := range drClusters {
+			drcluster := &drClusters[idx]
 			Expect(k8sClient.Create(
 				context.TODO(),
-				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: drClusters[idx].Name}},
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: drcluster.Name}},
 			)).To(Succeed())
-			Expect(k8sClient.Create(context.TODO(), &drClusters[idx])).To(Succeed())
-			// TODO: Validate cluster resource is reconciled
+			Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
+			drclusterConditionExpect(
+				drcluster,
+				!ramenConfig.DrClusterOperator.DeploymentAutomationEnabled,
+				metav1.ConditionTrue,
+				Equal("Succeeded"),
+				Ignore(),
+				ramen.DRClusterValidated,
+			)
 		}
 	})
 	Specify(`a drpolicy`, func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -72,7 +72,7 @@ var (
 	timeout  = time.Second * 10
 	interval = time.Millisecond * 10
 
-	plRuleNames []string
+	plRuleNames map[string]struct{}
 
 	s3Secrets      [1]corev1.Secret
 	s3Profiles     [6]ramendrv1alpha1.S3StoreProfile
@@ -215,9 +215,10 @@ var _ = BeforeSuite(func() {
 	s3Profiles[4] = s3ProfileNew("4", bucketListFail)
 
 	s3SecretsPolicyNamesSet := func() {
+		plRuleNames = make(map[string]struct{}, len(s3Secrets))
 		for idx := range s3Secrets {
 			_, _, v, _ := util.GeneratePolicyResourceNames(s3Secrets[idx].Name)
-			plRuleNames = append(plRuleNames, v)
+			plRuleNames[v] = struct{}{}
 		}
 	}
 	s3SecretCreate := func(s3Secret *corev1.Secret) {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -67,6 +67,8 @@ var (
 	ramenConfig *ramendrv1alpha1.RamenConfig
 	testLog     logr.Logger
 
+	namespaceDeletionSupported bool
+
 	timeout  = time.Second * 10
 	interval = time.Millisecond * 10
 
@@ -124,6 +126,10 @@ var _ = BeforeSuite(func() {
 			filepath.Join("..", "config", "crd", "bases"),
 			filepath.Join("..", "hack", "test"),
 		},
+	}
+
+	if testEnv.UseExistingCluster != nil && *testEnv.UseExistingCluster == true {
+		namespaceDeletionSupported = true
 	}
 
 	var err error

--- a/controllers/util/util_suite_test.go
+++ b/controllers/util/util_suite_test.go
@@ -80,9 +80,10 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).NotTo(BeNil())
 
 	secretsUtil = util.SecretsUtil{
-		Client: k8sClient,
-		Ctx:    context.TODO(),
-		Log:    ctrl.Log.WithName("secrets_util"),
+		Client:    k8sClient,
+		APIReader: k8sClient,
+		Ctx:       context.TODO(),
+		Log:       ctrl.Log.WithName("secrets_util"),
 	}
 })
 


### PR DESCRIPTION
secrets_util may fail to detect a placement rule already exists and not update it to add more clusters names.

This pull request includes:

- fix to check for placement rules from API server instead of cache
- adds debug info to tests
- disables some test namespace deletions when not using an existing cluster
- waits for drclusters to be reconciled before running drpolicy tests