### PR TITLE
[bz_2118702] : Modified the error message shown to the

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -1337,7 +1337,7 @@ func (d *DRPCInstance) checkPVsHaveBeenRestored(homeCluster string) (bool, error
 	vrg, err := d.reconciler.MCVGetter.GetVRGFromManagedCluster(d.instance.Name,
 		d.instance.Namespace, homeCluster, annotations)
 	if err != nil {
-		return false, fmt.Errorf("failed to VRG using MCV (error: %w)", err)
+		return false, fmt.Errorf("waiting for PVs to be restored to failover cluster (status: %w)", err)
 	}
 
 	// ClusterDataReady condition tells us whether the PVs have been applied on the


### PR DESCRIPTION
[bz_2118702] : During failover or relocate a series of checks happens , one such check is if PVs Have Been Restored to target or failover cluster. For this we try access VRG from MCV which fails and then failure goes away with the next reconcile. The failure is because VRG is just created as a ManifestWork, but not created on the ManagedCluster yet. Modified the error message shown to the user to mild with more appropriate information


Signed-off-by: Jolly Mishra <jmishra@redhat.com>