### PR TITLE
Deploy volsync as mgdclusteraddon

### DIFF
--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -235,6 +235,11 @@ type VolumeReplicationGroupStatus struct {
 	// All the protected pvcs
 	ProtectedPVCs []ProtectedPVC `json:"protectedPVCs,omitempty"`
 
+	// Count of VolRep PVCs
+	VolRepPVCCount int `json:"volRepPvcCount,omitempty"`
+	// Count of VolSync PVCs
+	VolSyncPVCCount int `json:"volSyncPvcCount,omitempty"`
+
 	// Conditions are the list of VRG's summary conditions and their status.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -626,6 +626,12 @@ spec:
               state:
                 description: State captures the latest state of the replication operation
                 type: string
+              volRepPvcCount:
+                description: Count of VolRep PVCs
+                type: integer
+              volSyncPvcCount:
+                description: Count of VolSync PVCs
+                type: integer
             type: object
         type: object
     served: true

--- a/config/hub/rbac/role.yaml
+++ b/config/hub/rbac/role.yaml
@@ -22,6 +22,17 @@ rules:
   - patch
   - update
 - apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - managedclusteraddons
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps.open-cluster-management.io
   resources:
   - placementrules

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,17 @@ rules:
   - list
   - watch
 - apiGroups:
+  - addon.open-cluster-management.io
+  resources:
+  - managedclusteraddons
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps.open-cluster-management.io
   resources:
   - placementrules

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -1393,6 +1393,12 @@ func (d *DRPCInstance) EnsureCleanup(clusterToSkip string) error {
 	// IFF we have VolSync PVCs, then no need to clean up
 	homeCluster := clusterToSkip
 
+	// Wait until the source has at least one protectedPVC before trying to determine if volsync is required
+	vrg := d.vrgs[homeCluster]
+	if vrg == nil || len(vrg.Status.ProtectedPVCs) == 0 {
+		return WaitForSourceCluster
+	}
+
 	repReq, err := d.IsVolSyncReplicationRequired(homeCluster)
 	if err != nil {
 		return fmt.Errorf("failed to check if VolSync replication is required (%w)", err)

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -1365,7 +1365,7 @@ func (d *DRPCInstance) checkPVsHaveBeenRestored(homeCluster string) (bool, error
 	return clusterDataReady.Status == metav1.ConditionTrue && clusterDataReady.ObservedGeneration == vrg.Generation, nil
 }
 
-//nolint:funlen,gocognit,cyclop
+//nolint:funlen,gocognit,cyclop,gocyclo
 func (d *DRPCInstance) EnsureCleanup(clusterToSkip string) error {
 	d.log.Info("ensuring cleanup on secondaries")
 
@@ -1396,7 +1396,7 @@ func (d *DRPCInstance) EnsureCleanup(clusterToSkip string) error {
 	// Wait until the source has at least one protectedPVC before trying to determine if volsync is required
 	vrg := d.vrgs[homeCluster]
 	if vrg == nil || len(vrg.Status.ProtectedPVCs) == 0 {
-		return WaitForSourceCluster
+		return fmt.Errorf("%w)", WaitForSourceCluster)
 	}
 
 	repReq, err := d.IsVolSyncReplicationRequired(homeCluster)

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -304,6 +304,7 @@ func (r *DRPlacementControlReconciler) SetupWithManager(mgr ctrl.Manager) error 
 // +kubebuilder:rbac:groups=apps.open-cluster-management.io,resources=placementrules/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps.open-cluster-management.io,resources=placementrules/finalizers,verbs=get;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=managedclusters,verbs=get;list;watch
+// +kubebuilder:rbac:groups=addon.open-cluster-management.io,resources=managedclusteraddons,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=view.open-cluster-management.io,resources=managedclusterviews,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=policy.open-cluster-management.io,resources=policies,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/drplacementcontrolvolsync.go
+++ b/controllers/drplacementcontrolvolsync.go
@@ -42,9 +42,7 @@ func (d *DRPCInstance) ensureVolSyncReplicationCommon(srcCluster string) error {
 	d.setProgression(rmn.ProgressionEnsuringVolSyncSetup)
 
 	volsyncClusters := []string{}
-	for _, clusterName := range rmnutil.DrpolicyClusterNames(d.drPolicy) {
-		volsyncClusters = append(volsyncClusters, clusterName)
-	}
+	volsyncClusters = append(volsyncClusters, rmnutil.DrpolicyClusterNames(d.drPolicy)...)
 
 	// Make sure VolSync deploy is triggered to clusters
 	err := volsync.DeployVolSyncToClusters(d.ctx, d.reconciler.Client, volsyncClusters, d.log)

--- a/controllers/volsync/deploy_volsync.go
+++ b/controllers/volsync/deploy_volsync.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2022 The RamenDR authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volsync
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	ManagedClusterAddOnKind    string = "ManagedClusterAddOn"
+	ManagedClusterAddOnGroup   string = "addon.open-cluster-management.io"
+	ManagedClusterAddOnVersion string = "v1alpha1"
+
+	VolsyncManagedClusterAddOnName string = "volsync" // Needs to have this name
+)
+
+//
+// Function to deploy Volsync from ACM to managed cluster via a ManagedClusterAddOn
+//
+// Calling this function requires a clusterrole that can create/update ManagedClusterAddOns
+//
+// Should be called from the Hub
+func DeployVolSyncToClusters(ctx context.Context, k8sClient client.Client,
+	destClusters []string, log logr.Logger,
+) error {
+	for _, managedCluster := range destClusters {
+		err := reconcileVolSyncManagedClusterAddOn(ctx, k8sClient, managedCluster,
+			log.WithValues("managedCluster", managedCluster))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func reconcileVolSyncManagedClusterAddOn(ctx context.Context, k8sClient client.Client,
+	managedCluster string, log logr.Logger) error {
+	log.Info("Reconciling VolSync ManagedClusterAddOn")
+
+	// Using unstructured to avoid needing to require ManagedClusterAddOn in client scheme
+	vsMCAO := &unstructured.Unstructured{}
+	vsMCAO.Object = map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name":      VolsyncManagedClusterAddOnName,
+			"namespace": managedCluster, // Needs to be deployed to managedcluster ns on hub
+		},
+	}
+	vsMCAO.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   ManagedClusterAddOnGroup,
+		Version: ManagedClusterAddOnVersion,
+		Kind:    ManagedClusterAddOnKind,
+	})
+
+	op, err := ctrlutil.CreateOrUpdate(ctx, k8sClient, vsMCAO, func() error {
+		// Do not update the ManagedClusterAddOn if it already exists - let users update settings if required
+		creationTimeStamp := vsMCAO.GetCreationTimestamp()
+		if creationTimeStamp.IsZero() {
+			// Create with empty spec - no spec settings required
+			vsMCAO.Object["spec"] = map[string]interface{}{}
+		}
+
+		return nil
+	})
+	if err != nil {
+		log.Error(err, "error creating or updating VolSync ManagedClusterAddOn")
+
+		return fmt.Errorf("error creating or updating VolSync ManagedClusterAddOn (%w)", err)
+	}
+
+	log.Info("VolSync ManagedClusterAddOn createOrUpdate Complete", "op", op)
+
+	return nil
+}

--- a/controllers/volsync/deploy_volsync_test.go
+++ b/controllers/volsync/deploy_volsync_test.go
@@ -1,0 +1,147 @@
+package volsync_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ramendr/ramen/controllers/volsync"
+)
+
+var _ = Describe("Deploy VolSync via ManagedClusterAddOn to managed clusters", func() {
+	var testManagedClusterNamespace1 *corev1.Namespace
+	var testManagedClusterName1 string
+
+	var testManagedClusterNamespace2 *corev1.Namespace
+	var testManagedClusterName2 string
+
+	BeforeEach(func() {
+		// Create namespaces for test - will be for the "managedclusters"
+		testManagedClusterNamespace1 = createManagedClusterNamespace()
+		testManagedClusterName1 = testManagedClusterNamespace1.GetName()
+
+		testManagedClusterNamespace2 = createManagedClusterNamespace()
+		testManagedClusterName2 = testManagedClusterNamespace2.GetName()
+	})
+
+	AfterEach(func() {
+		// All resources are namespaced, so this should clean it all up
+		Expect(k8sClient.Delete(ctx, testManagedClusterNamespace1)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, testManagedClusterNamespace2)).To(Succeed())
+	})
+
+	Context("When calling DeployVolSyncToClusters", func() {
+		var cluster1ManagedClusterAddOn *unstructured.Unstructured
+		var cluster2ManagedClusterAddOn *unstructured.Unstructured
+
+		var destClusters []string
+		BeforeEach(func() {
+			destClusters := []string{
+				testManagedClusterName1,
+				testManagedClusterName2,
+			}
+
+			Expect(volsync.DeployVolSyncToClusters(ctx, k8sClient, destClusters, logger)).To(Succeed())
+
+			cluster1ManagedClusterAddOn = getVolSyncManagedClusterAddon(testManagedClusterName1)
+			cluster2ManagedClusterAddOn = getVolSyncManagedClusterAddon(testManagedClusterName2)
+		})
+
+		It("Should create a volsync ManagedClusterAddOn for each managed cluster", func() {
+			// Should be an addon for each in the managedcluster namespace with name "volsync"
+			Expect(cluster1ManagedClusterAddOn.GetName()).To(Equal(volsync.VolsyncManagedClusterAddOnName))
+			Expect(cluster1ManagedClusterAddOn.Object["spec"]).To(Equal(map[string]interface{}{}))
+
+			Expect(cluster2ManagedClusterAddOn.GetName()).To(Equal(volsync.VolsyncManagedClusterAddOnName))
+			Expect(cluster2ManagedClusterAddOn.Object["spec"]).To(Equal(map[string]interface{}{}))
+		})
+
+		Context("When a managedclusteraddon for volsync already exists", func() {
+			// Outer beforeEach will have created a volsync managedcluster addon for each cluster
+			// Now modify them and run DeployVolSyncToClusters() again
+			BeforeEach(func() {
+				cluster1ManagedClusterAddOn.SetAnnotations(map[string]string{
+					"favorite-icecream": "chocolate",
+				})
+				Expect(k8sClient.Update(ctx, cluster1ManagedClusterAddOn)).To(Succeed())
+
+				cluster2ManagedClusterAddOn.SetAnnotations(map[string]string{
+					"favorite-icecream": "mango",
+					"favorite-color":    "yellow",
+				})
+				Expect(k8sClient.Update(ctx, cluster2ManagedClusterAddOn)).To(Succeed())
+
+				// Make sure the cache picks up the annotation updates
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster1ManagedClusterAddOn),
+						cluster1ManagedClusterAddOn)
+					if err != nil {
+						return false
+					}
+
+					err2 := k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster2ManagedClusterAddOn),
+						cluster2ManagedClusterAddOn)
+					if err2 != nil {
+						return false
+					}
+
+					return len(cluster1ManagedClusterAddOn.GetAnnotations()) == 1 &&
+						len(cluster1ManagedClusterAddOn.GetAnnotations()) == 2
+				})
+			})
+
+			It("Should not modify the volsync ManagedClusterAddOns", func() {
+				Expect(volsync.DeployVolSyncToClusters(ctx, k8sClient, destClusters, logger)).To(Succeed())
+
+				cluster1McaoReloaded := getVolSyncManagedClusterAddon(testManagedClusterName1)
+				Expect(cluster1McaoReloaded.Object["spec"]).To(Equal(map[string]interface{}{}))
+				Expect(len(cluster1McaoReloaded.GetAnnotations())).To(Equal(1))
+
+				cluster2McaoReloaded := getVolSyncManagedClusterAddon(testManagedClusterName2)
+				Expect(cluster2McaoReloaded.Object["spec"]).To(Equal(map[string]interface{}{}))
+				Expect(len(cluster2McaoReloaded.GetAnnotations())).To(Equal(2))
+			})
+		})
+	})
+})
+
+func getVolSyncManagedClusterAddon(managedClusterName string) *unstructured.Unstructured {
+	mcAddon := &unstructured.Unstructured{}
+
+	mcAddon.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   volsync.ManagedClusterAddOnGroup,
+		Version: volsync.ManagedClusterAddOnVersion,
+		Kind:    volsync.ManagedClusterAddOnKind,
+	})
+
+	Eventually(func() error {
+		return k8sClient.Get(ctx, client.ObjectKey{
+			Namespace: managedClusterName,
+			Name:      volsync.VolsyncManagedClusterAddOnName,
+		}, mcAddon)
+	}, maxWait, interval).Should(Succeed())
+
+	return mcAddon
+}
+
+func createManagedClusterNamespace() *corev1.Namespace {
+	// Create namespace for test - ns will be for the "managedcluster"
+	testNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-mgd-cluster-ns-",
+		},
+	}
+	Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
+	Expect(testNamespace.GetName()).NotTo(BeEmpty())
+
+	Eventually(func() error {
+		return k8sClient.Get(ctx, client.ObjectKeyFromObject(testNamespace), testNamespace)
+	}, maxWait, interval).Should(Succeed())
+
+	return testNamespace
+}

