### PR TITLE
Cephfs readonly pvc for volsync

### DIFF
--- a/api/v1alpha1/ramenconfig_types.go
+++ b/api/v1alpha1/ramenconfig_types.go
@@ -137,6 +137,11 @@ type RamenConfig struct {
 	VolSync struct {
 		// Disabled is used to disable VolSync usage in Ramen. Defaults to false.
 		Disabled bool `json:"disabled,omitempty"`
+
+		// Default cephFS CSIDriver name used to enable ROX volumes. If this name matches
+		// the PVC's storageclass provisioner, a new storageclass will be created and the
+		// name of it passed to VolSync alongside the readOnly flag access mode.
+		CephFSCSIDriverName string `json:"cephFSCSIDriverName,omitempty"`
 	} `json:"volSync,omitempty"`
 }
 

--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -96,8 +96,10 @@ rules:
   resources:
   - storageclasses
   verbs:
+  - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - storage.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -312,8 +312,10 @@ rules:
   resources:
   - storageclasses
   verbs:
+  - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - storage.k8s.io

--- a/controllers/ramenconfig.go
+++ b/controllers/ramenconfig.go
@@ -52,6 +52,7 @@ const (
 	drClusterOperatorChannelNameDefault               = "alpha"
 	drClusterOperatorCatalogSourceNameDefault         = "ramen-catalog"
 	drClusterOperatorClusterServiceVersionNameDefault = drClusterOperatorPackageNameDefault + ".v0.0.1"
+	DefaultCephFSCSIDriverName                        = "openshift-storage.cephfs.csi.ceph.com"
 )
 
 // FIXME
@@ -299,4 +300,12 @@ func drClusterOperatorClusterServiceVersionNameOrDefault(ramenConfig *ramendrv1a
 	}
 
 	return ramenConfig.DrClusterOperator.ClusterServiceVersionName
+}
+
+func cephFSCSIDriverNameOrDefault(ramenConfig *ramendrv1alpha1.RamenConfig) string {
+	if ramenConfig.VolSync.CephFSCSIDriverName == "" {
+		return DefaultCephFSCSIDriverName
+	}
+
+	return ramenConfig.VolSync.CephFSCSIDriverName
 }

--- a/controllers/volsync/vshandler.go
+++ b/controllers/volsync/vshandler.go
@@ -70,23 +70,25 @@ const (
 )
 
 type VSHandler struct {
-	ctx                     context.Context
-	client                  client.Client
-	log                     logr.Logger
-	owner                   metav1.Object
-	asyncSpec               *ramendrv1alpha1.VRGAsyncSpec
-	volumeSnapshotClassList *snapv1.VolumeSnapshotClassList
+	ctx                        context.Context
+	client                     client.Client
+	log                        logr.Logger
+	owner                      metav1.Object
+	asyncSpec                  *ramendrv1alpha1.VRGAsyncSpec
+	defaultCephFSCSIDriverName string
+	volumeSnapshotClassList    *snapv1.VolumeSnapshotClassList
 }
 
 func NewVSHandler(ctx context.Context, client client.Client, log logr.Logger, owner metav1.Object,
-	asyncSpec *ramendrv1alpha1.VRGAsyncSpec) *VSHandler {
+	asyncSpec *ramendrv1alpha1.VRGAsyncSpec, defaultCephFSCSIDriverName string) *VSHandler {
 	return &VSHandler{
-		ctx:                     ctx,
-		client:                  client,
-		log:                     log,
-		owner:                   owner,
-		asyncSpec:               asyncSpec,
-		volumeSnapshotClassList: nil, // Do not initialize until we need it
+		ctx:                        ctx,
+		client:                     client,
+		log:                        log,
+		owner:                      owner,
+		asyncSpec:                  asyncSpec,
+		defaultCephFSCSIDriverName: defaultCephFSCSIDriverName,
+		volumeSnapshotClassList:    nil, // Do not initialize until we need it
 	}
 }
 
