### PR TITLE
Fix cert-manager rollout timeout

### DIFF
--- a/test/cert-manager/start
+++ b/test/cert-manager/start
@@ -26,6 +26,6 @@ drenv.kubectl(
     "wait", "deploy", "--all",
     "--for=condition=Available",
     "--namespace", "cert-manager",
-    "--timeout=60s",
+    "--timeout", "300s",
     profile=cluster,
 )


### PR DESCRIPTION
60 seconds timeout works most of the time, but we need much larger timeout to get a reliable setup in various conditions. We use 300 seconds in all other components.

In a future we need to improve the infrastructure so most calls could use a default timeout.