### PR TITLE
Install missing OCM components

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -27,6 +27,10 @@ environment.
    You need `minikube` version supporting the `--extra-disks` option.
    The tool was tested with `minikube` v1.26.1.
 
+1. Install `clusteradm` tool. See
+   [Open Cluster Management Quick Start guide](https://open-cluster-management.io/getting-started/quick-start/#install-clusteradm-cli-tool)
+   for the details.
+
 1. Install the `drenv` package in a virtual environment:
 
    Run this once in the root of the source tree:

--- a/test/cluster-manager/start
+++ b/test/cluster-manager/start
@@ -25,7 +25,7 @@ drenv.kubectl(
 # We don't know which version will be installed yet. Wait until the version is
 # reported by the subscription.
 current_csv = drenv.wait_for(
-    "subscription/my-cluster-manager",
+    "sub/my-cluster-manager",
     output="jsonpath={.status.currentCSV}",
     namespace="operators",
     profile=cluster,

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -46,20 +46,7 @@ def kubectl(*args, profile=None, input=None, verbose=True):
     cmd.append("--")
     cmd.extend(args)
 
-    cp = subprocess.run(
-        cmd,
-        input=input.encode() if input else None,
-        stdout=subprocess.PIPE,
-        check=True)
-
-    out = cp.stdout.decode().rstrip()
-
-    # Log output for debugging so we don't need to log manually for every
-    # command.
-    if out and verbose:
-        log_detail(out)
-
-    return out
+    return run(*cmd, input=input, verbose=verbose)
 
 
 def wait_for(resource, output="jsonpath={.metadata.name}", timeout=300,
@@ -97,6 +84,31 @@ def wait_for(resource, output="jsonpath={.metadata.name}", timeout=300,
             raise RuntimeError(f"Timeout waiting for {resource}")
 
         time.sleep(delay)
+
+
+def run(*args, input=None, verbose=True):
+    """
+    Run a command and return the output.
+
+    You can set input to the text to pipe into the commnad stdin.
+
+    The underlying command output is logged using log_detail(). Set
+    verbose=False to suppress the log.
+    """
+    cp = subprocess.run(
+        args,
+        input=input.encode() if input else None,
+        stdout=subprocess.PIPE,
+        check=True)
+
+    out = cp.stdout.decode().rstrip()
+
+    # Log output for debugging so we don't need to log manually for every
+    # command.
+    if out and verbose:
+        log_detail(out)
+
+    return out
 
 
 def template(path):

--- a/test/klusterlet/start
+++ b/test/klusterlet/start
@@ -23,7 +23,7 @@ def deploy_klusterlet(cluster):
 
 def wait_until_klusterlet_is_rolled_out(cluster):
     current_csv = drenv.wait_for(
-        "subscription/my-klusterlet",
+        "sub/my-klusterlet",
         output="jsonpath={.status.currentCSV}",
         namespace="operators",
         profile=cluster,

--- a/test/klusterlet/start
+++ b/test/klusterlet/start
@@ -147,7 +147,7 @@ def wait_until_instance_is_registered(cluster, hub):
 
 def approve_registration(cluster, hub):
     drenv.log_progress(f"Fetch certificate signning request for {cluster}")
-    csr = drenv.kubectl(
+    out = drenv.kubectl(
         "get", "csr",
         "--selector",  f"open-cluster-management.io/cluster-name={cluster}",
         "--field-selector", "spec.signerName=kubernetes.io/kube-apiserver-client",
@@ -155,8 +155,12 @@ def approve_registration(cluster, hub):
         profile=hub,
     )
 
-    drenv.log_progress(f"Approve certificate signning request for {cluster}")
-    drenv.kubectl("certificate", "approve", csr, profile=hub)
+    # When installing klusterlet we have one csr. After installing subscription
+    # operator we have 2 csrs. It is not clear how to detect the right csr, so
+    # we approve all.
+    for csr in out.splitlines():
+        drenv.log_progress(f"Approve certificate signning request for {cluster}")
+        drenv.kubectl("certificate", "approve", csr, profile=hub)
 
     drenv.log_progress(f"Acccepting managed cluster {cluster}")
     drenv.kubectl(

--- a/test/ocm-controller/kustomization.yaml
+++ b/test/ocm-controller/kustomization.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Based on upstream deploy/foundation/hub/kustomization.yaml
+# excluding ocm proxyserver and webhook controllers.
+
+---
+resources:
+- $base_url/resources/crds/action.open-cluster-management.io_managedclusteractions.yaml
+- $base_url/resources/crds/internal.open-cluster-management.io_managedclusterinfos.yaml
+- $base_url/resources/crds/imageregistry.open-cluster-management.io_managedclusterimageregistries.yaml
+- $base_url/resources/crds/inventory.open-cluster-management.io_baremetalassets.yaml
+- $base_url/resources/crds/view.open-cluster-management.io_managedclusterviews.yaml
+- $base_url/resources/crds/hive.openshift.io_syncsets.yaml
+- $base_url/resources/crds/hive.openshift.io_clusterdeployments.yaml
+- $base_url/resources/crds/hiveinternal.openshift.io_clustersyncs.yaml
+- $base_url/resources/crds/hive.openshift.io_clusterclaims.yaml
+- $base_url/resources/crds/hive.openshift.io_clusterpools.yaml
+- $base_url/resources/clusterrole.yaml
+- $base_url/resources/agent-clusterrole.yaml
+- $base_url/resources/controller.yaml
+
+
+images:
+- name: quay.io/stolostron/multicloud-manager
+  newName: quay.io/stolostron/multicloud-manager
+  newTag: latest
+
+
+patchesStrategicMerge:
+- $base_url/patches.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/test/ocm-controller/start
+++ b/test/ocm-controller/start
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+import yaml
+
+import drenv
+
+TAG = "v2.4.4-ACM"
+BASE_URL = f"https://raw.githubusercontent.com/stolostron/multicloud-operators-foundation/{TAG}/deploy/foundation/hub"
+NAMESPACE = "open-cluster-management"
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} cluster")
+    sys.exit(1)
+
+cluster = sys.argv[1]
+
+# The namespace is created when deploying the registration-operator, but when
+# we install via olm the operator is created without the namespace.
+drenv.log_progress(f"Creating namespace {NAMESPACE} in cluster {cluster}")
+namespace = {
+    "apiVersion": "v1",
+    "kind": "Namespace",
+    "metadata": {
+        "name": NAMESPACE,
+    },
+}
+drenv.kubectl(
+    "apply", "--filename", "-",
+    input=yaml.safe_dump(namespace),
+    profile=cluster,
+)
+
+drenv.log_progress(f"Deploying ocm controller in cluster {cluster}")
+with drenv.kustomization(
+    "ocm-controller/kustomization.yaml",
+    base_url=BASE_URL,
+) as kustomization:
+    drenv.kubectl("apply", "--kustomize", kustomization, profile=cluster)
+
+drenv.wait_for("deploy/ocm-controller", namespace=NAMESPACE, profile=cluster)
+
+drenv.log_progress("Waiting for ocm controller rollout")
+drenv.kubectl(
+    "rollout", "status", "deploy/ocm-controller",
+    "--namespace", NAMESPACE,
+    "--timeout", "300s",
+    profile=cluster,
+)

--- a/test/policy-framework/start
+++ b/test/policy-framework/start
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+import drenv
+
+HUB_NAMESPACE = "open-cluster-management"
+CLUSTER_NAMESPACE = "open-cluster-management-agent-addon"
+
+def deploy_hub(hub):
+    drenv.log_progress(
+        f"Installing governance policy framework in cluster {hub}",
+    )
+    drenv.run(
+        "clusteradm", "install", "hub-addon",
+        "--names", "governance-policy-framework",
+        "--context", hub,
+    )
+
+
+def wait_for_hub_deployments(hub):
+    for suffix in "propagator", "addon-controller":
+        drenv.log_progress(
+            f"Waiting until governance-policy-{suffix} is rolled out in "
+            f"cluster {hub}",
+        )
+        drenv.kubectl(
+            "rollout", "status", f"deploy/governance-policy-{suffix}",
+            "--namespace", HUB_NAMESPACE,
+            "--timeout", "300s",
+            profile=hub,
+        )
+
+
+def deploy_clusters(hub, clusters):
+    drenv.log_progress(
+        f"Installing governance policy framework addons in clusters {clusters}"
+    )
+    drenv.run(
+        "clusteradm", "addon", "enable",
+        "--names", "governance-policy-framework",
+        "--clusters", ",".join(clusters),
+        "--context", hub,
+    )
+
+    drenv.log_progress(
+        f"Installing config policy controller addon in clusters {clusters}",
+    )
+    drenv.run(
+        "clusteradm", "addon", "enable",
+        "--names", "config-policy-controller",
+        "--clusters", ",".join(clusters),
+        "--context", hub,
+    )
+
+
+def wait_for_clusters_deployments(clusters):
+    for cluster in clusters:
+        for deploy in "governance-policy-framework", "config-policy-controller":
+            drenv.wait_for(
+                f"deploy/{deploy}",
+                namespace=CLUSTER_NAMESPACE,
+                profile=cluster,
+            )
+            drenv.log_progress(
+                f"Waiting until {deploy} is rolled out in cluster {cluster}",
+            )
+            drenv.kubectl(
+                "rollout", "status", "deploy", deploy,
+                "--namespace", CLUSTER_NAMESPACE,
+                "--timeout", "300s",
+                profile=cluster,
+            )
+
+
+if len(sys.argv) != 4:
+    print(f"Usage: {sys.argv[0]} cluster1 cluster2 hub")
+    sys.exit(1)
+
+clusters = sys.argv[1:3]
+hub = sys.argv[3]
+
+# Deploy hub and managed clusters
+deploy_hub(hub)
+deploy_clusters(hub, clusters)
+
+# And wait in parallel for all deploymnets.
+wait_for_hub_deployments(hub)
+wait_for_clusters_deployments(clusters)

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -31,6 +31,8 @@ scripts:
     args: ["dr1", "dr2", "hub"]
   - file: klusterlet/test
     args: ["dr1", "dr2", "hub"]
+  - file: subscription-operator/start
+    args: ["dr1", "dr2", "hub"]
   - file: rbd-mirror/start
     args: ["dr1", "dr2"]
   - file: rbd-mirror/test

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -33,6 +33,8 @@ scripts:
     args: ["dr1", "dr2", "hub"]
   - file: subscription-operator/start
     args: ["dr1", "dr2", "hub"]
+  - file: policy-framework/start
+    args: ["dr1", "dr2", "hub"]
   - file: rbd-mirror/start
     args: ["dr1", "dr2"]
   - file: rbd-mirror/test

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -25,6 +25,7 @@ profiles:
     scripts:
       - file: olm/start
       - file: cluster-manager/start
+      - file: ocm-controller/start
 scripts:
   - file: klusterlet/start
     args: ["dr1", "dr2", "hub"]

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -6,6 +6,7 @@
 profiles:
   - name: "dr1"
     network: default
+    memory: "6g"
     extra_disks: 1
     disk_size: "50g"
     scripts:
@@ -14,6 +15,7 @@ profiles:
       - file: minio/start
   - name: "dr2"
     network: default
+    memory: "6g"
     extra_disks: 1
     disk_size: "50g"
     scripts:
@@ -21,6 +23,7 @@ profiles:
       - file: rook/start
       - file: minio/start
   - name: "hub"
+    memory: "4g"
     network: default
     scripts:
       - file: olm/start

--- a/test/subscription-operator/common.yaml
+++ b/test/subscription-operator/common.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+resources:
+  - $base_url/deploy/common/apps.open-cluster-management.io_channels_crd.yaml
+  - $base_url/deploy/common/apps.open-cluster-management.io_deployables_crd.yaml
+  - $base_url/deploy/common/apps.open-cluster-management.io_helmreleases_crd.yaml
+  - $base_url/deploy/common/apps.open-cluster-management.io_placementrules_crd.yaml
+  - $base_url/deploy/common/apps.open-cluster-management.io_subscriptions.yaml
+  - $base_url/deploy/common/clusterrole.yaml
+  - $base_url/deploy/common/clusterrole_binding.yaml
+  - $base_url/deploy/common/namespace.yaml
+  - $base_url/deploy/common/service.yaml
+  - $base_url/deploy/common/service_account.yaml
+
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/test/subscription-operator/hub.yaml
+++ b/test/subscription-operator/hub.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+resources:
+  - $base_url/deploy/hub/application-operator.yaml
+  - $base_url/deploy/hub/operator.yaml
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: multicluster-operators-subscription
+      namespace: multicluster-operators
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: quay.io/open-cluster-management/multicluster-operators-subscription:$image_tag

--- a/test/subscription-operator/managed.yaml
+++ b/test/subscription-operator/managed.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+resources:
+  - $base_url/deploy/managed/operator.yaml
+patchesJson6902:
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: multicluster-operators-subscription
+      namespace: multicluster-operators
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: quay.io/open-cluster-management/multicluster-operators-subscription:$image_tag
+      - op: replace
+        path: /spec/template/spec/containers/0/command/2
+        value: --cluster-name=$cluster_name
+      - op: replace
+        path: /spec/template/spec/containers/0/command/3
+        value: --cluster-namespace=$cluster_name

--- a/test/subscription-operator/start
+++ b/test/subscription-operator/start
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+import drenv
+
+# Current upstream looks very different (e.g. no application-operator.yaml).
+IMAGE_TAG = "2.3.0"
+TAG = "v2.3.0-ACM"
+BASE_URL = f"https://raw.githubusercontent.com/stolostron/multicloud-operators-subscription/{TAG}"
+NAMESPACE = "multicluster-operators"
+
+if len(sys.argv) != 4:
+    print(f"Usage: {sys.argv[0]} cluster1 cluster2 hub")
+    sys.exit(1)
+
+cluster1 = sys.argv[1]
+cluster2 = sys.argv[2]
+hub = sys.argv[3]
+
+hub_kubeconfig = os.path.join(drenv.config_dir(hub), "kubeconfig")
+
+for cluster in hub, cluster1, cluster2:
+    drenv.log_progress(f"Deploying common resources in cluster {cluster}")
+    with drenv.kustomization(
+        "subscription-operator/common.yaml",
+        base_url=BASE_URL,
+    ) as kustomization:
+        drenv.kubectl("apply", "--kustomize", kustomization, profile=cluster)
+
+for cluster in cluster1, cluster2:
+    # Add label name=cluster_name to managed clusters in the hub.
+    # https://github.com/open-cluster-management-io/multicloud-operators-subscription/issues/16
+    # TODO: Check this hack is still needed.
+    drenv.log_progress(
+        f"Label managedcluster {cluster} in cluster {hub}"
+    )
+    drenv.kubectl(
+        "label", f"managedclusters/{cluster}", f"name={cluster}",
+        "--overwrite",
+        profile=hub,
+    )
+
+    # Create secret with hub config in managed clusters.
+    drenv.log_progress(
+        f"Create secret appmgr-hub-kubeconfig in cluster {cluster}"
+    )
+    secret_yaml = drenv.kubectl(
+        "create", "secret", "generic", "appmgr-hub-kubeconfig",
+        f"--from-file=kubeconfig={hub_kubeconfig}",
+        "--dry-run=client",
+        "--output=yaml",
+        verbose=False,
+        profile=cluster,
+    )
+    drenv.kubectl(
+        "apply",
+        "--filename", "-",
+        "--namespace", NAMESPACE,
+        input=secret_yaml,
+        profile=cluster,
+    )
+
+drenv.log_progress(f"Deploying hub operators in cluster {cluster}")
+with drenv.kustomization(
+    f"subscription-operator/hub.yaml",
+    base_url=BASE_URL,
+    image_tag=IMAGE_TAG,
+) as kustomization:
+    drenv.kubectl("apply", "--kustomize", kustomization, profile=hub)
+
+for cluster in cluster1, cluster2:
+    drenv.log_progress(f"Deploying managed cluster operators in cluster {cluster}")
+    with drenv.kustomization(
+        f"subscription-operator/managed.yaml",
+        base_url=BASE_URL,
+        image_tag=IMAGE_TAG,
+        cluster_name=cluster,
+    ) as kustomization:
+        drenv.kubectl("apply", "--kustomize", kustomization, profile=cluster)
+
+for cluster in hub, cluster1, cluster2:
+    drenv.log_progress(f"Waiting for {NAMESPACE} deployments in cluster {cluster}")
+    drenv.kubectl(
+        "wait", "deploy",
+        "--all",
+        "--namespace", NAMESPACE,
+        "--for", "condition=available",
+        "--timeout", "120s",
+        profile=cluster,
+    )


### PR DESCRIPTION
This adds the missing OCM components:
- multicloud-operators-foundation
- multicloud-operators-subscription
- governance policy framework

And fixes issues in cluster-manager and klusterlet, revealed by installing 
the subscription operator.

There is no self test for any of the new components, we can add this later.