### PR TITLE
Use image specs from alm examples

### DIFF
--- a/test/cluster-manager/cluster-manager.yaml
+++ b/test/cluster-manager/cluster-manager.yaml
@@ -9,10 +9,10 @@ metadata:
 spec:
   deployOption:
     mode: Default
-  placementImagePullSpec: 'quay.io/open-cluster-management/placement:v0.9.0'
+  placementImagePullSpec: $placementImage
   registrationConfiguration:
     featureGates:
       - feature: DefaultClusterSet
         mode: Enable
-  registrationImagePullSpec: 'quay.io/open-cluster-management/registration:v0.9.0'
-  workImagePullSpec: 'quay.io/open-cluster-management/work:v0.9.0'
+  registrationImagePullSpec: $registrationImage
+  workImagePullSpec: $workImage

--- a/test/cluster-manager/start
+++ b/test/cluster-manager/start
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
 import sys
 
@@ -55,12 +56,23 @@ drenv.kubectl(
     profile=cluster,
 )
 
-drenv.log_progress("Creating cluster manager instance")
-drenv.kubectl(
-    "apply",
-    "--filename", "cluster-manager/cluster-manager.yaml",
+drenv.log_progress("Fetching cluster manager alm examples")
+examples_json = drenv.kubectl(
+    "get", f"csv/{current_csv}",
+    "--output", "jsonpath={.metadata.annotations.alm-examples}",
+    "--namespace", "operators",
     profile=cluster,
 )
+example_spec = json.loads(examples_json)[0]["spec"]
+
+drenv.log_progress("Creating cluster manager instance")
+instance_template = drenv.template("cluster-manager/cluster-manager.yaml")
+instance_yaml = instance_template.substitute(
+  placementImage=example_spec["placementImagePullSpec"],
+  registrationImage=example_spec["registrationImagePullSpec"],
+  workImage=example_spec["workImagePullSpec"],
+)
+drenv.kubectl("apply", "--filename", "-", input=instance_yaml, profile=cluster)
 
 drenv.wait_for("namespace/open-cluster-management-hub", profile=cluster)
 

--- a/test/klusterlet/klusterlet.yaml
+++ b/test/klusterlet/klusterlet.yaml
@@ -18,5 +18,5 @@ spec:
     featureGates:
       - feature: AddonManagement
         mode: Enable
-  registrationImagePullSpec: 'quay.io/open-cluster-management/registration:v0.9.0'
-  workImagePullSpec: 'quay.io/open-cluster-management/work:v0.9.0'
+  registrationImagePullSpec: $registrationImage
+  workImagePullSpec: $workImage

--- a/test/klusterlet/start
+++ b/test/klusterlet/start
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
 import sys
 
@@ -52,8 +53,10 @@ def wait_until_klusterlet_is_rolled_out(cluster):
         profile=cluster,
     )
 
+    return current_csv
 
-def create_klusterlet_instance(cluster, hub):
+
+def create_klusterlet_instance(cluster, hub, csv):
     drenv.log_progress(f"Creating namespace {NAMESPACE} in cluster {cluster}")
     namespace_yaml = drenv.kubectl(
         "create", "namespace", NAMESPACE,
@@ -89,11 +92,22 @@ def create_klusterlet_instance(cluster, hub):
         profile=cluster,
     )
 
+    drenv.log_progress("Fetching klusterlet alm examples")
+    examples_json = drenv.kubectl(
+        "get", f"csv/{csv}",
+        "--output", "jsonpath={.metadata.annotations.alm-examples}",
+        "--namespace", "operators",
+        profile=cluster,
+    )
+    example_spec = json.loads(examples_json)[0]["spec"]
+
     klusterlet_template = drenv.template("klusterlet/klusterlet.yaml")
 
     klusterlet_yaml = klusterlet_template.substitute(
         clusterName=cluster,
         namespace=NAMESPACE,
+        registrationImage=example_spec["registrationImagePullSpec"],
+        workImage=example_spec["workImagePullSpec"],
     )
 
     drenv.log_progress(f"Creating klusterlet instance in cluster {cluster}")
@@ -187,11 +201,11 @@ hub = sys.argv[3]
 deploy_klusterlet(cluster1)
 deploy_klusterlet(cluster2)
 
-wait_until_klusterlet_is_rolled_out(cluster1)
-wait_until_klusterlet_is_rolled_out(cluster2)
+cluster1_csv = wait_until_klusterlet_is_rolled_out(cluster1)
+cluster2_csv = wait_until_klusterlet_is_rolled_out(cluster2)
 
-create_klusterlet_instance(cluster1, hub)
-create_klusterlet_instance(cluster2, hub)
+create_klusterlet_instance(cluster1, hub, cluster1_csv)
+create_klusterlet_instance(cluster2, hub, cluster2_csv)
 
 wait_until_instance_is_registered(cluster1, hub)
 wait_until_instance_is_registered(cluster2, hub)

--- a/test/klusterlet/start
+++ b/test/klusterlet/start
@@ -5,7 +5,6 @@
 
 import os
 import sys
-from string import Template
 
 import drenv
 
@@ -90,8 +89,7 @@ def create_klusterlet_instance(cluster, hub):
         profile=cluster,
     )
 
-    with open("klusterlet/klusterlet.yaml") as f:
-        klusterlet_template = Template(f.read())
+    klusterlet_template = drenv.template("klusterlet/klusterlet.yaml")
 
     klusterlet_yaml = klusterlet_template.substitute(
         clusterName=cluster,


### PR DESCRIPTION
Change cluster manager and klusterlet to use image specs from the csv alm-examples.
This avoids breakage when they are updated to use a new image.