### PR TITLE
make DRClusters mandatory in DRPolicy 

### DIFF
--- a/api/v1alpha1/drpolicy_types.go
+++ b/api/v1alpha1/drpolicy_types.go
@@ -45,7 +45,7 @@ type DRPolicySpec struct {
 	VolumeSnapshotClassSelector metav1.LabelSelector `json:"volumeSnapshotClassSelector,omitempty"`
 
 	// List of DRCluster resources that are governed by this policy
-	DRClusters []string `json:"drClusters,omitempty"`
+	DRClusters []string `json:"drClusters"`
 }
 
 // DRPolicyStatus defines the observed state of DRPolicy

--- a/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
@@ -140,6 +140,8 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+            required:
+            - drClusters
             type: object
           status:
             description: 'DRPolicyStatus defines the observed state of DRPolicy INSERT

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -131,6 +131,10 @@ func validateDRPolicy(ctx context.Context,
 	// If new DRPolicy and clusters are deleted, then fail reconciliation?
 	found := 0
 
+	if len(drpolicy.Spec.DRClusters) == 0 {
+		return ReasonValidationFailed, fmt.Errorf("value for DRCluster cannot be empty")
+	}
+
 	for _, specCluster := range drpolicy.Spec.DRClusters {
 		for _, cluster := range drclusters.Items {
 			if cluster.Name == specCluster {

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -132,7 +132,7 @@ func validateDRPolicy(ctx context.Context,
 	found := 0
 
 	if len(drpolicy.Spec.DRClusters) == 0 {
-		return ReasonValidationFailed, fmt.Errorf("value for DRCluster cannot be empty")
+		return ReasonValidationFailed, fmt.Errorf("missing DRClusters list in policy")
 	}
 
 	for _, specCluster := range drpolicy.Spec.DRClusters {


### PR DESCRIPTION
1. DRPolicy creation fails if DRClusters is not set 
2. DRPolicy validation fails if DRClusters have an empty list i.e `[]string{}` 

This for BZ: 2122954
