### PR TITLE
Wait until rook operator is running

### DIFF
--- a/test/rook/start
+++ b/test/rook/start
@@ -68,7 +68,7 @@ drenv.kubectl(
 drenv.log_progress("Waiting until rook ceph operator is ready")
 drenv.kubectl(
     "wait", "pod",
-    "--for", "condition=Ready",
+    "--for", "jsonpath={.status.phase}=Running",
     "--namespace", "rook-ceph",
     "--selector", "app=rook-ceph-operator",
     "--timeout", "300s",


### PR DESCRIPTION
We used to wait for condition=Ready, waiting for status.phase=Running seems to be more reliable when we restart a cluster.

According to the docs, checking for readiness[1] is more better than checking for running phase[2], but in practice we get more random errors this way. Maybe we want to check for both?

[1] https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions [2] https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase

Signed-off-by: Nir Soffer <nsoffer@redhat.com>