### PR TITLE
Enable sanity workflow on any branch

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -2,16 +2,13 @@
 # yamllint disable rule:line-length
 
 name: PR and branch sanity
+
+# This workflow will run when developer push a topic branch to their
+# fork in github, minimizing noise for maintainers.
 on:  # yamllint disable-line rule:truthy
-  push:
-    tags:
-      - v*
-    branches:
-      - release-*
-      - main
-  pull_request:
-    branches:
-      - '*'
+  - push
+  - pull_request
+
 env:
   GO_VERSION: "1.18"
   IMAGE_TAG_BASE: "quay.io/ramendr/ramen"


### PR DESCRIPTION
Currently when you push a topic branch to your github fork the workflow does not run. You have to create a pull request on your fork, or create a pull request on the upstream project to get the workflow running. Then you many need several iterations until all tests pass, creating lot of noise for the maintainer.

With this change the workflow run when developer push a topic branch to their fork in github, and developers can create a pull request when the tests pass.

Example run in my fork:
https://github.com/nirs/ramen/actions/runs/3339418866

Signed-off-by: Nir Soffer <nsoffer@redhat.com>