### PR TITLE
Add volSync and kubeObjectProtection options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,8 +208,6 @@ uninstall-dr-cluster: manifests kustomize ## Uninstall dr-cluster CRDs from the 
 dr-cluster-config: kustomize
 	cd config/dr-cluster/default && $(KUSTOMIZE) edit set image kube-rbac-proxy=$(RBAC_PROXY_IMG)
 	cd config/dr-cluster/manager && $(KUSTOMIZE) edit set image controller=${IMG};\
-	sed -n '/^kubeObjectProtection:/{:1;n;/^ /b1};p' ramen_manager_config.yaml>a;mv a ramen_manager_config.yaml;\
-	if (: $${KUBE_OBJECT_PROTECTION_DISABLED?})2>/dev/null;then printf 'kubeObjectProtection:\n  disabled: true\n'>>ramen_manager_config.yaml;fi
 
 deploy-dr-cluster: manifests kustomize dr-cluster-config ## Deploy dr-cluster controller to the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/dr-cluster/default | kubectl apply -f -

--- a/config/dr-cluster/manager/ramen_manager_config.yaml
+++ b/config/dr-cluster/manager/ramen_manager_config.yaml
@@ -10,3 +10,7 @@ leaderElection:
   leaderElect: true
   resourceName: dr-cluster.ramendr.openshift.io
 ramenControllerType: dr-cluster
+volSync:
+  disabled: false
+kubeObjectProtection:
+  disabled: false

--- a/config/hub/manager/ramen_manager_config.yaml
+++ b/config/hub/manager/ramen_manager_config.yaml
@@ -10,3 +10,7 @@ leaderElection:
   leaderElect: true
   resourceName: hub.ramendr.openshift.io
 ramenControllerType: dr-hub
+volSync:
+  disabled: false
+kubeObjectProtection:
+  disabled: false


### PR DESCRIPTION
With the current test environment we don't have volsync or volero, so we need to disable volSync and kubeObjectProtection manually after deploying ramen.

Make this manual task easier and less error prone by including the relevant options in the config.

Without this you need to go to source to get the right names and type too much manually. There is no validation of the config map, so invalid configuration is accepted silently.

Remove option to disable kubeObjectProtection in the makefile since it deletes the config added by this change, and soon there will be no need to disable this protection.

I think we should add all the options and documentation for every option in the default yaml, something like[1] but we can improve this later.

[1] https://github.com/oVirt/ovirt-imageio/blob/master/data/README

Signed-off-by: Nir Soffer <nsoffer@redhat.com>