### PR TITLE
Change DRCluster resource to a cluster scoped resource

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -36,7 +36,7 @@ resources:
   version: v1alpha1
 - api:
     crdVersion: v1
-    namespaced: true
+    namespaced: false
   controller: true
   domain: openshift.io
   group: ramendr

--- a/api/v1alpha1/drcluster_types.go
+++ b/api/v1alpha1/drcluster_types.go
@@ -78,6 +78,7 @@ type DRClusterStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:scope=Cluster
 
 // DRCluster is the Schema for the drclusters API
 type DRCluster struct {

--- a/config/crd/bases/ramendr.openshift.io_drclusters.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drclusters.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: DRClusterList
     plural: drclusters
     singular: drcluster
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1alpha1
     schema:

--- a/controllers/drcluster_controller.go
+++ b/controllers/drcluster_controller.go
@@ -592,7 +592,6 @@ func (r *DRClusterReconciler) drClusterConfigMapMapFunc(configMap client.Object)
 	requests := make([]reconcile.Request, len(drcusters.Items))
 	for i, drcluster := range drcusters.Items {
 		requests[i].Name = drcluster.GetName()
-		requests[i].Namespace = drcluster.GetNamespace()
 	}
 
 	return requests

--- a/controllers/drcluster_controller_test.go
+++ b/controllers/drcluster_controller_test.go
@@ -119,8 +119,7 @@ var _ = Describe("DRClusterController", func() {
 		drclusters = append(drclusters,
 			ramen.DRCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "drc-cluster0",
-					Namespace: ramenNamespace,
+					Name: "drc-cluster0",
 				},
 				Spec: ramen.DRClusterSpec{
 					S3ProfileName: s3Profiles[0].S3ProfileName,
@@ -130,8 +129,7 @@ var _ = Describe("DRClusterController", func() {
 			},
 			ramen.DRCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "drc-cluster1",
-					Namespace: ramenNamespace,
+					Name: "drc-cluster1",
 				},
 				Spec: ramen.DRClusterSpec{
 					S3ProfileName: s3Profiles[0].S3ProfileName,

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -550,7 +550,7 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(ctx context.Context,
 	for _, managedCluster := range rmnutil.DrpolicyClusterNames(drPolicy) {
 		drCluster := &rmn.DRCluster{}
 
-		err := r.Client.Get(ctx, types.NamespacedName{Name: managedCluster, Namespace: NamespaceName()}, drCluster)
+		err := r.Client.Get(ctx, types.NamespacedName{Name: managedCluster}, drCluster)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get DRCluster (%s) %w", managedCluster, err)
 		}

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -448,15 +448,15 @@ func populateDRClusters() {
 	drClusters = nil
 	drClusters = append(drClusters,
 		rmn.DRCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: East1ManagedCluster, Namespace: ramenNamespace},
+			ObjectMeta: metav1.ObjectMeta{Name: East1ManagedCluster},
 			Spec:       rmn.DRClusterSpec{S3ProfileName: s3Profiles[0].S3ProfileName, Region: "east"},
 		},
 		rmn.DRCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: West1ManagedCluster, Namespace: ramenNamespace},
+			ObjectMeta: metav1.ObjectMeta{Name: West1ManagedCluster},
 			Spec:       rmn.DRClusterSpec{S3ProfileName: s3Profiles[0].S3ProfileName, Region: "west"},
 		},
 		rmn.DRCluster{
-			ObjectMeta: metav1.ObjectMeta{Name: East2ManagedCluster, Namespace: ramenNamespace},
+			ObjectMeta: metav1.ObjectMeta{Name: East2ManagedCluster},
 			Spec:       rmn.DRClusterSpec{S3ProfileName: s3Profiles[0].S3ProfileName, Region: "east"},
 		},
 	)
@@ -1095,8 +1095,7 @@ func deleteDRPolicySync() {
 
 func getLatestDRCluster(cluster string) *rmn.DRCluster {
 	drclusterLookupKey := types.NamespacedName{
-		Name:      cluster,
-		Namespace: ramenNamespace,
+		Name: cluster,
 	}
 	latestDRCluster := &rmn.DRCluster{}
 	err := apiReader.Get(context.TODO(), drclusterLookupKey, latestDRCluster)

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -91,7 +91,6 @@ func (r *DRPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	drclusters := &ramen.DRClusterList{}
 
-	// TODO: Is this namespaced listing?
 	if err := r.Client.List(ctx, drclusters); err != nil {
 		return ctrl.Result{}, fmt.Errorf("drclusters list: %w", u.validatedSetFalse("drClusterListFailed", err))
 	}
@@ -351,7 +350,7 @@ func (r *DRPolicyReconciler) secretMapFunc(secret client.Object) []reconcile.Req
 		return []reconcile.Request{}
 	}
 
-	// TODO: Add optimzation to only reconcile polocies that refer to the changed secret
+	// TODO: Add optimzation to only reconcile policies that refer to the changed secret
 	requests := make([]reconcile.Request, len(drpolicies.Items))
 	for i, drpolicy := range drpolicies.Items {
 		requests[i].Name = drpolicy.GetName()

--- a/controllers/drpolicy_controller_test.go
+++ b/controllers/drpolicy_controller_test.go
@@ -177,15 +177,15 @@ var _ = Describe("DrpolicyController", func() {
 		drClusters = nil
 		drClusters = append(drClusters,
 			ramen.DRCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "drp-cluster0", Namespace: ramenNamespace},
+				ObjectMeta: metav1.ObjectMeta{Name: "drp-cluster0"},
 				Spec:       ramen.DRClusterSpec{S3ProfileName: s3Profiles[0].S3ProfileName, Region: "east"},
 			},
 			ramen.DRCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "drp-cluster1", Namespace: ramenNamespace},
+				ObjectMeta: metav1.ObjectMeta{Name: "drp-cluster1"},
 				Spec:       ramen.DRClusterSpec{S3ProfileName: s3Profiles[0].S3ProfileName, Region: "west"},
 			},
 			ramen.DRCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: "drp-cluster2", Namespace: ramenNamespace},
+				ObjectMeta: metav1.ObjectMeta{Name: "drp-cluster2"},
 				Spec:       ramen.DRClusterSpec{S3ProfileName: s3Profiles[0].S3ProfileName, Region: "east"},
 			},
 		)

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -583,9 +583,6 @@ ramen_samples_channel_and_drpolicy_deploy()
 	      - op: replace
 	        path: /metadata/name
 	        value: $4
-	      - op: replace
-	        path: /metadata/namespace
-	        value: ramen-system
 	  - target:
 	      group: ramendr.openshift.io
 	      version: v1alpha1
@@ -601,9 +598,6 @@ ramen_samples_channel_and_drpolicy_deploy()
 	      - op: replace
 	        path: /metadata/name
 	        value: $3
-	      - op: replace
-	        path: /metadata/namespace
-	        value: ramen-system
 	  - target:
 	      group: ramendr.openshift.io
 	      version: v1alpha1


### PR DESCRIPTION
A DRCluster represents a 1:1 relationship to a managed
cluster, and hence for reasons such as fencing, we need
to maintain a single instance of the same across the hub
control plane as well.

Moving this to a cluster scoped resource as a result.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>