### PR TITLE
Create and Update Events for DRPC

### DIFF
--- a/controllers/util/events.go
+++ b/controllers/util/events.go
@@ -71,16 +71,40 @@ const (
 	// deploys ramen and the application in the managed cluster initially
 	EventReasonDeploySuccess = "DRPCDeploySuccess"
 
+	//  EventReasonCreateVRGManifestWork is generated to create VRG ManifestWork
+	EventReasonCreateVRGManifestWork = "CreateVRGManifestWork"
+
+	//  EventReasonVRGManifestWorkCreationFailed is generated when DRPC failed to
+	// create VRG ManifestWork
+	EventReasonVRGManifestWorkCreationFailed = "CreateVRGManifestWorkFailed"
+
+	// EventReasonUpdateUserPlacementRule is generated to update the user PlacementRule
+	EventReasonUpdateUserPlacementRule = "UpdateUserPlacementRule"
+
+	// EventReasonUpdateUserPlacementRuleFailed is generated when
+	// DRPC fails to update the user PlacementRule
+	EventReasonUpdateUserPlacementRuleFailed = "UpdateUserPlacementRuleFailed"
+
+	// EventReasonDeployFail is generic, can we re-use it with appropriate failure reason?
+
 	// EventReasonFailingOver is an event generated when DRPC starts the failover
 	// process
 	EventReasonFailingOver = "DRPCFailingOver"
 
-	// EventReasonFailoverSuccess is an evenet generated when DRPC does a successful
+	// EventReasonFailoverUnsuccessful is an event generated when DRPC can
+	// not proceed with the failover
+	EventReasonFailoverUnsuccessful = "DRPCFailoverUnsuccessful"
+
+	// EventReasonFailoverSuccess is an event generated when DRPC does a successful
 	// failover
 	EventReasonFailoverSuccess = "DRPCFailoverSuccess"
 
 	// EventReasonRelocating is an event generated when DRPC starts relocating
 	EventReasonRelocating = "DRPCRelocating"
+
+	// EventReasonRelocationUnsuccessful is an event generated when DRPC can not proceed
+	// with the relocate
+	EventReasonRelocationUnsuccessful = "DRPCRelocationUnsuccessful"
 
 	// EventReasonRelocationSuccess is an event generated when DRPC successfully
 	// relocates an application along with ramen managed cluster component(s)
@@ -89,6 +113,31 @@ const (
 	// EventReasonSwitchFailed is generated when DRPC fails to switch the cluster
 	// where the app is placed
 	EventReasonSwitchFailed = "DRPCClusterSwitchFailed"
+
+	// EventReasonPlacementNeedsFixing generated when the DRPC Status is empty, the Placement
+	// decision is empty, and  the config have VRG(s) in the managed clusters during a failover
+	// or a relocate
+	EventReasonPlacementNeedsFixing = "PlacementNeedsFixing"
+
+	// EventReasonPlacementNeedsFixingFailed generated when the DRPC
+	// failed to fix the PlacementRule during a failover or a relocate
+	EventReasonPlacementFixingFailed = "PlacementFixingFailed"
+
+	// EventReasonPlacementNeedsFixingSuccessful generated when the DRPC
+	// successfully fix the PlacementRule during a failover or a relocate
+	EventReasonPlacementFixingSuccessful = "PlacementFixingSuccessful"
+
+	// EventReasonStartingSecondaryCleanup is generated when DRPC starts cleaning  the secondary
+	// or the source cluster
+	EventReasonStartingSecondaryCleanup = "StartingSecondaryCleanup"
+
+	//  EventReasonCleanupSecondaryUnsuccessful is generated when DRPC fails to clean up
+	//  secondary or the source cluster
+	EventReasonCleanupSecondaryUnsuccessful = "CleanupSecondaryUnsuccessful"
+
+	//  EventReasonCleanupSecondarySuccessful is generated when DRPC completes cleaning up
+	//  secondary or the source cluster
+	EventReasonCleanupSecondarySuccessful = "CleanupSecondarySuccessful"
 )
 
 // EventReporter is custom events reporter type which allows user to limit the events


### PR DESCRIPTION

Added few DRPC events in the code for 
1. Deployment 2. Failover and 3. Relocate
Yet add events for metro/sync  failure /relocate scenarios.
Log snippet 
2428:2022-11-23T16:16:16.083+0530       DEBUG   events  Preparing for exectuion {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"542"}, "reason": "DRPCInitiating"}
2429:2022-11-23T16:16:16.083+0530       DEBUG   events  Deploying the application and VRG       {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"542"}, "reason": "DRPCDeploying"}
2430:2022-11-23T16:16:16.083+0530       DEBUG   events  Creating VRG ManifestWork       {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"542"}, "reason": "CreateVRGManifestWork"}
2435:2022-11-23T16:16:16.085+0530       DEBUG   events  Updating userPlacementRule user-placement-rule  {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"542"}, "reason": "UpdateUserPlacementRule"}
2439:2022-11-23T16:16:16.087+0530       DEBUG   events  Successfully deployed the application and VRG   {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"542"}, "reason": "DRPCDeploySuccess"}
2465:2022-11-23T16:16:16.094+0530       DEBUG   events  Initial Deployment completed    {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"548"}, "reason": "DRPCDeploySuccess"}
2493:2022-11-23T16:16:16.099+0530       DEBUG   events  Successfully deployed the application and VRG   {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"554"}, "reason": "DRPCDeploySuccess"}
2494:2022-11-23T16:16:16.099+0530       DEBUG   events  Initial Deployment completed    {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"554"}, "reason": "DRPCDeploySuccess"}
2519:2022-11-23T16:16:16.105+0530       DEBUG   events  Successfully deployed the application and VRG   {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"554"}, "reason": "DRPCDeploySuccess"}
2520:2022-11-23T16:16:16.105+0530       DEBUG   events  Initial Deployment completed    {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"554"}, "reason": "DRPCDeploySuccess"}
2563:2022-11-23T16:16:16.118+0530       DEBUG   events  Preparing for exectuion {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"560"}, "reason": "DRPCInitiating"}
2566:2022-11-23T16:16:16.118+0530       DEBUG   events  Failing over the application and VRG    {"type": "Warning", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"560"}, "reason": "DRPCFailingOver"}
2567:2022-11-23T16:16:16.118+0530       DEBUG   events  Creating VRG ManifestWork       {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"560"}, "reason": "CreateVRGManifestWork"}
2571:2022-11-23T16:16:16.120+0530       DEBUG   events  Waiting for PV restore to complete...)  {"type": "Warning", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"560"}, "reason": "DRPCClusterSwitchFailed"}
2941:2022-11-23T16:16:26.131+0530       DEBUG   events  Updating userPlacementRule user-placement-rule  {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"571"}, "reason": "UpdateUserPlacementRule"}
2947:2022-11-23T16:16:26.133+0530       DEBUG   events  Successfully failedover the application and VRG {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"571"}, "reason": "DRPCFailoverSuccess"}
2977:2022-11-23T16:16:26.140+0530       DEBUG   events  Cleanup starting on Secondary   {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"576"}, "reason": "StartingSecondaryCleanup"}
2981:2022-11-23T16:16:26.142+0530       DEBUG   events  Failed to cleanup on Secondary  {"type": "Warning", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"576"}, "reason": "CleanupSecondaryUnsuccessful"}
3010:2022-11-23T16:16:26.148+0530       DEBUG   events  Cleanup starting on Secondary   {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"580"}, "reason": "StartingSecondaryCleanup"}
3023:2022-11-23T16:16:26.153+0530       DEBUG   events  Cleanup completed       {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"580"}, "reason": "CleanupSecondarySuccessful"}
3055:2022-11-23T16:16:26.159+0530       DEBUG   events  Cleanup starting on Secondary   {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"585"}, "reason": "StartingSecondaryCleanup"}
3086:2022-11-23T16:16:26.170+0530       DEBUG   events  Updating userPlacementRule user-placement-rule  {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"588"}, "reason": "UpdateUserPlacementRule"}
3096:2022-11-23T16:16:26.172+0530       DEBUG   events  Successfully failedover the application and VRG {"type": "Normal", "object": {"kind":"DRPlacementControl","namespace":"app-namespace","name":"app-volume-replication-test","uid":"a79c9853-b867-46e2-a11f-e7b7b3ab2859","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"588"}, "reason": "DRPCFailoverSuccess"}





Signed-off-by: Jolly Mishra <jmishra@redhat.com>