### PR TITLE
Allow multiple failovers when PVCs are not deleted

### DIFF
--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -6,6 +6,7 @@ package controllers
 import (
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/go-logr/logr"
@@ -157,8 +158,8 @@ func (v *VRGInstance) reconcileVRAsSecondary(pvc *corev1.PersistentVolumeClaim, 
 func (v *VRGInstance) isPVCReadyForSecondary(pvc *corev1.PersistentVolumeClaim, log logr.Logger) bool {
 	const ready bool = true
 
-	// If PVC is not being deleted, it is not ready for Secondary
-	if pvc.GetDeletionTimestamp().IsZero() {
+	// If PVC is not being deleted, it is not ready for Secondary, unless action is failover
+	if v.instance.Spec.Action != ramendrv1alpha1.VRGActionFailover && pvc.GetDeletionTimestamp().IsZero() {
 		log.Info("VolumeReplication cannot become Secondary, as its PersistentVolumeClaim is not marked for deletion")
 
 		msg := "unable to transition to Secondary as PVC is not deleted"
@@ -1752,14 +1753,20 @@ func (v *VRGInstance) validatePVExistence(pv *corev1.PersistentVolume) error {
 
 	err := v.reconciler.Get(v.ctx, types.NamespacedName{Name: pv.Name}, existingPV)
 	if err != nil {
-		return fmt.Errorf("failed to get existing PV (%w)", err)
+		return fmt.Errorf("failed to get PV (%s) (%w)", existingPV.GetName(), err)
 	}
 
 	if existingPV.ObjectMeta.Annotations != nil &&
 		existingPV.ObjectMeta.Annotations[PVRestoreAnnotation] == "True" {
 		// Should we check and see if PV in being deleted? Should we just treat it as exists
 		// and then we don't care if deletion takes place later, which is what we do now?
-		v.log.Info("PV exists and managed by Ramen", "PV", existingPV)
+		v.log.Info("PV exists and managed by Ramen", "PV", existingPV.GetName())
+
+		return nil
+	}
+
+	if v.pvMatches(existingPV, pv) {
+		v.log.Info("existing PV matches and is bound to the same claim", "PV", existingPV.GetName())
 
 		return nil
 	}
@@ -1770,12 +1777,67 @@ func (v *VRGInstance) validatePVExistence(pv *corev1.PersistentVolume) error {
 	// restore can be missing for the sync mode. Skip the check for the
 	// annotation in this case.
 	if v.instance.Spec.Sync != nil {
-		v.log.Info("PV exists, will update for sync", "PV", existingPV)
+		v.log.Info("PV exists and will be updated for sync", "PV", existingPV.GetName())
 
 		return v.updateExistingPVForSync(existingPV)
 	}
 
-	return fmt.Errorf("found PV object not restored by Ramen for PV %s", existingPV.Name)
+	return fmt.Errorf("found existing PV (%s) not restored by Ramen and not matching with backed up PV", existingPV.Name)
+}
+
+// PVMatches checks if the PVs fields match, and is bound to a PVC. Used to detect PVCs that were not
+// deleted, and hence PVC and PV is retained and available for use
+//
+//nolint:cyclop
+func (v *VRGInstance) pvMatches(x, y *corev1.PersistentVolume) bool {
+	switch {
+	case x.GetName() != y.GetName():
+		v.log.Info("PVs Name mismatch", "x", x.GetName(), "y", y.GetName())
+
+		return false
+	case x.Status.Phase != corev1.VolumeBound:
+		v.log.Info("PV not bound", "x", x.Status.Phase)
+
+		return false
+	case x.Spec.PersistentVolumeSource.CSI == nil || y.Spec.PersistentVolumeSource.CSI == nil:
+		v.log.Info("PV(s) not managed by a CSI driver", "x", x.Spec.PersistentVolumeSource.CSI,
+			"y", y.Spec.PersistentVolumeSource.CSI)
+
+		return false
+	case x.Spec.PersistentVolumeSource.CSI.Driver != y.Spec.PersistentVolumeSource.CSI.Driver:
+		v.log.Info("PVs CSI drivers mismatch", "x", x.Spec.PersistentVolumeSource.CSI.Driver,
+			"y", y.Spec.PersistentVolumeSource.CSI.Driver)
+
+		return false
+	case x.Spec.PersistentVolumeSource.CSI.FSType != y.Spec.PersistentVolumeSource.CSI.FSType:
+		v.log.Info("PVs CSI FSType mismatch", "x", x.Spec.PersistentVolumeSource.CSI.FSType,
+			"y", y.Spec.PersistentVolumeSource.CSI.FSType)
+
+		return false
+	case x.Spec.ClaimRef.Kind != y.Spec.ClaimRef.Kind:
+		v.log.Info("PVs ClaimRef.Kind mismatch", "x", x.Spec.ClaimRef.Kind, "y", y.Spec.ClaimRef.Kind)
+
+		return false
+	case x.Spec.ClaimRef.Namespace != y.Spec.ClaimRef.Namespace:
+		v.log.Info("PVs ClaimRef.Namespace mismatch", "x", x.Spec.ClaimRef.Namespace,
+			"y", y.Spec.ClaimRef.Namespace)
+
+		return false
+	case x.Spec.ClaimRef.Name != y.Spec.ClaimRef.Name:
+		v.log.Info("PVs ClaimRef.Name mismatch", "x", x.Spec.ClaimRef.Name, "y", y.Spec.ClaimRef.Name)
+
+		return false
+	case !reflect.DeepEqual(x.Spec.AccessModes, y.Spec.AccessModes):
+		v.log.Info("PVs AccessMode mismatch", "x", x.Spec.AccessModes, "y", y.Spec.AccessModes)
+
+		return false
+	case !reflect.DeepEqual(x.Spec.VolumeMode, y.Spec.VolumeMode):
+		v.log.Info("PVs VolumeMode mismatch", "x", x.Spec.VolumeMode, "y", y.Spec.VolumeMode)
+
+		return false
+	default:
+		return true
+	}
 }
 
 // cleanupPVForRestore cleans up required PV fields, to ensure restore succeeds to a new cluster, and

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -1766,7 +1766,7 @@ func (v *VRGInstance) validatePVExistence(pv *corev1.PersistentVolume) error {
 	}
 
 	if v.pvMatches(existingPV, pv) {
-		v.log.Info("existing PV matches and is bound to the same claim", "PV", existingPV.GetName())
+		v.log.Info("Existing PV matches and is bound to the same claim", "PV", existingPV.GetName())
 
 		return nil
 	}
@@ -1785,7 +1785,7 @@ func (v *VRGInstance) validatePVExistence(pv *corev1.PersistentVolume) error {
 	return fmt.Errorf("found existing PV (%s) not restored by Ramen and not matching with backed up PV", existingPV.Name)
 }
 
-// PVMatches checks if the PVs fields match, and is bound to a PVC. Used to detect PVCs that were not
+// pvMatches checks if the PVs fields match, and is bound to a PVC. Used to detect PVCs that were not
 // deleted, and hence PVC and PV is retained and available for use
 //
 //nolint:cyclop

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -147,11 +147,43 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			restoreTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
 			numPVs := 3
 			vtest := newVRGTestCaseCreate(0, restoreTestTemplate, true, false)
-			pvList := generateFakePVs("pv", numPVs)
+			pvList := vtest.generateFakePVs("pv", numPVs)
 			populateS3Store(vtest.s3KeyPrefix(), pvList)
 			vtest.VRGTestCaseStart()
 			waitForPVRestore(pvList)
 			cleanupS3Store()
+		})
+	})
+
+	// Test restore success when bound PV/PVC are present
+	var vrgTestBoundPV *vrgTest
+	Context("restore test case for existing and bound PV/PVC", func() {
+		restoreTestTemplate := &template{
+			ClaimBindInfo:          corev1.ClaimBound,
+			VolumeBindInfo:         corev1.VolumeBound,
+			schedulingInterval:     "1h",
+			storageClassName:       "manual",
+			replicationClassName:   "test-replicationclass",
+			vrcProvisioner:         "manual.storage.com",
+			scProvisioner:          "manual.storage.com",
+			replicationClassLabels: map[string]string{"protection": "ramen"},
+		}
+		It("populates the S3 store with PVs and starts vrg as primary", func() {
+			restoreTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
+			vrgTestBoundPV = newVRGTestCaseCreate(3, restoreTestTemplate, true, false)
+			pvList := vrgTestBoundPV.generatePVs()
+			populateS3Store(vrgTestBoundPV.s3KeyPrefix(), pvList)
+			vrgTestBoundPV.VRGTestCaseStart()
+		})
+		It("waits for VRG to create a VR for each PVC", func() {
+			vrgTestBoundPV.waitForVRCountToMatch(len(vrgTestBoundPV.pvcNames))
+		})
+		It("waits for VRG status to match", func() {
+			vrgTestBoundPV.promoteVolReps()
+			vrgTestBoundPV.verifyVRGStatusExpectation(true)
+		})
+		It("cleans up after testing", func() {
+			vrgTestBoundPV.cleanup()
 		})
 	})
 
@@ -643,6 +675,25 @@ func newVRGTestCaseCreateAndStart(pvcCount int, testTemplate *template, checkBin
 	return v
 }
 
+func (v *vrgTest) generatePVs() []corev1.PersistentVolume {
+	pvList := []corev1.PersistentVolume{}
+
+	// The generator has a limit of 9999 unique names.
+	if v.pvcCount > 9999 {
+		return pvList
+	}
+
+	// Create the requested number of PVs and corresponding PVCs
+	for i := 0; i < v.pvcCount; i++ {
+		pvName := fmt.Sprintf("pv-%v-%02d", v.uniqueID, i)
+		pvcName := fmt.Sprintf("pvc-%v-%02d", v.uniqueID, i)
+
+		pvList = append(pvList, *v.generatePV(pvName, pvcName))
+	}
+
+	return pvList
+}
+
 func (v *vrgTest) createPVCandPV(claimBindInfo corev1.PersistentVolumeClaimPhase,
 	volumeBindInfo corev1.PersistentVolumePhase,
 ) {
@@ -674,7 +725,7 @@ func cleanupS3Store() {
 	Expect((*vrgObjectStorer).DeleteObjects("")).To(Succeed())
 }
 
-func generateFakePVs(pvNamePrefix string, count int) []corev1.PersistentVolume {
+func (v *vrgTest) generateFakePVs(pvNamePrefix string, count int) []corev1.PersistentVolume {
 	pvList := []corev1.PersistentVolume{}
 
 	// The generator has a limit of 9999 unique names.
@@ -684,58 +735,10 @@ func generateFakePVs(pvNamePrefix string, count int) []corev1.PersistentVolume {
 
 	for i := 1; i <= count; i++ {
 		pvName := fmt.Sprintf("%s%04d", pvNamePrefix, i)
-		pv := getSamplePV(pvName)
-		pvList = append(pvList, pv)
+		pvList = append(pvList, *v.generatePV(pvName, "PVC_of_"+pvName))
 	}
 
 	return pvList
-}
-
-func getSamplePV(pvName string) corev1.PersistentVolume {
-	capacity := corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")}
-	accessModes := []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
-	hostPathType := corev1.HostPathDirectoryOrCreate
-
-	pv := corev1.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{Name: pvName},
-		Spec: corev1.PersistentVolumeSpec{
-			Capacity: capacity,
-			PersistentVolumeSource: corev1.PersistentVolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/tmp/kube",
-					Type: &hostPathType,
-				},
-			},
-			AccessModes: accessModes,
-			ClaimRef: &corev1.ObjectReference{
-				Kind:      "PersistentVolumeClaim",
-				Namespace: "my-namespace",
-				Name:      "PVC_of_" + pvName,
-			},
-			PersistentVolumeReclaimPolicy: "Delete",
-			StorageClassName:              "manual",
-			MountOptions:                  []string{},
-			NodeAffinity: &corev1.VolumeNodeAffinity{
-				Required: &corev1.NodeSelector{
-					NodeSelectorTerms: []corev1.NodeSelectorTerm{
-						{
-							MatchExpressions: []corev1.NodeSelectorRequirement{
-								{
-									Key:      "KeyNode",
-									Operator: corev1.NodeSelectorOpIn,
-									Values: []string{
-										"node1",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	return pv
 }
 
 func (v *vrgTest) vrgNamespacedName() types.NamespacedName {
@@ -768,25 +771,42 @@ func (v *vrgTest) createNamespace() {
 func (v *vrgTest) createPV(pvName, claimName string, bindInfo corev1.PersistentVolumePhase) {
 	By("creating PV " + pvName)
 
+	pv := v.generatePV(pvName, claimName)
+
+	err := k8sClient.Create(context.TODO(), pv)
+	expectedErr := errors.NewAlreadyExists(
+		schema.GroupResource{Resource: "persistentvolumes"}, pvName)
+	Expect(err).To(SatisfyAny(BeNil(), MatchError(expectedErr)),
+		"failed to create PV %s", pvName)
+
+	pv.Status.Phase = bindInfo
+	err = k8sClient.Status().Update(context.TODO(), pv)
+	Expect(err).To(BeNil(),
+		"failed to update status of PV %s", pvName)
+}
+
+func (v *vrgTest) generatePV(pvName, claimName string) *corev1.PersistentVolume {
 	capacity := corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")}
 	accessModes := []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
-	hostPathType := corev1.HostPathDirectoryOrCreate
-	pv := &corev1.PersistentVolume{
+	volumeMode := corev1.PersistentVolumeFilesystem
+
+	return &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{Name: pvName},
 		Spec: corev1.PersistentVolumeSpec{
 			Capacity: capacity,
 			PersistentVolumeSource: corev1.PersistentVolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/tmp/kube",
-					Type: &hostPathType,
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver:       "fake.csi",
+					FSType:       "ext4",
+					VolumeHandle: "fakeVolumeHandle",
 				},
 			},
 			AccessModes: accessModes,
+			VolumeMode:  &volumeMode,
 			ClaimRef: &corev1.ObjectReference{
 				Kind:      "PersistentVolumeClaim",
 				Namespace: v.namespace,
 				Name:      claimName,
-				// UID:       types.UID(claimName),
 			},
 			PersistentVolumeReclaimPolicy: "Delete",
 			StorageClassName:              v.storageClass,
@@ -810,17 +830,6 @@ func (v *vrgTest) createPV(pvName, claimName string, bindInfo corev1.PersistentV
 			},
 		},
 	}
-
-	err := k8sClient.Create(context.TODO(), pv)
-	expectedErr := errors.NewAlreadyExists(
-		schema.GroupResource{Resource: "persistentvolumes"}, pvName)
-	Expect(err).To(SatisfyAny(BeNil(), MatchError(expectedErr)),
-		"failed to create PV %s", pvName)
-
-	pv.Status.Phase = bindInfo
-	err = k8sClient.Status().Update(context.TODO(), pv)
-	Expect(err).To(BeNil(),
-		"failed to update status of PV %s", pvName)
 }
 
 func (v *vrgTest) createPVC(pvcName, namespace, volumeName string, labels map[string]string,


### PR DESCRIPTION
Currently when recovering a failed cluster, we
wait for the PVC to be deleted to prevent potential future usage of the same, before moving the VR to
Secondary.

This commit ignores the PVC deletion state on failover on the failed cluster which is moved to Secondary. This is safe as on failover the PV contents are resynced hence not waiting for the PVC to be deleted is acceptable.

The commit also does not fail PV restores for PVCs and PVs that are bound and are the same as the PVs from the S3 store.

The entire change hence allows, multiple failovers when PVCs are not deleted by the workload.

Relocate still would need the PVCs to be deleted to ensure there is no potential use of the same.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>