### PR TITLE
VRG tests: Get VRG from API server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,10 +131,16 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 setup-envtest:
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR)
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR)
 
 test: generate manifests setup-envtest ## Run tests.
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out $(GO_TEST_GINKGO_ARGS)
+	go test ./... -coverprofile cover.out $(GO_TEST_GINKGO_ARGS)
+
+test-vrg-vr: generate manifests setup-envtest
+	go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus VolumeReplicationGroupVolRep
+
+test-vrg-vs: generate manifests setup-envtest
+	go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus VolumeReplicationGroupVolSync
 
 ##@ Build
 

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -35,7 +35,7 @@ func init() {
 	rand.Seed(time.Now().Unix())
 }
 
-var _ = Describe("Test VolumeReplicationGroup", func() {
+var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	conditionExpect := func(conditions []metav1.Condition, typ string) *metav1.Condition {
 		condition := meta.FindStatusCondition(conditions, typ)
 		Expect(condition).ToNot(BeNil())

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -1031,7 +1031,7 @@ func (v *vrgTest) getVRG(vrgName string) *ramendrv1alpha1.VolumeReplicationGroup
 	}
 
 	vrg := &ramendrv1alpha1.VolumeReplicationGroup{}
-	err := k8sClient.Get(context.TODO(), key, vrg)
+	err := apiReader.Get(context.TODO(), key, vrg)
 	Expect(err).NotTo(HaveOccurred(),
 		"failed to get VRG %s", vrgName)
 

--- a/controllers/vrg_volsync_test.go
+++ b/controllers/vrg_volsync_test.go
@@ -30,7 +30,7 @@ const (
 	testVolumeSnapshotClass = "fakevolumesnapshotclass"
 )
 
-var _ = Describe("VolumeReplicationGroupController", func() {
+var _ = Describe("VolumeReplicationGroupVolSyncController", func() {
 	var testNamespace *corev1.Namespace
 	testLogger := zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
 	var testCtx context.Context


### PR DESCRIPTION
The following test fails with some regularity in my environment:

```go
VolumeReplicationGroupVolRepController in primary state
  waits for VRG status to match
  ramen/controllers/vrg_volrep_test.go:181
```
It tries to get a nascent VRG expecting it to succeed immediately, but it is not found:
```go
1.6566750405615325e+09  INFO    controllers.VolumeReplicationGroup      Entering reconcile loop {"VolumeReplicationGroup": "envtest-ns-txthe/vrg-txthe"}
• Failure [0.001 seconds]
VolumeReplicationGroupVolRepController
ramen/controllers/vrg_volrep_test.go:38
  in primary state
  ramen/controllers/vrg_volrep_test.go:166
    waits for VRG status to match [It]
    ramen/controllers/vrg_volrep_test.go:181

    failed to get VRG vrg-txthe
    Unexpected error:
        <*errors.StatusError | 0xc0003b2500>: {
            ErrStatus: {
                TypeMeta: {Kind: "", APIVersion: ""},
                ListMeta: {
                    SelfLink: "",
                    ResourceVersion: "",
                    Continue: "",
                    RemainingItemCount: nil,
                },
                Status: "Failure",
                Message: "VolumeReplicationGroup.ramendr.openshift.io \"vrg-txthe\" not found",
                Reason: "NotFound",
                Details: {
                    Name: "vrg-txthe",
                    Group: "ramendr.openshift.io",
                    Kind: "VolumeReplicationGroup",
                    UID: "",
                    Causes: nil,
                    RetryAfterSeconds: 0,
                },
                Code: 404,
            },
        }
        VolumeReplicationGroup.ramendr.openshift.io "vrg-txthe" not found
    occurred

    ramen/controllers/vrg_volrep_test.go:1035
```
The problem has not recurred with this patch that gets using an API reader instead of a caching client.