### PR TITLE
Fix silent merge conflict

### DIFF
--- a/controllers/drcluster_controller_test.go
+++ b/controllers/drcluster_controller_test.go
@@ -534,7 +534,7 @@ var _ = Describe("DRClusterController", func() {
 				drcluster.Spec.ClusterFence = "Fenced"
 				drcluster.Spec.S3ProfileName = s3Profiles[4].S3ProfileName
 				Expect(k8sClient.Update(context.TODO(), drcluster)).To(Succeed())
-				drclusterConditionExpect(drcluster, false, metav1.ConditionTrue,
+				drclusterConditionExpectEventually(drcluster, false, metav1.ConditionTrue,
 					Equal(controllers.DRClusterConditionReasonFenced), Ignore(),
 					ramen.DRClusterConditionTypeFenced)
 			})
@@ -548,7 +548,7 @@ var _ = Describe("DRClusterController", func() {
 				// up the fencing resource. So, by the time this check is made,
 				// either the cluster should have been unfenced or completely
 				// cleaned
-				drclusterConditionExpect(drcluster, false, metav1.ConditionFalse,
+				drclusterConditionExpectEventually(drcluster, false, metav1.ConditionFalse,
 					BeElementOf(controllers.DRClusterConditionReasonUnfenced, controllers.DRClusterConditionReasonCleaning,
 						controllers.DRClusterConditionReasonClean),
 					Ignore(), ramen.DRClusterConditionTypeFenced)


### PR DESCRIPTION
PR #503 added a helper function `drclusterConditionExpectEventually` instead of calling directly `drclusterConditionExpect`.  Somehow, the merge with mainline didn't go smoothly.  IOW, it silently conflicted with PR #505. The merge of PR #503 was allowed, but it eventually failed to build due to a missing argument error:
```
Error: controllers/drcluster_controller_test.go:537:29: not enough arguments in call to drclusterConditionExpect
	have (*"github.com/ramendr/ramen/api/v1alpha1".DRCluster, bool, "k8s.io/apimachinery/pkg/apis/meta/v1".ConditionStatus, "github.com/onsi/gomega/types".GomegaMatcher, "github.com/onsi/gomega/types".GomegaMatcher, string)
	want (*"github.com/ramendr/ramen/api/v1alpha1".DRCluster, bool, "k8s.io/apimachinery/pkg/apis/meta/v1".ConditionStatus, "github.com/onsi/gomega/types".GomegaMatcher, "github.com/onsi/gomega/types".GomegaMatcher, string, bool)
```
This PR fixes the issue.