@@ -1183,7 +1185,7 @@ func (v *VSHandler) getRsyncServiceType() *corev1.ServiceType {
 // above.
 func (v *VSHandler) ModifyRSSpecForCephFS(rsSpec *ramendrv1alpha1.VolSyncReplicationSourceSpec,
 	storageClass *storagev1.StorageClass) error {
-	if storageClass.Provisioner != "openshift-storage.cephfs.csi.ceph.com" { // TODO: confirm this is correct
+	if storageClass.Provisioner != v.defaultCephFSCSIDriverName {
 		return nil // No workaround required
 	}
 

--- a/controllers/volsync/vshandler.go
+++ b/controllers/volsync/vshandler.go
@@ -383,7 +383,18 @@ func (v *VSHandler) createOrUpdateRS(rsSpec ramendrv1alpha1.VolSyncReplicationSo
 ) {
 	l := v.log.WithValues("rsSpec", rsSpec, "runFinalSync", runFinalSync)
 
-	volumeSnapshotClassName, err := v.GetVolumeSnapshotClassFromPVCStorageClass(rsSpec.ProtectedPVC.StorageClassName)
+	storageClass, err := v.getStorageClass(rsSpec.ProtectedPVC.StorageClassName)
+	if err != nil {
+		return nil, err
+	}
+
+	volumeSnapshotClassName, err := v.getVolumeSnapshotClassFromPVCStorageClass(storageClass)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fix for CephFS (replication source only) - may need different storageclass and access modes
+	err = v.ModifyRSSpecForCephFS(&rsSpec, storageClass)
 	if err != nil {
 		return nil, err
 	}
@@ -439,7 +450,8 @@ func (v *VSHandler) createOrUpdateRS(rsSpec ramendrv1alpha1.VolSyncReplicationSo
 				// storage classes that support it in the future
 				CopyMethod:              volsyncv1alpha1.CopyMethodSnapshot,
 				VolumeSnapshotClassName: &volumeSnapshotClassName,
-				// Not setting storageclassname - volsync can find that from the sourcePVC
+				StorageClassName:        rsSpec.ProtectedPVC.StorageClassName,
+				AccessModes:             rsSpec.ProtectedPVC.AccessModes,
 			},
 		}
 
@@ -1157,21 +1169,76 @@ func (v *VSHandler) getRsyncServiceType() *corev1.ServiceType {
 	return &DefaultRsyncServiceType
 }
 
-func (v *VSHandler) GetVolumeSnapshotClassFromPVCStorageClass(storageClassName *string) (string, error) {
-	if storageClassName == nil || *storageClassName == "" {
-		err := fmt.Errorf("no storageClassName given, cannot proceed")
-		v.log.Error(err, "Failed to get StorageClass")
+// Workaround for cephfs issue: FIXME:
+// For CephFS only, there is a problem where restoring a PVC from snapshot can be very slow when there are a lot of
+// files - on every replication cycle we need to create a PVC from snapshot in order to get a point-in-time copy of
+// the source PVC to sync with the replicationdestination.
+// This workaround follows the instructions here:
+// https://github.com/ceph/ceph-csi/blob/devel/docs/cephfs-snapshot-backed-volumes.md
+//
+// Steps:
+// 1. If the storageclass detected is cephfs, create a new storageclass with backingSnapshot: "true" parameter
+// (or reuse if it already exists).  If not cephfs, return and do not modify rsSpec.
+// 2. Modify rsSpec to use the new storageclass and also update AccessModes to 'ReadOnlyMany' as per the instructions
+// above.
+func (v *VSHandler) ModifyRSSpecForCephFS(rsSpec *ramendrv1alpha1.VolSyncReplicationSourceSpec,
+	storageClass *storagev1.StorageClass) error {
+	if storageClass.Provisioner != "openshift-storage.cephfs.csi.ceph.com" { // TODO: confirm this is correct
+		return nil // No workaround required
+	}
 
+	v.log.Info("CephFS storageclass detected on source PVC, creating replicationsource with read-only "+
+		" PVC from snapshot", "storageClassName", storageClass.GetName())
+
+	// Create/update readOnlyPVCStorageClass
+	readOnlyPVCStorageClass := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: storageClass.GetName() + "-vrg",
+		},
+	}
+
+	op, err := ctrlutil.CreateOrUpdate(v.ctx, v.client, readOnlyPVCStorageClass, func() error {
+		// Do not update the storageclass if it already exists - Provisioner and Parameters are immutable anyway
+		if readOnlyPVCStorageClass.CreationTimestamp.IsZero() {
+			readOnlyPVCStorageClass.Provisioner = storageClass.Provisioner
+
+			// Copy other parameters from the original storage class
+			readOnlyPVCStorageClass.Parameters = map[string]string{}
+			for k, v := range storageClass.Parameters {
+				readOnlyPVCStorageClass.Parameters[k] = v
+			}
+
+			// Set backingSnapshot parameter to true
+			readOnlyPVCStorageClass.Parameters["backingSnapshot"] = "true"
+
+			// Note - not copying volumebindingmode or reclaim policy from the source storageclass will leave defaults
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	v.log.Info("StorageClass for readonly cephfs PVC createOrUpdate Complete", "op", op)
+
+	// Update the rsSpec with access modes and the special storageclass
+	rsSpec.ProtectedPVC.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany}
+	rsSpec.ProtectedPVC.StorageClassName = &readOnlyPVCStorageClass.Name
+
+	return nil
+}
+
+func (v *VSHandler) GetVolumeSnapshotClassFromPVCStorageClass(storageClassName *string) (string, error) {
+	storageClass, err := v.getStorageClass(storageClassName)
+	if err != nil {
 		return "", err
 	}
 
-	storageClass := &storagev1.StorageClass{}
-	if err := v.client.Get(v.ctx, types.NamespacedName{Name: *storageClassName}, storageClass); err != nil {
-		v.log.Error(err, "Failed to get StorageClass", "name", storageClassName)
+	return v.getVolumeSnapshotClassFromPVCStorageClass(storageClass)
+}
 
-		return "", fmt.Errorf("error getting storage class (%w)", err)
-	}
-
+func (v *VSHandler) getVolumeSnapshotClassFromPVCStorageClass(storageClass *storagev1.StorageClass) (string, error) {
 	volumeSnapshotClasses, err := v.GetVolumeSnapshotClasses()
 	if err != nil {
 		return "", err
@@ -1198,6 +1265,24 @@ func (v *VSHandler) GetVolumeSnapshotClassFromPVCStorageClass(storageClassName *
 	}
 
 	return matchedVolumeSnapshotClassName, nil
+}
+
+func (v *VSHandler) getStorageClass(storageClassName *string) (*storagev1.StorageClass, error) {
+	if storageClassName == nil || *storageClassName == "" {
+		err := fmt.Errorf("no storageClassName given, cannot proceed")
+		v.log.Error(err, "Failed to get StorageClass")
+
+		return nil, err
+	}
+
+	storageClass := &storagev1.StorageClass{}
+	if err := v.client.Get(v.ctx, types.NamespacedName{Name: *storageClassName}, storageClass); err != nil {
+		v.log.Error(err, "Failed to get StorageClass", "name", storageClassName)
+
+		return nil, fmt.Errorf("error getting storage class (%w)", err)
+	}
+
+	return storageClass, nil
 }
 
 func isDefaultVolumeSnapshotClass(volumeSnapshotClass snapv1.VolumeSnapshotClass) bool {

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -82,7 +82,7 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 			var vsHandler *volsync.VSHandler
 
 			BeforeEach(func() {
-				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec)
+				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec, "none")
 			})
 
 			It("GetVolumeSnapshotClasses() should find all volume snapshot classes", func() {
@@ -111,7 +111,7 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 					},
 				}
 
-				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec)
+				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec, "none")
 			})
 
 			It("GetVolumeSnapshotClasses() should find matching volume snapshot classes", func() {
@@ -154,7 +154,7 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 					},
 				}
 
-				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec)
+				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec, "none")
 			})
 
 			It("GetVolumeSnapshotClasses() should find matching volume snapshot classes", func() {
@@ -210,7 +210,8 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 			}
 
 			// Initialize a vshandler
-			vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec)
+			vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec,
+				"openshift-storage.cephfs.csi.ceph.com")
 		})
 
 		JustBeforeEach(func() {
@@ -425,12 +426,13 @@ var _ = Describe("VolSync Handler", func() {
 		Expect(ownerCm.GetName()).NotTo(BeEmpty())
 		owner = ownerCm
 
-		vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, owner, asyncSpec)
+		vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, owner, asyncSpec, "none")
 	})
 
 	AfterEach(func() {
 		// All resources are namespaced, so this should clean it all up
-		Expect(k8sClient.Delete(ctx, testNamespace)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, testNamespace)).To(Succeed(),
+			"none")
 	})
 
 	Describe("Reconcile ReplicationDestination", func() {
@@ -1396,7 +1398,7 @@ var _ = Describe("VolSync Handler", func() {
 			}
 			Expect(k8sClient.Create(ctx, otherOwnerCm)).To(Succeed())
 			Expect(otherOwnerCm.GetName()).NotTo(BeEmpty())
-			otherVSHandler := volsync.NewVSHandler(ctx, k8sClient, logger, otherOwnerCm, asyncSpec)
+			otherVSHandler := volsync.NewVSHandler(ctx, k8sClient, logger, otherOwnerCm, asyncSpec, "none")
 
 			for i := 0; i < 2; i++ {
 				otherOwnerRdSpec := ramendrv1alpha1.VolSyncReplicationDestinationSpec{
@@ -1585,7 +1587,7 @@ var _ = Describe("VolSync Handler", func() {
 			}
 			Expect(k8sClient.Create(ctx, otherOwnerCm)).To(Succeed())
 			Expect(otherOwnerCm.GetName()).NotTo(BeEmpty())
-			otherVSHandler := volsync.NewVSHandler(ctx, k8sClient, logger, otherOwnerCm, asyncSpec)
+			otherVSHandler := volsync.NewVSHandler(ctx, k8sClient, logger, otherOwnerCm, asyncSpec, "none")
 
 			for i := 0; i < 2; i++ {
 				otherOwnerRsSpec := ramendrv1alpha1.VolSyncReplicationSourceSpec{

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -254,7 +254,7 @@ func filterPVC(mgr manager.Manager, pvc *corev1.PersistentVolumeClaim, log logr.
 // +kubebuilder:rbac:groups=ramendr.openshift.io,resources=volumereplicationgroups/finalizers,verbs=update
 // +kubebuilder:rbac:groups=replication.storage.openshift.io,resources=volumereplications,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=replication.storage.openshift.io,resources=volumereplicationclasses,verbs=get;list;watch
-// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=volumeattachments,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -309,7 +309,13 @@ func (r *VolumeReplicationGroupReconciler) Reconcile(ctx context.Context, req ct
 			req.NamespacedName, err)
 	}
 
-	v.volSyncHandler = volsync.NewVSHandler(ctx, r.Client, log, v.instance, v.instance.Spec.Async)
+	_, ramenConfig, err := ConfigMapGet(ctx, r.APIReader)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get Ramen configmap: %w", err)
+	}
+
+	v.volSyncHandler = volsync.NewVSHandler(ctx, r.Client, log, v.instance,
+		v.instance.Spec.Async, cephFSCSIDriverNameOrDefault(ramenConfig))
 
 	if v.instance.Status.ProtectedPVCs == nil {
 		v.instance.Status.ProtectedPVCs = []ramendrv1alpha1.ProtectedPVC{}


### PR DESCRIPTION
Implements workaround for cephfs issue where pvc from snapshot can be very slow when the pvc has many files.

- will create a custom storageclass required for the workaround if it does not exist