### PR TITLE
Capture Kube objects after relocate quiesce

### DIFF
--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -257,11 +257,12 @@ type ProtectedPVC struct {
 type KubeObjectsCaptureIdentifier struct {
 	Number int64 `json:"number"`
 	//+nullable
-	StartTime metav1.Time `json:"startTime,omitempty"`
+	StartTime       metav1.Time `json:"startTime,omitempty"`
+	StartGeneration int64       `json:"startGeneration,omitempty"`
 }
 
 type KubeObjectProtectionStatus struct {
-	// +optional
+	//+optional
 	CaptureToRecoverFrom *KubeObjectsCaptureIdentifier `json:"captureToRecoverFrom,omitempty"`
 }
 

--- a/config/crd/bases/ramendr.openshift.io_protectedvolumereplicationgrouplists.yaml
+++ b/config/crd/bases/ramendr.openshift.io_protectedvolumereplicationgrouplists.yaml
@@ -495,6 +495,31 @@ spec:
                                         description: Resources set in the claim to
                                           be replicated
                                         properties:
+                                          claims:
+                                            description: "Claims lists the names of
+                                              resources, defined in spec.resourceClaims,
+                                              that are used by this container. \n
+                                              This is an alpha field and requires
+                                              enabling the DynamicResourceAllocation
+                                              feature gate. \n This field is immutable."
+                                            items:
+                                              description: ResourceClaim references
+                                                one entry in PodSpec.ResourceClaims.
+                                              properties:
+                                                name:
+                                                  description: Name must match the
+                                                    name of one entry in pod.spec.resourceClaims
+                                                    of the Pod where this field is
+                                                    used. It makes that resource available
+                                                    inside a container.
+                                                  type: string
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - name
+                                            x-kubernetes-list-type: map
                                           limits:
                                             additionalProperties:
                                               anyOf:
@@ -666,6 +691,9 @@ spec:
                             captureToRecoverFrom:
                               properties:
                                 number:
+                                  format: int64
+                                  type: integer
+                                startGeneration:
                                   format: int64
                                   type: integer
                                 startTime:
@@ -847,6 +875,29 @@ spec:
                               resources:
                                 description: Resources set in the claim to be replicated
                                 properties:
+                                  claims:
+                                    description: "Claims lists the names of resources,
+                                      defined in spec.resourceClaims, that are used
+                                      by this container. \n This is an alpha field
+                                      and requires enabling the DynamicResourceAllocation
+                                      feature gate. \n This field is immutable."
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: Name must match the name of
+                                            one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes
+                                            that resource available inside a container.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
                                   limits:
                                     additionalProperties:
                                       anyOf:

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -420,6 +420,29 @@ spec:
                             resources:
                               description: Resources set in the claim to be replicated
                               properties:
+                                claims:
+                                  description: "Claims lists the names of resources,
+                                    defined in spec.resourceClaims, that are used
+                                    by this container. \n This is an alpha field and
+                                    requires enabling the DynamicResourceAllocation
+                                    feature gate. \n This field is immutable."
+                                  items:
+                                    description: ResourceClaim references one entry
+                                      in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: Name must match the name of one
+                                          entry in pod.spec.resourceClaims of the
+                                          Pod where this field is used. It makes that
+                                          resource available inside a container.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
                                 limits:
                                   additionalProperties:
                                     anyOf:
@@ -576,6 +599,9 @@ spec:
                   captureToRecoverFrom:
                     properties:
                       number:
+                        format: int64
+                        type: integer
+                      startGeneration:
                         format: int64
                         type: integer
                       startTime:
@@ -742,6 +768,27 @@ spec:
                     resources:
                       description: Resources set in the claim to be replicated
                       properties:
+                        claims:
+                          description: "Claims lists the names of resources, defined
+                            in spec.resourceClaims, that are used by this container.
+                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
+                            feature gate. \n This field is immutable."
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: Name must match the name of one entry
+                                  in pod.spec.resourceClaims of the Pod where this
+                                  field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
                         limits:
                           additionalProperties:
                             anyOf:

--- a/controllers/kubeobjects/requests.go
+++ b/controllers/kubeobjects/requests.go
@@ -109,6 +109,7 @@ type RequestsManager interface {
 		requestNamespaceName string,
 		protectRequestName string,
 		labels map[string]string,
+		annotations map[string]string,
 	) (ProtectRequest, error)
 	RecoverRequestCreate(
 		c context.Context, w client.Writer, r client.Reader, l logr.Logger,
@@ -124,6 +125,7 @@ type RequestsManager interface {
 		protectRequestName string,
 		recoverRequestName string,
 		labels map[string]string,
+		annotations map[string]string,
 	) (RecoverRequest, error)
 	ProtectRequestsGet(
 		c context.Context, r client.Reader, requestNamespaceName string, labels map[string]string,

--- a/controllers/reconcile_result.go
+++ b/controllers/reconcile_result.go
@@ -17,6 +17,10 @@ func delayResetIfRequeueTrue(result *ctrl.Result, log logr.Logger) {
 	}
 }
 
+func delaySetMinimum(result *ctrl.Result) {
+	result.RequeueAfter = time.Nanosecond
+}
+
 func delaySetIfLess(result *ctrl.Result, delay time.Duration, log logr.Logger) {
 	if result.RequeueAfter > 0 && result.RequeueAfter <= delay {
 		log.Info("Delay not set because current delay is more than zero and less than new delay",

--- a/controllers/s3_store_accessors.go
+++ b/controllers/s3_store_accessors.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"github.com/go-logr/logr"
+	ramen "github.com/ramendr/ramen/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type s3StoreAccessor struct {
+	ObjectStorer
+	profileName                 string
+	url                         string
+	bucketName                  string
+	regionName                  string
+	veleroNamespaceSecretKeyRef *corev1.SecretKeySelector
+}
+
+func s3StoreAccessorsGet(
+	s3ProfileNames []string,
+	objectStorerGet func(string) (ObjectStorer, ramen.S3StoreProfile, error),
+	log logr.Logger,
+) []s3StoreAccessor {
+	s3StoreAccessors := make([]s3StoreAccessor, 0, len(s3ProfileNames))
+
+	for _, s3ProfileName := range s3ProfileNames {
+		if s3ProfileName == NoS3StoreAvailable {
+			log.Info("Kube object protection store dummy")
+
+			continue
+		}
+
+		objectStorer, s3StoreProfile, err := objectStorerGet(s3ProfileName)
+		if err != nil {
+			log.Error(err, "Kube object protection store inaccessible", "name", s3ProfileName)
+
+			return nil
+		}
+
+		s3StoreAccessors = append(s3StoreAccessors, s3StoreAccessor{
+			objectStorer,
+			s3ProfileName,
+			s3StoreProfile.S3CompatibleEndpoint,
+			s3StoreProfile.S3Bucket,
+			s3StoreProfile.S3Region,
+			s3StoreProfile.VeleroNamespaceSecretKeyRef,
+		})
+	}
+
+	return s3StoreAccessors
+}

--- a/controllers/s3utils.go
+++ b/controllers/s3utils.go
@@ -320,6 +320,10 @@ func (s *s3ObjectStore) PurgeBucket(bucket string) (
 	return nil
 }
 
+func s3PathNamePrefix(namespaceName, objectName string) string {
+	return S3KeyPrefix(types.NamespacedName{Namespace: namespaceName, Name: objectName}.String())
+}
+
 func S3KeyPrefix(namespacedName string) string {
 	return namespacedName + "/"
 }

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -69,6 +69,8 @@ const (
 	VRGConditionReasonVolSyncFinalSyncComplete   = "Synced"
 )
 
+const clusterDataProtectedTrueMessage = "Kube objects protected"
+
 // Just when VRG has been picked up for reconciliation when nothing has been
 // figured out yet.
 func setVRGInitialCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -413,23 +413,22 @@ type cachedObjectStorer struct {
 }
 
 type VRGInstance struct {
-	reconciler                   *VolumeReplicationGroupReconciler
-	ctx                          context.Context
-	log                          logr.Logger
-	instance                     *ramendrv1alpha1.VolumeReplicationGroup
-	savedInstanceStatus          ramendrv1alpha1.VolumeReplicationGroupStatus
-	ramenConfig                  *ramendrv1alpha1.RamenConfig
-	volRepPVCs                   []corev1.PersistentVolumeClaim
-	volSyncPVCs                  []corev1.PersistentVolumeClaim
-	replClassList                *volrep.VolumeReplicationClassList
-	storageClassCache            map[string]*storagev1.StorageClass
-	vrgObjectProtected           *metav1.Condition
-	kubeObjectsProtected         *metav1.Condition
-	kubeObjectsFinalSyncComplete bool
-	vrcUpdated                   bool
-	namespacedName               string
-	volSyncHandler               *volsync.VSHandler
-	objectStorers                map[string]cachedObjectStorer
+	reconciler           *VolumeReplicationGroupReconciler
+	ctx                  context.Context
+	log                  logr.Logger
+	instance             *ramendrv1alpha1.VolumeReplicationGroup
+	savedInstanceStatus  ramendrv1alpha1.VolumeReplicationGroupStatus
+	ramenConfig          *ramendrv1alpha1.RamenConfig
+	volRepPVCs           []corev1.PersistentVolumeClaim
+	volSyncPVCs          []corev1.PersistentVolumeClaim
+	replClassList        *volrep.VolumeReplicationClassList
+	storageClassCache    map[string]*storagev1.StorageClass
+	vrgObjectProtected   *metav1.Condition
+	kubeObjectsProtected *metav1.Condition
+	vrcUpdated           bool
+	namespacedName       string
+	volSyncHandler       *volsync.VSHandler
+	objectStorers        map[string]cachedObjectStorer
 }
 
 const (

--- a/controllers/vrg_kubeobjects.go
+++ b/controllers/vrg_kubeobjects.go
@@ -143,6 +143,8 @@ func (v *VRGInstance) kubeObjectsCaptureStartOrResumeOrDelayIfEnabled(
 	result *ctrl.Result, s3StoreAccessors []s3StoreAccessor,
 ) {
 	if v.kubeObjectProtectionDisabled("capture") {
+		v.kubeObjectsFinalSyncPrepared = true
+
 		return
 	}
 

--- a/controllers/vrg_kubeobjects.go
+++ b/controllers/vrg_kubeobjects.go
@@ -79,6 +79,8 @@ func (v *VRGInstance) kubeObjectsProtect(
 	}
 
 	if len(s3StoreAccessors) == 0 {
+		v.log.Info("Kube objects capture store list empty")
+
 		result.Requeue = true // TODO remove; watch config map instead
 
 		return
@@ -139,6 +141,7 @@ func (v *VRGInstance) kubeObjectsCaptureStartOrResumeOrDelay(
 			if v.kubeObjectsCaptureDelete(result, s3StoreAccessors, number, pathName) != nil {
 				return
 			}
+
 			captureStartOrResume(vrg.GetGeneration(), "start")
 		},
 	)
@@ -159,7 +162,6 @@ func kubeObjectsCaptureStartConditionallySecondary(
 	}
 
 	v.kubeObjectsCaptureStatusFalse(VRGConditionReasonUploading, "Kube objects capture for relocate pending")
-
 	captureStart()
 }
 
@@ -302,9 +304,6 @@ func (v *VRGInstance) kubeObjectsCaptureComplete(
 		Number: captureNumber, StartTime: startTime,
 		StartGeneration: startGeneration,
 	}
-
-	v.kubeObjectsCaptureStatus(metav1.ConditionTrue, VRGConditionReasonUploaded, clusterDataProtectedTrueMessage)
-
 	captureStartTimeSince := time.Since(startTime.Time)
 	v.log.Info("Kube objects captured", "recovery point", status.CaptureToRecoverFrom, "duration", captureStartTimeSince)
 	captureStartConditionally(

--- a/controllers/vrg_kubeobjects.go
+++ b/controllers/vrg_kubeobjects.go
@@ -296,6 +296,8 @@ func (v *VRGInstance) kubeObjectsCaptureComplete(
 		v.log.Error(err, "Kube objects capture generation string to int64 conversion error")
 	}
 
+	v.kubeObjectsCaptureStatus(metav1.ConditionTrue, VRGConditionReasonUploaded, clusterDataProtectedTrueMessage)
+
 	status.CaptureToRecoverFrom = &ramen.KubeObjectsCaptureIdentifier{
 		Number: captureNumber, StartTime: startTime,
 		StartGeneration: startGeneration,

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -30,17 +30,6 @@ const (
 	AnnotationSchemeGroup = "apps.open-cluster-management.io"
 )
 
-func (v *VRGInstance) updateFinalSyncStatus() {
-	// We don't need the final sync preparation for VolRep. Just mark it complete
-	if v.instance.Spec.PrepareForFinalSync && len(v.volSyncPVCs) == 0 {
-		v.instance.Status.PrepareForFinalSyncComplete = true
-	}
-	// We don't need to run the final sync for VolRep. Just mark it complete
-	if v.instance.Spec.RunFinalSync && len(v.volSyncPVCs) == 0 {
-		v.instance.Status.FinalSyncComplete = true
-	}
-}
-
 // reconcileVolRepsAsPrimary creates/updates VolumeReplication CR for each pvc
 // from pvcList. If it fails (even for one pvc), then requeue is set to true.
 func (v *VRGInstance) reconcileVolRepsAsPrimary(requeue *bool) {
@@ -96,8 +85,6 @@ func (v *VRGInstance) reconcileVolRepsAsPrimary(requeue *bool) {
 
 		log.Info("Successfully processed VolumeReplication for PersistentVolumeClaim")
 	}
-
-	v.updateFinalSyncStatus()
 }
 
 // reconcileVolRepsAsSecondary reconciles VolumeReplication resources for the VRG as secondary

--- a/controllers/vrg_volsync.go
+++ b/controllers/vrg_volsync.go
@@ -63,6 +63,20 @@ func (v *VRGInstance) restorePVsForVolSync() error {
 }
 
 func (v *VRGInstance) reconcileVolSyncAsPrimary() (requeue bool) {
+	finalSyncStatusUpdate := func() {
+		v.volSyncFinalSyncPrepared = true
+
+		if v.instance.Spec.RunFinalSync {
+			v.instance.Status.FinalSyncComplete = true
+		}
+	}
+
+	if len(v.volSyncPVCs) == 0 {
+		finalSyncStatusUpdate()
+
+		return
+	}
+
 	v.log.Info(fmt.Sprintf("Reconciling VolSync as Primary. VolSyncPVCs %d. VolSyncSpec %+v",
 		len(v.volSyncPVCs), v.instance.Spec.VolSync))
 
@@ -92,14 +106,7 @@ func (v *VRGInstance) reconcileVolSyncAsPrimary() (requeue bool) {
 		return requeue
 	}
 
-	if v.instance.Spec.PrepareForFinalSync {
-		v.instance.Status.PrepareForFinalSyncComplete = true
-	}
-
-	if v.instance.Spec.RunFinalSync {
-		v.instance.Status.FinalSyncComplete = true
-	}
-
+	finalSyncStatusUpdate()
 	v.log.Info("Successfully reconciled VolSync as Primary")
 
 	return requeue

--- a/controllers/vrg_vrgobject.go
+++ b/controllers/vrg_vrgobject.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"github.com/go-logr/logr"
+	ramen "github.com/ramendr/ramen/api/v1alpha1"
+	"github.com/ramendr/ramen/controllers/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func vrgObjectProtect(
+	result *ctrl.Result,
+	s3StoreAccessors []s3StoreAccessor,
+	vrg ramen.VolumeReplicationGroup,
+	eventReporter *util.EventReporter,
+	log logr.Logger,
+) (vrgObjectProtected *metav1.Condition) {
+	for _, s3StoreAccessor := range s3StoreAccessors {
+		if err := VrgObjectProtect(s3StoreAccessor.ObjectStorer, vrg); err != nil {
+			util.ReportIfNotPresent(
+				eventReporter, &vrg, corev1.EventTypeWarning, util.EventReasonVrgUploadFailed, err.Error(),
+			)
+
+			const message = "VRG Kube object protect error"
+
+			log.Error(err, message, "profile", s3StoreAccessor.profileName)
+
+			vrgObjectProtected = newVRGClusterDataUnprotectedCondition(vrg.Generation, message)
+			result.Requeue = true
+
+			return
+		}
+
+		log.Info("VRG Kube object protected", "profile", s3StoreAccessor.profileName)
+
+		vrgObjectProtected = newVRGClusterDataProtectedCondition(vrg.Generation, clusterDataProtectedTrueMessage)
+	}
+
+	return
+}
+
+const vrgS3ObjectNameSuffix = "a"
+
+func VrgObjectProtect(objectStorer ObjectStorer, vrg ramen.VolumeReplicationGroup) error {
+	return uploadTypedObject(objectStorer, s3PathNamePrefix(vrg.Namespace, vrg.Name), vrgS3ObjectNameSuffix, vrg)
+}
+
+func VrgObjectUnprotect(objectStorer ObjectStorer, vrg ramen.VolumeReplicationGroup) error {
+	return DeleteTypedObjects(objectStorer, s3PathNamePrefix(vrg.Namespace, vrg.Name), vrgS3ObjectNameSuffix, vrg)
+}
+
+func vrgObjectDownload(objectStorer ObjectStorer, pathName string, vrg *ramen.VolumeReplicationGroup) error {
+	return downloadTypedObject(objectStorer, pathName, vrgS3ObjectNameSuffix, vrg)
+}

--- a/docs/vrg-usage.md
+++ b/docs/vrg-usage.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 
 1. Deploy **cluster1** VRG with `Spec.ReplicationState: primary` in
  application's namespace
-1. Wait for **cluster1** VRG `Status.Conditions.ClusterDataProtected: true`
+1. Wait for **cluster1** VRG condition `ClusterDataProtected`
  indicating application's Kube objects have been protected
 
 ## Unprotect application
@@ -30,45 +30,49 @@ SPDX-License-Identifier: Apache-2.0
  `namespace` it was in and with the `name` it had on **cluster1**
    - Kube objects are recovered from the first available replica store specified
  in VRG's `spec.s3Profiles` containing a replica for its `namespace` and `name`
-1. Wait for **cluster2** VRG `status.condtions`:
-   - `clusterDataReady: true` indicating its Kube objects have been recovered
-   - `dataReady: true` indicating its volumes have been recovered
+1. Wait for **cluster2** VRG condition
+   - `ClusterDataReady` indicating its Kube objects have been recovered
+   - `DataReady` indicating its volumes have been recovered
 1. **cluster2** application protection resumes automatically
 
 ## Failback/Relocate application from cluster2 to cluster1
 
-1. Set **cluster1** VRG `spec.replicationState: secondary`
+1. Set **cluster1** VRG `spec.replicationState: secondary` and
+ `spec.action: Failover`
+   - This disables its Kube object replication and preserves its Kube object
+ replicas when VRG is deleted in a subsequent step
 1. Undeploy **cluster1** application
    - Its PVCs can finally be deleted once VRG is deleted in a subsequent step
    - This allows its Kube objects to be recovered in a subsequent step
+1. Wait for **cluster1** VRG `Status.State: Secondary` indicating volume data
+  and Kube object replication can resume from **cluster2** to **cluster1**
 1. Delete **cluster1** VRG
    - This allows its PVCs to finally be deleted
 1. Unfence **cluster1** and **cluster2** VRGs from each other's Kube object
  replicas
    - This is typically accomplished by network unfencing
 1. Unfence **cluster1** and **cluster2** VRGs from each other's volume data
-   - For `async` mode, this is typically accomplished by setting **cluster1**
- VRG `spec.replicationState: secondary`
+   - For `async` mode, this is accomplished when **cluster1** VRG
+ `status.state: Secondary`
    - For `sync` mode, this is typically accomplished by network unfencing
 1. Quiesce **cluster2** application Kube objects
    - Desired quiesced states in captured Kube objects are reset in a subsequent step
 1. Set **cluster2** VRG `spec.replicationState: secondary` and
  `spec.action: Relocate`
-1. Wait for **cluster2** VRG `status.conditions.clusterDataProtected: true`
- indicating Kube objects capture has completed
+1. Wait for **cluster2** VRG condition `ClusterDataProtected` indicating
+ Kube objects have been replicated to **cluster1**
 1. Undeploy **cluster2** application
    - Its PVCs can finally be deleted once VRG is deleted in a subsequent step
-1. For `async` mode, synchronize volume data:
-   - Deploy **cluster1** VRG with `spec.replicationState: secondary`
-   - Wait for **cluster1** VRG `status.conditions.dataReady: true` indicating its
- volume data are in-sync with **cluster2**'s
-1. Delete **cluster2** VRG
-   - This allows its PVCs to finally be deleted
-1. Set, for `async` mode, or deploy, for `sync` mode, **cluster1** VRG
- `spec.replicationState: primary` to recover its volumes and Kube objects
-1. Wait for **cluster1** VRG `status.condtions`:
-   - `clusterDataReady: true` indicating its Kube objects have been recovered
-   - `dataReady: true` indicating its volumes have been recovered
+1. Wait for **cluster2** VRG `status.state: Secondary`
+1. Wait for **cluster2** VRG condition `DataProtected` indicating **cluster1**'s
+  volume data are synchronized with **cluster2**'s
+1. Deploy **cluster1** VRG with `spec.replicationState: primary`
+ to recover its volumes and Kube objects
+1. Wait for **cluster1** VRG condition
+   - `ClusterDataReady` indicating its Kube objects have been recovered
+   - `DataReady` indicating its volumes have been recovered
 1. **cluster1** application protection resumes automatically
 1. Unquiesce **cluster1** application Kube objects
    - Reset desired quiesced states in recovered Kube objects
+1. Delete **cluster2** VRG
+   - This allows its PVCs to finally be deleted

--- a/docs/vrg-usage.md
+++ b/docs/vrg-usage.md
@@ -23,21 +23,21 @@ SPDX-License-Identifier: Apache-2.0
  replicas
    - This is typically accomplished by network fencing
 1. Fence **cluster1** and **cluster2** VRGs from each other's volume data
-   - For `Async` mode, this is typically accomplished by setting **cluster2**
- VRG `Spec.ReplicationState: primary`
-   - For `Sync` mode, this is typically accomplished by network fencing
-1. Deploy **cluster2** VRG with `Spec.ReplicationState: primary` in the
- `Namespace` it was in and with the `Name` it had on **cluster1**
+   - For `async` mode, this is typically accomplished by setting **cluster2**
+ VRG `spec.replicationState: primary`
+   - For `sync` mode, this is typically accomplished by network fencing
+1. Deploy **cluster2** VRG with `spec.replicationState: primary` in the
+ `namespace` it was in and with the `name` it had on **cluster1**
    - Kube objects are recovered from the first available replica store specified
- in VRG's `Spec.S3Profiles` containing a replica for its `Namespace` and `Name`
-1. Wait for **cluster2** VRG `Status.Condtions`:
-   - `ClusterDataReady: true` indicating its Kube objects have been recovered
-   - `DataReady: true` indicating its volumes have been recovered
+ in VRG's `spec.s3Profiles` containing a replica for its `namespace` and `name`
+1. Wait for **cluster2** VRG `status.condtions`:
+   - `clusterDataReady: true` indicating its Kube objects have been recovered
+   - `dataReady: true` indicating its volumes have been recovered
 1. **cluster2** application protection resumes automatically
 
 ## Failback/Relocate application from cluster2 to cluster1
 
-1. Set **cluster1** VRG `Spec.ReplicationState: secondary`
+1. Set **cluster1** VRG `spec.replicationState: secondary`
 1. Undeploy **cluster1** application
    - Its PVCs can finally be deleted once VRG is deleted in a subsequent step
    - This allows its Kube objects to be recovered in a subsequent step
@@ -47,22 +47,28 @@ SPDX-License-Identifier: Apache-2.0
  replicas
    - This is typically accomplished by network unfencing
 1. Unfence **cluster1** and **cluster2** VRGs from each other's volume data
-   - For `Async` mode, this is typically accomplished by setting **cluster1**
- VRG `Spec.ReplicationState: secondary`
-   - For `Sync` mode, this is typically accomplished by network unfencing
-1. Wait for **cluster2** VRG `Status.Conditions.ClusterDataProtected: true`
-1. Set **cluster2** VRG `Spec.ReplicationState: secondary`
+   - For `async` mode, this is typically accomplished by setting **cluster1**
+ VRG `spec.replicationState: secondary`
+   - For `sync` mode, this is typically accomplished by network unfencing
+1. Quiesce **cluster2** application Kube objects
+   - Desired quiesced states in captured Kube objects are reset in a subsequent step
+1. Set **cluster2** VRG `spec.replicationState: secondary` and
+ `spec.action: Relocate`
+1. Wait for **cluster2** VRG `status.conditions.clusterDataProtected: true`
+ indicating Kube objects capture has completed
 1. Undeploy **cluster2** application
    - Its PVCs can finally be deleted once VRG is deleted in a subsequent step
-1. For `Async` mode, synchronize volume data:
-   1. Deploy **cluster1** VRG with `Spec.ReplicationState: secondary`
-   1. Wait for **cluster1** VRG `Status.Conditions.DataReady: true` indicating its
+1. For `async` mode, synchronize volume data:
+   - Deploy **cluster1** VRG with `spec.replicationState: secondary`
+   - Wait for **cluster1** VRG `status.conditions.dataReady: true` indicating its
  volume data are in-sync with **cluster2**'s
 1. Delete **cluster2** VRG
    - This allows its PVCs to finally be deleted
-1. Set, for `Async` mode, or deploy, for `Sync` mode, **cluster1** VRG
- `Spec.ReplicationState: primary` to recover its volumes and Kube objects
-1. Wait for **cluster1** VRG `Status.Condtions`:
-   - `ClusterDataReady: true` indicating its Kube objects have been recovered
-   - `DataReady: true` indicating its volumes have been recovered
+1. Set, for `async` mode, or deploy, for `sync` mode, **cluster1** VRG
+ `spec.replicationState: primary` to recover its volumes and Kube objects
+1. Wait for **cluster1** VRG `status.condtions`:
+   - `clusterDataReady: true` indicating its Kube objects have been recovered
+   - `dataReady: true` indicating its volumes have been recovered
 1. **cluster1** application protection resumes automatically
+1. Unquiesce **cluster1** application Kube objects
+   - Reset desired quiesced states in recovered Kube objects

--- a/hack/minikube-ramen.sh
+++ b/hack/minikube-ramen.sh
@@ -44,6 +44,9 @@ manager_redeploy() {
 	wait
 	manager_deploy
 }
+manager_log() {
+	kubectl --context $1 -nramen-system logs deploy/ramen-dr-cluster-operator manager
+}
 application_sample_namespace_name=${application_sample_namespace_name:-default}
 application_sample_namespace_deploy() {
 	kubectl create namespace $application_sample_namespace_name --dry-run=client -oyaml|kubectl --context $1 apply -f-
@@ -98,6 +101,7 @@ unset -f application_sample_kubectl
 unset -f application_sample_namespace_undeploy
 unset -f application_sample_namespace_deploy
 unset -v application_sample_namespace_name
+unset -f manager_log
 unset -f manager_redeploy
 unset -f manager_undeploy
 unset -f manager_deploy

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -573,15 +573,27 @@ ramen_undeploy_spokes()
 	for cluster_name in $spoke_cluster_names; do ramen_undeploy_spoke $cluster_name; done; unset -v cluster_name
 }
 exit_stack_push unset -f ramen_undeploy_spokes
-ramen_recipe_crd_kubectl() {
-	kubectl --context $1 $2 -f https://raw.githubusercontent.com/RamenDR/recipe/main/config/crd/bases/ramendr.openshift.io_recipes.yaml
-}; exit_stack_push unset -f ramen_recipe_crd_kubectl
+volsync_crds_deploy() {
+	volsync_crds_kubectl $1 apply
+}; exit_stack_push unset -f volsync_crds_deploy
+volsync_crds_undeploy() {
+	volsync_crds_kubectl $1 delete\ --ignore-not-found
+}; exit_stack_push unset -f volsync_crds_undeploy
+volsync_crds_kubectl() {
+	kubectl --context $1 $2\
+		-f https://raw.githubusercontent.com/backube/volsync/main/config/crd/bases/volsync.backube_replicationdestinations.yaml\
+		-f https://raw.githubusercontent.com/backube/volsync/main/config/crd/bases/volsync.backube_replicationsources.yaml\
+
+}; exit_stack_push unset -f volsync_crds_kubectl
 ramen_recipe_crd_deploy() {
 	ramen_recipe_crd_kubectl $1 apply
 }; exit_stack_push unset -f ramen_recipe_crd_deploy
 ramen_recipe_crd_undeploy() {
 	ramen_recipe_crd_kubectl $1 delete\ --ignore-not-found
 }; exit_stack_push unset -f ramen_recipe_crd_undeploy
+ramen_recipe_crd_kubectl() {
+	kubectl --context $1 $2 -f https://raw.githubusercontent.com/RamenDR/recipe/main/config/crd/bases/ramendr.openshift.io_recipes.yaml
+}; exit_stack_push unset -f ramen_recipe_crd_kubectl
 olm_deploy_spokes()
 {
 	for cluster_name in $spoke_cluster_names; do olm_deploy $cluster_name; done; unset -v cluster_name

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -592,7 +592,9 @@ ramen_recipe_crd_undeploy() {
 	ramen_recipe_crd_kubectl $1 delete\ --ignore-not-found
 }; exit_stack_push unset -f ramen_recipe_crd_undeploy
 ramen_recipe_crd_kubectl() {
-	kubectl --context $1 $2 -f https://raw.githubusercontent.com/RamenDR/recipe/main/config/crd/bases/ramendr.openshift.io_recipes.yaml
+	set -- $1 "$2" main
+	set -- $1 "$2" 1fbc6bc31dea8b5ea40eefd8775821c233c5a66e
+	kubectl --context $1 $2 -f https://raw.githubusercontent.com/RamenDR/recipe/$3/config/crd/bases/ramendr.openshift.io_recipes.yaml
 }; exit_stack_push unset -f ramen_recipe_crd_kubectl
 olm_deploy_spokes()
 {

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -592,9 +592,7 @@ ramen_recipe_crd_undeploy() {
 	ramen_recipe_crd_kubectl $1 delete\ --ignore-not-found
 }; exit_stack_push unset -f ramen_recipe_crd_undeploy
 ramen_recipe_crd_kubectl() {
-	set -- $1 "$2" main
-	set -- $1 "$2" 1fbc6bc31dea8b5ea40eefd8775821c233c5a66e
-	kubectl --context $1 $2 -f https://raw.githubusercontent.com/RamenDR/recipe/$3/config/crd/bases/ramendr.openshift.io_recipes.yaml
+	kubectl --context $1 $2 -f https://raw.githubusercontent.com/RamenDR/recipe/main/config/crd/bases/ramendr.openshift.io_recipes.yaml
 }; exit_stack_push unset -f ramen_recipe_crd_kubectl
 olm_deploy_spokes()
 {

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -536,6 +536,8 @@ ramen_deploy_hub()
 exit_stack_push unset -f ramen_deploy_hub
 ramen_deploy_spoke()
 {
+	volsync_crds_deploy $1
+	ramen_recipe_crd_deploy $1
 	ramen_deploy_hub_or_spoke $1 dr-cluster
 }
 exit_stack_push unset -f ramen_deploy_spoke
@@ -557,6 +559,8 @@ exit_stack_push unset -f ramen_undeploy_hub
 ramen_undeploy_spoke()
 {
 	ramen_undeploy_hub_or_spoke $1 dr-cluster
+	ramen_recipe_crd_undeploy $1
+	volsync_crds_undeploy $1
 }
 exit_stack_push unset -f ramen_undeploy_spoke
 ramen_deploy_spokes()
@@ -569,6 +573,15 @@ ramen_undeploy_spokes()
 	for cluster_name in $spoke_cluster_names; do ramen_undeploy_spoke $cluster_name; done; unset -v cluster_name
 }
 exit_stack_push unset -f ramen_undeploy_spokes
+ramen_recipe_crd_kubectl() {
+	kubectl --context $1 $2 -f https://raw.githubusercontent.com/RamenDR/recipe/main/config/crd/bases/ramendr.openshift.io_recipes.yaml
+}; exit_stack_push unset -f ramen_recipe_crd_kubectl
+ramen_recipe_crd_deploy() {
+	ramen_recipe_crd_kubectl $1 apply
+}; exit_stack_push unset -f ramen_recipe_crd_deploy
+ramen_recipe_crd_undeploy() {
+	ramen_recipe_crd_kubectl $1 delete\ --ignore-not-found
+}; exit_stack_push unset -f ramen_recipe_crd_undeploy
 olm_deploy_spokes()
 {
 	for cluster_name in $spoke_cluster_names; do olm_deploy $cluster_name; done; unset -v cluster_name

--- a/hack/shio-demo.sh
+++ b/hack/shio-demo.sh
@@ -217,13 +217,13 @@ vrg_apply() {
 	    - group: everything-but-deploy-po-pv-rs-vr-vrg
 	    - group: deployments-and-naked-pods
 	a
-	vrg_appendix="$3${4:+"\n  action: "$4}
+	vrg_appendix="
   kubeObjectProtection:
     captureInterval: 1m
     recipeRef:
       name: asdf
-      recoverWorkflowName: recover
-" \
+      recoverWorkflowName: recover$3${4:+
+  action: $4}" \
 	cluster_names=$s3_store_cluster_names application_sample_namespace_name=asdf $ramen_hack_directory_path_name/minikube-ramen.sh application_sample_vrg_deploy$2 $1
 }; exit_stack_push unset -f vrg_apply
 
@@ -259,7 +259,7 @@ vrg_final_sync() {
 }; exit_stack_push unset -f vrg_final_sync
 
 vrg_fence() {
-	vrg_demote $1
+	vrg_demote $1 failover
 }; exit_stack_push unset -f vrg_fence
 
 vrg_finalizer0_remove() {

--- a/hack/shio-demo.sh
+++ b/hack/shio-demo.sh
@@ -130,8 +130,7 @@ app_deploy() {
 		|kubectl --context $1 -nasdf apply -f-
 	kubectl create --dry-run=client -oyaml secret generic asdf --from-literal=key1=value1\
 		|kubectl --context $1 -nasdf apply -f-
-	kubectl create --dry-run=client -oyaml deploy asdf --image busybox -- sh -c while\ true\;do\ date\;sleep\ 60\;done\
-		|kubectl --context $1 -nasdf apply -f-
+	kubectl --context $1 -nasdf run asdf --image busybox -- sh -c while\ true\;do\ date\;sleep\ 60\;done
 	kubectl create --dry-run=client -oyaml -k https://github.com/RamenDR/ocm-ramen-samples/busybox -nasdf\
 		|kubectl --context $1 apply -f-
 	app_list $1
@@ -161,12 +160,12 @@ app_list_custom() {
 		vrg/bb\
 		$(pv_names $1)\
 		-nasdf\
-		pvc/busybox-pvc\
 		vr/busybox-pvc\
-		po/busybox\
+		pvc/busybox-pvc\
+		deploy/busybox\
 		$(app_replicaset_pod_name $1)\
 		$(app_deployment_replicaset_name $1)\
-		deploy/asdf\
+		po/asdf\
 		cm/asdf\
 		secret/asdf\
 		$2
@@ -174,7 +173,7 @@ app_list_custom() {
 
 app_undeploy() {
 	kubectl --context $1 -nasdf delete --ignore-not-found -k https://github.com/RamenDR/ocm-ramen-samples/busybox
-	kubectl --context $1 -nasdf delete --ignore-not-found deploy/asdf secret/asdf configmap/asdf
+	kubectl --context $1 -nasdf delete --ignore-not-found po/asdf secret/asdf configmap/asdf
 	app_namespace_undeploy $1
 	app_list $1
 }; exit_stack_push unset -f app_undeploy

--- a/hack/shio-demo.sh
+++ b/hack/shio-demo.sh
@@ -178,7 +178,7 @@ app_undeploy() {
 }; exit_stack_push unset -f app_undeploy
 
 vrg_apply() {
-	vrg_appendix="
+	vrg_appendix="${kube_object_protection_spec-
   kubeObjectProtection:
     captureInterval: 1m
     recoverOrder:
@@ -199,8 +199,7 @@ vrg_apply() {
       labelSelector:
         matchExpressions:
         - key: pod-template-hash
-          operator: DoesNotExist$3${4:+"\n  action: "$4}
-" \
+          operator: DoesNotExist}$3${4:+"\n  action: "$4}" \
 	cluster_names=$s3_store_cluster_names application_sample_namespace_name=asdf $ramen_hack_directory_path_name/minikube-ramen.sh application_sample_vrg_deploy$2 $1
 }; exit_stack_push unset -f vrg_apply
 

--- a/hack/shio-demo.sh
+++ b/hack/shio-demo.sh
@@ -161,6 +161,7 @@ app_list_custom() {
 		$(pv_names $1)\
 		-nasdf\
 		pvc/busybox-pvc\
+		vr/busybox-pvc\
 		po/busybox\
 		$(app_replicaset_pod_name $1)\
 		$(app_deployment_replicaset_name $1)\
@@ -322,10 +323,12 @@ app_failover() {
 
 app_failback() {
 	set -- cluster1 cluster2
-	app_undeploy_unprotected $1
+	app_undeploy_failback $1
 	vrg_final_sync $2
-	app_undeploy_unprotected $2 app_pv_sync_wait\ $1
-	app_recover $1 relocate
+	set -x
+	time kubectl --context $2 -nasdf wait vrg/bb --for condition=clusterdataprotected
+	{ set +x; } 2>/dev/null
+	app_undeploy_failback $2 app_recover_failback\ $1\ $2
 }; exit_stack_push unset -f app_failback
 
 app_recover() {
@@ -344,22 +347,23 @@ app_recover() {
 	date
 }; exit_stack_push unset -f app_recover
 
-app_undeploy_unprotected() {
+app_undeploy_failback() {
 	vrg_demote $1
 	# "PVC not being deleted. Not ready to become Secondary"
 	app_undeploy $1& # pvc finalizer remains until vrg deletes its vr
+	until_true_or_n 30 eval test \"\$\(kubectl --context $1 -nasdf get vrg/bb -ojsonpath='{.status.state}'\)\" = Secondary
 	$2
 	vrg_undeploy $1&
 	wait
-}; exit_stack_push unset -f app_undeploy_unprotected
+}; exit_stack_push unset -f app_undeploy_failback
 
-app_pv_sync_wait() {
-	vrg_demote $1
+app_recover_failback() {
 	# "VolumeReplication resource for the pvc as Secondary is in sync with Primary"
 	set -x
-	time kubectl --context $1 -nasdf wait vrg/bb --for condition=dataready --timeout 10m
+	time kubectl --context $2 -nasdf wait vrg/bb --for condition=dataready --timeout 10m
 	{ set +x; } 2>/dev/null
-}; exit_stack_push unset -f app_pv_sync_wait
+	app_recover $1 relocate
+}; exit_stack_push unset -f app_recover_failback
 
 app_velero_kube_object_name=asdf--bb--
 exit_stack_push unset -v app_velero_kube_object_name

--- a/hack/shio-demo.sh
+++ b/hack/shio-demo.sh
@@ -246,7 +246,7 @@ vrg_finalizer0_remove() {
 vr_finalizer0_remove() {
 	true_if_exit_status_and_stderr 1 'Error from server (NotFound): volumereplications.replication.storage.openshift.io "busybox-pvc" not found' \
 	kubectl --context $1 -nasdf patch volumereplication/busybox-pvc --type json -p '[{"op":remove, "path":/metadata/finalizers/0}]'
-}; exit_stack_push unset -f vrg_finalizer0_remove
+}; exit_stack_push unset -f vr_finalizer0_remove
 
 vrg_get() {
 	kubectl --context $1 -nasdf get vrg/bb --ignore-not-found -oyaml

--- a/hack/shio-demo.sh
+++ b/hack/shio-demo.sh
@@ -205,7 +205,10 @@ vrg_apply() {
 	  - includedResourceTypes:
 	    - deployments
 	    - pods
-	    labelSelector: !pod-template-hash
+	    labelSelector:
+	      matchExpressions:
+	      - key: pod-template-hash
+	        operator: DoesNotExist
 	    name: deployments-and-naked-pods
 	    type: resource
 	  workflows:

--- a/hack/shio-demo.sh
+++ b/hack/shio-demo.sh
@@ -205,15 +205,13 @@ vrg_apply() {
 	  - includedResourceTypes:
 	    - deployments
 	    - pods
-	    labelSelector: !pod-template-hash
-#	    labelSelector:
-#	      matchExpressions:
-#	      - key: pod-template-hash
-#	        operator: DoesNotExist
+	    labelSelector:
+	      matchExpressions:
+	      - key: pod-template-hash
+	        operator: DoesNotExist
 	    name: deployments-and-naked-pods
 	    type: resource
-	  workflows:
-	  - name: recover
+	  recoverWorkflow:
 	    sequence:
 	    - group: everything-but-deploy-po-pv-rs-vr-vrg
 	    - group: deployments-and-naked-pods
@@ -222,8 +220,7 @@ vrg_apply() {
   kubeObjectProtection:
     captureInterval: 1m
     recipeRef:
-      name: asdf
-      recoverWorkflowName: recover$3${4:+
+      name: asdf$3${4:+
   action: $4}" \
 	cluster_names=$s3_store_cluster_names application_sample_namespace_name=asdf $ramen_hack_directory_path_name/minikube-ramen.sh application_sample_vrg_deploy$2 $1
 }; exit_stack_push unset -f vrg_apply

--- a/hack/test/velero.io_restores.yaml
+++ b/hack/test/velero.io_restores.yaml
@@ -205,14 +205,14 @@ spec:
                                       properties:
                                         args:
                                           description: 'Arguments to the entrypoint.
-                                            The docker image''s CMD is used if this
-                                            is not provided. Variable references $(VAR_NAME)
-                                            are expanded using the container''s environment.
-                                            If a variable cannot be resolved, the
-                                            reference in the input string will be
-                                            unchanged. Double $$ are reduced to a
-                                            single $, which allows for escaping the
-                                            $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                            The container image''s CMD is used if
+                                            this is not provided. Variable references
+                                            $(VAR_NAME) are expanded using the container''s
+                                            environment. If a variable cannot be resolved,
+                                            the reference in the input string will
+                                            be unchanged. Double $$ are reduced to
+                                            a single $, which allows for escaping
+                                            the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
                                             will produce the string literal "$(VAR_NAME)".
                                             Escaped references will never be expanded,
                                             regardless of whether the variable exists
@@ -223,15 +223,15 @@ spec:
                                           type: array
                                         command:
                                           description: 'Entrypoint array. Not executed
-                                            within a shell. The docker image''s ENTRYPOINT
-                                            is used if this is not provided. Variable
-                                            references $(VAR_NAME) are expanded using
-                                            the container''s environment. If a variable
-                                            cannot be resolved, the reference in the
-                                            input string will be unchanged. Double
-                                            $$ are reduced to a single $, which allows
-                                            for escaping the $(VAR_NAME) syntax: i.e.
-                                            "$$(VAR_NAME)" will produce the string
+                                            within a shell. The container image''s
+                                            ENTRYPOINT is used if this is not provided.
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the container''s environment. If
+                                            a variable cannot be resolved, the reference
+                                            in the input string will be unchanged.
+                                            Double $$ are reduced to a single $, which
+                                            allows for escaping the $(VAR_NAME) syntax:
+                                            i.e. "$$(VAR_NAME)" will produce the string
                                             literal "$(VAR_NAME)". Escaped references
                                             will never be expanded, regardless of
                                             whether the variable exists or not. Cannot
@@ -427,8 +427,8 @@ spec:
                                             type: object
                                           type: array
                                         image:
-                                          description: 'Docker image name. More info:
-                                            https://kubernetes.io/docs/concepts/containers/images
+                                          description: 'Container image name. More
+                                            info: https://kubernetes.io/docs/concepts/containers/images
                                             This field is optional to allow higher
                                             level config management to default or
                                             override container images in workload
@@ -456,9 +456,8 @@ spec:
                                                 info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                               properties:
                                                 exec:
-                                                  description: One and only one of
-                                                    the following should be specified.
-                                                    Exec specifies the action to take.
+                                                  description: Exec specifies the
+                                                    action to take.
                                                   properties:
                                                     command:
                                                       description: Command is the
@@ -534,11 +533,13 @@ spec:
                                                   - port
                                                   type: object
                                                 tcpSocket:
-                                                  description: 'TCPSocket specifies
-                                                    an action involving a TCP port.
-                                                    TCP hooks not yet supported TODO:
-                                                    implement a realistic TCP lifecycle
-                                                    hook'
+                                                  description: Deprecated. TCPSocket
+                                                    is NOT supported as a LifecycleHandler
+                                                    and kept for the backward compatibility.
+                                                    There are no validation of this
+                                                    field and lifecycle hooks will
+                                                    fail in runtime when tcp handler
+                                                    is specified.
                                                   properties:
                                                     host:
                                                       description: 'Optional: Host
@@ -566,23 +567,21 @@ spec:
                                                 such as liveness/startup probe failure,
                                                 preemption, resource contention, etc.
                                                 The handler is not called if the container
-                                                crashes or exits. The reason for termination
-                                                is passed to the handler. The Pod''s
-                                                termination grace period countdown
-                                                begins before the PreStop hooked is
-                                                executed. Regardless of the outcome
-                                                of the handler, the container will
-                                                eventually terminate within the Pod''s
-                                                termination grace period. Other management
-                                                of the container blocks until the
-                                                hook completes or until the termination
-                                                grace period is reached. More info:
-                                                https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                                                crashes or exits. The Pod''s termination
+                                                grace period countdown begins before
+                                                the PreStop hook is executed. Regardless
+                                                of the outcome of the handler, the
+                                                container will eventually terminate
+                                                within the Pod''s termination grace
+                                                period (unless delayed by finalizers).
+                                                Other management of the container
+                                                blocks until the hook completes or
+                                                until the termination grace period
+                                                is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                               properties:
                                                 exec:
-                                                  description: One and only one of
-                                                    the following should be specified.
-                                                    Exec specifies the action to take.
+                                                  description: Exec specifies the
+                                                    action to take.
                                                   properties:
                                                     command:
                                                       description: Command is the
@@ -658,11 +657,13 @@ spec:
                                                   - port
                                                   type: object
                                                 tcpSocket:
-                                                  description: 'TCPSocket specifies
-                                                    an action involving a TCP port.
-                                                    TCP hooks not yet supported TODO:
-                                                    implement a realistic TCP lifecycle
-                                                    hook'
+                                                  description: Deprecated. TCPSocket
+                                                    is NOT supported as a LifecycleHandler
+                                                    and kept for the backward compatibility.
+                                                    There are no validation of this
+                                                    field and lifecycle hooks will
+                                                    fail in runtime when tcp handler
+                                                    is specified.
                                                   properties:
                                                     host:
                                                       description: 'Optional: Host
@@ -691,9 +692,8 @@ spec:
                                             More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                           properties:
                                             exec:
-                                              description: One and only one of the
-                                                following should be specified. Exec
-                                                specifies the action to take.
+                                              description: Exec specifies the action
+                                                to take.
                                               properties:
                                                 command:
                                                   description: Command is the command
@@ -720,6 +720,29 @@ spec:
                                                 3. Minimum value is 1.
                                               format: int32
                                               type: integer
+                                            grpc:
+                                              description: GRPC specifies an action
+                                                involving a GRPC port. This is a beta
+                                                field and requires enabling GRPCContainerProbe
+                                                feature gate.
+                                              properties:
+                                                port:
+                                                  description: Port number of the
+                                                    gRPC service. Number must be in
+                                                    the range 1 to 65535.
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  description: "Service is the name
+                                                    of the service to place in the
+                                                    gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                    \n If this is not specified, the
+                                                    default behavior is defined by
+                                                    gRPC."
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
                                             httpGet:
                                               description: HTTPGet specifies the http
                                                 request to perform.
@@ -793,10 +816,8 @@ spec:
                                               format: int32
                                               type: integer
                                             tcpSocket:
-                                              description: 'TCPSocket specifies an
-                                                action involving a TCP port. TCP hooks
-                                                not yet supported TODO: implement
-                                                a realistic TCP lifecycle hook'
+                                              description: TCPSocket specifies an
+                                                action involving a TCP port.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -918,9 +939,8 @@ spec:
                                             Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                           properties:
                                             exec:
-                                              description: One and only one of the
-                                                following should be specified. Exec
-                                                specifies the action to take.
+                                              description: Exec specifies the action
+                                                to take.
                                               properties:
                                                 command:
                                                   description: Command is the command
@@ -947,6 +967,29 @@ spec:
                                                 3. Minimum value is 1.
                                               format: int32
                                               type: integer
+                                            grpc:
+                                              description: GRPC specifies an action
+                                                involving a GRPC port. This is a beta
+                                                field and requires enabling GRPCContainerProbe
+                                                feature gate.
+                                              properties:
+                                                port:
+                                                  description: Port number of the
+                                                    gRPC service. Number must be in
+                                                    the range 1 to 65535.
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  description: "Service is the name
+                                                    of the service to place in the
+                                                    gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                    \n If this is not specified, the
+                                                    default behavior is defined by
+                                                    gRPC."
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
                                             httpGet:
                                               description: HTTPGet specifies the http
                                                 request to perform.
@@ -1020,10 +1063,8 @@ spec:
                                               format: int32
                                               type: integer
                                             tcpSocket:
-                                              description: 'TCPSocket specifies an
-                                                action involving a TCP port. TCP hooks
-                                                not yet supported TODO: implement
-                                                a realistic TCP lifecycle hook'
+                                              description: TCPSocket specifies an
+                                                action involving a TCP port.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name
@@ -1121,13 +1162,17 @@ spec:
                                                 no_new_privs flag will be set on the
                                                 container process. AllowPrivilegeEscalation
                                                 is true always when the container
-                                                is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                                                is: 1) run as Privileged 2) has CAP_SYS_ADMIN
+                                                Note that this field cannot be set
+                                                when spec.os.name is windows.'
                                               type: boolean
                                             capabilities:
                                               description: The capabilities to add/drop
                                                 when running containers. Defaults
                                                 to the default set of capabilities
                                                 granted by the container runtime.
+                                                Note that this field cannot be set
+                                                when spec.os.name is windows.
                                               properties:
                                                 add:
                                                   description: Added capabilities
@@ -1148,7 +1193,9 @@ spec:
                                               description: Run container in privileged
                                                 mode. Processes in privileged containers
                                                 are essentially equivalent to root
-                                                on the host. Defaults to false.
+                                                on the host. Defaults to false. Note
+                                                that this field cannot be set when
+                                                spec.os.name is windows.
                                               type: boolean
                                             procMount:
                                               description: procMount denotes the type
@@ -1157,12 +1204,15 @@ spec:
                                                 uses the container runtime defaults
                                                 for readonly paths and masked paths.
                                                 This requires the ProcMountType feature
-                                                flag to be enabled.
+                                                flag to be enabled. Note that this
+                                                field cannot be set when spec.os.name
+                                                is windows.
                                               type: string
                                             readOnlyRootFilesystem:
                                               description: Whether this container
                                                 has a read-only root filesystem. Default
-                                                is false.
+                                                is false. Note that this field cannot
+                                                be set when spec.os.name is windows.
                                               type: boolean
                                             runAsGroup:
                                               description: The GID to run the entrypoint
@@ -1171,7 +1221,9 @@ spec:
                                                 in PodSecurityContext.  If set in
                                                 both SecurityContext and PodSecurityContext,
                                                 the value specified in SecurityContext
-                                                takes precedence.
+                                                takes precedence. Note that this field
+                                                cannot be set when spec.os.name is
+                                                windows.
                                               format: int64
                                               type: integer
                                             runAsNonRoot:
@@ -1196,7 +1248,9 @@ spec:
                                                 PodSecurityContext.  If set in both
                                                 SecurityContext and PodSecurityContext,
                                                 the value specified in SecurityContext
-                                                takes precedence.
+                                                takes precedence. Note that this field
+                                                cannot be set when spec.os.name is
+                                                windows.
                                               format: int64
                                               type: integer
                                             seLinuxOptions:
@@ -1207,7 +1261,9 @@ spec:
                                                 container.  May also be set in PodSecurityContext.  If
                                                 set in both SecurityContext and PodSecurityContext,
                                                 the value specified in SecurityContext
-                                                takes precedence.
+                                                takes precedence. Note that this field
+                                                cannot be set when spec.os.name is
+                                                windows.
                                               properties:
                                                 level:
                                                   description: Level is SELinux level
@@ -1231,7 +1287,9 @@ spec:
                                                 use by this container. If seccomp
                                                 options are provided at both the pod
                                                 & container level, the container options
-                                                override the pod options.
+                                                override the pod options. Note that
+                                                this field cannot be set when spec.os.name
+                                                is windows.
                                               properties:
                                                 localhostProfile:
                                                   description: localhostProfile indicates
@@ -1264,7 +1322,8 @@ spec:
                                                 will be used. If set in both SecurityContext
                                                 and PodSecurityContext, the value
                                                 specified in SecurityContext takes
-                                                precedence.
+                                                precedence. Note that this field cannot
+                                                be set when spec.os.name is linux.
                                               properties:
                                                 gmsaCredentialSpec:
                                                   description: GMSACredentialSpec
@@ -1326,9 +1385,8 @@ spec:
                                             updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                           properties:
                                             exec:
-                                              description: One and only one of the
-                                                following should be specified. Exec
-                                                specifies the action to take.
+                                              description: Exec specifies the action
+                                                to take.
                                               properties:
                                                 command:
                                                   description: Command is the command
@@ -1355,6 +1413,29 @@ spec:
                                                 3. Minimum value is 1.
                                               format: int32
                                               type: integer
+                                            grpc:
+                                              description: GRPC specifies an action
+                                                involving a GRPC port. This is a beta
+                                                field and requires enabling GRPCContainerProbe
+                                                feature gate.
+                                              properties:
+                                                port:
+                                                  description: Port number of the
+                                                    gRPC service. Number must be in
+                                                    the range 1 to 65535.
+                                                  format: int32
+                                                  type: integer
+                                                service:
+                                                  description: "Service is the name
+                                                    of the service to place in the
+                                                    gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                                    \n If this is not specified, the
+                                                    default behavior is defined by
+                                                    gRPC."
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
                                             httpGet:
                                               description: HTTPGet specifies the http
                                                 request to perform.
@@ -1428,10 +1509,8 @@ spec:
                                               format: int32
                                               type: integer
                                             tcpSocket:
-                                              description: 'TCPSocket specifies an
-                                                action involving a TCP port. TCP hooks
-                                                not yet supported TODO: implement
-                                                a realistic TCP lifecycle hook'
+                                              description: TCPSocket specifies an
+                                                action involving a TCP port.
                                               properties:
                                                 host:
                                                   description: 'Optional: Host name


### PR DESCRIPTION
## App relocation sequence
The application relocation process, orchestrated by DRPC, quiesces a declaratively-defined application by deleting it.  In contrast, an imperatively-defined application must be quiesced but not deleted so that its Kube objects can be captured for relocation, and unquiesced upon restoration.

## Changes
- Require a final Kube object capture start and complete when a VRG's `spec.replicationState: secondary` and `spec.action: Relocate`
- Set `ClusterDataProtected` to `false` while the capture is in-progress and `true` when it completes without a change to `generation`, i.e., any field in `spec`
- Store `VRG.generation` from time of Kube objects capture start in velero `Backup` request `ramendr.openshift.io/vrg-generation` annotation and copy it to `VRG.status.kubeObjectProtection.captureToRecoverFrom.startGeneration` when capture completes
- Script DRPC final sync behavior in `hack/shio-demo.sh`'s `app_failback` routine

## End-to-end test record
```sh
$ . hack/shio-demo.sh
$ app_deploy
$ app_protect
$ app_failover
$ app_failback

Tue Apr 25 09:51:27 PDT 2023
volumereplicationgroup.ramendr.openshift.io/bb configured # spec.replicationState=secondary

$ kubectl --context cluster2 -nasdf wait vrg/bb --for condition=clusterdataprotected --timeout -1s
volumereplicationgroup.ramendr.openshift.io/bb condition met
real    0m7.909s
```

Last capture as primary takes 7.7 seconds, delay 52 seconds
```
2023-04-25T16:50:14.773Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:322      Kube objects captured   {"VolumeReplicationGroup": "asdf/bb", "rid": "ecf4f287-cd09-471b-950c-60be5f39408e", "State": "primary", "recovery point": {"number":0,"startTime":"2023-04-25T16:50:07Z","startGeneration":2}, "duration": "7.773318055s"}
2023-04-25T16:50:14.773Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:189      Kube objects capture start delay        {"VolumeReplicationGroup": "asdf/bb", "rid": "ecf4f287-cd09-471b-950c-60be5f39408e", "State": "primary", "delay": "52.226681945s", "interval": "1m0s"}
```

Last reconcile as primary: delay 3 more seconds
```
2023-04-25T16:51:03.309Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/volumereplicationgroup_controller.go:828    Entering processing VolumeReplicationGroup as Primary   {"VolumeReplicationGroup": "asdf/bb", "rid": "3596a17c-6ba6-4aea-827c-3e735fa85929", "State": "primary"}
2023-04-25T16:51:03.319Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:189      Kube objects capture start delay        {"VolumeReplicationGroup": "asdf/bb", "rid": "3596a17c-6ba6-4aea-827c-3e735fa85929", "State": "primary", "delay": "3.68085192s", "interval": "1m0s"}
2023-04-25T16:51:03.584Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/volumereplicationgroup_controller.go:1036   ClusterDataProtected    {"VolumeReplicationGroup": "asdf/bb", "rid": "3596a17c-6ba6-4aea-827c-3e735fa85929", "State": "primary", "subconditions": [null,{"type":"ClusterDataProtected","status":"True","observedGeneration":4,"lastTransitionTime":null,"reason":"Uploaded","message":"Cluster data of all PVs are protected"},{"type":"ClusterDataProtected","status":"True","observedGeneration":4,"lastTransitionTime":null,"reason":"Uploaded","message":"Kube objects protected"},null]}
```

First reconcile as secondary: start relocate capture, no capture pending
```
2023-04-25T16:51:04.491Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/volumereplicationgroup_controller.go:888    Entering processing VolumeReplicationGroup as Secondary {"VolumeReplicationGroup": "asdf/bb", "rid": "e9bedde0-ce5f-459e-9a49-d6c84d30d546", "State": "secondary"}
2023-04-25T16:51:04.551Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:129      Kube objects capture start      {"VolumeReplicationGroup": "asdf/bb", "rid": "e9bedde0-ce5f-459e-9a49-d6c84d30d546", "State": "secondary", "number": 1, "generation": 5}
2023-04-25T16:51:04.842Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/volumereplicationgroup_controller.go:1036   ClusterDataProtected    {"VolumeReplicationGroup": "asdf/bb", "rid": "e9bedde0-ce5f-459e-9a49-d6c84d30d546", "State": "secondary", "subconditions": [null,{"type":"ClusterDataProtected","status":"True","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploaded","message":"Cluster data of all PVs are protected"},{"type":"ClusterDataProtected","status":"True","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploaded","message":"Kube objects protected"},{"type":"ClusterDataProtected","status":"False","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploading","message":"Kube objects capture for relocate in-progress"}]}
```

Capture still in-progress
```
2023-04-25T16:51:04.889Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:129      Kube objects capture resume     {"VolumeReplicationGroup": "asdf/bb", "rid": "33e80a0a-dbd3-4efc-aed2-2ca765590961", "State": "secondary", "number": 1, "generation": 1}
2023-04-25T16:51:05.180Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/volumereplicationgroup_controller.go:1036   ClusterDataProtected    {"VolumeReplicationGroup": "asdf/bb", "rid": "33e80a0a-dbd3-4efc-aed2-2ca765590961", "State": "secondary", "subconditions": [null,{"type":"ClusterDataProtected","status":"True","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploaded","message":"Cluster data of all PVs are protected"},{"type":"ClusterDataProtected","status":"True","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploaded","message":"Kube objects protected"},{"type":"ClusterDataProtected","status":"False","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploading","message":"Kube objects capture for relocate in-progress"}]}
```

Capture still in-progress
```
2023-04-25T16:51:06.079Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_volrep.go:2328  Cluster data of all PVs are protected   {"VolumeReplicationGroup": "asdf/bb", "rid": "18566be6-7a9b-4e96-85ab-f98fc13c8492", "State": "secondary"}
2023-04-25T16:51:06.079Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/volumereplicationgroup_controller.go:1036   ClusterDataProtected    {"VolumeReplicationGroup": "asdf/bb", "rid": "18566be6-7a9b-4e96-85ab-f98fc13c8492", "State": "secondary", "subconditions": [null,{"type":"ClusterDataProtected","status":"True","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploaded","message":"Cluster data of all PVs are protected"},{"type":"ClusterDataProtected","status":"True","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploaded","message":"Kube objects protected"},{"type":"ClusterDataProtected","status":"False","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploading","message":"Kube objects capture for relocate in-progress"}]}
```

Capture still in-progress
```
2023-04-25T16:51:11.593Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/volumereplicationgroup_controller.go:1036   ClusterDataProtected    {"VolumeReplicationGroup": "asdf/bb", "rid": "65d256c2-0c50-4918-975c-1437f0c889ff", "State": "secondary", "subconditions": [null,{"type":"ClusterDataProtected","status":"True","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploaded","message":"Cluster data of all PVs are protected"},{"type":"ClusterDataProtected","status":"True","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploaded","message":"Kube objects protected"},{"type":"ClusterDataProtected","status":"False","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploading","message":"Kube objects capture for relocate in-progress"}]}
```

Capture complete, took 8 seconds
```
2023-04-25T16:51:12.329Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:322      Kube objects captured   {"VolumeReplicationGroup": "asdf/bb", "rid": "25763be0-022a-4c3c-99d2-fc20967a45a7", "State": "secondary", "recovery point": {"number":1,"startTime":"2023-04-25T16:51:04Z","startGeneration":5}, "duration": "8.329700029s"}
2023-04-25T16:51:12.329Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:174      Kube objects capture for relocate complete      {"VolumeReplicationGroup": "asdf/bb", "rid": "25763be0-022a-4c3c-99d2-fc20967a45a7", "State": "secondary", "generation": 5}
2023-04-25T16:51:12.460Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/volumereplicationgroup_controller.go:1036   ClusterDataProtected    {"VolumeReplicationGroup": "asdf/bb", "rid": "25763be0-022a-4c3c-99d2-fc20967a45a7", "State": "secondary", "subconditions": [null,{"type":"ClusterDataProtected","status":"True","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploaded","message":"Cluster data of all PVs are protected"},{"type":"ClusterDataProtected","status":"True","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploaded","message":"Kube objects protected"},{"type":"ClusterDataProtected","status":"True","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploaded","message":"Kube objects protected"}]}
```

No more capture work
```
2023-04-25T16:51:12.580Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_volrep.go:196   VolumeReplication cannot become Secondary, as its PersistentVolumeClaim is potentially in use by a pod  {"VolumeReplicationGroup": "asdf/bb", "rid": "a79b2d28-0a0b-4552-8084-4abe84d6fbde", "State": "secondary", "pvc": "asdf/busybox-pvc", "errorValue": null}
2023-04-25T16:51:12.580Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/volumereplicationgroup_controller.go:939    Updating VRG status     {"VolumeReplicationGroup": "asdf/bb", "rid": "a79b2d28-0a0b-4552-8084-4abe84d6fbde", "State": "secondary"}
2023-04-25T16:51:12.581Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/volumereplicationgroup_controller.go:1036   ClusterDataProtected    {"VolumeReplicationGroup": "asdf/bb", "rid": "a79b2d28-0a0b-4552-8084-4abe84d6fbde", "State": "secondary", "subconditions": [null,{"type":"ClusterDataProtected","status":"True","observedGeneration":5,"lastTransitionTime":null,"reason":"Uploaded","message":"Cluster data of all PVs are protected"},null,null]}
```
