### PR TITLE
vrg: Set each status condition once per reconcile

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -127,24 +127,32 @@ func setVRGInitialCondition(conditions *[]metav1.Condition, observedGeneration i
 
 // sets conditions when VRG as Secondary is replicating the data with Primary.
 func setVRGDataReplicatingCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
-	setStatusCondition(conditions, metav1.Condition{
+	setStatusCondition(conditions, *newVRGDataReplicatingCondition(observedGeneration, message))
+}
+
+func newVRGDataReplicatingCondition(observedGeneration int64, message string) *metav1.Condition {
+	return &metav1.Condition{
 		Type:               VRGConditionTypeDataReady,
 		Reason:             VRGConditionReasonReplicating,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionTrue,
 		Message:            message,
-	})
+	}
 }
 
 // sets conditions when VRG as Secondary has completed its data sync with Primary.
 func setVRGDataReplicatedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
-	setStatusCondition(conditions, metav1.Condition{
+	setStatusCondition(conditions, *newVRGDataReplicatedCondition(observedGeneration, message))
+}
+
+func newVRGDataReplicatedCondition(observedGeneration int64, message string) *metav1.Condition {
+	return &metav1.Condition{
 		Type:               VRGConditionTypeDataReady,
 		Reason:             VRGConditionReasonReplicated,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionTrue,
 		Message:            message,
-	})
+	}
 }
 
 // sets conditions when VRG DataProtected is correct which means
@@ -159,69 +167,93 @@ func setVRGAsDataProtectedCondition(conditions *[]metav1.Condition, observedGene
 	message string) {
 	// This means, for this VRG (as secondary) data sync has happened
 	// with a remote peer. Hence DataProtected is true
-	setStatusCondition(conditions, metav1.Condition{
+	setStatusCondition(conditions, *newVRGAsDataProtectedCondition(observedGeneration, message))
+}
+
+func newVRGAsDataProtectedCondition(observedGeneration int64, message string) *metav1.Condition {
+	return &metav1.Condition{
 		Type:               VRGConditionTypeDataProtected,
 		Reason:             VRGConditionReasonDataProtected,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionTrue,
 		Message:            message,
-	})
+	}
 }
 
 func setVRGAsDataNotProtectedCondition(conditions *[]metav1.Condition, observedGeneration int64,
 	message string) {
-	setStatusCondition(conditions, metav1.Condition{
+	setStatusCondition(conditions, *newVRGAsDataNotProtectedCondition(observedGeneration, message))
+}
+
+func newVRGAsDataNotProtectedCondition(observedGeneration int64, message string) *metav1.Condition {
+	return &metav1.Condition{
 		Type:               VRGConditionTypeDataProtected,
 		Reason:             VRGConditionReasonError,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
 		Message:            message,
-	})
+	}
 }
 
 func setVRGDataProtectionProgressCondition(conditions *[]metav1.Condition, observedGeneration int64,
 	message string) {
-	setStatusCondition(conditions, metav1.Condition{
+	setStatusCondition(conditions, *newVRGDataProtectionProgressCondition(observedGeneration, message))
+}
+
+func newVRGDataProtectionProgressCondition(observedGeneration int64, message string) *metav1.Condition {
+	return &metav1.Condition{
 		Type:               VRGConditionTypeDataProtected,
 		Reason:             VRGConditionReasonReplicating,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
 		Message:            message,
-	})
+	}
 }
 
 // sets conditions when Primary VRG data replication is established
 func setVRGAsPrimaryReadyCondition(conditions *[]metav1.Condition, observedGeneration int64,
 	message string) {
-	setStatusCondition(conditions, metav1.Condition{
+	setStatusCondition(conditions, *newVRGAsPrimaryReadyCondition(observedGeneration, message))
+}
+
+func newVRGAsPrimaryReadyCondition(observedGeneration int64, message string) *metav1.Condition {
+	return &metav1.Condition{
 		Type:               VRGConditionTypeDataReady,
 		Reason:             VRGConditionReasonReady,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionTrue,
 		Message:            message,
-	})
+	}
 }
 
 // sets conditions when VRG data is progressing
 func setVRGDataProgressingCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
