### PR TITLE
vrg: Preserve status across updates

### DIFF
--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -705,15 +705,40 @@ func (v *VRGInstance) deleteVRGHandleMode() bool {
 	return v.reconcileVRsForDeletion()
 }
 
+// addFinalizer adds a finalizer to VRG, to act as deletion protection
+func (v *VRGInstance) addFinalizer(finalizer string) error {
+	if containsString(v.instance.ObjectMeta.Finalizers, finalizer) {
+		return nil
+	}
+
+	v.instance.ObjectMeta.Finalizers = append(v.instance.ObjectMeta.Finalizers, finalizer)
+	status := v.instance.Status
+
+	if err := v.reconciler.Update(v.ctx, v.instance); err != nil {
+		v.log.Error(err, "Failed to add finalizer", "finalizer", finalizer)
+
+		return fmt.Errorf("failed to add finalizer to VolumeReplicationGroup resource (%s/%s), %w",
+			v.instance.Namespace, v.instance.Name, err)
+	}
+
+	v.instance.Status = status
+
+	return nil
+}
+
 // removeFinalizer removes VRG finalizer form the resource
 func (v *VRGInstance) removeFinalizer(finalizer string) error {
 	v.instance.ObjectMeta.Finalizers = removeString(v.instance.ObjectMeta.Finalizers, finalizer)
+	status := v.instance.Status
+
 	if err := v.reconciler.Update(v.ctx, v.instance); err != nil {
 		v.log.Error(err, "Failed to remove finalizer", "finalizer", finalizer)
 
 		return fmt.Errorf("failed to remove finalizer from VolumeReplicationGroup resource (%s/%s), %w",
 			v.instance.Namespace, v.instance.Name, err)
 	}
+
+	v.instance.Status = status
 
 	return nil
 }

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -1466,21 +1466,6 @@ func (v *VRGInstance) addProtectedAnnotationForPVC(pvc *corev1.PersistentVolumeC
 	return nil
 }
 
-// addFinalizer adds a finalizer to VRG, to act as deletion protection
-func (v *VRGInstance) addFinalizer(finalizer string) error {
-	if !containsString(v.instance.ObjectMeta.Finalizers, finalizer) {
-		v.instance.ObjectMeta.Finalizers = append(v.instance.ObjectMeta.Finalizers, finalizer)
-		if err := v.reconciler.Update(v.ctx, v.instance); err != nil {
-			v.log.Error(err, "Failed to add finalizer", "finalizer", finalizer)
-
-			return fmt.Errorf("failed to add finalizer to VolumeReplicationGroup resource (%s/%s), %w",
-				v.instance.Namespace, v.instance.Name, err)
-		}
-	}
-
-	return nil
-}
-
 func (v *VRGInstance) addProtectedFinalizerToPVC(pvc *corev1.PersistentVolumeClaim,
 	log logr.Logger) error {
 	if containsString(pvc.Finalizers, pvcVRFinalizerProtected) {


### PR DESCRIPTION
## Problem

controller-runtime's client.Update routine updates the provided object's status locally, not on the API server

## Proposed solution

Save and restore status across client.Update calls