### PR TITLE
Unify drenv scripts

### DIFF
--- a/test/cert-manager/start
+++ b/test/cert-manager/start
@@ -7,8 +7,25 @@ import sys
 
 import drenv
 
-TAG = "v1.10.0"
-URL = f"https://github.com/cert-manager/cert-manager/releases/download/{TAG}/cert-manager.yaml"
+VERSION = "v1.10.0"
+URL = f"https://github.com/cert-manager/cert-manager/releases/download/{VERSION}/cert-manager.yaml"
+
+
+def deploy(cluster):
+    drenv.log_progress("Deploying cert-manager")
+    drenv.kubectl("apply", "--filename", URL, profile=cluster)
+
+
+def wait(cluster):
+    drenv.log_progress("Waiting until all deployments are available")
+    drenv.kubectl(
+        "wait", "deploy", "--all",
+        "--for=condition=Available",
+        "--namespace", "cert-manager",
+        "--timeout", "300s",
+        profile=cluster,
+    )
+
 
 if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
@@ -16,16 +33,5 @@ if len(sys.argv) != 2:
 
 cluster = sys.argv[1]
 
-drenv.log_progress(f"Deploying cert-manager in cluster {cluster}")
-drenv.kubectl("apply", "--filename", URL, profile=cluster)
-
-drenv.log_progress(
-    f"Waiting until all deployments are available cluster {cluster}",
-)
-drenv.kubectl(
-    "wait", "deploy", "--all",
-    "--for=condition=Available",
-    "--namespace", "cert-manager",
-    "--timeout", "300s",
-    profile=cluster,
-)
+deploy(cluster)
+wait(cluster)

--- a/test/minio/start
+++ b/test/minio/start
@@ -7,19 +7,27 @@ import sys
 
 import drenv
 
+
+def deploy(cluster):
+    drenv.log_progress("Deploying minio")
+    drenv.kubectl("apply", "--filename", "minio/minio.yaml", profile=cluster)
+
+
+def wait(cluster):
+    drenv.log_progress("Waiting until minio is rolled out")
+    drenv.kubectl(
+        "rollout", "status", "deployment/minio",
+        "--namespace", "minio",
+        "--timeout", "300s",
+        profile=cluster,
+    )
+
+
 if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
 cluster = sys.argv[1]
 
-drenv.log_progress("Deploying minio")
-drenv.kubectl("apply", "--filename", "minio/minio.yaml", profile=cluster)
-
-drenv.log_progress("Waiting until minio is rolled out")
-drenv.kubectl(
-    "rollout", "status", "deployment/minio",
-    "--namespace", "minio",
-    "--timeout", "180s",
-    profile=cluster,
-)
+deploy(cluster)
+wait(cluster)

--- a/test/ocm-cluster/start
+++ b/test/ocm-cluster/start
@@ -25,6 +25,87 @@ HUB_DEPLOYMENTS = (
     "cluster-manager-work-webhook",
 )
 
+
+def deploy(cluster, hub):
+    wait_for_hub(hub)
+    join_cluster(cluster, hub)
+    accept_cluster(cluster, hub)
+    enable_addons(cluster, hub)
+
+
+def wait(cluster):
+    drenv.log_progress("Waiting until deployments are rolled out")
+    for name in ADDONS:
+        deployment = f"deploy/{name}"
+        drenv.wait_for(deployment, namespace=ADDONS_NAMESPACE, profile=cluster)
+        drenv.kubectl(
+            "rollout", "status", deployment,
+            "--namespace", ADDONS_NAMESPACE,
+            "--timeout", "300s",
+            profile=cluster,
+        )
+
+
+def wait_for_hub(hub):
+    drenv.log_progress(f"Waiting until cluster {hub} is ready")
+
+    drenv.wait_for_cluster(hub)
+    drenv.wait_for(f"namespace/{HUB_NAMESPACE}", profile=hub)
+
+    for name in HUB_DEPLOYMENTS:
+        deployment = f"deploy/{name}"
+        drenv.wait_for(deployment, namespace=HUB_NAMESPACE, profile=hub)
+        drenv.kubectl(
+            "rollout", "status", deployment,
+            "--namespace", HUB_NAMESPACE,
+            "--timeout", "300s",
+            profile=hub,
+        )
+
+
+def join_cluster(cluster, hub):
+    drenv.log_progress(f"Joining to cluster {hub}")
+
+    # We can get the token from the first line of the response.
+    out = drenv.run(
+        "clusteradm", "get", "token", "--context", hub,
+        verbose=False,
+    )
+
+    token_line = out.splitlines()[0]
+    key, hub_token = token_line.split("=", 1)
+    assert key == "token"
+
+    drenv.run(
+        "clusteradm", "join",
+        "--hub-token", hub_token,
+        "--hub-apiserver", drenv.cluster_info(hub)["cluster"]["server"],
+        "--cluster-name", cluster,
+        "--wait",
+        "--context", cluster,
+    )
+
+
+def accept_cluster(cluster, hub):
+    drenv.log_progress("Accepting cluster")
+    drenv.run(
+        "clusteradm", "accept",
+        "--clusters", cluster,
+        "--wait",
+        "--context", hub,
+    )
+
+
+def enable_addons(cluster, hub):
+    drenv.log_progress("Enabling addons")
+    drenv.run(
+        "clusteradm", "addon", "enable",
+        "--names", ",".join(ADDONS),
+        "--clusters", cluster,
+        "--context", hub,
+    )
+
+
 if len(sys.argv) != 3:
     print(f"Usage: {sys.argv[0]} cluster hub")
     sys.exit(1)
