### PR TITLE
Improve reliability of restarting a test environment

### DIFF
--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -138,17 +138,17 @@ def cluster_info(cluster):
     Return cluster info from kubectl config. Returns empty dict if the cluster
     is not configured with kubectl yet.
     """
-    out = kubectl(
-        "config", "view",
-        "--output", f"jsonpath={{.clusters[?(@.name=='{cluster}')]}}",
-        verbose=False,
-    )
+    out = kubectl("config", "view", "--output", "json", verbose=False)
+    config = json.loads(out)
 
-    # Empty output means the cluster was not configured yet in kubectl config.
-    if not out:
-        return {}
+    # We get null instead of [].
+    clusters = config.get("clusters") or ()
 
-    return json.loads(out)
+    for c in clusters:
+        if c["name"] == cluster:
+            return c
+
+    return {}
 
 
 def run(*args, input=None, verbose=True):

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -14,7 +14,7 @@ from collections import deque
 
 import yaml
 
-from . import config_dir
+import drenv
 
 CMD_PREFIX = "cmd_"
 
@@ -161,7 +161,7 @@ def delete_cluster(profile):
     start = time.monotonic()
     logging.info("[%s] Deleting cluster", profile["name"])
     minikube("delete", profile=profile["name"])
-    profile_config = config_dir(profile["name"])
+    profile_config = drenv.config_dir(profile["name"])
     if os.path.exists(profile_config):
         logging.info("[%s] Removing config %s",
                      profile["name"], profile_config)


### PR DESCRIPTION
Stopping and starting the environment:

    drevn start regional-dr.yaml
    drenv stop regional-dr.yaml
    drenv start regional-dr.yaml 

 or starting a running environment:
   
    drenv start regional-dr.yaml
    drenv start regional-dr.yaml 

is flaky. Running `minikube start` restart the Kubernetest on the node
and after that kubectl reports stale status for a while. If we start 
the scripts immediately we get lot of random errors, typically from 
rook admission webhook.

This change improves this, but does not resolve the issue completely.