-	setStatusCondition(conditions, metav1.Condition{
+	setStatusCondition(conditions, *newVRGDataProgressingCondition(observedGeneration, message))
+}
+
+func newVRGDataProgressingCondition(observedGeneration int64, message string) *metav1.Condition {
+	return &metav1.Condition{
 		Type:               VRGConditionTypeDataReady,
 		Reason:             VRGConditionReasonProgressing,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
 		Message:            message,
-	})
+	}
 }
 
 // sets conditions when VRG sees failures in data sync
 func setVRGDataErrorCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
-	setStatusCondition(conditions, metav1.Condition{
+	setStatusCondition(conditions, *newVRGDataErrorCondition(observedGeneration, message))
+}
+
+func newVRGDataErrorCondition(observedGeneration int64, message string) *metav1.Condition {
+	return &metav1.Condition{
 		Type:               VRGConditionTypeDataReady,
 		Reason:             VRGConditionReasonError,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
 		Message:            message,
-	})
+	}
 }
 
 // sets conditions when VolumeReplicationGroup is unable
@@ -262,35 +294,47 @@ func setVRGClusterDataErrorCondition(conditions *[]metav1.Condition, observedGen
 
 // sets conditions when PV cluster data is protected
 func setVRGClusterDataProtectedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
-	setStatusCondition(conditions, metav1.Condition{
+	setStatusCondition(conditions, *newVRGClusterDataProtectedCondition(observedGeneration, message))
+}
+
+func newVRGClusterDataProtectedCondition(observedGeneration int64, message string) *metav1.Condition {
+	return &metav1.Condition{
 		Type:               VRGConditionTypeClusterDataProtected,
 		Reason:             VRGConditionReasonUploaded,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionTrue,
 		Message:            message,
-	})
+	}
 }
 
 // sets conditions when PV cluster data is being protected
 func setVRGClusterDataProtectingCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
-	setStatusCondition(conditions, metav1.Condition{
+	setStatusCondition(conditions, *newVRGClusterDataProtectingCondition(observedGeneration, message))
+}
+
+func newVRGClusterDataProtectingCondition(observedGeneration int64, message string) *metav1.Condition {
+	return &metav1.Condition{
 		Type:               VRGConditionTypeClusterDataProtected,
 		Reason:             VRGConditionReasonUploading,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
 		Message:            message,
-	})
+	}
 }
 
 // sets conditions when PV cluster data failed to be protected
 func setVRGClusterDataUnprotectedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
-	setStatusCondition(conditions, metav1.Condition{
+	setStatusCondition(conditions, *newVRGClusterDataUnprotectedCondition(observedGeneration, message))
+}
+
+func newVRGClusterDataUnprotectedCondition(observedGeneration int64, message string) *metav1.Condition {
+	return &metav1.Condition{
 		Type:               VRGConditionTypeClusterDataProtected,
 		Reason:             VRGConditionReasonUploadError,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
 		Message:            message,
-	})
+	}
 }
 
 func setStatusConditionIfNotFound(existingConditions *[]metav1.Condition, newCondition metav1.Condition) {

--- a/controllers/util/conditions.go
+++ b/controllers/util/conditions.go
@@ -98,3 +98,29 @@ func ConditionAppend(
 		},
 	)
 }
+
+func ConditionSetFirstFalseOrLastTrue(
+	conditionSet func(*[]metav1.Condition, metav1.Condition),
+	conditions *[]metav1.Condition,
+	subConditions ...*metav1.Condition,
+) {
+	trueSubConditions := make([]*metav1.Condition, 0, len(subConditions))
+
+	for _, subCondition := range subConditions {
+		if subCondition == nil {
+			continue
+		}
+
+		if subCondition.Status == metav1.ConditionFalse {
+			conditionSet(conditions, *subCondition)
+
+			return
+		}
+
+		trueSubConditions = append(trueSubConditions, subCondition)
+	}
+
+	if len(trueSubConditions) > 0 {
+		conditionSet(conditions, *trueSubConditions[len(trueSubConditions)-1])
+	}
+}

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -948,22 +948,20 @@ func getStatusStateFromSpecState(state ramendrv1alpha1.ReplicationState) ramendr
 // The VRGConditionTypeClusterDataReady summary condition is not a PVC level
 // condition and is updated elsewhere.
 func (v *VRGInstance) updateVRGConditions() {
-	v.updateVRGDataReadyCondition()
-	v.updateVRGDataProtectedCondition()
-	v.updateVRGClusterDataProtectedCondition()
-}
-
-func (v *VRGInstance) updateVRGDataReadyCondition() {
 	rmnutil.ConditionSetFirstFalseOrLastTrue(setStatusCondition, &v.instance.Status.Conditions,
 		v.aggregateVolSyncDataReadyCondition(),
 		v.aggregateVolRepDataReadyCondition(),
 	)
-}
 
