### PR TITLE
Read secret placement rule from API server

### DIFF
--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 	errorswrapper "github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -784,14 +785,24 @@ func ensureDRPolicyIsNotDeleted(drpc *rmn.DRPlacementControl) {
 	}, timeout, interval).Should(BeTrue(), "DRPolicy deleted prematurely, with active DRPC references")
 }
 
-func ensureDRPolicyIsDeleted(drpc *rmn.DRPlacementControl) {
-	Eventually(func() bool {
-		drpolicy := &rmn.DRPolicy{}
-		name := drpc.Spec.DRPolicyRef.Name
-		err := apiReader.Get(context.TODO(), types.NamespacedName{Name: name}, drpolicy)
-
-		return err != nil
-	}, timeout, interval).Should(BeTrue(), "DRPolicy not deleted, though there is no active DRPC referring to it")
+func ensureDRPolicyIsDeleted(drpolicyName string) {
+	drpolicy := &rmn.DRPolicy{}
+	Eventually(func() error {
+		return apiReader.Get(context.TODO(), types.NamespacedName{Name: drpolicyName}, drpolicy)
+	}, timeout, interval).Should(
+		MatchError(
+			errors.NewNotFound(
+				schema.GroupResource{
+					Group:    rmn.GroupVersion.Group,
+					Resource: "drpolicies",
+				},
+				drpolicyName,
+			),
+		),
+		"DRPolicy %s not not found\n%s",
+		drpolicyName,
+		format.Object(*drpolicy, 0),
+	)
 }
 
 func checkIfDRPCFinalizerNotAdded(drpc *rmn.DRPlacementControl) {
@@ -1490,9 +1501,14 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // Roles MW only
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
-				ensureDRPolicyIsDeleted(drpc)
-				deleteDRClustersAsync()
 			})
