### PR TITLE
Log improvement in VRG status update: 

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -76,7 +76,7 @@ func (d *DRPCInstance) startProcessing() bool {
 	done, processingErr := d.processPlacement()
 
 	if d.shouldUpdateStatus() || d.statusUpdateTimeElapsed() {
-		if err := d.reconciler.updateDRPCStatus(d.instance, d.userPlacementRule); err != nil {
+		if err := d.reconciler.updateDRPCStatus(d.instance, d.userPlacementRule, d.log); err != nil {
 			d.log.Error(err, "failed to update status")
 
 			return requeue
@@ -1131,7 +1131,7 @@ func (d *DRPCInstance) updateUserPlacementRule(homeCluster, homeClusterNamespace
 		Decisions: newPD,
 	}
 
-	return d.reconciler.updateUserPlacementRuleStatus(d.userPlacementRule, newStatus)
+	return d.reconciler.updateUserPlacementRuleStatus(d.userPlacementRule, newStatus, d.log)
 }
 
 func (d *DRPCInstance) clearUserPlacementRuleStatus() error {
@@ -1139,7 +1139,7 @@ func (d *DRPCInstance) clearUserPlacementRuleStatus() error {
 
 	newStatus := plrv1.PlacementRuleStatus{}
 
-	return d.reconciler.updateUserPlacementRuleStatus(d.userPlacementRule, newStatus)
+	return d.reconciler.updateUserPlacementRuleStatus(d.userPlacementRule, newStatus, d.log)
 }
 
 func (d *DRPCInstance) createVRGManifestWork(homeCluster string) error {

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -855,18 +855,22 @@ func (v *VRGInstance) updateVRGStatus(updateConditions bool) (bool, error) {
 	if !reflect.DeepEqual(v.savedInstanceStatus, v.instance.Status) {
 		v.instance.Status.LastUpdateTime = metav1.Now()
 		if err := v.reconciler.Status().Update(v.ctx, v.instance); err != nil {
-			v.log.Info(fmt.Sprintf("Failed to update VRG status (%s/%s/%v/%+v)",
-				v.instance.Name, v.instance.Namespace, err, v.instance.Status))
+			v.log.Info(fmt.Sprintf("Failed to update VRG status (%v/%+v)",
+				err, v.instance.Status))
 
 			return true, fmt.Errorf("failed to update VRG status (%s/%s)", v.instance.Name, v.instance.Namespace)
 		}
 
-		v.log.Info(fmt.Sprintf("Updated VRG Status %+v", v.instance.Status))
+		dataReadyCondition := findCondition(v.instance.Status.Conditions, VRGConditionTypeDataReady)
+		v.log.Info(fmt.Sprintf("Updated VRG Status VolRep pvccount (%d), VolSync pvccount(%d)"+
+			" DataReady Condition (%s)",
+			len(v.volRepPVCs), len(v.volSyncPVCs), dataReadyCondition))
 
 		return !v.areRequiredConditionsReady(), nil
 	}
 
-	v.log.Info(fmt.Sprintf("Nothing to update %+v", v.instance.Status))
+	v.log.Info(fmt.Sprintf("Nothing to update VolRep pvccount (%d), VolSync pvccount(%d)",
+		len(v.volRepPVCs), len(v.volSyncPVCs)))
 
 	return !v.areRequiredConditionsReady(), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/csi-addons/volume-replication-operator v0.3.1-0.20220623123415-de6a161ca0ed
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v1.2.3
+	github.com/google/uuid v1.3.0
 	github.com/kubernetes-csi/external-snapshotter/client/v4 v4.2.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
@@ -55,7 +56,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect


### PR DESCRIPTION
When large no of PVCs consumed by the workload, VRG status update flooded with all pvc name , s3 profile name,  pvc information in the log file. Removed v.instance.Status and added  name, namespace, pvccount and VRG DataReadycondition 