### PR TITLE
Look at volumeattachment resource to determine pvc in-use

### DIFF
--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -17,14 +17,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - persistentvolumeclaims
   verbs:
   - create
@@ -95,6 +87,14 @@ rules:
   - storage.k8s.io
   resources:
   - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
   verbs:
   - get
   - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -113,14 +113,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - create
@@ -314,6 +306,14 @@ rules:
   - storage.k8s.io
   resources:
   - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
   verbs:
   - get
   - list

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -1667,6 +1667,7 @@ func createDummyPVC(namespace string, capacity resource.Quantity,
 		if setDummyVolumeName {
 			return dummyPVC.Spec.VolumeName != ""
 		}
+
 		return true
 	}, maxWait, interval).Should(BeTrue())
 

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -257,7 +257,7 @@ func filterPVC(mgr manager.Manager, pvc *corev1.PersistentVolumeClaim, log logr.
 // +kubebuilder:rbac:groups=replication.storage.openshift.io,resources=volumereplications,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=replication.storage.openshift.io,resources=volumereplicationclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
-// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=volumeattachments,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=persistentvolumes,verbs=get;list;watch;update;patch;create
 // +kubebuilder:rbac:groups=volsync.backube,resources=replicationdestinations,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/vrg_volsync_test.go
+++ b/controllers/vrg_volsync_test.go
@@ -396,6 +396,7 @@ func createPVCWithVolumeAttachment(ctx context.Context, namespace string,
 		if err != nil {
 			return false
 		}
+
 		return pvc.Spec.VolumeName == dummyPVName && pvc.Status.Phase == corev1.ClaimBound
 	}, testMaxWait, testInterval).Should(BeTrue())
 


### PR DESCRIPTION
- previously looked at pod mounts - updated code  no longer need 
  to query pods
- rbac updated to remove access to pods and add for
  volumeattachments
- index still used on volumeattachment as it is a cluster scoped
  resource and we would need to iterate through them all to find
  a match where the spec had the PV in question referenced. This
  way provides a very simple lookup by pvname

Signed-off-by: Tesshu Flower <tflower@redhat.com>