### PR TITLE
creating ProgressionStatus conditions type

### DIFF
--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -84,6 +84,26 @@ const (
 	ReasonNotStarted  = "NotStarted"
 )
 
+type ProgressionStatus string
+
+const (
+	ProgressionCompleted            = ProgressionStatus("Completed")
+	ProgressionCreatingMW           = ProgressionStatus("CreatingMW")
+	ProgressionUpdatingPlRule       = ProgressionStatus("UpdatingPlRule")
+	ProgressionWaitForReadiness     = ProgressionStatus("WaitForReadiness")
+	ProgressionCleaningUp           = ProgressionStatus("Cleaning Up")
+	ProgressionFailingOverToCluster = ProgressionStatus("FailingOverToCluster")
+	ProgressionPreparingFinalSync   = ProgressionStatus("PreparingFinalSync")
+	ProgressionClearingPlRule       = ProgressionStatus("ClearingPlRule")
+	ProgressionRunningFinalSync     = ProgressionStatus("RunningFinalSync")
+	ProgressionFinalSyncComplete    = ProgressionStatus("FinalSyncComplete")
+	ProgressionMovingToSecondary    = ProgressionStatus("MovingToSecondary")
+	ProgressionWaitingForPVRestore  = ProgressionStatus("WaitingForPVRestore")
+	ProgressionUpdatedPlRule        = ProgressionStatus("UpdatedPlRule")
+	ProgressionEnsuringVolSyncSetup = ProgressionStatus("EnsuringVolSyncSetup")
+	ProgressionSettingupVolsyncDest = ProgressionStatus("SettingUpVolSyncDest")
+)
+
 // DRPlacementControlSpec defines the desired state of DRPlacementControl
 type DRPlacementControlSpec struct {
 	// PlacementRef is the reference to the PlacementRule used by DRPC
@@ -144,7 +164,7 @@ type DRPlacementControlStatus struct {
 	Phase              DRState                 `json:"phase,omitempty"`
 	ActionStartTime    *metav1.Time            `json:"actionStartTime,omitempty"`
 	ActionDuration     *metav1.Duration        `json:"actionDuration,omitempty"`
-	Progression        string                  `json:"progression,omitempty"`
+	Progression        ProgressionStatus       `json:"progression,omitempty"`
 	PreferredDecision  plrv1.PlacementDecision `json:"preferredDecision,omitempty"`
 	Conditions         []metav1.Condition      `json:"conditions,omitempty"`
 	ResourceConditions VRGConditions           `json:"resourceConditions,omitempty"`

--- a/controllers/drplacementcontrolvolsync.go
+++ b/controllers/drplacementcontrolvolsync.go
@@ -39,7 +39,7 @@ func (d *DRPCInstance) EnsureVolSyncReplicationSetup(homeCluster string) error {
 
 func (d *DRPCInstance) ensureVolSyncReplicationCommon(srcCluster string) error {
 	// Make sure we have Source and Destination VRGs - Source should already have been created at this point
-	d.setProgression("EnsuringVolSyncSetup")
+	d.setProgression(rmn.ProgressionEnsuringVolSyncSetup)
 
 	const maxNumberOfVRGs = 2
 	if len(d.vrgs) != maxNumberOfVRGs {
@@ -91,7 +91,7 @@ func (d *DRPCInstance) ensureVolSyncReplicationCommon(srcCluster string) error {
 }
 
 func (d *DRPCInstance) ensureVolSyncReplicationDestination(srcCluster string) error {
-	d.setProgression("SettingUpVolSyncDest")
+	d.setProgression(rmn.ProgressionSettingupVolsyncDest)
 
 	srcVRG, found := d.vrgs[srcCluster]
 	if !found {


### PR DESCRIPTION
Progression Statuses were of type string and were directly used in the functions. There was a small typo in one of the statuses. using the statuses as predefined, there would only be one place to change the strings/status msgs rather than changing the status messages in the underlying functions. 

Signed-off-by: rakeshgm <rakeshgm@redhat.com>