### PR TITLE
Use a higher granular rate limiter for VRG reconciles

### DIFF
--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -478,6 +478,13 @@ func (v *VRGInstance) validateVRGMode() error {
 }
 
 func (v *VRGInstance) restorePVs() error {
+	if v.instance.Spec.PrepareForFinalSync || v.instance.Spec.RunFinalSync {
+		msg := "PV restore skipped, as VRG is orchestrating final sync"
+		setVRGClusterDataReadyCondition(&v.instance.Status.Conditions, v.instance.Generation, msg)
+
+		return nil
+	}
+
 	clusterDataReady := findCondition(v.instance.Status.Conditions, VRGConditionTypeClusterDataReady)
 	if clusterDataReady != nil {
 		v.log.Info("ClusterDataReady condition",

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/stolostron/multicloud-operators-placementrule v1.2.4-1-20220311-8eedb3f.0.20220411162042-3de0a2f908f1
 	go.uber.org/zap v1.21.0
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292
+	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8
 	k8s.io/api v0.23.6
 	k8s.io/apimachinery v0.23.6
 	k8s.io/client-go v12.0.0+incompatible
@@ -76,7 +77,6 @@ require (
 	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect


### PR DESCRIPTION
The default rate limiter has a 5ms baseDelay and a max
of 1000 seconds.

Reconcilig at such low base delays is highly frequent in
the case of DR actions in VRG where we are waiting for
storage state changes. Further the max delay is very high
causing unwarranted delays.

Changing this to 1 second and a minute as the base and max
delays.

Further removing existing 1 second reconcile frequency for
certain VRG reconciliation requests.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>