### PR TITLE
Disable self test

### DIFF
--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -32,13 +32,9 @@ profiles:
 scripts:
   - file: klusterlet/start
     args: ["dr1", "dr2", "hub"]
-  - file: klusterlet/test
-    args: ["dr1", "dr2", "hub"]
   - file: subscription-operator/start
     args: ["dr1", "dr2", "hub"]
   - file: policy-framework/start
     args: ["dr1", "dr2", "hub"]
   - file: rbd-mirror/start
-    args: ["dr1", "dr2"]
-  - file: rbd-mirror/test
     args: ["dr1", "dr2"]


### PR DESCRIPTION
Disable self tests to speed up starting an environment.

Need to add a way to run all tests or included them when starting.

Fixes #594
Based on #559

