### PR TITLE
Fix install instructions in pre-commit hook

### DIFF
--- a/hack/pre-commit.sh
+++ b/hack/pre-commit.sh
@@ -38,10 +38,10 @@ function run_check() {
 # Install via: gem install mdl
 run_check '.*\.md' mdl --style "${scriptdir}/mdl-style.rb"
 
-# Install via: dnf install shellcheck
+# Install via: dnf install ShellCheck
 run_check '.*\.(ba)?sh' shellcheck
 
-# Install via: pip install yamllint
+# Install via: dnf install yamllint
 run_check '.*\.ya?ml' yamllint -s -c "${scriptdir}/yamlconfig.yaml"
 
 (! < "${OUTPUTS_FILE}" read -r)


### PR DESCRIPTION
- shellcheck package name is ShellCheck
- Install yamlint via dnf

Tested on Fedora 36:

    $ rpm -q yamllint ShellCheck
    yamllint-1.28.0-1.fc36.noarch
    ShellCheck-0.7.2-5.fc36.x86_64

Signed-off-by: Nir Soffer <nsoffer@redhat.com>