### PR TITLE
Clear the error message in the DRPC status condition on success

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -154,11 +154,7 @@ func (d *DRPCInstance) RunInitialDeployment() (bool, error) {
 			return !done, err
 		}
 
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
-			d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), "Initial deployment completed")
-
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
-			metav1.ConditionTrue, rmn.ReasonSuccess, "Ready")
+		d.setConditionOnInitialDeploymentCompletion()
 
 		return !done, nil
 	}
@@ -174,12 +170,9 @@ func (d *DRPCInstance) RunInitialDeployment() (bool, error) {
 	if d.getLastDRState() == rmn.DRState("") {
 		d.instance.Status.PreferredDecision = d.userPlacementRule.Status.Decisions[0]
 		d.setDRState(rmn.Deployed)
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
-			d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), "Already deployed")
-
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
-			metav1.ConditionTrue, rmn.ReasonSuccess, "Ready")
 	}
+
+	d.setConditionOnInitialDeploymentCompletion()
 
 	d.setProgression(rmn.ProgressionCompleted)
 
@@ -2090,6 +2083,14 @@ func (d *DRPCInstance) setMetricsTimer(
 		wrapper.histogram.Observe(d.metricsTimer.timer.ObserveDuration().Seconds()) // add timer to histogram
 		d.metricsTimer.reconcileState = reconcileState
 	}
+}
+
+func (d *DRPCInstance) setConditionOnInitialDeploymentCompletion() {
+	d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+		d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), "Initial deployment completed")
+
+	d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
+		metav1.ConditionTrue, rmn.ReasonSuccess, "Ready")
 }
 
 func (d *DRPCInstance) setDRPCCondition(conditions *[]metav1.Condition, condType string,


### PR DESCRIPTION
This commit fixes the cosmetic issue detailed here: https://bugzilla.redhat.com/show_bug.cgi?id=2096604#c3

When DRPC current state reflects its desired state, the status does not get updated. If during that time (reconciliation), an intermittent failure occurs, like DRPolicy goes to NOT validated, The DRPC 'Available' status condition is updated with that error and its status is set to false.
Once the failure goes away, the DRPC condition does not get updated as it finds the current state equals the desired state.