### PR TITLE
makefile: allow users to define a dockercmd

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -19,6 +19,7 @@ env:
   IMAGE_REPOSITORY: "ramendr"
   IMAGE_NAME: "ramen"
   IMAGE_TAG: "sanity"
+  DOCKERCMD: "podman"
 defaults:
   run:
     shell: bash
@@ -77,7 +78,7 @@ jobs:
         run: GO_TEST_GINKGO_ARGS="" make test
 
       - name: Export image
-        run: docker save -o /tmp/ramen-operator.tar ${IMAGE_TAG_BASE}-operator:${IMAGE_TAG}
+        run: ${{env.DOCKERCMD}} save -o /tmp/ramen-operator.tar ${IMAGE_TAG_BASE}-operator:${IMAGE_TAG}
 
       - name: Save image artifact
         uses: actions/upload-artifact@v2
@@ -138,8 +139,7 @@ jobs:
 
       - name: Load image artifact
         run: |
-          docker load -i /tmp/ramen-operator.tar
-          kind load docker-image ${IMAGE_TAG_BASE}-operator:${IMAGE_TAG} --name ${KIND_CLUSTER_NAME}
+          kind load image-archive /tmp/ramen-operator.tar --name ${KIND_CLUSTER_NAME}
 
       - name: Install cert-manager
         run: |
@@ -194,7 +194,7 @@ jobs:
 
       - name: Load image artifact
         run: |
-          docker load -i /tmp/ramen-operator.tar
+          ${{env.DOCKERCMD}} load -i /tmp/ramen-operator.tar
 
       - name: Login to Quay
         uses: docker/login-action@v1
@@ -225,8 +225,8 @@ jobs:
 
       - name: Push operator image to Quay
         run: |
-          docker tag "${IMAGE_TAG_BASE}-operator:${IMAGE_TAG}" "${IMAGE_TAG_BASE}-operator:${{ env.publish_image_tag }}"
-          docker push "${IMAGE_TAG_BASE}-operator:${{ env.publish_image_tag }}"
+          ${{env.DOCKERCMD}} tag "${IMAGE_TAG_BASE}-operator:${IMAGE_TAG}" "${IMAGE_TAG_BASE}-operator:${{ env.publish_image_tag }}"
+          ${{env.DOCKERCMD}} push "${IMAGE_TAG_BASE}-operator:${{ env.publish_image_tag }}"
 
       # TODO: We do not need to build bundles and catalogs each time, fix once we reach alpha
       - name: Checkout source

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -59,6 +59,21 @@ jobs:
         with:
           version: v1.49.0
 
+  unit-test:
+    name: Unit tests
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Run unit tests
+        run: GO_TEST_GINKGO_ARGS="" make test
+
   build-image-and-ensure-clean-branch:
     name: Build image and ensure clean branch
     runs-on: ubuntu-20.04
@@ -73,9 +88,6 @@ jobs:
 
       - name: Build image
         run: make docker-build
-
-      - name: Run unit tests
-        run: GO_TEST_GINKGO_ARGS="" make test
 
       - name: Export image
         run: ${{env.DOCKERCMD}} save -o /tmp/ramen-operator.tar ${IMAGE_TAG_BASE}-operator:${IMAGE_TAG}
@@ -177,7 +189,7 @@ jobs:
 
   publish-image:
     name: Publish built image
-    needs: [deploy-check, lint, golangci]
+    needs: [deploy-check, lint, golangci, unit-test, build-image-and-ensure-clean-branch]
     if: >
       (github.event_name == 'push') &&
       (github.ref == 'refs/heads/main' ||

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,8 @@ endif
 
 GO_TEST_GINKGO_ARGS ?= -test.v -ginkgo.v -ginkgo.failFast
 
+DOCKERCMD ?= podman
+
 all: build
 
 ##@ General
@@ -168,10 +170,10 @@ run-dr-cluster: generate manifests ## Run DR manager controller from your host.
 	go run ./main.go --config=examples/dr_cluster_config.yaml
 
 docker-build: ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	$(DOCKERCMD) build -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	$(DOCKERCMD) push ${IMG}
 
 ##@ Deployment
 
@@ -290,7 +292,7 @@ bundle-hub: manifests kustomize operator-sdk ## Generate hub bundle manifests an
 
 .PHONY: bundle-hub-build
 bundle-hub-build: bundle-hub ## Build the hub bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG_HUB) .
+	$(DOCKERCMD) build -f bundle.Dockerfile -t $(BUNDLE_IMG_HUB) .
 
 .PHONY: bundle-hub-push
 bundle-hub-push: ## Push the hub bundle image.
@@ -307,7 +309,7 @@ bundle-dr-cluster: manifests kustomize dr-cluster-config operator-sdk ## Generat
 
 .PHONY: bundle-dr-cluster-build
 bundle-dr-cluster-build: bundle-dr-cluster ## Build the dr-cluster bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG_DRCLUSTER) .
+	$(DOCKERCMD) build -f bundle.Dockerfile -t $(BUNDLE_IMG_DRCLUSTER) .
 
 .PHONY: bundle-dr-cluster-push
 bundle-dr-cluster-push: ## Push the dr-cluster bundle image.
@@ -342,7 +344,7 @@ ifneq ($(origin CATALOG_BASE_IMG), undefined)
 FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
 endif
 
-BUNDLE_PULL_TOOL ?= docker
+BUNDLE_PULL_TOOL ?= $(DOCKERCMD)
 
 # Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
 # This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
@@ -354,7 +356,7 @@ catalog-build: opm ## Build a catalog image.
 		--tag $(CATALOG_IMG)\
 		--bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)\
 		--pull-tool $(BUNDLE_PULL_TOOL)\
-		--build-tool docker\
+		--build-tool $(DOCKERCMD)\
 
 # Push the catalog image.
 .PHONY: catalog-push


### PR DESCRIPTION
This allows one to use a different tool, say podman instead of docker for their container build.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>