### PR TITLE
Script dr-cluster deployment without ocm

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -6,11 +6,19 @@ Ramen dr-cluster end-to-end test script
 
 - cluster names are specified with the `cluster_names` variable
     - `cluster1` and `cluster2` by default
+- application sample namespace name is specified with the `application_sample_namespace_name`
+  variable
+    - `default` by default
 - takes a list of functions to execute:
     - `deploy` (default) deploys the environment including:
       minikube clusters, rook-ceph, minio s3 stores, ramen
     - `undeploy` undeploys the things deployed by `deploy`
     - `manager_redeploy` rebuilds and redeploys ramen manager
+    - `application_sample_deploy` deploys busybox-sample app to specified cluster
+    - `application_sample_undeploy` undeploys busybox-sample app from specified cluster
+    - `application_sample_vrg_deploy` deploys busybox-sample app vrg to 1st cluster
+    - `application_sample_vrg_undeploy` undeploys busybox-sample app vrg from 1st
+      cluster
 
 ## ocm-minikube-ramen.sh
 

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,6 +1,20 @@
-# ocm-minikube-ramen.sh
+# Ramen hack directory
 
-Ramen end-to-end test script
+## minikube-ramen.sh
+
+Ramen dr-cluster end-to-end test script
+
+- cluster names are specified with the `cluster_names` variable
+    - `cluster1` and `cluster2` by default
+- takes a list of functions to execute:
+    - `deploy` (default) deploys the environment including:
+      minikube clusters, rook-ceph, minio s3 stores, ramen
+    - `undeploy` undeploys the things deployed by `deploy`
+    - `manager_redeploy` rebuilds and redeploys ramen manager
+
+## ocm-minikube-ramen.sh
+
+open-cluster-management Ramen end-to-end test script
 
 - can be run from any directory; writes temporary files to /tmp
 - installs some dependencies (e.g. minikube, golang, etc), but not necessarily

--- a/hack/minikube-ramen.sh
+++ b/hack/minikube-ramen.sh
@@ -73,12 +73,12 @@ application_sample_vrg_kubectl()
 	  - minio-on-$1
 	  - minio-on-$2
 	  sync:
-	    mode: Disabled
+	    mode: Disabled$4
 	a
 }
 application_sample_vrg_deploy()
 {
-	application_sample_vrg_kubectl $cluster_names apply
+	application_sample_vrg_kubectl $cluster_names apply "$1"
 }
 application_sample_vrg_undeploy()
 {

--- a/hack/minikube-ramen.sh
+++ b/hack/minikube-ramen.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 # shellcheck disable=2086
-set -x
-set -e
 ramen_hack_directory_path_name=$(dirname $0)
 cluster_names=${cluster_names:-cluster1\ cluster2}
 deploy()
@@ -33,10 +31,74 @@ manager_redeploy()
 		minikube -p $cluster_name ssh -- docker images\|grep ramen
 	done; unset -v cluster_name
 }
+application_sample_namespace_name=${application_sample_namespace_name:-default}
+application_sample_namespace_deploy()
+{
+	kubectl create namespace $application_sample_namespace_name --dry-run=client -oyaml|kubectl --context $1 apply -f-
+}
+application_sample_namespace_undeploy()
+{
+	kubectl --context $1 delete namespace $application_sample_namespace_name
+}
+application_sample_kubectl()
+{
+	kubectl --context $1 -n$application_sample_namespace_name $2 -khttps://github.com/RamenDR/ocm-ramen-samples/busybox
+}
+application_sample_deploy()
+{
+	application_sample_kubectl $1 apply
+}
+application_sample_undeploy()
+{
+	application_sample_kubectl $1 delete
+}
+application_sample_vrg_kubectl()
+{
+	cat <<-a|kubectl --context $1 -n$application_sample_namespace_name $3 -f-
+	---
+	apiVersion: ramendr.openshift.io/v1alpha1
+	kind: VolumeReplicationGroup
+	metadata:
+	  name: bb
+	spec:
+	  async:
+	    mode: Enabled
+	    replicationClassSelector: {}
+	    schedulingInterval: 1m
+	  pvcSelector:
+	    matchLabels:
+	      appname: busybox
+	  replicationState: primary
+	  s3Profiles:
+	  - minio-on-$1
+	  - minio-on-$2
+	  sync:
+	    mode: Disabled
+	a
+}
+application_sample_vrg_deploy()
+{
+	application_sample_vrg_kubectl $cluster_names apply
+}
+application_sample_vrg_undeploy()
+{
+	application_sample_vrg_kubectl $cluster_names delete\ --ignore-not-found
+}
+set -ex
 for command in "${@:-deploy}"; do
 	$command
 done
+{ set +x; } 2>/dev/null
 unset -v command
+unset -f application_sample_vrg_undeploy
+unset -f application_sample_vrg_deploy
+unset -f application_sample_vrg_kubectl
+unset -f application_sample_undeploy
+unset -f application_sample_deploy
+unset -f application_sample_kubectl
+unset -f application_sample_namespace_undeploy
+unset -f application_sample_namespace_deploy
+unset -v application_sample_namespace_name
 unset -f manager_redeploy
 unset -f undeploy
 unset -f deploy

