### PR TITLE
test: Lower Consistently() duration from 10s to 1s

### DIFF
--- a/controllers/drcluster_controller_test.go
+++ b/controllers/drcluster_controller_test.go
@@ -141,7 +141,7 @@ func drclusterConditionExpect(
 	case false:
 		Eventually(testFunc, timeout, interval).Should(matchElements)
 	case true:
-		Consistently(testFunc, timeout, interval).Should(matchElements)
+		Consistently(testFunc).Should(matchElements)
 	}
 
 	// TODO: Validate finaliziers and labels

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -818,7 +818,7 @@ func ensureDRPolicyIsNotDeleted(drpc *rmn.DRPlacementControl) {
 		err := apiReader.Get(context.TODO(), types.NamespacedName{Name: name}, drpolicy)
 		// TODO: Technically we need to Expect deletion TS is non-zero as well here!
 		return err == nil
-	}, timeout, interval).Should(BeTrue(), "DRPolicy deleted prematurely, with active DRPC references")
+	}).Should(BeTrue(), "DRPolicy deleted prematurely, with active DRPC references")
 }
 
 func ensureDRPolicyIsDeleted(drpolicyName string) {
@@ -857,7 +857,7 @@ func checkIfDRPCFinalizerNotAdded(drpc *rmn.DRPlacementControl) {
 		}
 
 		return true
-	}, timeout, interval).Should(BeTrue(), "DRPlacementControl reconciled with a finalizer",
+	}).Should(BeTrue(), "DRPlacementControl reconciled with a finalizer",
 		"when DRPolicy is in a deleted state")
 }
 
@@ -997,7 +997,7 @@ func verifyUserPlacementRuleDecisionUnchanged(name, namespace, homeCluster strin
 		err := k8sClient.Get(context.TODO(), usrPlRuleLookupKey, usrPlRule)
 
 		return err == nil && usrPlRule.Status.Decisions[0].ClusterName == homeCluster
-	}, timeout, interval).Should(BeTrue())
+	}).Should(BeTrue())
 
 	Expect(usrPlRule.ObjectMeta.Annotations[controllers.DRPCNameAnnotation]).Should(Equal(DRPCName))
 	Expect(usrPlRule.ObjectMeta.Annotations[controllers.DRPCNamespaceAnnotation]).Should(Equal(DRPCNamespaceName))

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -113,6 +113,9 @@ func createOperatorNamespace(ramenNamespace string) {
 var _ = BeforeSuite(func() {
 	// onsi.github.io/gomega/#adjusting-output
 	format.MaxLength = 0
+
+	SetDefaultConsistentlyDuration(1 * time.Second)
+
 	testLogger = zap.New(zap.UseFlagOptions(&zap.Options{
 		Development: true,
 		DestWriter:  GinkgoWriter,

--- a/controllers/volsync/volsync_suite_test.go
+++ b/controllers/volsync/volsync_suite_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
@@ -60,6 +61,9 @@ func TestVolsync(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	SetDefaultConsistentlyDuration(1 * time.Second)
+	SetDefaultConsistentlyPollingInterval(250 * time.Millisecond)
+
 	logger = zap.New(zap.UseFlagOptions(&zap.Options{
 		Development: true,
 		DestWriter:  GinkgoWriter,

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -471,7 +471,7 @@ var _ = Describe("VolSync Handler", func() {
 					Consistently(func() error {
 						return k8sClient.Get(ctx,
 							types.NamespacedName{Name: rdSpec.ProtectedPVC.Name, Namespace: testNamespace.GetName()}, createdRD)
-					}, 1*time.Second, interval).ShouldNot(BeNil())
+					}).ShouldNot(BeNil())
 				})
 			})
 
@@ -714,7 +714,7 @@ var _ = Describe("VolSync Handler", func() {
 					Consistently(func() error {
 						return k8sClient.Get(ctx,
 							types.NamespacedName{Name: rsSpec.ProtectedPVC.Name, Namespace: testNamespace.GetName()}, createdRS)
-					}, 1*time.Second, interval).ShouldNot(BeNil())
+					}).ShouldNot(BeNil())
 				})
 			})
 
@@ -753,7 +753,7 @@ var _ = Describe("VolSync Handler", func() {
 						Consistently(func() error {
 							return k8sClient.Get(ctx,
 								types.NamespacedName{Name: rsSpec.ProtectedPVC.Name, Namespace: testNamespace.GetName()}, createdRS)
-						}, 1*time.Second, interval).ShouldNot(BeNil())
+						}).ShouldNot(BeNil())
 					})
 				})
 
