### PR TITLE
Before final sync check volumeattachments to make sure PVC unmounted

### DIFF
--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -100,6 +100,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - multicluster.x-k8s.io
   resources:
   - serviceexports

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -317,6 +317,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - view.open-cluster-management.io
   resources:
   - managedclusterviews

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -257,6 +257,7 @@ func filterPVC(mgr manager.Manager, pvc *corev1.PersistentVolumeClaim, log logr.
 // +kubebuilder:rbac:groups=replication.storage.openshift.io,resources=volumereplications,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=replication.storage.openshift.io,resources=volumereplicationclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=volumeattachments,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=persistentvolumes,verbs=get;list;watch;update;patch;create


### PR DESCRIPTION
- During relocate, before running a final sync - keep the check to
  ensure no pod is mounting the PVC - if no pod is, then do an
  additional check of checking for volumeattachments to make sure
  the underlying PV has been unmounted from nodes (and therefore I/O
  writes complete).  If a CSI driver does not support volumeattachments
  then this check will not find any, and will assume the PVC is
  unmounted.


This is meant to replace PR: https://github.com/RamenDR/ramen/pull/466

See discussion that triggered these changes, starting here:
https://github.com/RamenDR/ramen/pull/466#issuecomment-1140725421

Essentially we may not be able to depend on the volumeattachments to determine that a PVC is no longer "in-use" (so we can run a final sync during a Relocate).  

This approach keeps the pod checks, but adds the extra volume attachment check afterwards.  For CSI drivers that support volumeattachments, this should let ramen wait until the underlying PV is completely detached before running the final sync operation.

Signed-off-by: Tesshu Flower <tflower@redhat.com>