### PR TITLE
When VolSync is used, requeue every 5s until DataProtected cond status is true

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -59,6 +59,7 @@ const (
 	VRGConditionTypeVolSyncFinalSyncInProgress = "FinalSyncInProgress"
 	VRGConditionTypeVolSyncRepDestinationSetup = "ReplicationDestinationSetup"
 	VRGConditionTypeVolSyncPVsRestored         = "PVsRestored"
+	VRGConditionTypeVolSyncDataProtected       = "DataProtected"
 )
 
 // VRG condition reasons
@@ -388,6 +389,18 @@ func setVRGConditionTypeVolSyncPVRestoreError(conditions *[]metav1.Condition, ob
 		Reason:             VRGConditionReasonError,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+}
+
+// sets conditions when Primary anccountered an error initializing the Replication Destination
+func setVRGConditionTypeVolSyncDataProtected(conditions *[]metav1.Condition, observedGeneration int64,
+	status metav1.ConditionStatus, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               VRGConditionTypeVolSyncDataProtected,
+		Reason:             VRGConditionReasonDataProtected,
+		ObservedGeneration: observedGeneration,
+		Status:             status,
 		Message:            message,
 	})
 }


### PR DESCRIPTION
In PR #493 the requeue process was refined. It introduced an issue causing VolSync to take a
long time for the DataProtected condition status to change from false to true. When VolSync
is used and DataProtected condition status is false, we will keep reconciling every 5 seconds
until the data is protected.