### PR TITLE
Require mdl version be greater than 0.11

### DIFF
--- a/hack/pre-commit.sh
+++ b/hack/pre-commit.sh
@@ -40,6 +40,20 @@ function run_check() {
 # markdownlint: https://github.com/markdownlint/markdownlint
 # https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
 # Install via: gem install mdl
+mdl_version_test() {
+	IFS=. read -r x y _ <<-a
+	$(mdl --version)
+	a
+	test "$x" -gt 0 || test "$x" -eq 0 && test "$y" -gt 11
+	set -- $?
+	unset -v x y
+	return "$1"
+}
+if ! mdl_version_test; then
+	echo error: mdl version precedes minimum
+	exit 1
+fi
+unset -f mdl_version_test
 run_check '.*\.md' mdl --style "${scriptdir}/mdl-style.rb"
 
 # Install via: dnf install ShellCheck


### PR DESCRIPTION
# Problem
`mdl` (markdownlint) [deprecated](https://github.com/markdownlint/markdownlint/commit/2e48d4a712408257316120c1769ff1ea651473b3) the MD013 (line length) `code_blocks` option.  Ramen [complied](https://github.com/RamenDR/ramen/commit/5405a0bf69b9138dd7b22e45f0efb3a6e84664bb), but doing so   causes mdl versions less than or equal to 0.11.0 to fail, e.g.:
```sh
$ make lint
testbin/golangci-lint run ./... --config=./.golangci.yaml
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'scopelint' is deprecated (since v1.39.0) due to: The repository of the linter has been deprecated by the owner.  Replaced by exportloopref.
WARN [runner] The linter 'maligned' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.  Replaced by govet 'fieldalignment'.
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'ifshort' is deprecated (since v1.48.0) due to: The repository of the linter has been deprecated by the owner.
WARN [linters context] rowserrcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] sqlclosecheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] structcheck is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.
WARN [linters context] wastedassign is disabled because of generics. You can track the evolution of the generics support by following the https://github.com/golangci/golangci-lint/issues/2649.
hack/pre-commit.sh
/tmp/tool-errors-TRFE9T
=====  mdl  =====
./docs/krp.md:64: MD013 Line length
./docs/krp.md:71: MD013 Line length
./docs/krp.md:77: MD013 Line length
./docs/krp.md:78: MD013 Line length
./docs/krp.md:84: MD013 Line length
./docs/design/VRG-TypeSequence.md:50: MD013 Line length
./docs/design/VRG-TypeSequence.md:89: MD013 Line length
./docs/design/VRG-TypeSequence.md:139: MD013 Line length
./docs/design/VRG-TypeSequence.md:140: MD013 Line length
./test/README.md:156: MD013 Line length
./test/README.md:158: MD013 Line length
./test/README.md:159: MD013 Line length
./test/README.md:219: MD013 Line length
./test/README.md:220: MD013 Line length
./test/README.md:223: MD013 Line length
./test/README.md:224: MD013 Line length
./test/README.md:225: MD013 Line length
./test/README.md:229: MD013 Line length
./test/README.md:230: MD013 Line length
./test/README.md:234: MD013 Line length
./test/README.md:240: MD013 Line length
./test/README.md:241: MD013 Line length
./test/README.md:249: MD013 Line length
./test/README.md:251: MD013 Line length

A detailed description of the rules is available at https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md


=====  shellcheck  =====


=====  yamllint  =====


Makefile:130: recipe for target 'lint' failed
make: *** [lint] Error 1
```

# Proposed solution
if `mdl` version number reported is less than or equal to `0.11`, then exit with an error and message. 
 Automating its update and re-checking its version was considered but excluded from this patch as the updated version was not used because the old version was the first one found in the `PATH`.