### PR TITLE
Fix bare images

### DIFF
--- a/hack/minio-deployment.yaml
+++ b/hack/minio-deployment.yaml
@@ -74,7 +74,7 @@ spec:
             readOnly: false
       containers:
         - name: minio
-          image: minio/minio:latest
+          image: quay.io/minio/minio:latest
           imagePullPolicy: IfNotPresent
           args:
             - server
@@ -131,7 +131,7 @@ spec:
             readOnly: false
       containers:
         - name: mc
-          image: minio/mc:latest
+          image: quay.io/minio/mc:latest
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh

--- a/test/example/deployment.yaml
+++ b/test/example/deployment.yaml
@@ -4,21 +4,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: nginx-deployment
+  name: example-deployment
   labels:
-    app: nginx
+    app: example
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: nginx
+      app: example
   template:
     metadata:
       labels:
-        app: nginx
+        app: example
     spec:
       containers:
-      - name: nginx
-        image: nginx:1.14.2
-        ports:
-        - containerPort: 80
+      - name: example
+        image: quay.io/quay/busybox
+        command: ["sleep", "60"]

--- a/test/example/start
+++ b/test/example/start
@@ -13,9 +13,9 @@ if len(sys.argv) != 2:
 
 cluster = sys.argv[1]
 
-drenv.log_progress(f"Deploying nginx on cluster {cluster}")
+drenv.log_progress("Deploying example")
 drenv.kubectl(
     "apply",
-    "--filename", "example/ngix-deployment.yaml",
+    "--filename", "example/deployment.yaml",
     profile=cluster,
 )

--- a/test/example/test
+++ b/test/example/test
@@ -15,14 +15,14 @@ cluster1, cluster2 = sys.argv[1:]
 
 drenv.log_progress(f"Testing example deploymnet on cluster {cluster1}")
 drenv.kubectl(
-    "rollout", "status", "deploy/nginx-deployment",
+    "rollout", "status", "deploy/example-deployment",
     "--timeout", "60s",
     profile=cluster1,
 )
 
 drenv.log_progress(f"Testing example deploymnet on cluster {cluster2}")
 drenv.kubectl(
-    "rollout", "status", "deploy/nginx-deployment",
+    "rollout", "status", "deploy/example-deployment",
     "--timeout", "60s",
     profile=cluster2,
 )

--- a/test/minio/minio.yaml
+++ b/test/minio/minio.yaml
@@ -65,7 +65,7 @@ spec:
             readOnly: false
       containers:
         - name: minio
-          image: minio/minio:latest
+          image: quay.io/minio/minio:latest
           imagePullPolicy: IfNotPresent
           args:
             - server
@@ -122,7 +122,7 @@ spec:
             readOnly: false
       containers:
         - name: mc
-          image: minio/mc:latest
+          image: quay.io/minio/mc:latest
           imagePullPolicy: IfNotPresent
           command:
             - /bin/sh


### PR DESCRIPTION
Change bare images (e.g. image: busybox) to consume from quay.io, to avoid docker.io rate limits and have more predictable setup.