### PR TITLE
Don't own volsync resources if disabled

### DIFF
--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -89,9 +89,14 @@ func (r *VolumeReplicationGroupReconciler) SetupWithManager(
 		}).
 		For(&ramendrv1alpha1.VolumeReplicationGroup{}).
 		Watches(&source.Kind{Type: &corev1.PersistentVolumeClaim{}}, pvcMapFun, builder.WithPredicates(pvcPredicate)).
-		Owns(&volrep.VolumeReplication{}).
-		Owns(&volsyncv1alpha1.ReplicationDestination{}).
-		Owns(&volsyncv1alpha1.ReplicationSource{})
+		Owns(&volrep.VolumeReplication{})
+
+	if !ramenConfig.VolSync.Disabled {
+		builder.Owns(&volsyncv1alpha1.ReplicationDestination{}).
+			Owns(&volsyncv1alpha1.ReplicationSource{})
+	} else {
+		r.Log.Info("VolSync disabled; don't own volsync resources")
+	}
 
 	r.kubeObjects = velero.RequestsManager{}
 	if !ramenConfig.KubeObjectProtection.Disabled {


### PR DESCRIPTION
If volsync is disabled in ramen-dr-cluster-operator-config:

```
  volSync:
    disabled: true
```

ramen-dr-cluster-operator fails many times with:

    2022-11-11T00:50:12.795Z	ERROR	controller-runtime.source
    source/source.go:139	if kind is a CRD, it should be installed before
    calling Start	{"kind": "ReplicationDestination.volsync.backube",
        "error": "no matches for kind \"ReplicationDestination\" in version
            \"volsync.backube/v1alpha1\""}

Reproduced by deploying ramen in drevn setup that contains no volsync crds:

    $ kubectl api-resources | grep volsync
    (nothing)

This will probably not be an issue once we add volsync to the environment, but it makes sense to respect the configuration.

Skip owning volsync resources in the same way we skip kube object protection watching.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>