@@ -32,66 +113,5 @@ if len(sys.argv) != 3:
 cluster = sys.argv[1]
 hub = sys.argv[2]
 
-drenv.log_progress(f"Waiting until cluster {hub} is ready")
-
-drenv.wait_for_cluster(hub)
-
-drenv.wait_for(f"namespace/{HUB_NAMESPACE}", profile=hub)
-
-for name in HUB_DEPLOYMENTS:
-    deployment = f"deploy/{name}"
-    drenv.wait_for(deployment, namespace=HUB_NAMESPACE, profile=hub)
-    drenv.kubectl(
-        "rollout", "status", deployment,
-        "--namespace", HUB_NAMESPACE,
-        "--timeout", "300s",
-        profile=hub,
-    )
-
-drenv.log_progress(f"Joining to cluster {hub}")
-
-# We can get the token from the first line of the response.
-out = drenv.run(
-    "clusteradm", "get", "token", "--context", hub,
-    verbose=False,
-)
-
-token_line = out.splitlines()[0]
-key, hub_token = token_line.split("=", 1)
-assert key == "token"
-
-drenv.run(
-    "clusteradm", "join",
-    "--hub-token", hub_token,
-    "--hub-apiserver", drenv.cluster_info(hub)["cluster"]["server"],
-    "--cluster-name", cluster,
-    "--wait",
-    "--context", cluster,
-)
-
-drenv.log_progress("Approving join request")
-drenv.run(
-    "clusteradm", "accept",
-    "--clusters", cluster,
-    "--wait",
-    "--context", hub,
-)
-
-drenv.log_progress("Enabling addons")
-drenv.run(
-    "clusteradm", "addon", "enable",
-    "--names", ",".join(ADDONS),
-    "--clusters", cluster,
-    "--context", hub,
-)
-
-drenv.log_progress("Waiting until deployments are rolled out")
-for name in ADDONS:
-    deployment = f"deploy/{name}"
-    drenv.wait_for(deployment, namespace=ADDONS_NAMESPACE, profile=cluster)
-    drenv.kubectl(
-        "rollout", "status", deployment,
-        "--namespace", ADDONS_NAMESPACE,
-        "--timeout", "300s",
-        profile=cluster,
-    )
+deploy(cluster, hub)
+wait(cluster)

--- a/test/ocm-cluster/test
+++ b/test/ocm-cluster/test
@@ -7,6 +7,78 @@ import sys
 
 import drenv
 
+
+def deploy_work(cluster, hub, work):
+    drenv.log_progress(f"Applying manifestwork to namespace {cluster}")
+    drenv.kubectl("apply", "--filename", "-", input=work, profile=hub)
+
+
+def wait_for_work(cluster, hub):
+    drenv.log_progress(
+        f"Waiting until manifestwork is applied in namespace {cluster}"
+    )
+    drenv.kubectl(
+        "wait", "manifestwork/example-manifestwork",
+        "--for", "condition=applied",
+        "--namespace", cluster,
+        "--timeout", "60s",
+        profile=hub,
+    )
+
+
+def wait_for_deployment(cluster, hub):
+    drenv.log_progress(
+        f"Waiting until manifestwork is available in namespace {cluster}"
+    )
+    drenv.kubectl(
+        "wait", "manifestwork/example-manifestwork",
+        "--for", "condition=available",
+        "--namespace", cluster,
+        "--timeout", "60s",
+        profile=hub,
+    )
+
+    drenv.log_progress(
+        f"Waiting until deployment is available in cluster {cluster}"
+    )
+    drenv.kubectl(
+        "wait", "deploy/example-deployment",
+        "--for", "condition=available",
+        "--timeout", "60s",
+        profile=cluster,
+    )
+
+
+def delete_work(cluster, hub, work):
+    drenv.log_progress(F"Deleting manifestwork from namespace {cluster}")
+    drenv.kubectl("delete", "--filename", "-", input=work, profile=hub)
+
+
+def wait_for_delete_work(cluster, hub):
+    drenv.log_progress(
+        f"Waiting until manifestwork is deleted from namspace {cluster}"
+    )
+    drenv.kubectl(
+        "wait", "manifestwork/example-manifestwork",
+        "--for", "delete",
+        "--namespace", cluster,
+        "--timeout", "60s",
+        profile=hub,
+    )
+
+
+def wait_for_delete_deployment(cluster):
+    drenv.log_progress(
+        f"Waiting until deployment is deleted from cluster {cluster}"
+    )
+    drenv.kubectl(
+        "wait", "deploy/example-deployment",
+        "--for", "delete",
+        "--timeout", "60s",
+        profile=cluster,
+    )
+
+
 if len(sys.argv) != 3:
     print(f"Usage: {sys.argv[0]} cluster hub")
     sys.exit(1)
