### PR TITLE
Cache object storer for subsequent uploads

### DIFF
--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -291,6 +291,7 @@ func (r *VolumeReplicationGroupReconciler) Reconcile(ctx context.Context, req ct
 		volSyncPVCs:    []corev1.PersistentVolumeClaim{},
 		replClassList:  &volrep.VolumeReplicationClassList{},
 		namespacedName: req.NamespacedName.String(),
+		objectStorers:  make(map[string]cachedObjectStorer),
 	}
 
 	// Fetch the VolumeReplicationGroup instance
@@ -325,6 +326,11 @@ func (r *VolumeReplicationGroupReconciler) Reconcile(ctx context.Context, req ct
 	return res, err
 }
 
+type cachedObjectStorer struct {
+	storer ObjectStorer
+	err    error
+}
+
 type VRGInstance struct {
 	reconciler          *VolumeReplicationGroupReconciler
 	ctx                 context.Context
@@ -337,6 +343,7 @@ type VRGInstance struct {
 	vrcUpdated          bool
 	namespacedName      string
 	volSyncHandler      *volsync.VSHandler
+	objectStorers       map[string]cachedObjectStorer
 }
 
 const (


### PR DESCRIPTION
Currently for each s3 profile that the PVs need to be
uploaded to, we connect to the s3 store for each volume
that is protected by the current instance of VRG.

This causes a 2 minute slowdown in case the s3 store is
unreachable, which can happen during failover cases.

For a workload with n PVCs as a result the failover takes
n*120 seconds, which is far too long.

This is fixed by connecting to the s3 profile once per VRG
reconciliation, and using the cached connection/storer to
perform subsequent uploads or error out immediately.

Alternative: was to upload PVs post creating VRs for the same
but that would still reconcile the current VRG for n*120
seconds in the second loop, hence is dropped as an
alternative.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>