@@ -775,7 +775,7 @@ var _ = Describe("VolSync Handler", func() {
 						Consistently(func() error {
 							return k8sClient.Get(ctx,
 								types.NamespacedName{Name: rsSpec.ProtectedPVC.Name, Namespace: testNamespace.GetName()}, createdRS)
-						}, 1*time.Second, interval).ShouldNot(BeNil())
+						}).ShouldNot(BeNil())
 					})
 				})
 
@@ -798,7 +798,7 @@ var _ = Describe("VolSync Handler", func() {
 						Consistently(func() error {
 							return k8sClient.Get(ctx,
 								types.NamespacedName{Name: rsSpec.ProtectedPVC.Name, Namespace: testNamespace.GetName()}, createdRS)
-						}, 1*time.Second, interval).ShouldNot(BeNil())
+						}).ShouldNot(BeNil())
 					})
 				})
 

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -1102,7 +1102,7 @@ func (v *vrgTest) verifyVRGStatusCondition(conditionName string, expectedStatus 
 		Eventually(testFunc, vrgtimeout, vrginterval).Should(BeTrue(),
 			"while waiting for VRG %s TRUE condition %s/%s", conditionName, v.vrgName, v.namespace)
 	default: // false
-		Consistently(testFunc, vrgtimeout, vrginterval).Should(BeTrue(),
+		Consistently(testFunc).Should(BeTrue(),
 			"while waiting for VRG %s FALSE condition %s/%s", conditionName, v.vrgName, v.namespace)
 	}
 }


### PR DESCRIPTION
## Problem
Some Ramen tests use the same `Consistently` duration as `Eventually` timeouts.  The `Eventually` timeout is a _maximum_ wait time, while the `Consistently` duration is a _minimum_ wait time.

## Solution proposed
- reduce the consistently duration from 10 seconds to 1 second for `controllers/` tests
- leave the existing consistently polling intervals the same:
   - 10ms for `controllers/` tests
   - 250ms for `controllers/volsync/` tests
- use `SetDefaultConsistently[Duration|PollingInterval]` to set duration and polling interval defaults so that they don't need to be specified for every call
   - `controllers/` polling interval default did not need to be changed:
      https://onsi.github.io/gomega/#modifying-default-intervals
      > By default, Eventually will poll every 10 milliseconds for up to 1 second and Consistently will monitor every 10 milliseconds for up to 100 milliseconds.

## Measurements
Test time is reduced from approximately 140s to 40s (3.5x) on my machine.

10-second consistently duration:
```
$ time make test>/tmp/2
real    2m20.528s
user    1m59.373s
sys     0m20.388s
$ time make test>/tmp/2
real    2m19.922s
user    1m59.843s
sys     0m19.965s
$ time make test>/tmp/2
real    2m20.476s
user    1m56.901s
sys     0m20.209s
```

1-second consistently duration:
```
$ time make test>/tmp/1
real    0m36.676s
user    1m29.792s
sys     0m12.154s
$ time make test>/tmp/1
real    0m39.916s
user    1m29.706s
sys     0m11.572s
$ time make test>/tmp/1
real    0m40.885s
user    1m29.029s
sys     0m11.769s
```