@@ -17,71 +89,10 @@ hub = sys.argv[2]
 template = drenv.template("ocm-cluster/example-manifestwork.yaml")
 work = template.substitute(namespace=cluster)
 
-# Deploy a manifest work on the hub.
+deploy_work(cluster, hub, work)
+wait_for_work(cluster, hub)
+wait_for_deployment(cluster, hub)
 
-drenv.log_progress(F"Applying example manifestwork to namespace {cluster}")
-drenv.kubectl("apply", "--filename", "-", input=work, profile=hub)
-
-# Wait until the manifest work is applied to the hub and the deploymnet is
-# available on the cluster.
-
-drenv.log_progress(
-    f"Waiting until example manifestwork is applied in namespace {cluster}"
-)
-drenv.kubectl(
-    "wait", "manifestwork/example-manifestwork",
-    "--for", "condition=applied",
-    "--namespace", cluster,
-    "--timeout", "60s",
-    profile=hub,
-)
-
-drenv.log_progress(
-    f"Waiting until example manifestwork is available in namespace {cluster}"
-)
-drenv.kubectl(
-    "wait", "manifestwork/example-manifestwork",
-    "--for", "condition=available",
-    "--namespace", cluster,
-    "--timeout", "60s",
-    profile=hub,
-)
-
-drenv.log_progress(
-    f"Waiting until example deployment is available in cluster {cluster}"
-)
-drenv.kubectl(
-    "wait", "deploy/example-deployment",
-    "--for", "condition=available",
-    "--timeout", "60s",
-    profile=cluster,
-)
-
-# Delete the manitest work from the hub.
-
-drenv.log_progress(F"Deleting example manifestwork from namespace {cluster}")
-drenv.kubectl("delete", "--filename", "-", input=work, profile=hub)
-
-# Wait until the manifest work is deleted on the hub, and the deployment is
-# deleted from the cluster.
-
-drenv.log_progress(
-    f"Waiting until example manifestwork is deleted from namspace {cluster}"
-)
-drenv.kubectl(
-    "wait", "manifestwork/example-manifestwork",
-    "--for", "delete",
-    "--namespace", cluster,
-    "--timeout", "60s",
-    profile=hub,
-)
-
-drenv.log_progress(
-    f"Waiting until example deployment is deleted from cluster {cluster}"
-)
-drenv.kubectl(
-    "wait", "deploy/example-deployment",
-    "--for", "delete",
-    "--timeout", "60s",
-    profile=cluster,
-)
+delete_work(cluster, hub, work)
+wait_for_delete_work(cluster, hub)
+wait_for_delete_deployment(cluster)

--- a/test/ocm-controller/start
+++ b/test/ocm-controller/start
@@ -7,8 +7,8 @@ import sys
 
 import drenv
 
-TAG = "v2.4.4-ACM"
-BASE_URL = f"https://raw.githubusercontent.com/stolostron/multicloud-operators-foundation/{TAG}/deploy/foundation/hub"
+VERSION = "v2.4.4-ACM"
+BASE_URL = f"https://raw.githubusercontent.com/stolostron/multicloud-operators-foundation/{VERSION}/deploy/foundation/hub"
 
 
 def deploy(cluster):

--- a/test/ocm-hub/start
+++ b/test/ocm-hub/start
@@ -29,30 +29,38 @@ DEPLOYMENTS = {
     ),
 }
 
