### PR TITLE
Support embedded ObjectMeta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,23 +198,26 @@ undeploy-dr-cluster: ## Undeploy dr-cluster controller from the K8s cluster spec
 ##@ Tools
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
+controller_gen_version=v0.6.1
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
+	@test '$(shell $(CONTROLLER_GEN) --version)' = 'Version: $(controller_gen_version)' ||\
+	$(call go-get-tool,sigs.k8s.io/controller-tools/cmd/controller-gen@$(controller_gen_version))
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.8)
+	@test -f $(KUSTOMIZE) ||\
+	$(call go-get-tool,sigs.k8s.io/kustomize/kustomize/v3@v3.8.8)
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
+# go-get-tool will 'go get' any package $1 and install it to bin/.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
-@[ -f $(1) ] || { \
+{ \
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+echo "Downloading $(1)" ;\
+GOBIN=$(PROJECT_DIR)/bin go get $(1) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ BUNDLE_IMG_HUB ?= $(IMAGE_TAG_BASE)-hub-operator-bundle:$(IMAGE_TAG)
 # Image URL to use all building/pushing image targets
 IMG ?= $(IMAGE_TAG_BASE)-operator:$(IMAGE_TAG)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
+CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false,generateEmbeddedObjectMeta=true"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/config/crd/bases/ramendr.openshift.io_drclusters.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drclusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: drclusters.ramendr.openshift.io
 spec:

--- a/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: drplacementcontrols.ramendr.openshift.io
 spec:

--- a/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: drpolicies.ramendr.openshift.io
 spec:

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: volumereplicationgroups.ramendr.openshift.io
 spec:

--- a/controllers/objectmeta.go
+++ b/controllers/objectmeta.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2022 The RamenDR authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ObjectMetaEmbedded(objectMeta *metav1.ObjectMeta) metav1.ObjectMeta {
+	// github.com/kubernetes-sigs/controller-tools/pull/557
+	return metav1.ObjectMeta{
+		Namespace:   objectMeta.Namespace,
+		Name:        objectMeta.Name,
+		Annotations: objectMeta.Annotations,
+		Labels:      objectMeta.Labels,
+		Finalizers:  objectMeta.Finalizers,
+	}
+}


### PR DESCRIPTION
If an object type has more than one ObjectMeta `controller-gen` empties the latter ones in the CRD.  An option `generateEmbeddedObjectMeta=true` allows some of its fields, namely: `Name` `Namespace` `Annotations` `Labels` `Finalizers`.  This patch also updates `controller-gen` to get support for the feature.

This is needed to support the API defined in #438 