### PR TITLE
Declare VRG.Status.LastUpdateTime nullable

### DIFF
--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -221,8 +221,9 @@ type VolumeReplicationGroupStatus struct {
 
 	// observedGeneration is the last generation change the operator has dealt with
 	// +optional
-	ObservedGeneration int64       `json:"observedGeneration,omitempty"`
-	LastUpdateTime     metav1.Time `json:"lastUpdateTime,omitempty"`
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// +nullable
+	LastUpdateTime metav1.Time `json:"lastUpdateTime,omitempty"`
 
 	PrepareForFinalSyncComplete bool `json:"prepareForFinalSyncComplete,omitempty"`
 	FinalSyncComplete           bool `json:"finalSyncComplete,omitempty"`

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -483,6 +483,7 @@ spec:
                 type: boolean
               lastUpdateTime:
                 format: date-time
+                nullable: true
                 type: string
               observedGeneration:
                 description: observedGeneration is the last generation change the


### PR DESCRIPTION
This fix allows VRG status to be omitted.  Without it the following error occurs when test `s3bucketview`:
```
ERROR   controller.s3bucketview Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "S3BucketView", "name": "bv-0", "namespace": "", "error": "error during updateStatus: S3BucketView.ramendr.openshift.io \"bv-0\" is invalid: status.volumeReplicationGroups.status.lastUpdateTime: Invalid value: \"null\": status.volumeReplicationGroups.status.lastUpdateTime in body must be of type string: \"null\""}
