### PR TITLE
Add infrastructure for testing environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ config/hub/bundle
 *.swo
 *~
 .vscode
+
+# Test enviromemnt generated files
+test/drenv.egg-info/
+test/*/__pycache__/

--- a/test/README.md
+++ b/test/README.md
@@ -290,3 +290,8 @@ $ drenv delete example.yaml
     - `file`: Script filename
     - `args`: Optional argument to the script. If not specified the
       script is run without any arguments.
+
+## The regional-dr environment
+
+This is a configuration for testing regional DR using a hub cluster and
+2 managed clusters.

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,292 @@
+<!--
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Ramen test environment
+
+This directory provides tools and configuration for creating Ramen test
+environment.
+
+## Setup
+
+1. Add yourself to the libvirt group (required for minikube kvm2 driver).
+
+   ```
+   sudo usermod -a -G libvirt $(whoami)
+   ```
+
+1. Logout and login again for the change above to be in effect.
+
+1. Install minikube, for example on RHEL/CentOS/Fedora:
+
+   ```
+   sudo dnf install https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
+   ```
+
+   You need `minikube` version supporting the `--extra-disks` option.
+   The tool was tested with `minikube` v1.26.1.
+
+1. Install the `drenv` package in a virtual environment:
+
+   Run this once in the root of the source tree:
+
+   ```
+   python3 -m venv ~/.venv/ramen
+   source ~/.venv/ramen/bin/activate
+   pip install --upgrade pip
+   pip install -e ./test
+   ```
+
+   You can create the virtual environment anywhere, but keeping the
+   environment outside of the source tree is good practice.
+
+   This installs a link file in the virtual environment:
+
+   ```
+   $ cat /home/nsoffer/.venv/ramen/lib/python3.10/site-packages/drenv.egg-link
+   /home/nsoffer/src/ramen/test
+   ```
+
+   So changes in the `test/drenv` package are available immediately
+   without installing the package again.
+
+## Using the drenv tool
+
+Before running the `drenv` tool you need to activate the virtual
+environment:
+
+```
+source ~/.venv/ramen/bin/activate
+```
+
+The shell prompt will change to reflect that the `ramen` virtual
+environment is active:
+
+```
+(ramen) [user@host test]$
+```
+
+Change directory to the test directory where the environment yamls and
+scripts are:
+
+```
+cd test
+```
+
+To start the environment:
+
+```
+drenv start example.yaml
+```
+
+To stop the environment:
+
+```
+drenv stop example.yaml
+```
+
+To delete the environment:
+
+```
+drenv delete example.yaml
+```
+
+Useful options:
+
+- `-v`, `--verbose`: Show verbose logs
+- `-h`, `--help`: Show online help
+
+When you are done you can deactivate the virtual environment:
+
+```
+deactivate
+```
+
+## The environment file
+
+To create an environment you need an yaml file describing the
+clusters and how to deploy them.
+
+### Example environment file
+
+```
+# Example environment.
+
+profiles:
+  - name: "ex1"
+    scripts:
+      - file: example/start
+  - name: "ex2"
+    scripts:
+      - file: example/start
+scripts:
+  - file: example/test
+    args: ["ex1", "ex2"]
+```
+
+### Experimenting with the example environment
+
+You can play with the example environment to understand how the `drenv`
+tool works and how to write scripts.
+
+Starting the example environment:
+
+```
+$ drenv start example.yaml
+2022-09-22 20:47:32,368 INFO    [env] Using example.yaml
+2022-09-22 20:47:32,371 INFO    [ex1] Starting cluster
+2022-09-22 20:47:32,371 INFO    [ex2] Starting cluster
+2022-09-22 20:48:10,538 INFO    [ex2] Cluster started in 38.17 seconds
+2022-09-22 20:48:10,538 INFO    [ex2] Starting example/start
+2022-09-22 20:48:10,754 INFO    [ex2] example/start completed in 0.22 seconds
+2022-09-22 20:48:27,509 INFO    [ex1] Cluster started in 55.14 seconds
+2022-09-22 20:48:27,509 INFO    [ex1] Starting example/start
+2022-09-22 20:48:27,915 INFO    [ex1] example/start completed in 0.41 seconds
+2022-09-22 20:48:27,915 INFO    [env] Starting example/test
+2022-09-22 20:48:51,202 INFO    [env] example/test completed in 23.29 seconds
+2022-09-22 20:48:51,203 INFO    [env] Started in 78.83 seconds
+```
+
+We have 2 minikube profiles:
+
+```
+$ minikube profile list
+|---------|-----------|------------|----------------|------|---------|---------|-------|--------|
+| Profile | VM Driver |  Runtime   |       IP       | Port | Version | Status  | Nodes | Active |
+|---------|-----------|------------|----------------|------|---------|---------|-------|--------|
+| ex1     | kvm2      | containerd | 192.168.50.136 | 8443 | v1.24.3 | Running |     1 |        |
+| ex2     | kvm2      | containerd | 192.168.39.240 | 8443 | v1.24.3 | Running |     1 |        |
+|---------|-----------|------------|----------------|------|---------|---------|-------|--------|
+```
+
+ngix was deployed on both clusters:
+
+```
+$ minikube kubectl -p ex1 -- get pods
+NAME                                READY   STATUS    RESTARTS   AGE
+nginx-deployment-6595874d85-sr5nt   1/1     Running   0          3m32s
+
+$ minikube kubectl -p ex2 -- get pods
+NAME                                READY   STATUS    RESTARTS   AGE
+nginx-deployment-6595874d85-bq7lq   1/1     Running   0          4m19s
+```
+
+After starting both clusters, we run the `example/test` script. We can
+run the script manually again to test the clusters:
+
+```
+$ example/test ex1 ex2
+* Testing example deploymnet on cluster ex1
+  deployment "nginx-deployment" successfully rolled out
+* Testing example deploymnet on cluster ex2
+  deployment "nginx-deployment" successfully rolled out
+```
+
+If something failed while starting, we can run start again. This is
+typically much faster:
+
+```
+$ drenv start example.yaml
+2022-09-22 20:51:41,309 INFO    [env] Using example.yaml
+2022-09-22 20:51:41,311 INFO    [ex1] Starting cluster
+2022-09-22 20:51:41,311 INFO    [ex2] Starting cluster
+2022-09-22 20:51:55,456 INFO    [ex2] Cluster started in 14.14 seconds
+2022-09-22 20:51:55,456 INFO    [ex2] Starting example/start
+2022-09-22 20:51:55,671 INFO    [ex1] Cluster started in 14.36 seconds
+2022-09-22 20:51:55,671 INFO    [ex1] Starting example/start
+2022-09-22 20:51:55,678 INFO    [ex2] example/start completed in 0.22 seconds
+2022-09-22 20:51:55,868 INFO    [ex1] example/start completed in 0.20 seconds
+2022-09-22 20:51:55,868 INFO    [env] Starting example/test
+2022-09-22 20:51:56,089 INFO    [env] example/test completed in 0.22 seconds
+2022-09-22 20:51:56,089 INFO    [env] Started in 14.78 seconds
+```
+
+While debugging it is useful to use the `--verbose` option to see much
+more details from scripts:
+
+```
+$ drenv start example.yaml -v
+2022-09-22 20:52:20,518 INFO    [env] Using example.yaml
+2022-09-22 20:52:20,520 INFO    [ex1] Starting cluster
+2022-09-22 20:52:20,520 INFO    [ex2] Starting cluster
+2022-09-22 20:52:20,573 DEBUG   [ex1] * [ex1] minikube v1.26.1 on Fedora 36
+2022-09-22 20:52:20,573 DEBUG   [ex2] * [ex2] minikube v1.26.1 on Fedora 36
+2022-09-22 20:52:20,574 DEBUG   [ex2]   - MINIKUBE_HOME=/data/minikube
+2022-09-22 20:52:20,574 DEBUG   [ex1]   - MINIKUBE_HOME=/data/minikube
+2022-09-22 20:52:21,073 DEBUG   [ex2] * Using the kvm2 driver based on existing profile
+2022-09-22 20:52:21,082 DEBUG   [ex1] * Using the kvm2 driver based on existing profile
+2022-09-22 20:52:21,091 DEBUG   [ex2] * Starting control plane node ex2 in cluster ex2
+2022-09-22 20:52:21,109 DEBUG   [ex1] * Starting control plane node ex1 in cluster ex1
+2022-09-22 20:52:21,159 DEBUG   [ex2] * Updating the running kvm2 "ex2" VM ...
+2022-09-22 20:52:22,542 DEBUG   [ex1] * Updating the running kvm2 "ex1" VM ...
+2022-09-22 20:52:26,852 DEBUG   [ex2] * Preparing Kubernetes v1.24.3 on containerd 1.6.6 ...
+2022-09-22 20:52:27,986 DEBUG   [ex1] * Preparing Kubernetes v1.24.3 on containerd 1.6.6 ...
+2022-09-22 20:52:37,553 DEBUG   [ex2] * Configuring bridge CNI (Container Networking Interface) ...
+2022-09-22 20:52:37,811 DEBUG   [ex2] * Verifying Kubernetes components...
+2022-09-22 20:52:37,889 DEBUG   [ex2]   - Using image gcr.io/k8s-minikube/storage-provisioner:v5
+2022-09-22 20:52:38,661 DEBUG   [ex2] * Enabled addons: storage-provisioner, default-storageclass
+2022-09-22 20:52:38,664 DEBUG   [ex2] * kubectl not found. If you need it, try: 'minikube kubectl -- get pods -A'
+2022-09-22 20:52:38,665 DEBUG   [ex2] * Done! kubectl is now configured to use "ex2" cluster and "default" namespace by default
+2022-09-22 20:52:38,687 INFO    [ex2] Cluster started in 18.17 seconds
+2022-09-22 20:52:38,687 INFO    [ex2] Starting example/start
+2022-09-22 20:52:38,715 DEBUG   [ex2] * Deploying nginx on cluster ex2
+2022-09-22 20:52:38,786 DEBUG   [ex1] * Configuring bridge CNI (Container Networking Interface) ...
+2022-09-22 20:52:38,888 DEBUG   [ex2]   deployment.apps/nginx-deployment unchanged
+2022-09-22 20:52:38,892 INFO    [ex2] example/start completed in 0.20 seconds
+2022-09-22 20:52:38,999 DEBUG   [ex1] * Verifying Kubernetes components...
+2022-09-22 20:52:39,073 DEBUG   [ex1]   - Using image gcr.io/k8s-minikube/storage-provisioner:v5
+2022-09-22 20:52:39,990 DEBUG   [ex1] * Enabled addons: storage-provisioner, default-storageclass
+2022-09-22 20:52:39,992 DEBUG   [ex1] * kubectl not found. If you need it, try: 'minikube kubectl -- get pods -A'
+2022-09-22 20:52:39,994 DEBUG   [ex1] * Done! kubectl is now configured to use "ex1" cluster and "default" namespace by default
+2022-09-22 20:52:40,014 INFO    [ex1] Cluster started in 19.49 seconds
+2022-09-22 20:52:40,014 INFO    [ex1] Starting example/start
+2022-09-22 20:52:40,041 DEBUG   [ex1] * Deploying nginx on cluster ex1
+2022-09-22 20:52:40,207 DEBUG   [ex1]   deployment.apps/nginx-deployment unchanged
+2022-09-22 20:52:40,211 INFO    [ex1] example/start completed in 0.20 seconds
+2022-09-22 20:52:40,211 INFO    [env] Starting example/test
+2022-09-22 20:52:40,234 DEBUG   [env] * Testing example deploymnet on cluster ex1
+2022-09-22 20:52:40,339 DEBUG   [env]   deployment "nginx-deployment" successfully rolled out
+2022-09-22 20:52:40,339 DEBUG   [env] * Testing example deploymnet on cluster ex2
+2022-09-22 20:52:40,444 DEBUG   [env]   deployment "nginx-deployment" successfully rolled out
+2022-09-22 20:52:40,448 INFO    [env] example/test completed in 0.24 seconds
+2022-09-22 20:52:40,448 INFO    [env] Started in 19.93 seconds
+```
+
+We can stop the environment and start it later. This can be faster than
+recreating it from scratch, but tends to be flaky.
+
+To delete the environment:
+
+```
+$ drenv delete example.yaml
+2022-09-22 20:54:05,106 INFO    [env] Using example.yaml
+2022-09-22 20:54:05,108 INFO    [ex1] Deleting cluster
+2022-09-22 20:54:05,109 INFO    [ex2] Deleting cluster
+2022-09-22 20:54:05,863 INFO    [ex2] Cluster deleted in 0.75 seconds
+2022-09-22 20:54:05,906 INFO    [ex1] Cluster deleted in 0.80 seconds
+2022-09-22 20:54:05,906 INFO    [env] Deleted in 0.80 seconds
+```
+
+### The environment file format
+
+- `profiles`: list of profiles.
+    - `name`: profile name.
+    - `container_runtime`: The container runtime to be used. Valid
+      options: "docker", "cri-o", "containerd" (default: "containerd")
+    - `network`: The network to run minikube with. If left empty,
+      minikube will create a new isolated network.
+    - `extra_disks`: Number of extra disks (default 0)
+    - `disk_size`: Disk size string (default "50g")
+    - `nodes`: Number of cluster nodes (default 1)
+    - `cni`: Network plugin (default "auto")
+    - `cpus`: Number of CPUs per VM (default 2)
+    - `memory`: Memory per VM (default 4g)
+    - `scripts`: Optional list of scripts to run during start.
+        - `file`: Script filename
+        - `args`: Optional argument to the script. If not specified the
+          script is run without any arguments.
+- `scripts`: Optional list of scripts to run after the profile scripts.
+    - `file`: Script filename
+    - `args`: Optional argument to the script. If not specified the
+      script is run without any arguments.

--- a/test/cluster-manager/cluster-manager.yaml
+++ b/test/cluster-manager/cluster-manager.yaml
@@ -9,10 +9,10 @@ metadata:
 spec:
   deployOption:
     mode: Default
-  placementImagePullSpec: 'quay.io/open-cluster-management/placement:v0.8.0'
+  placementImagePullSpec: 'quay.io/open-cluster-management/placement:v0.9.0'
   registrationConfiguration:
     featureGates:
       - feature: DefaultClusterSet
         mode: Enable
-  registrationImagePullSpec: 'quay.io/open-cluster-management/registration:v0.8.0'
-  workImagePullSpec: 'quay.io/open-cluster-management/work:v0.8.0'
+  registrationImagePullSpec: 'quay.io/open-cluster-management/registration:v0.9.0'
+  workImagePullSpec: 'quay.io/open-cluster-management/work:v0.9.0'

--- a/test/cluster-manager/cluster-manager.yaml
+++ b/test/cluster-manager/cluster-manager.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: operator.open-cluster-management.io/v1
+kind: ClusterManager
+metadata:
+  name: cluster-manager
+spec:
+  deployOption:
+    mode: Default
+  placementImagePullSpec: 'quay.io/open-cluster-management/placement:v0.8.0'
+  registrationConfiguration:
+    featureGates:
+      - feature: DefaultClusterSet
+        mode: Enable
+  registrationImagePullSpec: 'quay.io/open-cluster-management/registration:v0.8.0'
+  workImagePullSpec: 'quay.io/open-cluster-management/work:v0.8.0'

--- a/test/cluster-manager/start
+++ b/test/cluster-manager/start
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -u
+#!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0

--- a/test/cluster-manager/start
+++ b/test/cluster-manager/start
@@ -1,0 +1,91 @@
+#!/usr/bin/env -S python3 -u
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+import drenv
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} cluster")
+    sys.exit(1)
+
+cluster = sys.argv[1]
+
+drenv.log_progress("Deploying cluster manager subscription")
+drenv.kubectl(
+    "apply",
+    "--filename", "https://operatorhub.io/install/stable/cluster-manager.yaml",
+    profile=cluster,
+)
+
+# Takes at least 37 seconds, about 80 seconds typically.
+drenv.wait_for(
+    "csv/cluster-manager.v0.8.0",
+    output="jsonpath={.status.phase}",
+    namespace="operators",
+    profile=cluster,
+)
+
+drenv.log_progress("Waiting until ocm cluster manager succeeds")
+drenv.kubectl(
+    "wait", "csv/cluster-manager.v0.8.0",
+    "--for", "jsonpath={.status.phase}=Succeeded",
+    "--namespace", "operators",
+    "--timeout", "300s",
+    profile=cluster,
+)
+
+drenv.log_progress("Waiting for ocm cluster manager rollout")
+drenv.kubectl(
+    "rollout", "status", "deployment/cluster-manager",
+    "--namespace", "operators",
+    "--timeout", "300s",
+    profile=cluster,
+)
+
+drenv.log_progress("Creating cluster manager instance")
+drenv.kubectl(
+    "apply",
+    "--filename", "cluster-manager/cluster-manager.yaml",
+    profile=cluster,
+)
+
+drenv.wait_for("namespace/open-cluster-management-hub", profile=cluster)
+
+for component in [
+    "placement-controller",
+    "registration-controller",
+    "registration-webhook",
+    "work-webhook",
+]:
+    drenv.wait_for(
+        f"deploy/cluster-manager-{component}",
+        namespace="open-cluster-management-hub",
+        profile=cluster,
+    )
+
+drenv.log_progress("Waiting until cluster manager deployments are avaialble")
+drenv.kubectl(
+    "wait", "deployment", "--all",
+    "--for", "condition=available",
+    "--namespace", "open-cluster-management-hub",
+    "--timeout", "300s",
+    profile=cluster,
+)
+
+drenv.log_progress("Create hub kubeconfig")
+config = drenv.kubectl(
+    "config", "view",
+    "--context", cluster,
+    "--flatten", "--minify",
+    verbose=False,
+)
+config_dir = drenv.config_dir(cluster)
+os.makedirs(config_dir, exist_ok=True)
+kubeconfig = os.path.join(config_dir, "kubeconfig")
+with open(kubeconfig, "w") as f:
+    f.write(config)
+drenv.log_detail(f"hub config created at {kubeconfig}")

--- a/test/cluster-manager/start
+++ b/test/cluster-manager/start
@@ -21,9 +21,18 @@ drenv.kubectl(
     profile=cluster,
 )
 
-# Takes at least 37 seconds, about 80 seconds typically.
+# We don't know which version will be installed yet. Wait until the version is
+# reported by the subscription.
+current_csv = drenv.wait_for(
+    "subscription/my-cluster-manager",
+    output="jsonpath={.status.currentCSV}",
+    namespace="operators",
+    profile=cluster,
+)
+
+# Now we can wait until this version reports its phase.
 drenv.wait_for(
-    "csv/cluster-manager.v0.8.0",
+    f"csv/{current_csv}",
     output="jsonpath={.status.phase}",
     namespace="operators",
     profile=cluster,
@@ -31,7 +40,7 @@ drenv.wait_for(
 
 drenv.log_progress("Waiting until ocm cluster manager succeeds")
 drenv.kubectl(
-    "wait", "csv/cluster-manager.v0.8.0",
+    "wait", f"csv/{current_csv}",
     "--for", "jsonpath={.status.phase}=Succeeded",
     "--namespace", "operators",
     "--timeout", "300s",

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import string
+import subprocess
+import tempfile
+import textwrap
+import time
+
+from contextlib import contextmanager
+
+
+def log_progress(msg):
+    """
+    Logs progress mesage to stdout.
+    """
+    print(f"* {msg}")
+
+
+def log_detail(text):
+    """
+    Logs details for the last progress message to stdout.
+    """
+    print(textwrap.indent(text, "  "))
+
+
+def kubectl(*args, profile=None, input=None, verbose=True):
+    """
+    Run `minikube kubectl` command for profile.
+
+    Some kubectl commands (e.g. config) do not work with profile and require
+    `--context profile` in the command arguments.
+
+    To pipe yaml into the kubectl command, use `--filename -` and pass the yaml
+    to the input argument.
+
+    The underlying kubectl command output is logged using log_detail(). Set
+    verbose=False the log.
+
+    Returns the underlying command output.
+    """
+    cmd = ["minikube", "kubectl"]
+    if profile:
+        cmd.extend(("--profile", profile))
+    cmd.append("--")
+    cmd.extend(args)
+
+    cp = subprocess.run(
+        cmd,
+        input=input.encode() if input else None,
+        stdout=subprocess.PIPE,
+        check=True)
+
+    out = cp.stdout.decode().rstrip()
+
+    # Log output for debugging so we don't need to log manually for every
+    # command.
+    if out and verbose:
+        log_detail(out)
+
+    return out
+
+
+def wait_for(resource, output="jsonpath={.metadata.name}", timeout=300,
+             namespace=None, profile=None):
+    """
+    Wait until resource exists. Once the resource exists, wait for it
+    using `kubectl wait`.
+
+    To wait for a specific part of the resource specify a kubectl output
+    specficiation (e.g. output="jsonpath={.status.phase}"). The function
+    returns when the output is non empty.
+
+    Raises RuntimeError if the resource does not exist within the specified
+    timeout.
+    """
+    log_progress(f"Waiting until {resource} exists")
+
+    args = ["get", resource, "--output", output, "--ignore-not-found"]
+    if namespace:
+        args.extend(("--namespace", namespace))
+
+    deadline = time.monotonic() + timeout
+    delay = min(1.0, timeout / 60)
+
+    while True:
+        out = kubectl(*args, profile=profile, verbose=False)
+        if out:
+            log_detail(f"{resource} exists")
+            break
+
+        if time.monotonic() > deadline:
+            raise RuntimeError(f"Timeout waiting for {resource}")
+
+        time.sleep(delay)
+
+
+def template(path):
+    """
+    Retrun a string.Template with contents of path.
+    """
+    with open(path) as f:
+        return string.Template(f.read())
+
+
+@contextmanager
+def kustomization(path, **kw):
+    """
+    Create a temporary kustomization directory using template at path,
+    substituting values from kw.
+
+    Yields the directory path to be used with `kubectl -k`.
+    """
+    yaml_template = template(path)
+    yaml = yaml_template.substitute(**kw)
+
+    with tempfile.TemporaryDirectory(prefix="drenv") as tmpdir:
+        kustomization_yaml = os.path.join(tmpdir, "kustomization.yaml")
+        with open(kustomization_yaml, "w") as f:
+            f.write(yaml)
+
+        yield tmpdir
+
+
+def config_dir(name):
+    """
+    Return configuration directory for profile name. This can be used to
+    share configuration between scripts.
+    """
+    path = os.path.join("~", ".config", "drenv", name)
+    return os.path.expanduser(path)

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -72,6 +72,9 @@ def wait_for(resource, output="jsonpath={.metadata.name}", timeout=300,
     specficiation (e.g. output="jsonpath={.status.phase}"). The function
     returns when the output is non empty.
 
+    Returns the resource .metadata.name, or if output was specified, the
+    specified outpout for the resource.
+
     Raises RuntimeError if the resource does not exist within the specified
     timeout.
     """
@@ -88,7 +91,7 @@ def wait_for(resource, output="jsonpath={.metadata.name}", timeout=300,
         out = kubectl(*args, profile=profile, verbose=False)
         if out:
             log_detail(f"{resource} exists")
-            break
+            return out
 
         if time.monotonic() > deadline:
             raise RuntimeError(f"Timeout waiting for {resource}")

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import concurrent.futures
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+
+from collections import deque
+
+import yaml
+
+from . import config_dir
+
+CMD_PREFIX = "cmd_"
+
+
+def main():
+    commands = [n[len(CMD_PREFIX):] for n in globals()
+                if n.startswith(CMD_PREFIX)]
+
+    p = argparse.ArgumentParser(prog="drenv")
+    p.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Be more verbose")
+    p.add_argument(
+        "command",
+        choices=commands,
+        help="Command to run")
+    p.add_argument(
+        "filename",
+        help="Environment filename")
+    args = p.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)-7s %(message)s")
+
+    env = read_env(args.filename)
+
+    func = globals()[CMD_PREFIX + args.command]
+    func(env)
+
+
+def read_env(filename):
+    logging.info("[env] Using %s", filename)
+    with open(filename) as f:
+        env = yaml.safe_load(f)
+    validate_env(env)
+    return env
+
+
+def validate_env(env):
+    if "profiles" not in env:
+        raise ValueError("Missing profiles")
+
+    for profile in env["profiles"]:
+        validate_profile(profile)
+
+    for script in env.setdefault("scripts", []):
+        validate_script(script)
+
+
+def validate_profile(profile):
+    if "name" not in profile:
+        raise ValueError("Missing profile name")
+
+    profile.setdefault("container_runtime", "containerd")
+    profile.setdefault("extra_disks", 0)
+    profile.setdefault("disk_size", "20g")
+    profile.setdefault("nodes", 1)
+    profile.setdefault("cni", "auto")
+    profile.setdefault("cpus", 2)
+    profile.setdefault("memory", "4g")
+    profile.setdefault("network", "")
+    profile.setdefault("scripts", [])
+
+    for script in profile["scripts"]:
+        validate_script(script, args=[profile["name"]])
+
+
+def validate_script(script, args=()):
+    if "file" not in script:
+        raise ValueError(f"Missing script 'file': {script}")
+    script.setdefault("args", list(args))
+
+
+def cmd_start(env):
+    start = time.monotonic()
+    execute(start_cluster, env["profiles"])
+    for script in env["scripts"]:
+        run_script(script)
+    logging.info("[env] Started in %.2f seconds", time.monotonic() - start)
+
+
+def cmd_stop(env):
+    start = time.monotonic()
+    execute(stop_cluster, env["profiles"])
+    logging.info("[env] Stopped in %.2f seconds", time.monotonic() - start)
+
+
+def cmd_delete(env):
+    start = time.monotonic()
+    execute(delete_cluster, env["profiles"])
+    logging.info("[env] Deleted in %.2f seconds", time.monotonic() - start)
+
+
+def execute(func, profiles):
+    failed = False
+
+    with concurrent.futures.ThreadPoolExecutor() as e:
+        futures = {e.submit(func, p): p["name"] for p in profiles}
+        for f in concurrent.futures.as_completed(futures):
+            try:
+                f.result()
+            except Exception:
+                logging.exception("[%s] Cluster failed", futures[f])
+                failed = True
+
+    if failed:
+        sys.exit(1)
+
+
+def start_cluster(profile):
+    start = time.monotonic()
+    logging.info("[%s] Starting cluster", profile["name"])
+    minikube("start",
+             "--driver", "kvm2",
+             "--container-runtime", profile["container_runtime"],
+             "--extra-disks", str(profile["extra_disks"]),
+             "--disk-size", profile["disk_size"],
+             "--network", profile["network"],
+             "--nodes", str(profile["nodes"]),
+             "--cni", profile["cni"],
+             "--cpus", str(profile["cpus"]),
+             "--memory", profile["memory"],
+             profile=profile["name"])
+    logging.info("[%s] Cluster started in %.2f seconds",
+                 profile["name"], time.monotonic() - start)
+
+    for script in profile["scripts"]:
+        run_script(script, name=profile["name"])
+
+
+def stop_cluster(profile):
+    start = time.monotonic()
+    logging.info("[%s] Stopping cluster", profile["name"])
+    minikube("stop", profile=profile["name"])
+    logging.info("[%s] Cluster stopped in %.2f seconds",
+                 profile["name"], time.monotonic() - start)
+
+
+def delete_cluster(profile):
+    start = time.monotonic()
+    logging.info("[%s] Deleting cluster", profile["name"])
+    minikube("delete", profile=profile["name"])
+    profile_config = config_dir(profile["name"])
+    if os.path.exists(profile_config):
+        logging.info("[%s] Removing config %s",
+                     profile["name"], profile_config)
+        shutil.rmtree(profile_config)
+    logging.info("[%s] Cluster deleted in %.2f seconds",
+                 profile["name"], time.monotonic() - start)
+
+
+def minikube(cmd, *args, profile=None):
+    run("minikube", cmd, "--profile", profile, *args, name=profile)
+
+
+def run_script(script, name="env"):
+    start = time.monotonic()
+    logging.info("[%s] Starting %s", name, script["file"])
+    run(script["file"], *script["args"], name=name)
+    logging.info("[%s] %s completed in %.2f seconds",
+                 name, script["file"], time.monotonic() - start)
+
+
+def run(*cmd, name=None):
+    p = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    messages = deque(maxlen=20)
+
+    for line in iter(p.stdout.readline, b""):
+        msg = line.decode().rstrip()
+        messages.append(msg)
+        logging.debug("[%s] %s", name, msg)
+
+    p.wait()
+    if p.returncode != 0:
+        last_messages = "\n".join("  " + m for m in messages)
+        raise RuntimeError(
+            f"[{name}] Command {cmd} failed rc={p.returncode}\n"
+            "\n"
+            "Last messages:\n"
+            f"{last_messages}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -181,10 +181,15 @@ def run_script(script, name="env"):
 
 
 def run(*cmd, name=None):
+    # Avoid delays in child process logs.
+    env = dict(os.environ)
+    env["PYTHONUNBUFFERED"] = "1"
+
     p = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        env=env,
     )
 
     messages = deque(maxlen=20)

--- a/test/example.yaml
+++ b/test/example.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Example environment.
+---
+profiles:
+  - name: "ex1"
+    scripts:
+      - file: example/start
+  - name: "ex2"
+    scripts:
+      - file: example/start
+scripts:
+  - file: example/test
+    args: ["ex1", "ex2"]

--- a/test/example/ngix-deployment.yaml
+++ b/test/example/ngix-deployment.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/test/example/start
+++ b/test/example/start
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -u
+#!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0

--- a/test/example/start
+++ b/test/example/start
@@ -1,0 +1,21 @@
+#!/usr/bin/env -S python3 -u
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+import drenv
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} cluster")
+    sys.exit(1)
+
+cluster = sys.argv[1]
+
+drenv.log_progress(f"Deploying nginx on cluster {cluster}")
+drenv.kubectl(
+    "apply",
+    "--filename", "example/ngix-deployment.yaml",
+    profile=cluster,
+)

--- a/test/example/test
+++ b/test/example/test
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -u
+#!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0

--- a/test/example/test
+++ b/test/example/test
@@ -1,0 +1,28 @@
+#!/usr/bin/env -S python3 -u
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+import drenv
+
+if len(sys.argv) != 3:
+    print(f"Usage: {sys.argv[0]} cluster1 cluster2")
+    sys.exit(1)
+
+cluster1, cluster2 = sys.argv[1:]
+
+drenv.log_progress(f"Testing example deploymnet on cluster {cluster1}")
+drenv.kubectl(
+    "rollout", "status", "deploy/nginx-deployment",
+    "--timeout", "60s",
+    profile=cluster1,
+)
+
+drenv.log_progress(f"Testing example deploymnet on cluster {cluster2}")
+drenv.kubectl(
+    "rollout", "status", "deploy/nginx-deployment",
+    "--timeout", "60s",
+    profile=cluster2,
+)

--- a/test/klusterlet/example-manifestwork.yaml
+++ b/test/klusterlet/example-manifestwork.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: work.open-cluster-management.io/v1
+kind: ManifestWork
+metadata:
+  namespace: $namespace
+  name: example-manifestwork
+spec:
+  workload:
+    manifests:
+      - apiVersion: v1
+        kind: ServiceAccount
+        metadata:
+          namespace: default
+          name: example-sa
+      - apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          namespace: default
+          name: example-deployment
+          labels:
+            app: busybox
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: busybox
+          template:
+            metadata:
+              labels:
+                app: busybox
+            spec:
+              serviceAccountName: example-sa
+              containers:
+                - name: busybox
+                  image: busybox
+                  command: ["sleep", "60"]

--- a/test/klusterlet/klusterlet.yaml
+++ b/test/klusterlet/klusterlet.yaml
@@ -18,5 +18,5 @@ spec:
     featureGates:
       - feature: AddonManagement
         mode: Enable
-  registrationImagePullSpec: 'quay.io/open-cluster-management/registration:v0.8.0'
-  workImagePullSpec: 'quay.io/open-cluster-management/work:v0.8.0'
+  registrationImagePullSpec: 'quay.io/open-cluster-management/registration:v0.9.0'
+  workImagePullSpec: 'quay.io/open-cluster-management/work:v0.9.0'

--- a/test/klusterlet/klusterlet.yaml
+++ b/test/klusterlet/klusterlet.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: operator.open-cluster-management.io/v1
+kind: Klusterlet
+metadata:
+  name: klusterlet
+spec:
+  clusterName: $clusterName
+  deployOption:
+    mode: Default
+  externalServerURLs:
+    # XXX use managed cluster url?
+    - url: 'https://localhost'
+  namespace: $namespace
+  registrationConfiguration:
+    featureGates:
+      - feature: AddonManagement
+        mode: Enable
+  registrationImagePullSpec: 'quay.io/open-cluster-management/registration:v0.8.0'
+  workImagePullSpec: 'quay.io/open-cluster-management/work:v0.8.0'

--- a/test/klusterlet/start
+++ b/test/klusterlet/start
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -u
+#!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0

--- a/test/klusterlet/start
+++ b/test/klusterlet/start
@@ -22,8 +22,15 @@ def deploy_klusterlet(cluster):
 
 
 def wait_until_klusterlet_is_rolled_out(cluster):
+    current_csv = drenv.wait_for(
+        "subscription/my-klusterlet",
+        output="jsonpath={.status.currentCSV}",
+        namespace="operators",
+        profile=cluster,
+    )
+
     drenv.wait_for(
-        "csv/klusterlet.v0.8.0",
+        f"csv/{current_csv}",
         output="jsonpath={.status.phase}",
         namespace="operators",
         profile=cluster,
@@ -31,7 +38,7 @@ def wait_until_klusterlet_is_rolled_out(cluster):
 
     drenv.log_progress(f"Waiting until klusterlet succeeds in cluster {cluster}")
     drenv.kubectl(
-        "wait", "csv/klusterlet.v0.8.0",
+        "wait", f"csv/{current_csv}",
         "--for", "jsonpath={.status.phase}=Succeeded",
         "--namespace", "operators",
         "--timeout", "300s",

--- a/test/klusterlet/start
+++ b/test/klusterlet/start
@@ -1,0 +1,198 @@
+#!/usr/bin/env -S python3 -u
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+from string import Template
+
+import drenv
+
+NAMESPACE = "open-cluster-management-agent"
+
+
+def deploy_klusterlet(cluster):
+    drenv.log_progress(f"Deploying klusterlet subscription to cluster {cluster}")
+    drenv.kubectl(
+        "apply",
+        "--filename", "https://operatorhub.io/install/klusterlet.yaml",
+        profile=cluster,
+    )
+
+
+def wait_until_klusterlet_is_rolled_out(cluster):
+    drenv.wait_for(
+        "csv/klusterlet.v0.8.0",
+        output="jsonpath={.status.phase}",
+        namespace="operators",
+        profile=cluster,
+    )
+
+    drenv.log_progress(f"Waiting until klusterlet succeeds in cluster {cluster}")
+    drenv.kubectl(
+        "wait", "csv/klusterlet.v0.8.0",
+        "--for", "jsonpath={.status.phase}=Succeeded",
+        "--namespace", "operators",
+        "--timeout", "300s",
+        profile=cluster,
+    )
+
+    drenv.log_progress(f"Waiting for klusterlet rollout in cluster {cluster}")
+    drenv.kubectl(
+        "rollout", "status", "deployment/klusterlet",
+        "--namespace", "operators",
+        "--timeout", "300s",
+        profile=cluster,
+    )
+
+
+def create_klusterlet_instance(cluster, hub):
+    drenv.log_progress(f"Creating namespace {NAMESPACE} in cluster {cluster}")
+    namespace_yaml = drenv.kubectl(
+        "create", "namespace", NAMESPACE,
+        "--dry-run=client",
+        "--output=yaml",
+        verbose=False,
+        profile=cluster,
+    )
+    drenv.kubectl(
+        "apply",
+        "--filename", "-",
+        input=namespace_yaml,
+        profile=cluster,
+    )
+
+    drenv.log_progress(
+        f"Create secret boostrap-hub-kubeconfig in cluster {cluster}"
+    )
+    hub_kubeconfig = os.path.join(drenv.config_dir(hub), "kubeconfig")
+    secret_yaml = drenv.kubectl(
+        "create", "secret", "generic", "bootstrap-hub-kubeconfig",
+        f"--from-file=kubeconfig={hub_kubeconfig}",
+        f"--namespace={NAMESPACE}",
+        "--dry-run=client",
+        "--output=yaml",
+        verbose=False,
+        profile=cluster,
+    )
+    drenv.kubectl(
+        "apply",
+        "--filename", "-",
+        input=secret_yaml,
+        profile=cluster,
+    )
+
+    with open("klusterlet/klusterlet.yaml") as f:
+        klusterlet_template = Template(f.read())
+
+    klusterlet_yaml = klusterlet_template.substitute(
+        clusterName=cluster,
+        namespace=NAMESPACE,
+    )
+
+    drenv.log_progress(f"Creating klusterlet instance in cluster {cluster}")
+    drenv.kubectl(
+        "apply",
+        "--filename", "-",
+        input=klusterlet_yaml,
+        profile=cluster,
+    )
+
+
+def wait_until_instance_is_registered(cluster, hub):
+    drenv.wait_for(
+        "deployment/klusterlet-registration-agent",
+        namespace="open-cluster-management-agent",
+        profile=cluster,
+    )
+
+    drenv.log_progress(
+        "Waiting until klusterlet registration agent deployment "
+        f"is avaialble in cluster {cluster}"
+    )
+    drenv.kubectl(
+        "wait", "deployment/klusterlet-registration-agent",
+        "--for", "condition=available",
+        "--namespace", "open-cluster-management-agent",
+        "--timeout", "300s",
+        profile=cluster,
+    )
+
+    drenv.wait_for(
+        f"managedclusters/{cluster}",
+        timeout=30,
+        profile=hub,
+    )
+
+
+def approve_registration(cluster, hub):
+    drenv.log_progress(f"Fetch certificate signning request for {cluster}")
+    csr = drenv.kubectl(
+        "get", "csr",
+        "--selector",  f"open-cluster-management.io/cluster-name={cluster}",
+        "--field-selector", "spec.signerName=kubernetes.io/kube-apiserver-client",
+        "--output", "name",
+        profile=hub,
+    )
+
+    drenv.log_progress(f"Approve certificate signning request for {cluster}")
+    drenv.kubectl("certificate", "approve", csr, profile=hub)
+
+    drenv.log_progress(f"Acccepting managed cluster {cluster}")
+    drenv.kubectl(
+        "patch", f"managedclusters/{cluster}",
+        "--patch", '{"spec":{"hubAcceptsClient":true}}',
+        "--type", "merge",
+        profile=hub,
+    )
+
+
+def wait_until_work_agent_available(cluster, hub):
+    drenv.log_progress(
+        f"Waiting until managed cluster {cluster} is available"
+    )
+    drenv.kubectl(
+        "wait", f"managedclusters/{cluster}",
+        "--for", "condition=ManagedClusterConditionAvailable",
+        "--timeout", "60s",
+        profile=hub,
+    )
+
+    drenv.log_progress(
+        f"Waiting until klusterlet work agent for {cluster} is available"
+    )
+    drenv.kubectl(
+        "wait", "deployment/klusterlet-work-agent",
+        "--for", "condition=available",
+        "--namespace", NAMESPACE,
+        "--timeout", "90s",
+        profile=cluster,
+    )
+
+
+if len(sys.argv) != 4:
+    print(f"Usage: {sys.argv[0]} cluster1 cluster2 hub")
+    sys.exit(1)
+
+cluster1 = sys.argv[1]
+cluster2 = sys.argv[2]
+hub = sys.argv[3]
+
+deploy_klusterlet(cluster1)
+deploy_klusterlet(cluster2)
+
+wait_until_klusterlet_is_rolled_out(cluster1)
+wait_until_klusterlet_is_rolled_out(cluster2)
+
+create_klusterlet_instance(cluster1, hub)
+create_klusterlet_instance(cluster2, hub)
+
+wait_until_instance_is_registered(cluster1, hub)
+wait_until_instance_is_registered(cluster2, hub)
+
+approve_registration(cluster1, hub)
+approve_registration(cluster2, hub)
+
+wait_until_work_agent_available(cluster1, hub)
+wait_until_work_agent_available(cluster2, hub)

--- a/test/klusterlet/test
+++ b/test/klusterlet/test
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -u
+#!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0

--- a/test/klusterlet/test
+++ b/test/klusterlet/test
@@ -1,0 +1,101 @@
+#!/usr/bin/env -S python3 -u
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import time
+
+import drenv
+
+
+def apply_manifestwork(template, cluster, hub):
+    drenv.log_progress(F"Applying example manifestwork to namespace {cluster}")
+    yaml = template.substitute(namespace=cluster)
+    drenv.kubectl("apply", "--filename", "-", input=yaml, profile=hub)
+
+
+def delete_manifestwork(template, cluster, hub):
+    drenv.log_progress(F"Deleting example manifestwork from namespace {cluster}")
+    yaml = template.substitute(namespace=cluster)
+    drenv.kubectl("delete", "--filename", "-", input=yaml, profile=hub)
+
+
+def wait_until_available(cluster, hub):
+    drenv.log_progress(
+        f"Waiting until example mnifestwork is applied in namespace {cluster}"
+    )
+    drenv.kubectl(
+        "wait", "manifestwork/example-manifestwork",
+        "--for", "condition=applied",
+        "--namespace", cluster,
+        "--timeout", "60s",
+        profile=hub,
+    )
+
+    drenv.log_progress(
+        f"Waiting until example mnifestwork is available in namespace {cluster}"
+    )
+    drenv.kubectl(
+        "wait", "manifestwork/example-manifestwork",
+        "--for", "condition=available",
+        "--namespace", cluster,
+        "--timeout", "60s",
+        profile=hub,
+    )
+
+    drenv.log_progress(
+        f"Waiting until example deployment is available in cluster {cluster}"
+    )
+    drenv.kubectl(
+        "wait", "deploy/example-deployment",
+        "--for", "condition=available",
+        "--timeout", "60s",
+        profile=cluster,
+    )
+
+
+def wait_until_deleted(cluster, hub):
+    drenv.log_progress(
+        f"Waiting until example mnifestwork is deleted from namspace {cluster}"
+    )
+    drenv.kubectl(
+        "wait", "manifestwork/example-manifestwork",
+        "--for", "delete",
+        "--namespace", cluster,
+        "--timeout", "60s",
+        profile=hub,
+    )
+
+    drenv.log_progress(
+        f"Waiting until example deployment is deleted from cluster {cluster}"
+    )
+    drenv.kubectl(
+        "wait", "deploy/example-deployment",
+        "--for", "delete",
+        "--timeout", "60s",
+        profile=cluster,
+    )
+
+
+if len(sys.argv) != 4:
+    print(f"Usage: {sys.argv[0]} cluster1 cluster2 hub")
+    sys.exit(1)
+
+cluster1 = sys.argv[1]
+cluster2 = sys.argv[2]
+hub = sys.argv[3]
+
+template = drenv.template("klusterlet/example-manifestwork.yaml")
+
+apply_manifestwork(template, cluster1, hub)
+apply_manifestwork(template, cluster2, hub)
+
+wait_until_available(cluster1, hub)
+wait_until_available(cluster2, hub)
+
+delete_manifestwork(template, cluster1, hub)
+delete_manifestwork(template, cluster2, hub)
+
+wait_until_deleted(cluster1, hub)
+wait_until_deleted(cluster2, hub)

--- a/test/minio/minio.yaml
+++ b/test/minio/minio.yaml
@@ -1,0 +1,134 @@
+# Copyright 2017 the Velero contributors.
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minio
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: minio
+  name: minio-config-pvc
+  labels:
+    component: minio
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: "rook-ceph-block"
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  namespace: minio
+  name: minio-storage-pvc
+  labels:
+    component: minio
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: "rook-ceph-block"
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: minio
+  name: minio
+  labels:
+    component: minio
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      component: minio
+  template:
+    metadata:
+      labels:
+        component: minio
+    spec:
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: minio-storage-pvc
+            readOnly: false
+        - name: config
+          persistentVolumeClaim:
+            claimName: minio-config-pvc
+            readOnly: false
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - server
+            - /storage
+            - --config-dir=/config
+          env:
+            - name: MINIO_ACCESS_KEY
+              value: "minio"
+            - name: MINIO_SECRET_KEY
+              value: "minio123"
+          ports:
+            - containerPort: 9000
+              hostPort: 9000
+          volumeMounts:
+            - name: storage
+              mountPath: "/storage"
+            - name: config
+              mountPath: "/config"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: minio
+  name: minio
+  labels:
+    component: minio
+spec:
+  type: NodePort
+  ports:
+    - port: 9000
+      targetPort: 9000
+      protocol: TCP
+      nodePort: 30000
+  selector:
+    component: minio
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: minio
+  name: minio-setup
+  labels:
+    component: minio
+spec:
+  template:
+    metadata:
+      name: minio-setup
+    spec:
+      restartPolicy: OnFailure
+      volumes:
+        - name: config
+          persistentVolumeClaim:
+            claimName: minio-config-pvc
+            readOnly: false
+      containers:
+        - name: mc
+          image: minio/mc:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - "mc --config-dir=/config config host add ramen http://minio:9000
+               minio minio123 && mc --config-dir=/config mb -p ramen/bucket"
+          volumeMounts:
+            - name: config
+              mountPath: "/config"

--- a/test/minio/start
+++ b/test/minio/start
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -u
+#!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0

--- a/test/minio/start
+++ b/test/minio/start
@@ -1,0 +1,25 @@
+#!/usr/bin/env -S python3 -u
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+import drenv
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} cluster")
+    sys.exit(1)
+
+cluster = sys.argv[1]
+
+drenv.log_progress("Deploying minio")
+drenv.kubectl("apply", "--filename", "minio/minio.yaml", profile=cluster)
+
+drenv.log_progress("Waiting until minio is rolled out")
+drenv.kubectl(
+    "rollout", "status", "deployment/minio",
+    "--namespace", "minio",
+    "--timeout", "180s",
+    profile=cluster,
+)

--- a/test/olm/start
+++ b/test/olm/start
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -u
+#!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0

--- a/test/olm/start
+++ b/test/olm/start
@@ -1,0 +1,81 @@
+#!/usr/bin/env -S python3 -u
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+import drenv
+
+OLM_BASE_URL = "https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.22.0"
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} cluster")
+    sys.exit(1)
+
+cluster = sys.argv[1]
+
+drenv.log_progress("Deploying olm crds")
+
+# Using Server-side Apply to avoid this failure:
+#   The CustomResourceDefinition "clusterserviceversions.operators.coreos.com"
+#   is invalid: metadata.annotations: Too long: must have at most 262144 bytes
+# See https://medium.com/pareture/kubectl-install-crd-failed-annotations-too-long-2ebc91b40c7d
+drenv.kubectl(
+    "apply",
+    "--filename", f"{OLM_BASE_URL}/crds.yaml",
+    "--server-side=true",
+    profile=cluster,
+)
+
+drenv.log_progress("Waiting until cdrs are established")
+drenv.kubectl(
+    "wait",
+    "--for", "condition=established",
+    "--filename", f"{OLM_BASE_URL}/crds.yaml",
+    profile=cluster,
+)
+
+drenv.log_progress("Deploying olm")
+drenv.kubectl(
+    "apply",
+    "--filename", f"{OLM_BASE_URL}/olm.yaml",
+    profile=cluster,
+)
+
+drenv.log_progress("Waiting until olm operator is rolled out")
+drenv.kubectl(
+    "rollout", "status", "deployment/olm-operator",
+    "--namespace", "olm",
+    profile=cluster,
+)
+
+drenv.log_progress("Waiting until olm catalog operator is rolled out")
+drenv.kubectl(
+    "rollout", "status", "deployment/catalog-operator",
+    "--namespace", "olm",
+    profile=cluster,
+)
+
+drenv.wait_for(
+    "csv/packageserver",
+    output="jsonpath={.status.phase}",
+    namespace="olm",
+    profile=cluster,
+)
+
+drenv.log_progress("Waiting until olm packageserver succeeds")
+drenv.kubectl(
+    "wait", "csv/packageserver",
+    "--namespace", "olm",
+    "--for", 'jsonpath={.status.phase}=Succeeded',
+    "--timeout", "300s",
+    profile=cluster,
+)
+
+drenv.log_progress("Waiting for olm pakcage server rollout")
+drenv.kubectl(
+    "rollout", "status", "deployment/packageserver",
+    "--namespace", "olm",
+    profile=cluster,
+)

--- a/test/rbd-mirror/rbd-mirror-secret.yaml
+++ b/test/rbd-mirror/rbd-mirror-secret.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+data:
+  pool: "$pool"
+  token: "$token"
+kind: Secret
+metadata:
+  name: "$name"
+  namespace: rook-ceph
+type: Opaque

--- a/test/rbd-mirror/rbd-mirror.yaml
+++ b/test/rbd-mirror/rbd-mirror.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: ceph.rook.io/v1
+kind: CephRBDMirror
+metadata:
+  name: my-rbd-mirror
+  namespace: rook-ceph
+spec:
+  count: 1

--- a/test/rbd-mirror/rbd-pvc.yaml
+++ b/test/rbd-mirror/rbd-pvc.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rbd-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: rook-ceph-block

--- a/test/rbd-mirror/start
+++ b/test/rbd-mirror/start
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -u
+#!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0

--- a/test/rbd-mirror/start
+++ b/test/rbd-mirror/start
@@ -1,0 +1,146 @@
+#!/usr/bin/env -S python3 -u
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import json
+import sys
+
+import drenv
+
+POOL_NAME = "replicapool"
+
+
+def fetch_secret_info(cluster):
+    info = {}
+
+    drenv.log_progress(f"Getting mirroring info site name for cluster {cluster}")
+    info["name"] = drenv.kubectl(
+        "get", "cephblockpools.ceph.rook.io", POOL_NAME,
+        "--output", "jsonpath={.status.mirroringInfo.site_name}",
+        "--namespace", "rook-ceph",
+        profile=cluster,
+    )
+
+    drenv.log_progress(f"Getting rbd mirror boostrap peer secret name for cluster {cluster}")
+    secret_name = drenv.kubectl(
+        "get", "cephblockpools.ceph.rook.io", POOL_NAME,
+        "--output", "jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}",
+        "--namespace", "rook-ceph",
+        profile=cluster,
+    )
+
+    drenv.log_progress(f"Getting secret {secret_name} token for cluster {cluster}")
+    info["token"] = drenv.kubectl(
+        "get", "secret", secret_name,
+        "--output", "jsonpath={.data.token}",
+        "--namespace", "rook-ceph",
+        profile=cluster,
+    )
+
+    # Must be encoded as base64 in secret .data section.
+    info["pool"] = base64.b64encode(POOL_NAME.encode()).decode()
+
+    return info
+
+
+def configure_rbd_mirroring(cluster, peer_info):
+    drenv.log_progress(f"Applying rbd mirror secret in cluster {cluster}")
+
+    template = drenv.template("rbd-mirror/rbd-mirror-secret.yaml")
+    yaml = template.substitute(peer_info)
+    drenv.kubectl(
+        "apply",
+        "--filename", "-",
+        "--namespace", "rook-ceph",
+        input=yaml,
+        profile=cluster,
+    )
+
+    drenv.log_progress(f"Configure peers for cluster {cluster}")
+    patch = {
+        "spec": {
+            "mirroring": {
+                "peers": {
+                    "secretNames": [
+                        peer_info["name"]]}}}}
+    drenv.kubectl(
+        "patch", "cephblockpool",  POOL_NAME,
+        "--type", "merge",
+        "--patch", json.dumps(patch),
+        "--namespace", "rook-ceph",
+        profile=cluster,
+    )
+
+    drenv.log_progress(f"Apply rbd mirror to cluster {cluster}")
+    drenv.kubectl(
+        "apply",
+        "--filename", "rbd-mirror/rbd-mirror.yaml",
+        "--namespace", "rook-ceph",
+        profile=cluster,
+    )
+
+
+def wait_until_pool_mirroring_is_healthy(cluster):
+    drenv.log_progress(f"Waiting until ceph mirror daemon is healthy in cluster {cluster}")
+    drenv.kubectl(
+        "wait", "cephblockpools.ceph.rook.io", POOL_NAME,
+        "--for", "jsonpath={.status.mirroringStatus.summary.daemon_health}=OK",
+        "--namespace", "rook-ceph",
+        "--timeout", "300s",
+        profile=cluster,
+    )
+
+    drenv.log_progress(f"Waiting until ceph mirror is healthy in cluster {cluster}")
+    drenv.kubectl(
+        "wait", "cephblockpools.ceph.rook.io", POOL_NAME,
+        "--for", "jsonpath={.status.mirroringStatus.summary.health}=OK",
+        "--namespace", "rook-ceph",
+        "--timeout", "300s",
+        profile=cluster,
+    )
+
+    drenv.log_progress(f"Waiting until ceph mirror image is healthy in cluster {cluster}")
+    drenv.kubectl(
+        "wait", "cephblockpools.ceph.rook.io", POOL_NAME,
+        "--for", "jsonpath={.status.mirroringStatus.summary.image_health}=OK",
+        "--namespace", "rook-ceph",
+        "--timeout", "300s",
+        profile=cluster,
+    )
+
+
+def deploy_vrc_sample(cluster):
+    drenv.log_progress(f"Applying vrc sample in cluster {cluster}")
+    drenv.kubectl(
+        "apply",
+        "--filename", "rbd-mirror/vrc-sample.yaml",
+        "--namespace", "rook-ceph",
+        profile=cluster,
+    )
+
+
+if len(sys.argv) != 3:
+    print(f"Usage: {sys.argv[0]} cluster1 cluster2")
+    sys.exit(1)
+
+cluster1 = sys.argv[1]
+cluster2 = sys.argv[2]
+
+cluster1_info = fetch_secret_info(cluster1)
+cluster2_info = fetch_secret_info(cluster2)
+
+drenv.log_progress(f"Setting up mirroring from '{cluster2}' to '{cluster1}'")
+configure_rbd_mirroring(cluster1, cluster2_info)
+
+drenv.log_progress(f"Setting up mirroring from '{cluster1}' to '{cluster2}'")
+configure_rbd_mirroring(cluster2, cluster1_info)
+
+wait_until_pool_mirroring_is_healthy(cluster1)
+wait_until_pool_mirroring_is_healthy(cluster2)
+
+deploy_vrc_sample(cluster1)
+deploy_vrc_sample(cluster2)
+
+drenv.log_progress("Mirroring was setup successfully")

--- a/test/rbd-mirror/test
+++ b/test/rbd-mirror/test
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -u
+#!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0

--- a/test/rbd-mirror/test
+++ b/test/rbd-mirror/test
@@ -1,0 +1,133 @@
+#!/usr/bin/env -S python3 -u
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import time
+
+import drenv
+
+POOL_NAME = "replicapool"
+PVC_NAME = "rbd-pvc"
+
+
+def test_volume_replication(primary, secondary):
+    drenv.log_progress(f"Deploying pvc {PVC_NAME} in cluster {primary}")
+    drenv.kubectl(
+        "apply",
+        "--filename", f"rbd-mirror/{PVC_NAME}.yaml",
+        "--namespace", "rook-ceph",
+        profile=primary,
+    )
+
+    drenv.log_progress(f"Waiting until pvc {PVC_NAME} is bound in cluster {primary}")
+    drenv.kubectl(
+        "wait", "pvc", PVC_NAME,
+        "--for", "jsonpath={.status.phase}=Bound",
+        "--namespace", "rook-ceph",
+        "--timeout", "300s",
+        profile=primary,
+    )
+
+    drenv.log_progress(f"Deploying vr vr-sample in cluster {primary}")
+    drenv.kubectl(
+        "apply",
+        "--filename", "rbd-mirror/vr-sample.yaml",
+        "--namespace", "rook-ceph",
+        profile=primary,
+    )
+
+    drenv.log_progress(f"Waiting until vr vr-sample is completed in cluster {primary}")
+    drenv.kubectl(
+        "wait", "volumereplication", "vr-sample",
+        "--for", "condition=Completed",
+        "--namespace", "rook-ceph",
+        "--timeout", "60s",
+        profile=primary,
+    )
+
+    drenv.log_progress(f"Waiting until vr vr-sample state is primary in cluster {primary}")
+    drenv.kubectl(
+        "wait", "volumereplication", "vr-sample",
+        "--for", "jsonpath={.status.state}=Primary",
+        "--namespace", "rook-ceph",
+        "--timeout", "60s",
+        profile=primary,
+    )
+
+    drenv.log_progress(f"Looking up pvc {PVC_NAME} pv name in cluster {primary}")
+    pv_name = drenv.kubectl(
+        "get", f"pvc/{PVC_NAME}",
+        "--output", "jsonpath={.spec.volumeName}",
+        "--namespace", "rook-ceph",
+        profile=primary,
+    )
+
+    drenv.log_progress(f"Looking up rbd image for pv {pv_name} in cluster {primary}")
+    rbd_image = drenv.kubectl(
+        "get", f"pv/{pv_name}",
+        "--output", "jsonpath={.spec.csi.volumeAttributes.imageName}",
+        "--namespace", "rook-ceph",
+        profile=primary,
+    )
+
+    drenv.log_progress(f"rbd image {rbd_image} info in cluster {primary}")
+    drenv.kubectl(
+        "exec", "deploy/rook-ceph-tools", "--namespace", "rook-ceph", "--",
+        "rbd", "info", rbd_image, "--pool", POOL_NAME,
+        profile=primary,
+    )
+
+    drenv.log_progress(f"Waiting until rbd image {rbd_image} is created in cluster {secondary}")
+    for i in range(60):
+        time.sleep(1)
+        out = drenv.kubectl(
+            "exec", "deploy/rook-ceph-tools", "--namespace", "rook-ceph", "--",
+            "rbd", "list", "--pool", POOL_NAME,
+            profile=secondary,
+        )
+        if rbd_image in out:
+            drenv.kubectl(
+                "exec", "deploy/rook-ceph-tools", "--namespace", "rook-ceph", "--",
+                "rbd", "info", rbd_image, "--pool", POOL_NAME,
+                profile=secondary,
+            )
+            break
+    else:
+        raise RuntimeError(f"Timeout waiting for image {rbd_image}")
+
+    drenv.log_progress(f"vr vr-sample info on primary cluster {primary}")
+    drenv.kubectl(
+        "get", "volumereplication", "vr-sample",
+        "--output", "yaml",
+        "--namespace", "rook-ceph",
+        profile=primary,
+    )
+
+    drenv.log_progress(f"Deleting vr vr-sample in primary cluster {primary}")
+    drenv.kubectl(
+        "delete", "volumereplication", "vr-sample",
+        "--namespace", "rook-ceph",
+        profile=primary,
+    )
+
+    drenv.log_progress(f"Deleting pvc {PVC_NAME} in primary cluster {primary}")
+    drenv.kubectl(
+        "delete", "pvc", PVC_NAME,
+        "--namespace", "rook-ceph",
+        profile=primary,
+    )
+
+    drenv.log_progress(f"Replication from cluster {primary} to cluster {secondary} successeded")
+
+
+if len(sys.argv) != 3:
+    print(f"Usage: {sys.argv[0]} cluster1 cluster2")
+    sys.exit(1)
+
+cluster1 = sys.argv[1]
+cluster2 = sys.argv[2]
+
+test_volume_replication(cluster1, cluster2)
+test_volume_replication(cluster2, cluster1)

--- a/test/rbd-mirror/test
+++ b/test/rbd-mirror/test
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import sys
 import time
 
@@ -10,6 +11,29 @@ import drenv
 
 POOL_NAME = "replicapool"
 PVC_NAME = "rbd-pvc"
+
+
+def rbd_mirror_image_status(cluster, image):
+    out = drenv.kubectl(
+        "exec", "deploy/rook-ceph-tools", "--namespace", "rook-ceph", "--",
+        "rbd", "mirror", "image", "status", f"{POOL_NAME}/{image}",
+        "--format", "json",
+        profile=cluster,
+        verbose=False,
+    )
+    status = json.loads(out)
+
+    # Exapand metrics json embdeded in the peer description.
+    for peer in status["peer_sites"]:
+        desc = peer.get("description", "")
+        if ", " in desc:
+            state, metrics = desc.split(", ", 1)
+            peer["description"] = {
+                "state": state,
+                "metrics": json.loads(metrics),
+            }
+
+    return status
 
 
 def test_volume_replication(primary, secondary):
@@ -104,6 +128,10 @@ def test_volume_replication(primary, secondary):
         "--namespace", "rook-ceph",
         profile=primary,
     )
+
+    drenv.log_progress(f"rbd mirror image status in cluster {primary}")
+    image_status = rbd_mirror_image_status(primary, rbd_image)
+    drenv.log_detail(json.dumps(image_status, indent=2))
 
     drenv.log_progress(f"Deleting vr vr-sample in primary cluster {primary}")
     drenv.kubectl(

--- a/test/rbd-mirror/vr-sample.yaml
+++ b/test/rbd-mirror/vr-sample.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: replication.storage.openshift.io/v1alpha1
+kind: VolumeReplication
+metadata:
+  name: vr-sample
+spec:
+  volumeReplicationClass: vrc-sample
+  replicationState: primary
+  dataSource:
+    kind: PersistentVolumeClaim
+    name: rbd-pvc
+  autoResync: true

--- a/test/rbd-mirror/vrc-sample.yaml
+++ b/test/rbd-mirror/vrc-sample.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: replication.storage.openshift.io/v1alpha1
+kind: VolumeReplicationClass
+metadata:
+  name: vrc-sample
+spec:
+  provisioner: rook-ceph.rbd.csi.ceph.com
+  parameters:
+    replication.storage.openshift.io/replication-secret-name: rook-csi-rbd-provisioner
+    replication.storage.openshift.io/replication-secret-namespace: rook-ceph
+    schedulingInterval: 1m

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -30,3 +30,7 @@ scripts:
     args: ["dr1", "dr2", "hub"]
   - file: klusterlet/test
     args: ["dr1", "dr2", "hub"]
+  - file: rbd-mirror/start
+    args: ["dr1", "dr2"]
+  - file: rbd-mirror/test
+    args: ["dr1", "dr2"]

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -11,6 +11,7 @@ profiles:
     scripts:
       - file: olm/start
       - file: rook/start
+      - file: minio/start
   - name: "dr2"
     network: default
     extra_disks: 1
@@ -18,6 +19,7 @@ profiles:
     scripts:
       - file: olm/start
       - file: rook/start
+      - file: minio/start
   - name: "hub"
     network: default
     scripts:

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -10,12 +10,14 @@ profiles:
     disk_size: "50g"
     scripts:
       - file: olm/start
+      - file: rook/start
   - name: "dr2"
     network: default
     extra_disks: 1
     disk_size: "50g"
     scripts:
       - file: olm/start
+      - file: rook/start
   - name: "hub"
     network: default
     scripts:

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -20,3 +20,9 @@ profiles:
     network: default
     scripts:
       - file: olm/start
+      - file: cluster-manager/start
+scripts:
+  - file: klusterlet/start
+    args: ["dr1", "dr2", "hub"]
+  - file: klusterlet/test
+    args: ["dr1", "dr2", "hub"]

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Enviroment for testing Regional-DR.
+---
+profiles:
+  - name: "dr1"
+    network: default
+    extra_disks: 1
+    disk_size: "50g"
+    scripts:
+      - file: olm/start
+  - name: "dr2"
+    network: default
+    extra_disks: 1
+    disk_size: "50g"
+    scripts:
+      - file: olm/start
+  - name: "hub"
+    network: default
+    scripts:
+      - file: olm/start

--- a/test/rook/cluster-test-kustomization.yaml
+++ b/test/rook/cluster-test-kustomization.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+resources:
+  - ${rook_base_url}/cluster-test.yaml
+patchesJson6902:
+  - target:
+      kind: CephCluster
+      name: my-cluster
+      namespace: rook-ceph
+    patch: |-
+      # Minikube does not persist /var/lib/rook, but it persists /data/*
+      # https://minikube.sigs.k8s.io/docs/handbook/persistent_volumes/#a-note-on-mounts-persistence-and-minikube-hosts
+      - op: replace
+        path: /spec/dataDirHostPath
+        value: /data/rook
+      # Enable host networking - ceph monitors will be available on the host
+      # network, exposed outside of the cluster.
+      - op: add
+        path: /spec/network
+        value:
+          provider: host

--- a/test/rook/operator-kustomization.yaml
+++ b/test/rook/operator-kustomization.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+resources:
+  - ${rook_base_url}/operator.yaml
+patchesJson6902:
+  - target:
+      kind: ConfigMap
+      name: rook-ceph-operator-config
+      namespace: rook-ceph
+    patch: |-
+      - op: add
+        path: /data/CSI_ENABLE_CSIADDONS
+        value: 'true'
+      - op: add
+        path: /data/ROOK_CSIADDONS_IMAGE
+        value: quay.io/csiaddons/k8s-sidecar:latest
+      - op: add
+        path: /data/CSI_ENABLE_OMAP_GENERATOR
+        value: 'true'
+      - op: add
+        path: /data/ROOK_CSI_ALLOW_UNSUPPORTED_VERSION
+        value: 'true'
+      - op: add
+        path: /data/ROOK_CSI_CEPH_IMAGE
+        value: quay.io/cephcsi/cephcsi:canary

--- a/test/rook/replica-pool.yaml
+++ b/test/rook/replica-pool.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: replicapool
+  namespace: rook-ceph
+spec:
+  replicated:
+    size: 1
+    requireSafeReplicaSize: false
+  mirroring:
+    enabled: true
+    mode: image
+    snapshotSchedules:
+      - interval: 2m
+        startTime: 14:00:00-05:00

--- a/test/rook/start
+++ b/test/rook/start
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -u
+#!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0

--- a/test/rook/start
+++ b/test/rook/start
@@ -1,0 +1,155 @@
+#!/usr/bin/env -S python3 -u
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+import drenv
+
+# Update this when upgrading rook.
+ROOK_BASE_URL = "https://raw.githubusercontent.com/rook/rook/release-1.10/deploy/examples"
+
+# Using main till a release is available with lastSyncTime.
+CSI_ADDON_BASE_URL = "https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/main/deploy/controller"
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} cluster")
+    sys.exit(1)
+
+cluster = sys.argv[1]
+
+drenv.log_progress("Deploying rook ceph crds")
+drenv.kubectl(
+    "apply",
+    "--filename", f"{ROOK_BASE_URL}/crds.yaml",
+    profile=cluster,
+)
+
+drenv.log_progress("Deploying rook common")
+drenv.kubectl(
+    "apply",
+    "--filename", f"{ROOK_BASE_URL}/common.yaml",
+    profile=cluster,
+)
+
+drenv.log_progress("Deploying csi addon for volume replication")
+drenv.kubectl(
+    "apply",
+    "--filename", f"{CSI_ADDON_BASE_URL}/crds.yaml",
+    profile=cluster,
+)
+drenv.kubectl(
+    "apply",
+    "--filename", f"{CSI_ADDON_BASE_URL}/rbac.yaml",
+    profile=cluster,
+)
+drenv.kubectl(
+    "apply",
+    "--filename", f"{CSI_ADDON_BASE_URL}/setup-controller.yaml",
+    profile=cluster,
+)
+
+drenv.log_progress("Deploying kustomized rook operator")
+with drenv.kustomization(
+    "rook/operator-kustomization.yaml",
+    rook_base_url=ROOK_BASE_URL,
+) as kustomization:
+    drenv.kubectl("apply", "--kustomize", kustomization, profile=cluster)
+
+drenv.log_progress("Waiting until rook ceph operator is rolled out")
+drenv.kubectl(
+    "rollout", "status", "deployment/rook-ceph-operator",
+    "--namespace", "rook-ceph",
+    "--timeout", "300s",
+    profile=cluster,
+)
+
+drenv.log_progress("Waiting until rook ceph operator is ready")
+drenv.kubectl(
+    "wait", "pod",
+    "--for", "condition=Ready",
+    "--namespace", "rook-ceph",
+    "--selector", "app=rook-ceph-operator",
+    "--timeout", "300s",
+    profile=cluster,
+)
+
+drenv.log_progress("Deploying kustomized rook ceph cluster")
+with drenv.kustomization(
+    "rook/cluster-test-kustomization.yaml",
+    rook_base_url=ROOK_BASE_URL,
+) as kustomization:
+    drenv.kubectl("apply", "--kustomize", kustomization, profile=cluster)
+
+drenv.log_progress("Creating a mirroring enabled RBD pool")
+drenv.kubectl(
+    "apply",
+    "--filename", "rook/replica-pool.yaml",
+    profile=cluster,
+)
+
+drenv.log_progress("Creating a storage class")
+drenv.kubectl(
+    "apply",
+    "--filename", "rook/storage-class.yaml",
+    profile=cluster,
+)
+
+drenv.wait_for(
+    "cephcluster/my-cluster",
+    output="jsonpath={.status.phase}",
+    namespace="rook-ceph",
+    timeout=60,
+    profile=cluster,
+)
+
+drenv.log_progress("Waiting until rook ceph cluster is ready")
+drenv.kubectl(
+    "wait", "CephCluster", "my-cluster",
+    "--for", "jsonpath={.status.phase}=Ready",
+    "--namespace", "rook-ceph",
+    "--timeout", "300s",
+    profile=cluster,
+)
+
+drenv.wait_for(
+    "cephblockpool/replicapool",
+    output="jsonpath={.status.phase}",
+    namespace="rook-ceph",
+    timeout=60,
+    profile=cluster,
+)
+
+drenv.log_progress("Waiting until ceph block pool is ready")
+drenv.kubectl(
+    "wait", "CephBlockPool", "replicapool",
+    "--for", "jsonpath={.status.phase}=Ready",
+    "--namespace", "rook-ceph",
+    "--timeout", "300s",
+    profile=cluster,
+)
+
+drenv.log_progress("Waiting for replica pool peer token")
+drenv.kubectl(
+    "wait", "CephBlockPool", "replicapool",
+    "--for", "jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}=pool-peer-token-replicapool",
+    "--namespace", "rook-ceph",
+    "--timeout", "300s",
+    profile=cluster,
+)
+
+drenv.log_progress("Deploying rook ceph toolbox")
+drenv.kubectl(
+    "apply",
+    "--filename", f"{ROOK_BASE_URL}/toolbox.yaml",
+    profile=cluster,
+)
+
+drenv.log_progress("Waiting until toolbox is rolled out")
+drenv.kubectl(
+    "rollout", "status", "deployment/rook-ceph-tools",
+    "--namespace", "rook-ceph",
+    "--timeout", "300s",
+    profile=cluster,
+)

--- a/test/rook/storage-class.yaml
+++ b/test/rook/storage-class.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+    name: rook-ceph-block
+provisioner: rook-ceph.rbd.csi.ceph.com
+parameters:
+    clusterID: rook-ceph
+    pool: replicapool
+    imageFormat: "2"
+    imageFeatures: layering
+    csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+    csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+    csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+    csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+    csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+    csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+    csi.storage.k8s.io/fstype: ext4
+reclaimPolicy: Delete

--- a/test/setup.py
+++ b/test/setup.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# flake8: noqa
+
+import setuptools
+
+with open("README.md", "r") as f:
+    long_description = f.read()
+
+setuptools.setup(
+    name="drenv",
+    version="0.1.0",
+    author="Nir Soffer",
+    author_email="nsoffer@redhat.com",
+    description="Create ramen testing environment",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/RamenDR/ramen",
+    packages=["drenv"],
+    install_requires=[
+        "PyYAML",
+    ],
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Environment :: Console",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3",
+        "Topic :: Software Development :: Testing",
+    ],
+    entry_points = {
+        'console_scripts': ['drenv=drenv.__main__:main'],
+    }
+)


### PR DESCRIPTION
This PR adds the `drenv` tool and python package for creating minikube based
local or CI test environment.

The changes includes a regional DR environment with ocm, rook, minio and rbd
mirroring.

The goal of this change:
- having an easy and reliable way to set up a testing environment, to make it
  easy for new contributors.
- having easy to understand and maintain code

When this work is finished, it should replace the hack deployment scripts.

Some components installed by hack/ocm-minimube.sh are missing:

- multicloud-operators-foundation
  https://github.com/stolostron/multicloud-operators-foundation

- multicloud-operators-subscription
  https://github.com/stolostron/multicloud-operators-subscription

- governance-policy-propagator
  https://github.com/open-cluster-management-io/governance-policy-propagator/

I'm not sure if these are needed, which version is required, which is
the right repo to install them from, and what changes are needed for 
ramen.

Building and installing ramen is not done yet since it depends on the missing
components.

The next step is adding environment for metro DR with external ceph storage.
This will probably require some changes in the rook scripts.