### PR TITLE
Use ISO 8601 timestamp format in logs

### DIFF
--- a/controllers/util/pvcs_util_test.go
+++ b/controllers/util/pvcs_util_test.go
@@ -28,12 +28,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var _ = Describe("PVCS_Util", func() {
 	var testNamespace *corev1.Namespace
-	testLogger := zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
 	var testCtx context.Context
 	var cancel context.CancelFunc
 

--- a/controllers/util/util_suite_test.go
+++ b/controllers/util/util_suite_test.go
@@ -14,6 +14,7 @@ import (
 	cpcv1 "github.com/stolostron/config-policy-controller/api/v1"
 	gppv1 "github.com/stolostron/governance-policy-propagator/api/v1"
 	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -33,7 +34,7 @@ var (
 	k8sClient   client.Client
 	testEnv     *envtest.Environment
 	secretsUtil util.SecretsUtil
-	testLog     logr.Logger
+	testLogger  logr.Logger
 )
 
 func TestUtil(t *testing.T) {
@@ -42,8 +43,13 @@ func TestUtil(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	testLog = ctrl.Log.WithName("tester")
+	testLogger = zap.New(zap.UseFlagOptions(&zap.Options{
+		Development: true,
+		DestWriter:  GinkgoWriter,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
+	}))
+	logf.SetLogger(testLogger)
+	testLog := ctrl.Log.WithName("tester")
 	testLog.Info("Starting the utils test suite", "time", time.Now())
 
 	By("Setting up KUBEBUILDER_ASSETS for envtest")

--- a/controllers/volsync/secret_propagator_test.go
+++ b/controllers/volsync/secret_propagator_test.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/ramendr/ramen/controllers/volsync"
 	cfgpolicyv1 "github.com/stolostron/config-policy-controller/api/v1"
@@ -26,8 +25,6 @@ var _ = Describe("Secret propagator", func() {
 	genericCodec := genericCodecs.UniversalDeserializer()
 
 	var testNamespace *corev1.Namespace
-	logger := zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
-
 	var owner metav1.Object
 
 	BeforeEach(func() {

--- a/controllers/volsync/secretgen_test.go
+++ b/controllers/volsync/secretgen_test.go
@@ -13,15 +13,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/ramendr/ramen/controllers/volsync"
 )
 
 var _ = Describe("Secretgen", func() {
 	var testNamespace *corev1.Namespace
-	logger := zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
-
 	var owner metav1.Object
 
 	BeforeEach(func() {

--- a/controllers/volsync/volsync_suite_test.go
+++ b/controllers/volsync/volsync_suite_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/ramendr/ramen/controllers/volsync"
@@ -14,6 +15,7 @@ import (
 	cfgpolicyv1 "github.com/stolostron/config-policy-controller/api/v1"
 	policyv1 "github.com/stolostron/governance-policy-propagator/api/v1"
 	plrulev1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
+	"go.uber.org/zap/zapcore"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -27,6 +29,7 @@ import (
 )
 
 var (
+	logger                         logr.Logger
 	k8sClient                      client.Client
 	testEnv                        *envtest.Environment
 	cancel                         context.CancelFunc
@@ -50,7 +53,12 @@ func TestVolsync(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	logger = zap.New(zap.UseFlagOptions(&zap.Options{
+		Development: true,
+		DestWriter:  GinkgoWriter,
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
+	}))
+	logf.SetLogger(logger)
 
 	ctx, cancel = context.WithCancel(context.TODO())
 

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
@@ -73,7 +72,6 @@ var _ = Describe("VolSync Handler - utils", func() {
 })
 
 var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
-	logger := zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
 	schedulingInterval := "1h"
 
 	Describe("Get volume snapshot classes", func() {
@@ -180,8 +178,6 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 
 var _ = Describe("VolSync Handler", func() {
 	var testNamespace *corev1.Namespace
-	logger := zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
-
 	var owner metav1.Object
 	var vsHandler *volsync.VSHandler
 

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -151,7 +151,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			vrgNamespacedName := vtest.namespace + "/" + vtest.vrgName + "/"
 			pvList := generateFakePVs("pv", numPVs)
 			objectStorer, err := fakeObjectStoreGetter{}.ObjectStore(
-				context.TODO(), apiReader, s3Profiles[0].S3ProfileName, "", testLog,
+				context.TODO(), apiReader, s3Profiles[0].S3ProfileName, "", testLogger,
 			)
 			Expect(err).To(BeNil())
 			populateS3Store(objectStorer, vrgNamespacedName, pvList)

--- a/controllers/vrg_volsync_test.go
+++ b/controllers/vrg_volsync_test.go
@@ -13,8 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
@@ -32,7 +30,6 @@ const (
 
 var _ = Describe("VolumeReplicationGroupVolSyncController", func() {
 	var testNamespace *corev1.Namespace
-	testLogger := zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
 	var testCtx context.Context
 	var cancel context.CancelFunc
 

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ import (
 	viewv1beta1 "github.com/stolostron/multicloud-operators-foundation/pkg/apis/view/v1beta1"
 	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
 	uberzap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -72,6 +73,7 @@ func newManager() (ctrl.Manager, error) {
 		ZapOpts: []uberzap.Option{
 			uberzap.AddCaller(),
 		},
+		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 
 	opts.BindFlags(flag.CommandLine)


### PR DESCRIPTION
Thanks @ShyamsundarR for finding this fix!

It seems this time encoding option was introduced to controller-runtime in v0.11.0 (Dec 14, 2021):
https://github.com/kubernetes-sigs/controller-runtime/commit/5bb6cb71f09f8adc76d63f1c614f88236590da05

I tried a few different off-the-shelf formats:

```sh
RFC 9333 Nano

2022-07-13T10:21:02.080805923-07:00     INFO    tester  Starting the controller test suite      {"time": "2022-07-13T10:21:02.080779928-07:00"}
STEP: bootstrapping test environment
2022-07-13T10:21:02.081105564-07:00     DEBUG   controller-runtime.test-env     starting control plane
2022-07-13T10:21:06.918841787-07:00     DEBUG   controller-runtime.test-env     installing CRDs
2022-07-13T10:21:06.918912996-07:00     DEBUG   controller-runtime.test-env     reading CRDs from path  {"path": "../config/crd/bases"}
2022-07-13T10:21:06.920396642-07:00     DEBUG   controller-runtime.test-env     read CRDs from file     {"file": "ramendr.openshift.io_drclusters.yaml"}
2022-07-13T10:21:06.923003282-07:00     DEBUG   controller-runtime.test-env     read CRDs from file     {"file": "ramendr.openshift.io_drplacementcontrols.yaml"}
2022-07-13T10:21:06.925019027-07:00     DEBUG   controller-runtime.test-env     read CRDs from file     {"file": "ramendr.openshift.io_drpolicies.yaml"}
2022-07-13T10:21:06.944220861-07:00     DEBUG   controller-runtime.test-env     read CRDs from file     {"file": "ramendr.openshift.io_volumereplicationgroups.yaml"}

RFC 9333

2022-07-13T10:24:33-07:00       INFO    tester  Starting the controller test suite      {"time": "2022-07-13T10:24:33-07:00"}
STEP: bootstrapping test environment
2022-07-13T10:24:33-07:00       DEBUG   controller-runtime.test-env     starting control plane
2022-07-13T10:24:39-07:00       DEBUG   controller-runtime.test-env     installing CRDs
2022-07-13T10:24:39-07:00       DEBUG   controller-runtime.test-env     reading CRDs from path  {"path": "../config/crd/bases"}
2022-07-13T10:24:39-07:00       DEBUG   controller-runtime.test-env     read CRDs from file     {"file": "ramendr.openshift.io_drclusters.yaml"}
2022-07-13T10:24:39-07:00       DEBUG   controller-runtime.test-env     read CRDs from file     {"file": "ramendr.openshift.io_drplacementcontrols.yaml"}
2022-07-13T10:24:39-07:00       DEBUG   controller-runtime.test-env     read CRDs from file     {"file": "ramendr.openshift.io_drpolicies.yaml"}
2022-07-13T10:24:39-07:00       DEBUG   controller-runtime.test-env     read CRDs from file     {"file": "ramendr.openshift.io_volumereplicationgroups.yaml"}


ISO 8601

2022-07-13T10:26:30.221-0700    INFO    tester  Starting the controller test suite      {"time": "2022-07-13T10:26:30.221-0700"}
STEP: bootstrapping test environment
2022-07-13T10:26:30.221-0700    DEBUG   controller-runtime.test-env     starting control plane
2022-07-13T10:26:35.828-0700    DEBUG   controller-runtime.test-env     installing CRDs
2022-07-13T10:26:35.828-0700    DEBUG   controller-runtime.test-env     reading CRDs from path  {"path": "../config/crd/bases"}
2022-07-13T10:26:35.830-0700    DEBUG   controller-runtime.test-env     read CRDs from file     {"file": "ramendr.openshift.io_drclusters.yaml"}
2022-07-13T10:26:35.834-0700    DEBUG   controller-runtime.test-env     read CRDs from file     {"file": "ramendr.openshift.io_drplacementcontrols.yaml"}
2022-07-13T10:26:35.836-0700    DEBUG   controller-runtime.test-env     read CRDs from file     {"file": "ramendr.openshift.io_drpolicies.yaml"}
```

The ISO 8601 looks good to me and is what this patch uses.  Though, I think it would be easier to read with a space instead of the T between date and time.