### PR TITLE
Support minikube addons

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -286,6 +286,7 @@ $ drenv delete example.yaml
     - `cni`: Network plugin (default "auto")
     - `cpus`: Number of CPUs per VM (default 2)
     - `memory`: Memory per VM (default 4g)
+    - `addons`: List of minikube addons to install
     - `scripts`: Optional list of scripts to run during start.
         - `file`: Script filename
         - `args`: Optional argument to the script. If not specified the

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -79,6 +79,7 @@ def validate_profile(profile):
     profile.setdefault("memory", "4g")
     profile.setdefault("network", "")
     profile.setdefault("scripts", [])
+    profile.setdefault("addons", [])
 
     for script in profile["scripts"]:
         validate_script(script, args=[profile["name"]])
@@ -139,6 +140,7 @@ def start_cluster(profile):
              "--cni", profile["cni"],
              "--cpus", str(profile["cpus"]),
              "--memory", profile["memory"],
+             "--addons", ",".join(profile["addons"]),
              profile=profile["name"])
     logging.info("[%s] Cluster started in %.2f seconds",
                  profile["name"], time.monotonic() - start)


### PR DESCRIPTION
Support `addons: []` profile property, allowing adding minikube addons to the profile without writing any code.

I added this for the registry and olm addons. I could not get any of them to work but this looks like a useful addition anyway.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>