### PR TITLE
Install cert-manager in all clusters

### DIFF
--- a/test/cert-manager/start
+++ b/test/cert-manager/start
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+import drenv
+
+TAG = "v1.10.0"
+URL = f"https://github.com/cert-manager/cert-manager/releases/download/{TAG}/cert-manager.yaml"
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} cluster")
+    sys.exit(1)
+
+cluster = sys.argv[1]
+
+drenv.log_progress(f"Deploying cert-manager in cluster {cluster}")
+drenv.kubectl("apply", "--filename", URL, profile=cluster)
+
+drenv.log_progress(
+    f"Waiting until all deployments are available cluster {cluster}",
+)
+drenv.kubectl(
+    "wait", "deploy", "--all",
+    "--for=condition=Available",
+    "--namespace", "cert-manager",
+    "--timeout=60s",
+    profile=cluster,
+)

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -10,6 +10,7 @@ profiles:
     extra_disks: 1
     disk_size: "50g"
     scripts:
+      - file: cert-manager/start
       - file: olm/start
       - file: rook/start
       - file: minio/start
@@ -19,6 +20,7 @@ profiles:
     extra_disks: 1
     disk_size: "50g"
     scripts:
+      - file: cert-manager/start
       - file: olm/start
       - file: rook/start
       - file: minio/start
@@ -26,6 +28,7 @@ profiles:
     memory: "4g"
     network: default
     scripts:
+      - file: cert-manager/start
       - file: olm/start
       - file: cluster-manager/start
       - file: ocm-controller/start


### PR DESCRIPTION
Without cert-manager `make deploy-hub` fails with:

    resource mapping not found for name: "ramen-hub-serving-cert"
    namespace: "ramen-system" from "STDIN": no matches for kind
    "Certificate" in version "cert-manager.io/v1" ensure CRDs are
    installed first

I'm not sure if this is the best way, but do the same in the kind clusters and adding cert-manager is pretty quick.

Fixes: #588 
Signed-off-by: Nir Soffer <nsoffer@redhat.com>