### PR TITLE
vrg: set VRG DataReady to true if no PVCs to protect

### DIFF
--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -1940,11 +1940,7 @@ func (v *VRGInstance) addPVRestoreAnnotation(pv *corev1.PersistentVolume) {
 //
 //nolint:funlen
 func (v *VRGInstance) aggregateVolRepDataReadyCondition() *metav1.Condition {
-	if len(v.volRepPVCs) == 0 {
-		return nil
-	}
-
-	vrgReady := len(v.instance.Status.ProtectedPVCs) != 0
+	vrgReady := true
 	vrgProgressing := false
 
 	for _, protectedPVC := range v.instance.Status.ProtectedPVCs {


### PR DESCRIPTION
If there are no PVCs in the ProtectedPVCs list, then it makes sense to just set the DataReady condition to true.

Co-Authored-by: rakeshgm <rakeshgm@redhat.com>
Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>