### PR TITLE
Start drenv.commands module

### DIFF
--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import selectors
+
+OUT = "out"
+ERR = "err"
+
+_Selector = getattr(selectors, "PollSelector", selectors.SelectSelector)
+
+
+def stream(proc, bufsize=32 << 10):
+    """
+    Stream data from process stdout and stderr.
+
+    proc is a subprocess.Popen instance created with stdout=subprocess.PIPE and
+    stderr=subprocess.PIPE. If only one stream is used don't use this, stream
+    directly from the single pipe.
+
+    Yields either (OUT, data) or (ERR, data) read from proc stdout and stderr.
+    Returns when both streams are closed.
+    """
+    with _Selector() as sel:
+        for f, src in (proc.stdout, OUT), (proc.stderr, ERR):
+            if f and not f.closed:
+                sel.register(f, selectors.EVENT_READ, src)
+
+        while sel.get_map():
+            for key, event in sel.select():
+                data = os.read(key.fd, bufsize)
+                if not data:
+                    sel.unregister(key.fileobj)
+                    key.fileobj.close()
+                    continue
+
+                yield key.data, data

--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+from contextlib import contextmanager
+
+from drenv import commands
+
+
+def test_nothing():
+    with run("true") as p:
+        stream = list(commands.stream(p))
+    assert stream == []
+
+
+def test_stdout():
+    with run("echo", "-n", "output") as p:
+        stream = list(commands.stream(p))
+    assert stream == [(commands.OUT, b"output")]
+
+
+def test_stderr():
+    with run("sh", "-c", "echo -n error >&2") as p:
+        stream = list(commands.stream(p))
+    assert stream == [(commands.ERR, b"error")]
+
+
+def test_both():
+    with run("sh", "-c", "echo -n output; echo -n error >&2") as p:
+        stream = list(commands.stream(p))
+    assert stream == [(commands.OUT, b"output"), (commands.ERR, b"error")]
+
+
+def test_large_output():
+    out = err = 0
+    with run("dd", "if=/dev/zero", "bs=1M", "count=100", "status=none") as p:
+        for src, data in commands.stream(p):
+            if src == commands.OUT:
+                out += len(data)
+            else:
+                err += len(data)
+    assert out == 100 << 20
+    assert err == 0
+
+
+def test_no_stdout():
+    # No reason to stream with one pipe, but it works.
+    with run("sh", "-c", "echo -n error >&2", stdout=None) as p:
+        stream = list(commands.stream(p))
+    assert stream == [(commands.ERR, b"error")]
+
+
+def test_no_stderr():
+    # No reason to stream with one pipe, but it works.
+    with run("sh", "-c", "echo -n output", stderr=None) as p:
+        stream = list(commands.stream(p))
+    assert stream == [(commands.OUT, b"output")]
+
+
+def test_no_streams():
+    # No reason without pipes, but it works.
+    with run("true", stdout=None, stderr=None) as p:
+        stream = list(commands.stream(p))
+    assert stream == []
+
+
+@contextmanager
+def run(*args, stdout=subprocess.PIPE, stderr=subprocess.PIPE):
+    p = subprocess.Popen(args, stdout=stdout, stderr=stderr)
+    try:
+        yield p
+    finally:
+        p.wait()


### PR DESCRIPTION
This module will provide helpers for running commands.

The module provides now `stream()` function for streaming data from commands.  Currently we redirect stderr to stdout, or read only stdout, which makes it harder to locate error messages.

`commands.stream()` makes it easy to read both streams:

    for src, data in commands.stream(proc):
        if src is commands.OUT:
            print("Output:", data)
        else:
            print("Error:", data)

Part-of: #648
Signed-off-by: Nir Soffer <nsoffer@redhat.com>