### PR TITLE
Fixes a flake in DRPC status check envtest

### DIFF
--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -1044,6 +1044,10 @@ func waitForUpdateDRPCStatus() {
 			if condition.ObservedGeneration != drpc.Generation {
 				return false
 			}
+
+			if condition.Status != metav1.ConditionTrue {
+				return false
+			}
 		}
 
 		return true


### PR DESCRIPTION
An update to DRPC post an action causes the envtest
to report errors like:
Message: "Operation cannot be fulfilled on
drplacementcontrols.ramendr.openshift.io
\"app-volume-replication-test\": the object has been
modified; please apply your changes to the latest
version and try again"

The reason is due to a DRPC reconciliation post the
previous test and the next, that changes the status
as appropriate. This causes envtest to use an outdated
version to post the next updates.

The fix is to further ensure all status conditions are
met before proceeding to the next test, thereby avoiding
spurious status updates and flakes as above.

NOTE: The condition is checked to be true always as
that is the test expectation, in the future if it can be
false, then the check needs to be made appropriately.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>