### PR TITLE
Add --name-prefix option

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -110,6 +110,7 @@ Useful options:
 
 - `-v`, `--verbose`: Show verbose logs
 - `-h`, `--help`: Show online help
+- `--name-prefix`: Add prefix to profiles names
 
 When you are done you can deactivate the virtual environment:
 
@@ -196,6 +197,77 @@ $ kubectl --context ex2 get pods
 NAME                                 READY   STATUS    RESTARTS      AGE
 example-deployment-fdf86bbfc-sd9wt   1/1     Running   1 (33s ago)   97s
 ```
+
+#### Isolating environments with --name-prefix
+
+To run multiple instances of the same environment, or multiple
+environments using the same profile names, use unique `--name-prefix`
+for each run.
+
+Start first instance:
+
+```
+$ drenv start --name-prefix test1- example.yaml
+2022-11-30 22:14:45,551 INFO    [test1-example] Starting environment
+2022-11-30 22:14:45,552 INFO    [test1-ex1] Starting cluster
+2022-11-30 22:14:46,053 INFO    [test1-ex2] Starting cluster
+2022-11-30 22:15:24,443 INFO    [test1-ex1] Cluster started in 38.89 seconds
+2022-11-30 22:15:24,443 INFO    [test1-ex1/0] Starting example/start
+2022-11-30 22:15:24,723 INFO    [test1-ex1/0] example/start completed in 0.28 seconds
+2022-11-30 22:15:39,555 INFO    [test1-ex2] Cluster started in 53.50 seconds
+2022-11-30 22:15:39,555 INFO    [test1-ex2/0] Starting example/start
+2022-11-30 22:15:39,787 INFO    [test1-ex2/0] example/start completed in 0.23 seconds
+2022-11-30 22:15:40,057 INFO    [test1-example/0] Starting example/test
+2022-11-30 22:15:55,026 INFO    [test1-example/0] example/test completed in 14.97 seconds
+2022-11-30 22:15:55,027 INFO    [test1-example] Environment started in 69.48 seconds
+```
+
+This creates:
+
+```
+$ minikube profile list
+|-----------|-----------|------------|---------------|------|---------|---------|-------|--------|
+|  Profile  | VM Driver |  Runtime   |      IP       | Port | Version | Status  | Nodes | Active |
+|-----------|-----------|------------|---------------|------|---------|---------|-------|--------|
+| test1-ex1 | kvm2      | containerd | 192.168.39.54 | 8443 | v1.25.3 | Running |     1 |        |
+| test1-ex2 | kvm2      | containerd | 192.168.50.76 | 8443 | v1.25.3 | Running |     1 |        |
+|-----------|-----------|------------|---------------|------|---------|---------|-------|--------|
+```
+
+Start second instance:
+
+```
+$ drenv start --name-prefix test2- example.yaml
+2022-11-30 22:16:25,855 INFO    [test2-example] Starting environment
+2022-11-30 22:16:25,856 INFO    [test2-ex1] Starting cluster
+2022-11-30 22:16:26,357 INFO    [test2-ex2] Starting cluster
+2022-11-30 22:17:06,130 INFO    [test2-ex1] Cluster started in 40.27 seconds
+2022-11-30 22:17:06,131 INFO    [test2-ex1/0] Starting example/start
+2022-11-30 22:17:06,376 INFO    [test2-ex1/0] example/start completed in 0.25 seconds
+2022-11-30 22:17:20,359 INFO    [test2-ex2] Cluster started in 54.00 seconds
+2022-11-30 22:17:20,360 INFO    [test2-ex2/0] Starting example/start
+2022-11-30 22:17:20,614 INFO    [test2-ex2/0] example/start completed in 0.25 seconds
+2022-11-30 22:17:20,861 INFO    [test2-example/0] Starting example/test
+2022-11-30 22:17:36,600 INFO    [test2-example/0] example/test completed in 15.74 seconds
+2022-11-30 22:17:36,600 INFO    [test2-example] Environment started in 70.74 seconds
+```
+
+This adds new profiles:
+
+```
+$ minikube profile list
+|-----------|-----------|------------|----------------|------|---------|---------|-------|--------|
+|  Profile  | VM Driver |  Runtime   |       IP       | Port | Version | Status  | Nodes | Active |
+|-----------|-----------|------------|----------------|------|---------|---------|-------|--------|
+| test1-ex1 | kvm2      | containerd | 192.168.39.54  | 8443 | v1.25.3 | Running |     1 |        |
+| test1-ex2 | kvm2      | containerd | 192.168.50.76  | 8443 | v1.25.3 | Running |     1 |        |
+| test2-ex1 | kvm2      | containerd | 192.168.72.116 | 8443 | v1.25.3 | Running |     1 |        |
+| test2-ex2 | kvm2      | containerd | 192.168.83.20  | 8443 | v1.25.3 | Running |     1 |        |
+|-----------|-----------|------------|----------------|------|---------|---------|-------|--------|
+```
+
+You must use the same `--name-prefix` when stopping or deleting the
+environments.
 
 #### Running scripts manually
 

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -34,6 +34,9 @@ def main():
         choices=commands,
         help="Command to run")
     p.add_argument(
+        "--name-prefix",
+        help="Prefix profile names")
+    p.add_argument(
         "filename",
         help="Environment filename")
     args = p.parse_args()
@@ -43,7 +46,7 @@ def main():
         format="%(asctime)s %(levelname)-7s %(message)s")
 
     with open(args.filename) as f:
-        env = envfile.load(f)
+        env = envfile.load(f, name_prefix=args.name_prefix)
 
     func = globals()[CMD_PREFIX + args.command]
     func(env)

--- a/test/drenv/envfile_test.py
+++ b/test/drenv/envfile_test.py
@@ -112,6 +112,64 @@ def test_valid():
     assert worker["scripts"][0]["args"] == []
 
 
+def test_name_prefix():
+    f = io.StringIO(valid_yaml)
+    env = envfile.load(f, name_prefix="prefix-")
+
+    # env
+
+    assert env["name"] == "prefix-test"
+
+    # profile dr1
+
+    profile = env["profiles"][0]
+    assert profile["name"] == "prefix-dr1"
+
+    worker = profile["workers"][0]
+    assert worker["name"] == "prefix-dr1/0"
+    assert worker["scripts"][0]["args"] == ["prefix-dr1"]
+    assert worker["scripts"][1]["args"] == ["prefix-dr1", "prefix-hub"]
+
+    worker = profile["workers"][1]
+    assert worker["name"] == "prefix-dr1/named-worker"
+
+    # profile dr2
+
+    profile = env["profiles"][1]
+    assert profile["name"] == "prefix-dr2"
+
+    worker = profile["workers"][0]
+    assert worker["name"] == "prefix-dr2/0"
+    assert worker["scripts"][0]["args"] == ["prefix-dr2"]
+    assert worker["scripts"][1]["args"] == ["prefix-dr2", "prefix-hub"]
+
+    worker = profile["workers"][1]
+    assert worker["name"] == "prefix-dr2/named-worker"
+
+    # profile hub
+
+    profile = env["profiles"][2]
+    assert profile["name"] == "prefix-hub"
+
+    worker = profile["workers"][0]
+    assert worker["name"] == "prefix-hub/0"
+    assert worker["scripts"][0]["args"] == ["prefix-dr1", "prefix-dr2"]
+
+    # env workers
+
+    worker = env["workers"][0]
+    assert worker["name"] == "prefix-test/named-worker"
+    assert worker["scripts"][0]["args"] == [
+        "prefix-dr1",
+        "prefix-dr2",
+        "other",
+    ]
+
+    worker = env["workers"][1]
+    assert worker["name"] == "prefix-test/1"
+    assert worker["scripts"][0]["args"] == []
+
+
 def test_require_env_name():
     s = """
 profiles: []

--- a/test/example_test.py
+++ b/test/example_test.py
@@ -7,3 +7,8 @@ from drenv import envfile
 def test_load():
     with open("example.yaml") as f:
         envfile.load(f)
+
+
+def test_load_prefix():
+    with open("example.yaml") as f:
+        envfile.load(f, name_prefix="test-")

--- a/test/ocm_test.py
+++ b/test/ocm_test.py
@@ -7,3 +7,8 @@ from drenv import envfile
 def test_load():
     with open("ocm.yaml") as f:
         envfile.load(f)
+
+
+def test_load_prefix():
+    with open("ocm.yaml") as f:
+        envfile.load(f, name_prefix="test-")

--- a/test/regional_dr_test.py
+++ b/test/regional_dr_test.py
@@ -7,3 +7,8 @@ from drenv import envfile
 def test_load():
     with open("regional-dr.yaml") as f:
         envfile.load(f)
+
+
+def test_load_prefix():
+    with open("regional-dr.yaml") as f:
+        envfile.load(f, name_prefix="test-")

--- a/test/rook_test.py
+++ b/test/rook_test.py
@@ -7,3 +7,8 @@ from drenv import envfile
 def test_load():
     with open("rook.yaml") as f:
         envfile.load(f)
+
+
+def test_load_prefix():
+    with open("rook.yaml") as f:
+        envfile.load(f, name_prefix="test-")


### PR DESCRIPTION
When specified, prefix environment name, profiles names, workers names,
and reference to profile names in scripts arguments with the specified
prefix. Prefixing the environment name and worker names is not required
but it creates more consistent logs.

This allows running multiple environment with the same profile names
(e.g. dr1) at the same time.

Templates names are not prefixed since they are not used in runtime.

We do a detailed test with embedded test yaml in envfile_test.py. The 
actual environments have only basic test ensuring that loading with name
prefix does not raise.

Fixes: #637