### PR TITLE
Restore ocm-controller deployment on the hub

### DIFF
--- a/test/ocm-controller/kustomization.yaml
+++ b/test/ocm-controller/kustomization.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Based on upstream deploy/foundation/hub/kustomization.yaml
+# excluding ocm proxyserver and webhook controllers.
+
+---
+resources:
+- $base_url/resources/crds/action.open-cluster-management.io_managedclusteractions.yaml
+- $base_url/resources/crds/internal.open-cluster-management.io_managedclusterinfos.yaml
+- $base_url/resources/crds/imageregistry.open-cluster-management.io_managedclusterimageregistries.yaml
+- $base_url/resources/crds/inventory.open-cluster-management.io_baremetalassets.yaml
+- $base_url/resources/crds/view.open-cluster-management.io_managedclusterviews.yaml
+- $base_url/resources/crds/hive.openshift.io_syncsets.yaml
+- $base_url/resources/crds/hive.openshift.io_clusterdeployments.yaml
+- $base_url/resources/crds/hiveinternal.openshift.io_clustersyncs.yaml
+- $base_url/resources/crds/hive.openshift.io_clusterclaims.yaml
+- $base_url/resources/crds/hive.openshift.io_clusterpools.yaml
+- $base_url/resources/clusterrole.yaml
+- $base_url/resources/agent-clusterrole.yaml
+- $base_url/resources/controller.yaml
+
+
+images:
+- name: quay.io/stolostron/multicloud-manager
+  newName: quay.io/stolostron/multicloud-manager
+  newTag: latest
+
+
+patchesStrategicMerge:
+- $base_url/patches.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/test/ocm-controller/start
+++ b/test/ocm-controller/start
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+import drenv
+
+TAG = "v2.4.4-ACM"
+BASE_URL = f"https://raw.githubusercontent.com/stolostron/multicloud-operators-foundation/{TAG}/deploy/foundation/hub"
+
+
+def deploy(cluster):
+    drenv.log_progress("Deploying ocm controller")
+    with drenv.kustomization(
+        "ocm-controller/kustomization.yaml",
+        base_url=BASE_URL,
+    ) as kustomization:
+        drenv.kubectl("apply", "--kustomize", kustomization, profile=cluster)
+
+
+def wait(cluster):
+    drenv.log_progress("Waiting for ocm controller rollout")
+    drenv.kubectl(
+        "rollout", "status", "deploy/ocm-controller",
+        "--namespace", "open-cluster-management",
+        "--timeout", "300s",
+        profile=cluster,
+    )
+
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} cluster")
+    sys.exit(1)
+
+cluster = sys.argv[1]
+
+deploy(cluster)
+wait(cluster)

--- a/test/ocm.yaml
+++ b/test/ocm.yaml
@@ -8,6 +8,7 @@ profiles:
     network: default
     scripts:
       - file: ocm-hub/start
+      - file: ocm-controller/start
   - name: "dr1"
     network: default
     scripts:

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -39,6 +39,7 @@ profiles:
       - file: cert-manager/start
       - file: olm/start
       - file: ocm-hub/start
+      - file: ocm-controller/start
 scripts:
   - file: rbd-mirror/start
     args: ["dr1", "dr2"]


### PR DESCRIPTION
Turns out that `clusteradm` does not install the ocm-controller and crds from `multicloud-operators-foundation` so we must install this manually. Without this ramen operator fails on the hub with:

    2022-11-20T22:09:59.869Z    ERROR    controller-runtime.source source/source.go:139
    if kind is a CRD, it should be installed before calling Start    {"kind":
    "ManagedClusterView.view.open-cluster-management.io", "error": "no matches for kind
    \"ManagedClusterView\" in version \"view.open-cluster-management.io/v1beta1\""}

This is a cherry-pick of commit 7df91b222e35

    Install ocm-controller on the hub

With few cleanups:
- Remove unused imports (removed in a later commit)
- Remove namespace creation and wait (the namespace already exists)
- Split code to deploy() and wait() functions (our current style)
- Add to ocm.yaml (was created after the original commit)

This should probably be fixed in `clusteradm` later.

Fixes: d4febf5686a0 (Use clusteradm based scripts in regional-dr.yaml)
Signed-off-by: Nir Soffer <nsoffer@redhat.com>