### PR TITLE
Replace Clients with Writers, StatusWriters and APIReaders

### DIFF
--- a/controllers/drcluster_controller.go
+++ b/controllers/drcluster_controller.go
@@ -101,7 +101,9 @@ func (r *DRClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, fmt.Errorf("config map get: %w", u.validatedSetFalse("ConfigMapGetFailed", err))
 	}
 
-	manifestWorkUtil = util.MWUtil{Client: r.Client, Ctx: ctx, Log: log, InstName: "", InstNamespace: ""}
+	manifestWorkUtil = util.MWUtil{
+		Client: r.Client, APIReader: r.APIReader, Ctx: ctx, Log: log, InstName: "", InstNamespace: "",
+	}
 	u.mwUtil = manifestWorkUtil
 
 	// DRCluster is marked for deletion

--- a/controllers/drcluster_controller.go
+++ b/controllers/drcluster_controller.go
@@ -103,7 +103,7 @@ func (r *DRClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	manifestWorkUtil = util.MWUtil{
-		Client: r.Writer, APIReader: r.APIReader, Ctx: ctx, Log: log, InstName: "", InstNamespace: "",
+		Writer: r.Writer, APIReader: r.APIReader, Ctx: ctx, Log: log, InstName: "", InstNamespace: "",
 	}
 	u.mwUtil = manifestWorkUtil
 

--- a/controllers/drclusters.go
+++ b/controllers/drclusters.go
@@ -145,7 +145,7 @@ func drClusterUndeploy(drcluster *rmn.DRCluster, mwu *util.MWUtil) error {
 	clusterNames := sets.String{}
 	drpolicies := rmn.DRPolicyList{}
 
-	if err := mwu.Client.List(mwu.Ctx, &drpolicies); err != nil {
+	if err := mwu.APIReader.List(mwu.Ctx, &drpolicies); err != nil {
 		return fmt.Errorf("drpolicies list: %w", err)
 	}
 

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -1185,7 +1185,7 @@ func (d *DRPCInstance) ensureVRGManifestWorkOnClusterDeleted(clusterName string)
 	mwName := d.mwu.BuildManifestWorkName(rmnutil.MWTypeVRG)
 	mw := &ocmworkv1.ManifestWork{}
 
-	err := d.reconciler.Get(d.ctx, types.NamespacedName{Name: mwName, Namespace: clusterName}, mw)
+	err := d.reconciler.APIReader.Get(d.ctx, types.NamespacedName{Name: mwName, Namespace: clusterName}, mw)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return done, nil
@@ -1433,7 +1433,7 @@ func (d *DRPCInstance) updateVRGStateToSecondary(clusterName string) error {
 
 	mw.Spec.Workload.Manifests[0] = *vrgClientManifest
 
-	err = d.reconciler.Update(d.ctx, mw)
+	err = d.reconciler.Writer.Update(d.ctx, mw)
 	if err != nil {
 		return fmt.Errorf("failed to update MW (%w)", err)
 	}

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -72,7 +72,6 @@ type ProgressCallback func(string, string)
 type ManagedClusterViewGetter interface {
 	GetVRGFromManagedCluster(
 		resourceName, resourceNamespace, managedCluster string) (*rmn.VolumeReplicationGroup, error)
-
 	GetNamespaceFromManagedCluster(resourceName, resourceNamespace, managedCluster string) (*corev1.Namespace, error)
 }
 
@@ -578,7 +577,10 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(ctx context.Context,
 	d := &DRPCInstance{
 		reconciler: r, ctx: ctx, log: r.Log, instance: drpc, needStatusUpdate: false, userPlacementRule: usrPlRule,
 		drpcPlacementRule: drpcPlRule, drPolicy: drPolicy, drClusters: drClusters, vrgs: vrgs,
-		mwu: rmnutil.MWUtil{Client: r.Client, Ctx: ctx, Log: r.Log, InstName: drpc.Name, InstNamespace: drpc.Namespace},
+		mwu: rmnutil.MWUtil{
+			Client: r.Client, APIReader: r.APIReader, Ctx: ctx, Log: r.Log,
+			InstName: drpc.Name, InstNamespace: drpc.Namespace,
+		},
 	}
 
 	r.Log.Info(fmt.Sprintf("PlacementRule is: (%+v)", usrPlRule))
@@ -717,7 +719,10 @@ func (r *DRPlacementControlReconciler) finalizeDRPC(ctx context.Context, drpc *r
 	r.Log.Info("Finalizing DRPC")
 
 	clonedPlRuleName := fmt.Sprintf(ClonedPlacementRuleNameFormat, drpc.Name, drpc.Namespace)
-	mwu := rmnutil.MWUtil{Client: r.Client, Ctx: ctx, Log: r.Log, InstName: drpc.Name, InstNamespace: drpc.Namespace}
+	mwu := rmnutil.MWUtil{
+		Client: r.Client, APIReader: r.APIReader, Ctx: ctx, Log: r.Log,
+		InstName: drpc.Name, InstNamespace: drpc.Namespace,
+	}
 
 	preferredCluster := drpc.Spec.PreferredCluster
 	if preferredCluster == "" {

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -76,7 +76,8 @@ type ManagedClusterViewGetter interface {
 }
 
 type ManagedClusterViewGetterImpl struct {
-	client.Client
+	client.Writer
+	APIReader client.Reader
 }
 
 func (m ManagedClusterViewGetterImpl) GetVRGFromManagedCluster(
@@ -192,11 +193,11 @@ func (m ManagedClusterViewGetterImpl) getOrCreateManagedClusterView(
 		},
 	}
 
-	err := m.Get(context.TODO(), types.NamespacedName{Name: meta.Name, Namespace: meta.Namespace}, mcv)
+	err := m.APIReader.Get(context.TODO(), types.NamespacedName{Name: meta.Name, Namespace: meta.Namespace}, mcv)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.Info(fmt.Sprintf("Creating ManagedClusterView %v", mcv))
-			err = m.Create(context.TODO(), mcv)
+			err = m.Writer.Create(context.TODO(), mcv)
 		}
 
 		if err != nil {

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -580,7 +580,7 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(ctx context.Context,
 		reconciler: r, ctx: ctx, log: r.Log, instance: drpc, needStatusUpdate: false, userPlacementRule: usrPlRule,
 		drpcPlacementRule: drpcPlRule, drPolicy: drPolicy, drClusters: drClusters, vrgs: vrgs,
 		mwu: rmnutil.MWUtil{
-			Client: r.Writer, APIReader: r.APIReader, Ctx: ctx, Log: r.Log,
+			Writer: r.Writer, APIReader: r.APIReader, Ctx: ctx, Log: r.Log,
 			InstName: drpc.Name, InstNamespace: drpc.Namespace,
 		},
 	}
@@ -722,7 +722,7 @@ func (r *DRPlacementControlReconciler) finalizeDRPC(ctx context.Context, drpc *r
 
 	clonedPlRuleName := fmt.Sprintf(ClonedPlacementRuleNameFormat, drpc.Name, drpc.Namespace)
 	mwu := rmnutil.MWUtil{
-		Client: r.Writer, APIReader: r.APIReader, Ctx: ctx, Log: r.Log,
+		Writer: r.Writer, APIReader: r.APIReader, Ctx: ctx, Log: r.Log,
 		InstName: drpc.Name, InstNamespace: drpc.Namespace,
 	}
 

--- a/controllers/drpolicy.go
+++ b/controllers/drpolicy.go
@@ -83,7 +83,7 @@ func drPolicyUndeploy(
 	drClustersMutex.Lock()
 	defer drClustersMutex.Unlock()
 
-	if err := secretsUtil.Client.List(secretsUtil.Ctx, &drpolicies); err != nil {
+	if err := secretsUtil.APIReader.List(secretsUtil.Ctx, &drpolicies); err != nil {
 		return fmt.Errorf("drpolicies list: %w", err)
 	}
 

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -97,7 +97,7 @@ func (r *DRPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, fmt.Errorf("drclusters list: %w", u.validatedSetFalse("drClusterListFailed", err))
 	}
 
-	secretsUtil := &util.SecretsUtil{Client: r.Writer, APIReader: r.APIReader, Ctx: ctx, Log: log}
+	secretsUtil := &util.SecretsUtil{Writer: r.Writer, APIReader: r.APIReader, Ctx: ctx, Log: log}
 	// DRPolicy is marked for deletion
 	if !drpolicy.ObjectMeta.DeletionTimestamp.IsZero() &&
 		controllerutil.ContainsFinalizer(drpolicy, drPolicyFinalizerName) {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -267,7 +267,8 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)).To(Succeed())
 
 	err = (&ramencontrollers.VolumeReplicationGroupReconciler{
-		Client:         k8sManager.GetClient(),
+		Writer:         k8sManager.GetClient(),
+		StatusWriter:   k8sManager.GetClient().Status(),
 		APIReader:      k8sManager.GetAPIReader(),
 		Log:            ctrl.Log.WithName("controllers").WithName("VolumeReplicationGroup"),
 		ObjStoreGetter: fakeObjectStoreGetter{},

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -258,7 +258,8 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)).To(Succeed())
 
 	Expect((&ramencontrollers.DRPolicyReconciler{
-		Client:            k8sManager.GetClient(),
+		Writer:            k8sManager.GetClient(),
+		StatusWriter:      k8sManager.GetClient().Status(),
 		APIReader:         k8sManager.GetAPIReader(),
 		Scheme:            k8sManager.GetScheme(),
 		ObjectStoreGetter: fakeObjectStoreGetter{},

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -251,7 +251,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	Expect((&ramencontrollers.DRClusterReconciler{
-		Client:            k8sManager.GetClient(),
+		Writer:            k8sManager.GetClient(),
+		StatusWriter:      k8sManager.GetClient().Status(),
 		APIReader:         k8sManager.GetAPIReader(),
 		Scheme:            k8sManager.GetScheme(),
 		ObjectStoreGetter: fakeObjectStoreGetter{},

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -279,12 +279,13 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	drpcReconciler := (&ramencontrollers.DRPlacementControlReconciler{
-		Client:    k8sManager.GetClient(),
-		APIReader: k8sManager.GetAPIReader(),
-		Log:       ctrl.Log.WithName("controllers").WithName("DRPlacementControl"),
-		MCVGetter: FakeMCVGetter{},
-		Scheme:    k8sManager.GetScheme(),
-		Callback:  FakeProgressCallback,
+		Writer:       k8sManager.GetClient(),
+		StatusWriter: k8sManager.GetClient().Status(),
+		APIReader:    k8sManager.GetAPIReader(),
+		Log:          ctrl.Log.WithName("controllers").WithName("DRPlacementControl"),
+		MCVGetter:    FakeMCVGetter{},
+		Scheme:       k8sManager.GetScheme(),
+		Callback:     FakeProgressCallback,
 	})
 	err = drpcReconciler.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/controllers/util/misc.go
+++ b/controllers/util/misc.go
@@ -33,7 +33,7 @@ func GenericAddLabelsAndFinalizers(
 	ctx context.Context,
 	object client.Object,
 	finalizerName string,
-	client client.Client,
+	client client.Writer,
 	log logr.Logger) error {
 	labelAdded := AddLabel(object, OCMBackupLabelKey, OCMBackupLabelValue)
 	finalizerAdded := AddFinalizer(object, finalizerName)
@@ -51,7 +51,7 @@ func GenericFinalizerRemove(
 	ctx context.Context,
 	object client.Object,
 	finalizerName string,
-	client client.Client,
+	client client.Writer,
 	log logr.Logger) error {
 	finalizerCount := len(object.GetFinalizers())
 	controllerutil.RemoveFinalizer(object, finalizerName)

--- a/controllers/util/mw_util.go
+++ b/controllers/util/mw_util.go
@@ -60,7 +60,7 @@ const (
 )
 
 type MWUtil struct {
-	client.Client
+	Client        client.Writer
 	APIReader     client.Reader
 	Ctx           context.Context
 	Log           logr.Logger

--- a/controllers/util/mw_util.go
+++ b/controllers/util/mw_util.go
@@ -60,7 +60,7 @@ const (
 )
 
 type MWUtil struct {
-	Client        client.Writer
+	Writer        client.Writer
 	APIReader     client.Reader
 	Ctx           context.Context
 	Log           logr.Logger
@@ -344,7 +344,7 @@ func (mwu *MWUtil) createOrUpdateManifestWork(
 
 		mwu.Log.Info("Creating ManifestWork", "cluster", managedClusternamespace, "MW", mw)
 
-		return mwu.Client.Create(mwu.Ctx, mw)
+		return mwu.Writer.Create(mwu.Ctx, mw)
 	}
 
 	if !reflect.DeepEqual(foundMW.Spec, mw.Spec) {
@@ -352,7 +352,7 @@ func (mwu *MWUtil) createOrUpdateManifestWork(
 
 		mwu.Log.Info("ManifestWork exists.", "name", mw, "namespace", foundMW)
 
-		return mwu.Client.Update(mwu.Ctx, foundMW)
+		return mwu.Writer.Update(mwu.Ctx, foundMW)
 	}
 
 	return nil
@@ -395,7 +395,7 @@ func (mwu *MWUtil) DeleteManifestWork(mwName, mwNamespace string) error {
 
 	mwu.Log.Info("Deleting ManifestWork", "name", mw.Name, "namespace", mwNamespace)
 
-	err = mwu.Client.Delete(mwu.Ctx, mw)
+	err = mwu.Writer.Delete(mwu.Ctx, mw)
 	if err != nil && !errors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete MW. Error %w", err)
 	}

--- a/controllers/util/mw_util.go
+++ b/controllers/util/mw_util.go
@@ -61,6 +61,7 @@ const (
 
 type MWUtil struct {
 	client.Client
+	APIReader     client.Reader
 	Ctx           context.Context
 	Log           logr.Logger
 	InstName      string
@@ -82,7 +83,7 @@ func (mwu *MWUtil) FindManifestWork(mwName, managedCluster string) (*ocmworkv1.M
 
 	mw := &ocmworkv1.ManifestWork{}
 
-	err := mwu.Client.Get(mwu.Ctx, types.NamespacedName{Name: mwName, Namespace: managedCluster}, mw)
+	err := mwu.APIReader.Get(mwu.Ctx, types.NamespacedName{Name: mwName, Namespace: managedCluster}, mw)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, fmt.Errorf("%w", err)
@@ -327,7 +328,7 @@ func (mwu *MWUtil) createOrUpdateManifestWork(
 	managedClusternamespace string) error {
 	foundMW := &ocmworkv1.ManifestWork{}
 
-	err := mwu.Client.Get(mwu.Ctx,
+	err := mwu.APIReader.Get(mwu.Ctx,
 		types.NamespacedName{Name: mw.Name, Namespace: managedClusternamespace},
 		foundMW)
 	if err != nil {
@@ -383,7 +384,7 @@ func (mwu *MWUtil) DeleteManifestWork(mwName, mwNamespace string) error {
 
 	mw := &ocmworkv1.ManifestWork{}
 
-	err := mwu.Client.Get(mwu.Ctx, types.NamespacedName{Name: mwName, Namespace: mwNamespace}, mw)
+	err := mwu.APIReader.Get(mwu.Ctx, types.NamespacedName{Name: mwName, Namespace: mwNamespace}, mw)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil

--- a/controllers/util/secrets_util_test.go
+++ b/controllers/util/secrets_util_test.go
@@ -67,14 +67,14 @@ var _ = Describe("Secrets_Util", func() {
 	plRuleAbsent := func(plRuleName, namespace string) bool {
 		plRule := &plrv1.PlacementRule{}
 
-		return errors.IsNotFound(k8sClient.Get(context.TODO(),
+		return errors.IsNotFound(apiReader.Get(context.TODO(),
 			types.NamespacedName{Name: plRuleName, Namespace: namespace},
 			plRule))
 	}
 
 	plRuleContains := func(plRuleName, namespace string, clusters []string) bool {
 		plRule := &plrv1.PlacementRule{}
-		if err := k8sClient.Get(
+		if err := apiReader.Get(
 			context.TODO(),
 			types.NamespacedName{Name: plRuleName, Namespace: namespace},
 			plRule); err != nil {
@@ -101,7 +101,7 @@ var _ = Describe("Secrets_Util", func() {
 
 	policyContains := func(policyName, namespace string, secret *corev1.Secret) bool {
 		policyObject := &gppv1.Policy{}
-		if err := k8sClient.Get(
+		if err := apiReader.Get(
 			context.TODO(),
 			types.NamespacedName{Name: policyName, Namespace: namespace},
 			policyObject); err != nil {
@@ -109,7 +109,7 @@ var _ = Describe("Secrets_Util", func() {
 		}
 
 		apiSecret := &corev1.Secret{}
-		if err := k8sClient.Get(
+		if err := apiReader.Get(
 			context.TODO(),
 			types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace},
 			apiSecret); err != nil {
@@ -127,7 +127,7 @@ var _ = Describe("Secrets_Util", func() {
 
 	finalizerPresent := func(secretName string) bool {
 		secret := &corev1.Secret{}
-		if err := k8sClient.Get(
+		if err := apiReader.Get(
 			context.TODO(),
 			types.NamespacedName{
 				Name:      secretName,
@@ -147,7 +147,7 @@ var _ = Describe("Secrets_Util", func() {
 
 	finalizerAbsent := func(secretName string) bool {
 		secret := &corev1.Secret{}
-		if err := k8sClient.Get(context.TODO(),
+		if err := apiReader.Get(context.TODO(),
 			types.NamespacedName{
 				Name:      secretName,
 				Namespace: tstNamespace,
@@ -166,7 +166,7 @@ var _ = Describe("Secrets_Util", func() {
 
 	updateSecret := func(secret *corev1.Secret, value string) bool {
 		secretFetched := &corev1.Secret{}
-		if err := k8sClient.Get(
+		if err := apiReader.Get(
 			context.TODO(),
 			types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace},
 			secretFetched); err != nil {
@@ -184,7 +184,7 @@ var _ = Describe("Secrets_Util", func() {
 	secretAbsent := func(secretName string) bool {
 		secret := &corev1.Secret{}
 
-		return errors.IsNotFound(k8sClient.Get(
+		return errors.IsNotFound(apiReader.Get(
 			context.TODO(),
 			types.NamespacedName{
 				Name:      secretName,

--- a/controllers/util/util_suite_test.go
+++ b/controllers/util/util_suite_test.go
@@ -80,9 +80,10 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).NotTo(BeNil())
 
 	secretsUtil = util.SecretsUtil{
-		Client: k8sClient,
-		Ctx:    context.TODO(),
-		Log:    ctrl.Log.WithName("secrets_util"),
+		Client:    k8sClient,
+		APIReader: k8sClient,
+		Ctx:       context.TODO(),
+		Log:       ctrl.Log.WithName("secrets_util"),
 	}
 })
 

--- a/controllers/util/util_suite_test.go
+++ b/controllers/util/util_suite_test.go
@@ -30,7 +30,8 @@ const (
 
 var (
 	cfg         *rest.Config
-	k8sClient   client.Client
+	k8sClient   client.Writer
+	apiReader   client.Reader
 	testEnv     *envtest.Environment
 	secretsUtil util.SecretsUtil
 	testLog     logr.Logger
@@ -75,13 +76,15 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Creating a k8s client")
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	client, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
+	Expect(client).NotTo(BeNil())
+	k8sClient = client
+	apiReader = client
 
 	secretsUtil = util.SecretsUtil{
 		Client:    k8sClient,
-		APIReader: k8sClient,
+		APIReader: apiReader,
 		Ctx:       context.TODO(),
 		Log:       ctrl.Log.WithName("secrets_util"),
 	}

--- a/controllers/util/util_suite_test.go
+++ b/controllers/util/util_suite_test.go
@@ -83,7 +83,7 @@ var _ = BeforeSuite(func() {
 	apiReader = client
 
 	secretsUtil = util.SecretsUtil{
-		Client:    k8sClient,
+		Writer:    k8sClient,
 		APIReader: apiReader,
 		Ctx:       context.TODO(),
 		Log:       ctrl.Log.WithName("secrets_util"),

--- a/main.go
+++ b/main.go
@@ -133,7 +133,7 @@ func setupReconcilers(mgr ctrl.Manager) {
 			StatusWriter: mgr.GetClient().Status(),
 			APIReader:    mgr.GetAPIReader(),
 			Log:          ctrl.Log.WithName("controllers").WithName("DRPlacementControl"),
-			MCVGetter:    controllers.ManagedClusterViewGetterImpl{Client: mgr.GetClient()},
+			MCVGetter:    controllers.ManagedClusterViewGetterImpl{Writer: mgr.GetClient(), APIReader: mgr.GetAPIReader()},
 			Scheme:       mgr.GetScheme(),
 			Callback:     func(string, string) {},
 		}).SetupWithManager(mgr); err != nil {

--- a/main.go
+++ b/main.go
@@ -118,7 +118,8 @@ func setupReconcilers(mgr ctrl.Manager) {
 		}
 
 		if err := (&controllers.DRClusterReconciler{
-			Client:            mgr.GetClient(),
+			Writer:            mgr.GetClient(),
+			StatusWriter:      mgr.GetClient().Status(),
 			APIReader:         mgr.GetAPIReader(),
 			Scheme:            mgr.GetScheme(),
 			ObjectStoreGetter: controllers.S3ObjectStoreGetter(),

--- a/main.go
+++ b/main.go
@@ -129,12 +129,13 @@ func setupReconcilers(mgr ctrl.Manager) {
 		}
 
 		if err := (&controllers.DRPlacementControlReconciler{
-			Client:    mgr.GetClient(),
-			APIReader: mgr.GetAPIReader(),
-			Log:       ctrl.Log.WithName("controllers").WithName("DRPlacementControl"),
-			MCVGetter: controllers.ManagedClusterViewGetterImpl{Client: mgr.GetClient()},
-			Scheme:    mgr.GetScheme(),
-			Callback:  func(string, string) {},
+			Writer:       mgr.GetClient(),
+			StatusWriter: mgr.GetClient().Status(),
+			APIReader:    mgr.GetAPIReader(),
+			Log:          ctrl.Log.WithName("controllers").WithName("DRPlacementControl"),
+			MCVGetter:    controllers.ManagedClusterViewGetterImpl{Client: mgr.GetClient()},
+			Scheme:       mgr.GetScheme(),
+			Callback:     func(string, string) {},
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "DRPlacementControl")
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -145,7 +145,8 @@ func setupReconcilers(mgr ctrl.Manager) {
 	}
 
 	if err := (&controllers.VolumeReplicationGroupReconciler{
-		Client:         mgr.GetClient(),
+		Writer:         mgr.GetClient(),
+		StatusWriter:   mgr.GetClient().Status(),
 		APIReader:      mgr.GetAPIReader(),
 		Log:            ctrl.Log.WithName("controllers").WithName("VolumeReplicationGroup"),
 		ObjStoreGetter: controllers.S3ObjectStoreGetter(),

--- a/main.go
+++ b/main.go
@@ -107,7 +107,8 @@ func newManager() (ctrl.Manager, error) {
 func setupReconcilers(mgr ctrl.Manager) {
 	if controllers.ControllerType == ramendrv1alpha1.DRHubType {
 		if err := (&controllers.DRPolicyReconciler{
-			Client:            mgr.GetClient(),
+			Writer:            mgr.GetClient(),
+			StatusWriter:      mgr.GetClient().Status(),
 			APIReader:         mgr.GetAPIReader(),
 			Scheme:            mgr.GetScheme(),
 			ObjectStoreGetter: controllers.S3ObjectStoreGetter(),


### PR DESCRIPTION
Non-API server reads have caused problems more than once:
- #239 
- #440 
- #477 
- #496 

This patch replaces Clients with Writers, StatusWriters, and APIReaders making it less likely to do non-API server reads.