+
+def deploy(cluster):
+    drenv.log_progress("Initializing hub")
+    drenv.run("clusteradm", "init", "--wait", "--context", cluster)
+
+    drenv.log_progress("Installing hub addons")
+    drenv.run(
+        "clusteradm", "install", "hub-addon",
+        "--names", ",".join(ADDONS),
+        "--context", cluster,
+    )
+
+
+def wait(cluster):
+    drenv.log_progress("Waiting until deployments are rolled out")
+    for ns, names in DEPLOYMENTS.items():
+        for name in names:
+            deployment = f"deploy/{name}"
+            drenv.wait_for(deployment, namespace=ns, profile=cluster)
+            drenv.kubectl(
+                "rollout", "status", deployment,
+                "--namespace", ns,
+                "--timeout", "300s",
+                profile=cluster,
+            )
+
+
 if len(sys.argv) != 2:
-    print(f"Usage: {sys.argv[0]} hub")
+    print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
-hub = sys.argv[1]
+cluster = sys.argv[1]
 
-drenv.log_progress("Initializing hub")
-drenv.run("clusteradm", "init", "--wait", "--context", hub)
-
-drenv.log_progress("Installing hub addons")
-drenv.run(
-    "clusteradm", "install", "hub-addon",
-    "--names", ",".join(ADDONS),
-    "--context", hub,
-)
-
-drenv.log_progress("Waiting until deployments are rolled out")
-for ns, names in DEPLOYMENTS.items():
-    for name in names:
-        deployment = f"deploy/{name}"
-        drenv.wait_for(deployment, namespace=ns, profile=hub)
-        drenv.kubectl(
-            "rollout", "status", deployment,
-            "--namespace", ns,
-            "--timeout", "300s",
-            profile=hub,
-        )
+deploy(cluster)
+wait(cluster)

--- a/test/olm/start
+++ b/test/olm/start
@@ -7,7 +7,77 @@ import sys
 
 import drenv
 
-OLM_BASE_URL = "https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.22.0"
+VERSION = "v0.22.0"
+BASE_URL = f"https://github.com/operator-framework/operator-lifecycle-manager/releases/download/{VERSION}"
+
+
+def deploy(cluster):
+    drenv.log_progress("Deploying olm crds")
+
+    # Using Server-side Apply to avoid this failure:
+    #   The CustomResourceDefinition "clusterserviceversions.operators.coreos.com"
+    #   is invalid: metadata.annotations: Too long: must have at most 262144 bytes
+    # See https://medium.com/pareture/kubectl-install-crd-failed-annotations-too-long-2ebc91b40c7d
+    drenv.kubectl(
+        "apply",
+        "--filename", f"{BASE_URL}/crds.yaml",
+        "--server-side=true",
+        profile=cluster,
+    )
+
+    drenv.log_progress("Waiting until cdrs are established")
+    drenv.kubectl(
+        "wait",
+        "--for", "condition=established",
+        "--filename", f"{BASE_URL}/crds.yaml",
+        profile=cluster,
+    )
+
+    drenv.log_progress("Deploying olm")
+    drenv.kubectl(
+        "apply",
+        "--filename", f"{BASE_URL}/olm.yaml",
+        profile=cluster,
+    )
+
+
+def wait(cluster):
+    drenv.log_progress("Waiting until olm operator is rolled out")
+    drenv.kubectl(
+        "rollout", "status", "deployment/olm-operator",
+        "--namespace", "olm",
+        profile=cluster,
+    )
+
+    drenv.log_progress("Waiting until olm catalog operator is rolled out")
+    drenv.kubectl(
+        "rollout", "status", "deployment/catalog-operator",
+        "--namespace", "olm",
+        profile=cluster,
+    )
+
+    drenv.log_progress("Waiting until olm packageserver succeeds")
+    drenv.wait_for(
+        "csv/packageserver",
+        output="jsonpath={.status.phase}",
+        namespace="olm",
+        profile=cluster,
+    )
+    drenv.kubectl(
+        "wait", "csv/packageserver",
+        "--namespace", "olm",
+        "--for", 'jsonpath={.status.phase}=Succeeded',
+        "--timeout", "300s",
+        profile=cluster,
+    )
+
+    drenv.log_progress("Waiting for olm pakcage server rollout")
+    drenv.kubectl(
+        "rollout", "status", "deployment/packageserver",
+        "--namespace", "olm",
+        profile=cluster,
+    )
+
 
 if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
@@ -15,66 +85,5 @@ if len(sys.argv) != 2:
 
 cluster = sys.argv[1]
 
