### PR TITLE
Trivial cleanups in drenv

### DIFF
--- a/test/klusterlet/start
+++ b/test/klusterlet/start
@@ -149,7 +149,7 @@ def approve_registration(cluster, hub):
     drenv.log_progress(f"Fetch certificate signning request for {cluster}")
     out = drenv.kubectl(
         "get", "csr",
-        "--selector",  f"open-cluster-management.io/cluster-name={cluster}",
+        "--selector", f"open-cluster-management.io/cluster-name={cluster}",
         "--field-selector", "spec.signerName=kubernetes.io/kube-apiserver-client",
         "--output", "name",
         profile=hub,

--- a/test/ocm-controller/start
+++ b/test/ocm-controller/start
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import sys
 import yaml
 

--- a/test/policy-framework/start
+++ b/test/policy-framework/start
@@ -3,13 +3,13 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import sys
 
 import drenv
 
 HUB_NAMESPACE = "open-cluster-management"
 CLUSTER_NAMESPACE = "open-cluster-management-agent-addon"
+
 
 def deploy_hub(hub):
     drenv.log_progress(

--- a/test/rbd-mirror/start
+++ b/test/rbd-mirror/start
@@ -66,7 +66,7 @@ def configure_rbd_mirroring(cluster, peer_info):
                     "secretNames": [
                         peer_info["name"]]}}}}
     drenv.kubectl(
-        "patch", "cephblockpool",  POOL_NAME,
+        "patch", "cephblockpool", POOL_NAME,
         "--type", "merge",
         "--patch", json.dumps(patch),
         "--namespace", "rook-ceph",

--- a/test/subscription-operator/start
+++ b/test/subscription-operator/start
@@ -67,7 +67,7 @@ for cluster in cluster1, cluster2:
 
 drenv.log_progress(f"Deploying hub operators in cluster {cluster}")
 with drenv.kustomization(
-    f"subscription-operator/hub.yaml",
+    "subscription-operator/hub.yaml",
     base_url=BASE_URL,
     image_tag=IMAGE_TAG,
 ) as kustomization:
@@ -76,7 +76,7 @@ with drenv.kustomization(
 for cluster in cluster1, cluster2:
     drenv.log_progress(f"Deploying managed cluster operators in cluster {cluster}")
     with drenv.kustomization(
-        f"subscription-operator/managed.yaml",
+        "subscription-operator/managed.yaml",
         base_url=BASE_URL,
         image_tag=IMAGE_TAG,
         cluster_name=cluster,


### PR DESCRIPTION
- Remove unused imports
- Fix space around `,`
- Fix spacing between functions
- Remove unneeded fstring without placeholders

Detected by flake8:

    $ flake8 test/*/start --ignore E501
    test/klusterlet/start:152:22: E241 multiple spaces after ','
    test/ocm-controller/start:6:1: F401 'os' imported but unused
    test/policy-framework/start:6:1: F401 'os' imported but unused
    test/policy-framework/start:14:1: E302 expected 2 blank lines, found 1
    test/rbd-mirror/start:69:34: E241 multiple spaces after ','
    test/subscription-operator/start:70:5: F541 f-string is missing placeholders
    test/subscription-operator/start:79:9: F541 f-string is missing placeholders

We need to add flake8 lint job later to avoid these issues.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>