### PR TITLE
added webhook validation for DRPolicy

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -27,6 +27,9 @@ resources:
   kind: DRPolicy
   path: github.com/ramendr/ramen/api/v1alpha1
   version: v1alpha1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/api/v1alpha1/drpolicy_webhook.go
+++ b/api/v1alpha1/drpolicy_webhook.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var drpolicylog = logf.Log.WithName("drpolicy-resource")
+
+func (r *DRPolicy) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//nolint
+//+kubebuilder:webhook:path=/validate-ramendr-openshift-io-v1alpha1-drpolicy,mutating=false,failurePolicy=fail,sideEffects=None,groups=ramendr.openshift.io,resources=drpolicies,verbs=update,versions=v1alpha1,name=vdrpolicy.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &DRPolicy{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *DRPolicy) ValidateCreate() error {
+	drpolicylog.Info("validate create", "name", r.Name)
+
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *DRPolicy) ValidateUpdate(old runtime.Object) error {
+	drpolicylog.Info("validate update", "name", r.Name)
+
+	oldDRPolicy, ok := old.(*DRPolicy)
+
+	if !ok {
+		return fmt.Errorf("error casting old DRPolicy")
+	}
+
+	// checks for immutability
+	if r.Spec.SchedulingInterval != oldDRPolicy.Spec.SchedulingInterval {
+		return fmt.Errorf("SchedulingInterval cannot be changed")
+	}
+
+	if !reflect.DeepEqual(r.Spec.ReplicationClassSelector, oldDRPolicy.Spec.ReplicationClassSelector) {
+		return fmt.Errorf("ReplicationClassSelector cannot be changed")
+	}
+
+	if !reflect.DeepEqual(r.Spec.VolumeSnapshotClassSelector, oldDRPolicy.Spec.VolumeSnapshotClassSelector) {
+		return fmt.Errorf("VolumeSnapshotClassSelector cannot be changed")
+	}
+
+	if !reflect.DeepEqual(r.Spec.DRClusters, oldDRPolicy.Spec.DRClusters) {
+		return fmt.Errorf("DRClusters cannot be changed")
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *DRPolicy) ValidateDelete() error {
+	drpolicylog.Info("validate delete", "name", r.Name)
+
+	return nil
+}

--- a/config/crd/patches/webhook_in_drpolicies.yaml
+++ b/config/crd/patches/webhook_in_drpolicies.yaml
@@ -12,3 +12,5 @@ spec:
           namespace: system
           name: webhook-service
           path: /convert
+      conversionReviewVersions:
+      - v1

--- a/config/hub/crd/kustomization.yaml
+++ b/config/hub/crd/kustomization.yaml
@@ -10,14 +10,14 @@ resources:
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_drpolicies.yaml
+- ../../crd/patches/webhook_in_drpolicies.yaml
 #- patches/webhook_in_DRPlacementControls.yaml
 - ../../crd/patches/webhook_in_drclusters.yaml
 # +kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_drpolicies.yaml
+- ../../crd/patches/cainjection_in_drpolicies.yaml
 #- patches/cainjection_in_DRPlacementControls.yaml
 - ../../crd/patches/cainjection_in_drclusters.yaml
 # +kubebuilder:scaffold:crdkustomizecainjectionpatch

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -25,3 +25,22 @@ webhooks:
     resources:
     - drclusters
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-ramendr-openshift-io-v1alpha1-drpolicy
+  failurePolicy: Fail
+  name: vdrpolicy.kb.io
+  rules:
+  - apiGroups:
+    - ramendr.openshift.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - UPDATE
+    resources:
+    - drpolicies
+  sideEffects: None

--- a/main.go
+++ b/main.go
@@ -177,6 +177,12 @@ func setupReconcilersHub(mgr ctrl.Manager) {
 		setupLog.Error(err, "unable to create webhook", "webhook", "DRCluster")
 		os.Exit(1)
 	}
+
+	// setup webhook for DRPolicy
+	if err := (&ramendrv1alpha1.DRPolicy{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "DRPolicy")
+		os.Exit(1)
+	}
 }
 
 func main() {


### PR DESCRIPTION
Adding webhook validation for DRPolicy. the following objects are immutable. 

`SchedulingInterval` 
`ReplicationClassSelector`
`VolumeSnapshotClassSelector`
`DRClusters` 

Related to BZ: [2005830](https://bugzilla.redhat.com/show_bug.cgi?id=2005830)

Signed-off-by: rakeshgm <rakeshgm@redhat.com>