--- a/hack/minikube-ramen.sh
+++ b/hack/minikube-ramen.sh
@@ -54,7 +54,7 @@ application_sample_undeploy()
 }
 application_sample_vrg_kubectl()
 {
-	cat <<-a|kubectl --context $1 -n$application_sample_namespace_name $3 -f-
+	cat <<-a|kubectl --context $1 -n$application_sample_namespace_name $2 -f-
 	---
 	apiVersion: ramendr.openshift.io/v1alpha1
 	kind: VolumeReplicationGroup
@@ -70,19 +70,18 @@ application_sample_vrg_kubectl()
 	      appname: busybox
 	  replicationState: primary
 	  s3Profiles:
-	  - minio-on-$1
-	  - minio-on-$2
+$(for cluster_name in $cluster_names; do echo \ \ -\ minio-on-$cluster_name; done; unset -v cluster_name)
 	  sync:
-	    mode: Disabled$4
+	    mode: Disabled$3
 	a
 }
 application_sample_vrg_deploy()
 {
-	application_sample_vrg_kubectl $cluster_names apply "$1"
+	application_sample_vrg_kubectl $1 apply "$2"
 }
 application_sample_vrg_undeploy()
 {
-	application_sample_vrg_kubectl $cluster_names delete\ --ignore-not-found
+	application_sample_vrg_kubectl $1 delete\ --ignore-not-found
 }
 set -ex
 for command in "${@:-deploy}"; do

--- a/hack/minikube-ramen.sh
+++ b/hack/minikube-ramen.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# shellcheck disable=2086
+set -x
+set -e
+ramen_hack_directory_path_name=$(dirname $0)
+cluster_names=${cluster_names:-cluster1\ cluster2}
+deploy()
+{
+	spoke_cluster_names=$cluster_names $ramen_hack_directory_path_name/ocm-minikube.sh minikube_start_spokes
+	spoke_cluster_names=$cluster_names $ramen_hack_directory_path_name/ocm-minikube-ramen.sh\
+		rook_ceph_deploy\
+		minio_deploy_spokes\
+		ramen_manager_image_build_and_archive\
+		ramen_deploy_spokes\
+
+}
+undeploy()
+{
+	spoke_cluster_names=$cluster_names $ramen_hack_directory_path_name/ocm-minikube-ramen.sh\
+		ramen_undeploy_spokes\
+		minio_undeploy_spokes\
+		rook_ceph_undeploy\
+
+}
+manager_redeploy()
+{
+	spoke_cluster_names=$cluster_names $ramen_hack_directory_path_name/ocm-minikube-ramen.sh\
+		ramen_undeploy_spokes\
+		ramen_manager_image_build_and_archive\
+		ramen_deploy_spokes\
+
+	for cluster_name in $cluster_names; do
+		minikube -p $cluster_name ssh -- docker images\|grep ramen
+	done; unset -v cluster_name
+}
+for command in "${@:-deploy}"; do
+	$command
+done
+unset -v command
+unset -f manager_redeploy
+unset -f undeploy
+unset -f deploy
+unset -v cluster_names
+unset -v ramen_hack_directory_path_name

--- a/hack/minikube.sh
+++ b/hack/minikube.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# shellcheck disable=2086
+minikube_minio_url()
+{
+	minikube --profile $1 -n minio service --url minio
+}
+minikube_unset()
+{
+	unset -f minikube_unset
+	unset -f minikube_minio_url
+}

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -10,6 +10,8 @@ exit_stack_push unset -f true_if_exit_status_and_stderr
 exit_stack_push unset -f until_true_or_n
 . $ramen_hack_directory_path_name/olm.sh
 exit_stack_push olm_unset
+. $ramen_hack_directory_path_name/minikube.sh
+exit_stack_push minikube_unset
 exit_stack_push unset -v ramen_hack_directory_path_name
 rook_ceph_deploy_spoke()
 {
@@ -498,14 +500,14 @@ ramen_config_deploy_hub_or_spoke()
 	s3StoreProfiles:
 	- s3ProfileName: minio-on-$4
 	  s3Bucket: bucket
-	  s3CompatibleEndpoint: $(minikube --profile $4 -n minio service --url minio)
+	  s3CompatibleEndpoint: $(minikube_minio_url $4)
 	  s3Region: us-east-1
 	  s3SecretRef:
 	    name: s3secret
 	    namespace: ramen-system
 	- s3ProfileName: minio-on-$5
 	  s3Bucket: bucket
-	  s3CompatibleEndpoint: $(minikube --profile $5 -n minio service --url minio)
+	  s3CompatibleEndpoint: $(minikube_minio_url $5)
 	  s3Region: us-west-1
 	  s3SecretRef:
 	    name: s3secret


### PR DESCRIPTION
- Create `minikube-ramen.sh` with the following routines:
  - `deploy` - deploys minikubes, rook-ceph, minio, ramen
  - `undeploy` - undeploys things deployed by `deploy`
  - `manager_redeploy` - rebuilds and redeploys ramen manager
  - `application_sample_deploy` - deploys busybox sample application
  - `application_sample_undeploy` - undeploys busybox sample application
  - `application_sample_vrg_deploy` - deploys busybox sample application vrg
  - `application_sample_vrg_undeploy` - undeploy busybox sample application vrg
- Create `minikube.sh` with the following routines:
  - `minikube_minio_url` - prints minikube cluster's minio service url
  - `minikube_unset` - unsets routines and variables that minikube.sh defines