### PR TITLE
Remove the useless error message and preserve the real one

### DIFF
--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -436,7 +436,7 @@ func (v *VRGInstance) uploadPVToS3Stores(pvc *corev1.PersistentVolumeClaim, log 
 
 	s3Profiles, err := v.PVUploadToObjectStores(pvc, log)
 	if err != nil {
-		return fmt.Errorf("error uploading PV cluster data to the list of s3 profiles")
+		return fmt.Errorf("failed to upload PV with error (%w). Uploaded to %v S3 profile(s)", err, s3Profiles)
 	}
 
 	numProfilesUploaded := len(s3Profiles)


### PR DESCRIPTION
The real error is lost in translation. A Useless error was returned instead.
This comit returns the original error.