### PR TITLE
Fix for unit test flake

### DIFF
--- a/controllers/volsync/vshandler.go
+++ b/controllers/volsync/vshandler.go
@@ -920,7 +920,6 @@ func (v *VSHandler) ensurePVCFromSnapshot(rdSpec ramendrv1alpha1.VolSyncReplicat
 func (v *VSHandler) validateSnapshotAndAddDoNotDeleteLabel(
 	volumeSnapshotRef corev1.TypedLocalObjectReference,
 ) (*snapv1.VolumeSnapshot, error) {
-	// Using unstructured to avoid needing to require VolumeSnapshot in client scheme
 	volSnap := &snapv1.VolumeSnapshot{}
 
 	err := v.client.Get(v.ctx, types.NamespacedName{


### PR DESCRIPTION
- Could be timing issue when unit test creates a volumesnapshot and then runs  vsHandler.EnsurePVCfromRD(rdSpec) which is expecting the volumesnapshot to exist.
- The flak most likely occurs because the volumesnapshot has not yet appeared in the k8s client cache.
- The unit test previously tried to get around this by re-loading the volumesnapshot, but was using unstructured.Unstructured which is not actually cached - so this check was ineffectual.
- Unit test does not need to use unstructured, as snapv1 is already imported, so moved to using snapv1.VolumeSnapshot like the rest of the code does.

Signed-off-by: Tesshu Flower <tflower@redhat.com>