--- a/controllers/volsync/secret_propagator.go
+++ b/controllers/volsync/secret_propagator.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The RamenDR authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package volsync
 
 import (

--- a/controllers/volsync/secretgen.go
+++ b/controllers/volsync/secretgen.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The RamenDR authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package volsync
 
 import (

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -867,6 +867,9 @@ func (v *VRGInstance) updateVRGStatus(updateConditions bool) error {
 
 	v.updateStatusState()
 
+	v.instance.Status.VolSyncPVCCount = len(v.volSyncPVCs)
+	v.instance.Status.VolRepPVCCount = len(v.volRepPVCs)
+
 	v.instance.Status.ObservedGeneration = v.instance.Generation
 
 	if !reflect.DeepEqual(v.savedInstanceStatus, v.instance.Status) {

--- a/hack/test/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
+++ b/hack/test/0000_01_addon.open-cluster-management.io_managedclusteraddons.crd.yaml
@@ -1,0 +1,194 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: managedclusteraddons.addon.open-cluster-management.io
+spec:
+  group: addon.open-cluster-management.io
+  names:
+    kind: ManagedClusterAddOn
+    listKind: ManagedClusterAddOnList
+    plural: managedclusteraddons
+    singular: managedclusteraddon
+  scope: Namespaced
+  preserveUnknownFields: false
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Available")].status
+          name: Available
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Degraded")].status
+          name: Degraded
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Progressing")].status
+          name: Progressing
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ManagedClusterAddOn is the Custom Resource object which holds the current state of an add-on. This object is used by add-on operators to convey their state. This resource should be created in the ManagedCluster namespace.
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds configuration that could apply to any operator.
+              type: object
+              properties:
+                installNamespace:
+                  description: installNamespace is the namespace on the managed cluster to install the addon agent. If it is not set, open-cluster-management-agent-addon namespace is used to install the addon agent.
+                  type: string
+                  maxLength: 63
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+            status:
+              description: status holds the information about the state of an operator.  It is consistent with status information across the Kubernetes ecosystem.
+              type: object
+              properties:
+                addOnConfiguration:
+                  description: addOnConfiguration is a reference to configuration information for the add-on. This resource is use to locate the configuration resource for the add-on.
+                  type: object
+                  properties:
+                    crName:
+                      description: crName is the name of the CR used to configure instances of the managed add-on. This field should be configured if add-on CR have a consistent name across the all of the ManagedCluster instaces.
+                      type: string
+                    crdName:
+                      description: crdName is the name of the CRD used to configure instances of the managed add-on. This field should be configured if the add-on have a CRD that controls the configuration of the add-on.
+                      type: string
+                    lastObservedGeneration:
+                      description: lastObservedGeneration is the observed generation of the custom resource for the configuration of the addon.
+                      type: integer
+                      format: int64
+                addOnMeta:
+                  description: addOnMeta is a reference to the metadata information for the add-on. This should be same as the addOnMeta for the corresponding ClusterManagementAddOn resource.
+                  type: object
+                  properties:
+                    description:
+                      description: description represents the detailed description of the add-on.
+                      type: string
+                    displayName:
+                      description: displayName represents the name of add-on that will be displayed.
+                      type: string
+                conditions:
+                  description: conditions describe the state of the managed and monitored components for the operator.
+                  type: array
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                    type: object
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        type: string
+                        format: date-time
+                      message:
+                        description: message is a human readable message indicating details about the transition. This may be an empty string.
+                        type: string
+                        maxLength: 32768
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        type: integer
+                        format: int64
+                        minimum: 0
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                        type: string
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        type: string
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                healthCheck:
+                  description: healthCheck indicates how to check the healthiness status of the current addon. It should be set by each addon implementation, by default, the lease mode will be used.
+                  type: object
+                  properties:
+                    mode:
+                      description: mode indicates which mode will be used to check the healthiness status of the addon.
+                      type: string
+                      default: Lease
+                      enum:
+                        - Lease
+                        - Customized
+                registrations:
+                  description: registrations is the conifigurations for the addon agent to register to hub. It should be set by each addon controller on hub to define how the addon agent on managedcluster is registered. With the registration defined, The addon agent can access to kube apiserver with kube style API or other endpoints on hub cluster with client certificate authentication. A csr will be created per registration configuration. If more than one registrationConfig is defined, a csr will be created for each registration configuration. It is not allowed that multiple registrationConfigs have the same signer name. After the csr is approved on the hub cluster, the klusterlet agent will create a secret in the installNamespace for the registrationConfig. If the signerName is "kubernetes.io/kube-apiserver-client", the secret name will be "{addon name}-hub-kubeconfig" whose contents includes key/cert and kubeconfig. Otherwise, the secret name will be "{addon name}-{signer name}-client-cert" whose contents includes key/cert.
+                  type: array
+                  items:
+                    description: RegistrationConfig defines the configuration of the addon agent to register to hub. The Klusterlet agent will create a csr for the addon agent with the registrationConfig.
+                    type: object
+                    properties:
+                      signerName:
+                        description: signerName is the name of signer that addon agent will use to create csr.
+                        type: string
+                        maxLength: 571
+                        minLength: 5
+                      subject:
+                        description: "subject is the user subject of the addon agent to be registered to the hub. If it is not set, the addon agent will have the default subject \"subject\": { \t\"user\": \"system:open-cluster-management:addon:{addonName}:{clusterName}:{agentName}\", \t\"groups: [\"system:open-cluster-management:addon\", \"system:open-cluster-management:addon:{addonName}\", \"system:authenticated\"] }"
+                        type: object
+                        properties:
+                          groups:
+                            description: groups is the user group of the addon agent.
+                            type: array
+                            items:
+                              type: string
+                          organizationUnit:
+                            description: organizationUnit is the ou of the addon agent
+                            type: array
+                            items:
+                              type: string
+                          user:
+                            description: user is the user name of the addon agent.
+                            type: string
+                relatedObjects:
+                  description: 'relatedObjects is a list of objects that are "interesting" or related to this operator. Common uses are: 1. the detailed resource driving the operator 2. operator namespaces 3. operand namespaces 4. related ClusterManagementAddon resource'
+                  type: array
+                  items:
+                    description: ObjectReference contains enough information to let you inspect or modify the referred object.
+                    type: object
+                    required:
+                      - group
+                      - name
+                      - resource
+                    properties:
+                      group:
+                        description: group of the referent.
+                        type: string
+                      name:
+                        description: name of the referent.
+                        type: string
+                      namespace:
+                        description: namespace of the referent.
+                        type: string
+                      resource:
+                        description: resource of the referent.
+                        type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
will deploy volsync from the ACM hub by creating the appropriate volsync managedclusteraddon for the managed cluster that needs volsync.  will only deploy the managedclusteraddon if it doesn't already exist (allowing users to customize their own if they've already done this).