-func (v *VRGInstance) updateVRGDataProtectedCondition() {
+	volSyncDataProtected, volSyncClusterDataProtected := v.aggregateVolSyncDataProtectedConditions()
+
 	rmnutil.ConditionSetFirstFalseOrLastTrue(setStatusCondition, &v.instance.Status.Conditions,
-		v.aggregateVolSyncDataProtectedCondition(),
+		volSyncDataProtected,
 		v.aggregateVolRepDataProtectedCondition(),
+	)
+	rmnutil.ConditionSetFirstFalseOrLastTrue(setStatusCondition, &v.instance.Status.Conditions,
+		volSyncClusterDataProtected,
+		v.aggregateVolRepClusterDataProtectedCondition(),
 	)
 }
 
@@ -982,13 +980,6 @@ func (v *VRGInstance) vrgReadyStatus() *metav1.Condition {
 	msg := "PVCs in the VolumeReplicationGroup are ready for use"
 
 	return newVRGAsPrimaryReadyCondition(v.instance.Generation, msg)
-}
-
-func (v *VRGInstance) updateVRGClusterDataProtectedCondition() {
-	rmnutil.ConditionSetFirstFalseOrLastTrue(setStatusCondition, &v.instance.Status.Conditions,
-		v.aggregateVolSyncClusterDataProtectedCondition(),
-		v.aggregateVolRepClusterDataProtectedCondition(),
-	)
 }
 
 // It might be better move the helper functions like these to a separate

--- a/controllers/vrg_volsync.go
+++ b/controllers/vrg_volsync.go
@@ -258,22 +258,18 @@ func (v *VRGInstance) aggregateVolSyncDataReadyCondition() *v1.Condition {
 	return dataReadyCondition
 }
 
-func (v *VRGInstance) aggregateVolSyncDataProtectedCondition() *v1.Condition {
-	return v.buildDataProtectedCondition()
-}
-
-func (v *VRGInstance) aggregateVolSyncClusterDataProtectedCondition() *v1.Condition {
-	// For VolSync, clusterDataProtectedCondition is the same as dataProtecedCondition - so copy it
-	dataProtectedCondition := findCondition(v.instance.Status.Conditions, VRGConditionTypeDataProtected)
+func (v *VRGInstance) aggregateVolSyncDataProtectedConditions() (*v1.Condition, *v1.Condition) {
+	// For VolSync, clusterDataProtectedCondition is the same as dataProtectedCondition - so copy it
+	dataProtectedCondition := v.buildDataProtectedCondition()
 
 	if dataProtectedCondition == nil {
-		return nil
+		return nil, nil
 	}
 
 	clusterDataProtectedCondition := dataProtectedCondition.DeepCopy()
 	clusterDataProtectedCondition.Type = VRGConditionTypeClusterDataProtected
 
-	return clusterDataProtectedCondition
+	return dataProtectedCondition, clusterDataProtectedCondition
 }
 
 //nolint:gocognit,funlen,gocyclo,cyclop


### PR DESCRIPTION
# Problem
S3 store out-of-space condition results in `vrg.status.clusterDataReady: false`, but its timestamp continues to be updated on each reconcile.  Watchers are notified and much resource is consumed despite states not changing.

1. `updateVRGClusterDataProtectedCondition` changes `clusterDataProtected` from false to true getting it from `aggregateVolSyncClusterDataProtectedCondition` which return `dataProtected: true` condition changing its type to `clusterDataProtected`
1.  `aggregateVolRepClusterDataProtectedCondition` changes `clusterDataProtected` condition from true back to false to reflect the out-of-space condition
1. `updateVRGStatus`'s `reflect.DeepEqual` call returns false because although most of the conditions fields did not change from those saved at the beginning of `Reconcile`, its timestamp did due to the internal toggling

# Proposed solution
- Update each status condition once per reconcile
  - If it is false, first found reason and message is used whether volsync's or volrep's
  - If it is true, and only volsync or only volrep is enabled, that one's reason and message is used
  - If it is true and both are volsync and volrep are enabled,
      - reason and message should encapsulate both volsync and volrep one could trump the other, e.g., data protected (6ffb9df2)
      - this pull request uses the last one's reason and message, i.e. volrep's

