### PR TITLE
Fix rook to survive restarts

### DIFF
--- a/hack/dev-rook-cluster.yaml
+++ b/hack/dev-rook-cluster.yaml
@@ -20,7 +20,9 @@ metadata:
   name: my-cluster
   namespace: rook-ceph
 spec:
-  dataDirHostPath: /var/lib/rook
+  # On Minikube /var/lib/rook is not persisted, but anything under /data is.
+  # https://minikube.sigs.k8s.io/docs/handbook/persistent_volumes/#a-note-on-mounts-persistence-and-minikube-hosts
+  dataDirHostPath: /data/rook
   cephVersion:
     image: quay.io/ceph/ceph:v16.2.6
     allowUnsupported: true

--- a/hack/minikube-rook-setup.sh
+++ b/hack/minikube-rook-setup.sh
@@ -29,19 +29,6 @@ usage()
 	exit 1
 }
 
-function wait_for_ssh() {
-    local tries=60
-    while ((tries > 0)); do
-        if minikube ssh "echo connected" --profile="$1" &>/dev/null; then
-            return 0
-        fi
-        tries=$((tries - 1))
-        sleep 1
-    done
-    echo ERROR: ssh did not come up >&2
-    exit 1
-}
-
 function wait_for_condition() {
     local count=121
     local condition=${1}
@@ -81,9 +68,6 @@ if [[ $1 == "stop" ]]; then
 fi
 
 if [[ $1 == "start" ]]; then
-	sudo virsh start "${PROFILE}"
-	wait_for_ssh "$PROFILE"
-	minikube ssh "sudo mkdir -p /mnt/vda1/rook/ && sudo ln -sf /mnt/vda1/rook/ /var/lib/rook" --profile="${PROFILE}"
 	minikube start --profile="${PROFILE}"
     exit 0
 fi
@@ -92,10 +76,7 @@ if [[ $1 == "create" ]]
 then
         ### $1 == "create"
         # TODO: Check if already created and bail out!
-        ## Preserve /var/lib/rook into existing vda1 disk ##
-        # TODO: minikube instance is assumed to be kvm2 based, check it?
-        minikube ssh "sudo mkdir -p /mnt/vda1/rook/ && sudo ln -sf /mnt/vda1/rook/ /var/lib/rook" --profile="${PROFILE}"
-        
+
         ## Create and attach an OSD disk for Ceph ##
         set +e
         pool=$(virsh pool-dumpxml $POOL_NAME)


### PR DESCRIPTION
The default rook dataDirHostPath (/var/lib/rook) does not work on
minikube, since minikube persists only certain directories[1].

This can be fixed by using `/data/rook`, as rook's cluster.yaml
recommends[2].

Now that the issue is fixed, we don't need the hack to start a node
using virsh and recreate the /var/lib/rook before starting the cluster
with minikube.

[1] https://minikube.sigs.k8s.io/docs/handbook/persistent_volumes/#a-note-on-mounts-persistence-and-minikube-hosts
[2] https://github.com/rook/rook/blob/8b512a14bb5726c8b7368c796ea60add2529f0e7/deploy/examples/cluster.yaml#L31