+			It("should delete the DRPC causing its referenced drpolicy to be deleted"+
+				" by drpolicy controller since no DRPCs reference it anymore", func() {
+				ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)
+			})
+		})
+		Specify("delete drclusters", func() {
+			deleteDRClustersAsync()
 		})
 	})
 	Context("DRPlacementControl Reconciler Sync DR", func() {

--- a/controllers/util/secrets_util.go
+++ b/controllers/util/secrets_util.go
@@ -547,7 +547,7 @@ func (sutil *SecretsUtil) RemoveSecretFromCluster(secretName, clusterName, names
 	}
 
 	// Fetch secret placement rule, success if not found
-	err = sutil.Client.Get(sutil.Ctx, plRuleName, plRule)
+	err = sutil.APIReader.Get(sutil.Ctx, plRuleName, plRule)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return errorswrapper.Wrap(err, "failed to get placementRule object")


### PR DESCRIPTION
The following test fails intermittently in my environment:

```
[Fail] DRPlacementControl Reconciler DRPlacementControl Reconciler Async DR when Deleting DRPC [It] Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)
/home/bhatfiel/ramen/controllers/drplacementcontrol_controller_test.go:794
```

Here's the end of the log:
```
2022-06-10T23:08:33.325-0700    INFO    controllers.DRPlacementControl  Entering reconcile loop {"DRPC": "app-namespace2/app-volume-replication-test"}
2022-06-10T23:08:33.327-0700    INFO    controllers.DRPlacementControl  DRCP object not found app-namespace2/app-volume-replication-test        {"DRPC": "app-namespace2/app-volume-replication-test"}
2022-06-10T23:08:33.327-0700    INFO    controllers.DRPlacementControl  Exiting reconcile loop  {"DRPC": "app-namespace2/app-volume-replication-test"}
2022-06-10T23:08:33.544-0700    INFO    controllers.drpolicy    reconcile enter {"name": "my-async-dr-peers"}
2022-06-10T23:08:33.547-0700    INFO    controllers.drpolicy    delete  {"name": "my-async-dr-peers"}
2022-06-10T23:08:33.547-0700    INFO    controllers.drpolicy    Remove Secret   {"name": "my-async-dr-peers", "cluster": "east1-cluster", "secret": "s3secret0"}
2022-06-10T23:08:33.548-0700    INFO    controllers.drpolicy    Updating placement rule for secret policy       {"name": "my-async-dr-peers", "secret": "s3secret0", "clusters": [{"name":"west1-cluster"}]}
2022-06-10T23:08:33.553-0700    INFO    controllers.drpolicy    Remove Secret   {"name": "my-async-dr-peers", "cluster": "west1-cluster", "secret": "s3secret0"}
2022-06-10T23:08:33.553-0700    INFO    controllers.drpolicy    Updating placement rule for secret policy       {"name": "my-async-dr-peers", "secret": "s3secret0", "clusters": [{"name":"east1-cluster"}]}
2022-06-10T23:08:33.557-0700    ERROR   controllers.drpolicy    unable to update placement rule {"name": "my-async-dr-peers", "placementRule": "plrule-s3secret0", "cluster": "west1-cluster", "error": "Operation cannot be fulfilled on placementrules.apps.open-cluster-management.io \"plrule-s3secret0\": the object has been modified; please apply your changes to the latest version and try again"}
github.com/ramendr/ramen/controllers/util.(*SecretsUtil).RemoveSecretFromCluster
        /home/bhatfiel/ramen/controllers/util/secrets_util.go:559
github.com/ramendr/ramen/controllers.drClustersUndeploySecrets
        /home/bhatfiel/ramen/controllers/drpolicy.go:127
github.com/ramendr/ramen/controllers.drPolicyUndeploy
        /home/bhatfiel/ramen/controllers/drpolicy.go:90
github.com/ramendr/ramen/controllers.(*drpolicyUpdater).deleteDRPolicy
        /home/bhatfiel/ramen/controllers/drpolicy_controller.go:257
github.com/ramendr/ramen/controllers.(*DRPolicyReconciler).Reconcile
        /home/bhatfiel/ramen/controllers/drpolicy_controller.go:102
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /home/bhatfiel/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.7/pkg/internal/controller/controller.go:298
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /home/bhatfiel/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.7/pkg/internal/controller/controller.go:253
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /home/bhatfiel/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.7/pkg/internal/controller/controller.go:214
2022-06-10T23:08:33.557-0700    INFO    controllers.drpolicy    reconcile exit  {"name": "my-async-dr-peers"}
2022-06-10T23:08:33.557-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "drpolicy undeploy: drcluster 'west1-cluster' s3Profile 's3secret0' secrets delete: unable to update placement rule (placementRule: plrule-s3secret0, cluster: west1-cluster): Operation cannot be fulfilled on placementrules.apps.open-cluster-management.io \"plrule-s3secret0\": the object has been modified; please apply your changes to the latest version and try again"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /home/bhatfiel/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.9.7/pkg/internal/controller/controller.go:214

• Failure [10.039 seconds]
DRPlacementControl Reconciler
/home/bhatfiel/ramen/controllers/drplacementcontrol_controller_test.go:1376
  DRPlacementControl Reconciler Async DR
  /home/bhatfiel/ramen/controllers/drplacementcontrol_controller_test.go:1380
    when Deleting DRPC
    /home/bhatfiel/ramen/controllers/drplacementcontrol_controller_test.go:1484
      Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster) [It]
      /home/bhatfiel/ramen/controllers/drplacementcontrol_controller_test.go:1485

      Timed out after 10.001s.
      DRPolicy not deleted, though there is no active DRPC referring to it
      Expected
          <bool>: false
      to be true

      /home/bhatfiel/ramen/controllers/drplacementcontrol_controller_test.go:794
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSTEP: tearing down the test environment
2022-06-10T23:08:43.146-0700    INFO    controllers.drpolicy    reconcile enter {"name": "my-async-dr-peers"}
2022-06-10T23:08:43.146-0700    INFO    controllers.drcluster   reconcile enter {"name": "west1-cluster"}
```

A secret placement rule update failed.  But why wasn't there an attempt to reconcile the drpolicy again?  It likely would have happened but not within the 10-second timeout as its backoff time exceeded that from failing to be deleted due to a drplacement control referencing it:
```
2022-06-10T23:07:57.392-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "Operation cannot be fulfilled on drpolicies.ramendr.openshift.io \"my-async-dr-peers\": the object has been modified; please apply your changes to the latest version and try again"}
2022-06-10T23:08:13.034-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "this drpolicy is referenced in existing drpc resource name 'app-volume-replication-test' "}
2022-06-10T23:08:13.042-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "this drpolicy is referenced in existing drpc resource name 'app-volume-replication-test' "}
2022-06-10T23:08:13.054-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "this drpolicy is referenced in existing drpc resource name 'app-volume-replication-test' "}
2022-06-10T23:08:13.077-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "this drpolicy is referenced in existing drpc resource name 'app-volume-replication-test' "}
2022-06-10T23:08:13.121-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "this drpolicy is referenced in existing drpc resource name 'app-volume-replication-test' "}
2022-06-10T23:08:13.203-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "this drpolicy is referenced in existing drpc resource name 'app-volume-replication-test' "}
2022-06-10T23:08:13.367-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "this drpolicy is referenced in existing drpc resource name 'app-volume-replication-test' "}
2022-06-10T23:08:13.690-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "this drpolicy is referenced in existing drpc resource name 'app-volume-replication-test' "}
2022-06-10T23:08:14.334-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "this drpolicy is referenced in existing drpc resource name 'app-volume-replication-test' "}
2022-06-10T23:08:15.618-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "this drpolicy is referenced in existing drpc resource name 'app-volume-replication-test' "}
2022-06-10T23:08:18.181-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "this drpolicy is referenced in existing drpc resource name 'app-volume-replication-test' "}
2022-06-10T23:08:23.304-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "this drpolicy is referenced in existing drpc resource name 'app-volume-replication-test' "}
2022-06-10T23:08:33.557-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "drpolicy undeploy: drcluster 'west1-cluster' s3Profile 's3secret0' secrets delete: unable to update placement rule (placementRule: plrule-s3secret0, cluster: west1-cluster): Operation cannot be fulfilled on placementrules.apps.open-cluster-management.io \"plrule-s3secret0\": the object has been modified; please apply your changes to the latest version and try again"}
2022-06-10T23:08:43.149-0700    ERROR   controller.drpolicy     Reconciler error        {"reconciler group": "ramendr.openshift.io", "reconciler kind": "DRPolicy", "name": "my-async-dr-peers", "namespace": "", "error": "config map get: Put \"https://127.0.0.1:41989/apis/ramendr.openshift.io/v1alpha1/drpolicies/my-async-dr-peers/status\": dial tcp 127.0.0.1:41989: connect: connection refused"}
```

A workaround is to avoid the stale placement rule by reading from the API server, which is what this patch does.

An alternative, and perhaps superior solution, is to return from drpolicy reconcile without error when a drpolicy is referenced by a drpc and have drpolicy controller watch for drplacement control deletion events and queue a reconcile attempt when a drpc referencing it is deleted.