### PR TITLE
update drpc status when vrg status condition changes

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -1822,7 +1822,25 @@ func (d *DRPCInstance) shouldUpdateStatus() bool {
 		}
 	}
 
-	return !reflect.DeepEqual(d.savedInstanceStatus, d.instance.Status)
+	if !reflect.DeepEqual(d.savedInstanceStatus, d.instance.Status) {
+		return true
+	}
+
+	homeCluster := ""
+	if len(d.userPlacementRule.Status.Decisions) != 0 {
+		homeCluster = d.userPlacementRule.Status.Decisions[0].ClusterName
+	}
+
+	if homeCluster == "" {
+		return false
+	}
+
+	vrg := d.vrgs[homeCluster]
+	if vrg == nil {
+		return false
+	}
+
+	return !reflect.DeepEqual(d.instance.Status.ResourceConditions.Conditions, vrg.Status.Conditions)
 }
 
 //nolint:exhaustive


### PR DESCRIPTION
If nothing has changed in the DRPC, then the status is not updated. The DRPC status contains the VRG status conditions and it wasn't checking whether the VRG status condition has changed. In this PR, we will force the DRPC status to update if the VRG status condition is changed.