### PR TITLE
Cache S3 errors from UploadPV

### DIFF
--- a/controllers/s3utils_test.go
+++ b/controllers/s3utils_test.go
@@ -22,6 +22,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/go-logr/logr"
 	"github.com/ramendr/ramen/controllers"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,11 +32,12 @@ import (
 type fakeObjectStoreGetter struct{}
 
 const (
-	bucketNameSucc  = "bucket"
-	bucketNameSucc2 = bucketNameSucc + "2"
-	bucketNameFail  = bucketNameSucc + "Fail"
-	bucketNameFail2 = bucketNameFail + "2"
-	bucketListFail  = bucketNameSucc + "ListFail"
+	bucketNameSucc         = "bucket"
+	bucketNameSucc2        = bucketNameSucc + "2"
+	bucketNameFail         = bucketNameSucc + "Fail"
+	bucketNameFail2        = bucketNameFail + "2"
+	bucketListFail         = bucketNameSucc + "ListFail"
+	bucketNameUploadAwsErr = bucketNameFail + "UploadAwsErr"
 
 	awsAccessKeyIDSucc = "succ"
 	awsAccessKeyIDFail = "fail"
@@ -92,6 +95,10 @@ type fakeObjectStorer struct {
 }
 
 func (f fakeObjectStorer) UploadObject(key string, object interface{}) error {
+	if f.bucketName == bucketNameUploadAwsErr {
+		return awserr.New(s3.ErrCodeInvalidObjectState, "fake error uploading object", fmt.Errorf("fake error"))
+	}
+
 	f.objects[key] = object
 
 	return nil

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -79,7 +79,7 @@ var (
 	plRuleNames map[string]struct{}
 
 	s3Secrets      [1]corev1.Secret
-	s3Profiles     [6]ramendrv1alpha1.S3StoreProfile
+	s3Profiles     [7]ramendrv1alpha1.S3StoreProfile
 	ramenNamespace = "ns-envtest"
 )
 
@@ -225,6 +225,8 @@ var _ = BeforeSuite(func() {
 	s3Profiles[2] = s3ProfileNew("2", bucketNameFail)
 	s3Profiles[3] = s3ProfileNew("3", bucketNameFail2)
 	s3Profiles[4] = s3ProfileNew("4", bucketListFail)
+	// s3Profiles[5] used and modified in DRCluster tests
+	s3Profiles[6] = s3ProfileNew("6", bucketNameUploadAwsErr)
 
 	s3SecretsPolicyNamesSet := func() {
 		plRuleNames = make(map[string]struct{}, len(s3Secrets))

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -334,6 +334,7 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 	})
 
 	var vrgStatusTests []*vrgTest
+	//nolint:dupl
 	Context("in primary state status check pending to bound", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
 			vrgTestTemplate.s3Profiles = []string{s3Profiles[0].S3ProfileName}
@@ -414,6 +415,7 @@ var _ = Describe("Test VolumeReplicationGroup", func() {
 		replicationClassLabels: map[string]string{"protection": "ramen"},
 	}
 	var vrgStatus3Tests []*vrgTest
+	//nolint:dupl
 	Context("in primary state status check create VRG first", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
 			vrgTest3Template.s3Profiles = []string{s3Profiles[0].S3ProfileName}


### PR DESCRIPTION
Initial cache of errors built in commit e7b7b9d1 did
not account for errors faced during uploads. Emperically
it is seen that connection errors are generated during
the upload phase than the intial session creation phase.

This commit adds updating the cache with S3 errors during
the upload as well.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>