### PR TITLE
disable volsync for metro-dr

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -457,6 +457,13 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(ctx context.Context,
 		},
 	}
 
+	isMetro, _ := dRPolicySupportsMetro(drPolicy, drClusters)
+	if isMetro {
+		d.volSyncDisabled = true
+
+		log.Info("volsync is set to disabled")
+	}
+
 	// Save the instance status
 	d.instance.Status.DeepCopyInto(&d.savedInstanceStatus)
 	log.Info(fmt.Sprintf("PlacementRule Status is: (%+v)", usrPlRule.Status))


### PR DESCRIPTION
volsync is enabled by default and to disable it, we need to add the config in the config-map. 
this patch is to disable volsync for metro-dr. 

Signed-off-by: rakeshgm <rakeshgm@redhat.com>