-drenv.log_progress("Deploying olm crds")
-
-# Using Server-side Apply to avoid this failure:
-#   The CustomResourceDefinition "clusterserviceversions.operators.coreos.com"
-#   is invalid: metadata.annotations: Too long: must have at most 262144 bytes
-# See https://medium.com/pareture/kubectl-install-crd-failed-annotations-too-long-2ebc91b40c7d
-drenv.kubectl(
-    "apply",
-    "--filename", f"{OLM_BASE_URL}/crds.yaml",
-    "--server-side=true",
-    profile=cluster,
-)
-
-drenv.log_progress("Waiting until cdrs are established")
-drenv.kubectl(
-    "wait",
-    "--for", "condition=established",
-    "--filename", f"{OLM_BASE_URL}/crds.yaml",
-    profile=cluster,
-)
-
-drenv.log_progress("Deploying olm")
-drenv.kubectl(
-    "apply",
-    "--filename", f"{OLM_BASE_URL}/olm.yaml",
-    profile=cluster,
-)
-
-drenv.log_progress("Waiting until olm operator is rolled out")
-drenv.kubectl(
-    "rollout", "status", "deployment/olm-operator",
-    "--namespace", "olm",
-    profile=cluster,
-)
-
-drenv.log_progress("Waiting until olm catalog operator is rolled out")
-drenv.kubectl(
-    "rollout", "status", "deployment/catalog-operator",
-    "--namespace", "olm",
-    profile=cluster,
-)
-
-drenv.log_progress("Waiting until olm packageserver succeeds")
-drenv.wait_for(
-    "csv/packageserver",
-    output="jsonpath={.status.phase}",
-    namespace="olm",
-    profile=cluster,
-)
-drenv.kubectl(
-    "wait", "csv/packageserver",
-    "--namespace", "olm",
-    "--for", 'jsonpath={.status.phase}=Succeeded',
-    "--timeout", "300s",
-    profile=cluster,
-)
-
-drenv.log_progress("Waiting for olm pakcage server rollout")
-drenv.kubectl(
-    "rollout", "status", "deployment/packageserver",
-    "--namespace", "olm",
-    profile=cluster,
-)
+deploy(cluster)
+wait(cluster)

--- a/test/olm/start
+++ b/test/olm/start
@@ -9,6 +9,7 @@ import drenv
 
 VERSION = "v0.22.0"
 BASE_URL = f"https://github.com/operator-framework/operator-lifecycle-manager/releases/download/{VERSION}"
+NAMESPACE = "olm"
 
 
 def deploy(cluster):
@@ -42,30 +43,24 @@ def deploy(cluster):
 
 
 def wait(cluster):
-    drenv.log_progress("Waiting until olm operator is rolled out")
-    drenv.kubectl(
-        "rollout", "status", "deployment/olm-operator",
-        "--namespace", "olm",
-        profile=cluster,
-    )
-
-    drenv.log_progress("Waiting until olm catalog operator is rolled out")
-    drenv.kubectl(
-        "rollout", "status", "deployment/catalog-operator",
-        "--namespace", "olm",
-        profile=cluster,
-    )
+    for operator in "olm-operator", "catalog-operator":
+        drenv.log_progress(f"Waiting until {operator} is rolled out")
+        drenv.kubectl(
+            "rollout", "status", "deploy", operator,
+            "--namespace", NAMESPACE,
+            profile=cluster,
+        )
 
     drenv.log_progress("Waiting until olm packageserver succeeds")
     drenv.wait_for(
         "csv/packageserver",
         output="jsonpath={.status.phase}",
-        namespace="olm",
+        namespace=NAMESPACE,
         profile=cluster,
     )
     drenv.kubectl(
         "wait", "csv/packageserver",
-        "--namespace", "olm",
+        "--namespace", NAMESPACE,
         "--for", 'jsonpath={.status.phase}=Succeeded',
         "--timeout", "300s",
         profile=cluster,
@@ -73,8 +68,8 @@ def wait(cluster):
 
     drenv.log_progress("Waiting for olm pakcage server rollout")
     drenv.kubectl(
-        "rollout", "status", "deployment/packageserver",
-        "--namespace", "olm",
+        "rollout", "status", "deploy/packageserver",
+        "--namespace", NAMESPACE,
         profile=cluster,
     )
 


### PR DESCRIPTION
Unify the drenv scripts so they are more consistent.

start scripts:
- Consistent argument parsing
- Consistent structure - have deploy() and wait() functions
- Extract VERSION from base url to make upgrading easy
- Rename TAG to VERSION
- Keep BASE_URL for remote resources base url
- Extract NAMESPACE constant
- Use loop to wait for deployments
- Consistent use of short type names (e.g. deploy)
- Use standard timeout (300s)
- Remove unneeded info from log (e.g. cluster logged by drenv)

test scripts:
- Extract functions to make the flow clear