### PR TITLE
Lower DRPolicy and DRCluster max exponential backoff

### DIFF
--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -821,7 +821,7 @@ func ensureDRPolicyIsDeleted(drpolicyName string) {
 	drpolicy := &rmn.DRPolicy{}
 	Eventually(func() error {
 		return apiReader.Get(context.TODO(), types.NamespacedName{Name: drpolicyName}, drpolicy)
-	}, timeout, interval).Should(
+	}, drpolicytimeout, interval).Should(
 		MatchError(
 			errors.NewNotFound(
 				schema.GroupResource{

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -61,8 +61,9 @@ var (
 
 	namespaceDeletionSupported bool
 
-	timeout  = time.Second * 10
-	interval = time.Millisecond * 10
+	timeout         = time.Second * 10
+	drpolicytimeout = time.Second * 70
+	interval        = time.Millisecond * 10
 
 	plRuleNames map[string]struct{}
 


### PR DESCRIPTION
With the current exponential backoff, if DRCluster is not created later than DRPolicy, the policy may take exponentially long time to reconcile and update its status.

The right fix is to watch for clusters and trigger policy reconciles, such that there is no wait and also further there are no spurious reconciles.

This is a short term fix to reduce the exponential backoff for the reconcile of these resources, to ensure that the delays are not high. Further, as these resources are not frequently reconciled, the lower exponential backoff is acceptable.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>