### PR TITLE
Use new clusteradm json output

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -32,7 +32,7 @@ environment.
 
 1. Install `clusteradm` tool. See
    [Open Cluster Management Quick Start guide](https://open-cluster-management.io/getting-started/quick-start/#install-clusteradm-cli-tool)
-   for the details.
+   for the details. Version 0.5.0 or later is required.
 
 1. Install the `drenv` package in a virtual environment:
 

--- a/test/drenv/clusteradm.py
+++ b/test/drenv/clusteradm.py
@@ -16,11 +16,13 @@ def init(wait=False, context=None):
     _watch(*cmd)
 
 
-def get(what, context=None):
+def get(what, output=None, context=None):
     """
     Get information from the cluster.
     """
     cmd = ["clusteradm", "get", what]
+    if output:
+        cmd.extend(("--output", output))
     if context:
         cmd.extend(("--context", context))
     return commands.run(*cmd)

--- a/test/drenv/clusteradm.py
+++ b/test/drenv/clusteradm.py
@@ -26,11 +26,13 @@ def get(what, context=None):
     return commands.run(*cmd)
 
 
-def install(what, names, context=None):
+def install(what, names, bundle_version=None, context=None):
     """
     Install a feature.
     """
     cmd = ["clusteradm", "install", what, "--names", ",".join(names)]
+    if bundle_version:
+        cmd.extend(("--bundle-version", bundle_version))
     if context:
         cmd.extend(("--context", context))
     _watch(*cmd)

--- a/test/ocm-cluster/start
+++ b/test/ocm-cluster/start
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import sys
 
 import drenv
@@ -70,16 +71,12 @@ def wait_for_hub(hub):
 def join_cluster(cluster, hub):
     print(f"Joining to cluster {hub}")
 
-    # We can get the token from the first line of the response.
-    out = clusteradm.get("token", context=hub)
-
-    token_line = out.splitlines()[0]
-    key, hub_token = token_line.split("=", 1)
-    assert key == "token"
+    out = clusteradm.get("token", output="json", context=hub)
+    hub_info = json.loads(out)
 
     clusteradm.join(
-        hub_token=hub_token,
-        hub_apiserver=drenv.cluster_info(hub)["cluster"]["server"],
+        hub_token=hub_info["hub-token"],
+        hub_apiserver=hub_info["hub-apiserver"],
         cluster_name=cluster,
         wait=True,
         context=cluster,

--- a/test/ocm-hub/start
+++ b/test/ocm-hub/start
@@ -16,7 +16,7 @@ ADDONS = (
     },
     {
         "name": "governance-policy-framework",
-        "version": "default",
+        "version": "latest",  # v0.10.0 not available yet.
     },
 )
 

--- a/test/ocm-hub/start
+++ b/test/ocm-hub/start
@@ -10,8 +10,14 @@ from drenv import kubectl
 from drenv import clusteradm
 
 ADDONS = (
-    "application-manager",
-    "governance-policy-framework",
+    {
+        "name": "application-manager",
+        "version": "default",
+    },
+    {
+        "name": "governance-policy-framework",
+        "version": "default",
+    },
 )
 
 DEPLOYMENTS = {
@@ -37,7 +43,13 @@ def deploy(cluster):
     clusteradm.init(wait=True, context=cluster)
 
     print("Installing hub addons")
-    clusteradm.install("hub-addon", names=ADDONS, context=cluster)
+    for addon in ADDONS:
+        clusteradm.install(
+            "hub-addon",
+            names=[addon["name"]],
+            bundle_version=addon["version"],
+            context=cluster,
+        )
 
 
 def wait(cluster):


### PR DESCRIPTION
Use new json output[1] in `clusteradm get token` to get hub info.

clusteradm 0.5.0 was released, but it tries to install version 0.10.0 of the policy
framework which was not tagged yet. We install the latest version to work around this.

With this, we can required clusteradm 0.5.0 and use the new json output to simplify
the code.