### PR TITLE
Add python linters and code formatting

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -98,6 +98,10 @@ jobs:
         run: make pylint
         working-directory: test
 
+      - name: Run black
+        run: make black
+        working-directory: test
+
       - name: Run tests
         run: make test
         working-directory: test

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -90,6 +90,10 @@ jobs:
       - name: Install drenv
         run: pip install -e test
 
+      - name: Run flake8
+        run: make flake8
+        working-directory: test
+
       - name: Run tests
         run: make test
         working-directory: test

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -91,11 +91,11 @@ jobs:
         run: pip install -e test
 
       - name: Run tests
-        run: coverage3 run --source drenv -m pytest
+        run: python3 -m coverage run --source drenv -m pytest
         working-directory: test
 
       - name: Report test coverage
-        run: coverage3 report
+        run: python3 -m coverage report
         working-directory: test
 
   build-image-and-ensure-clean-branch:

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -94,6 +94,10 @@ jobs:
         run: make flake8
         working-directory: test
 
+      - name: Run pylint
+        run: make pylint
+        working-directory: test
+
       - name: Run tests
         run: make test
         working-directory: test

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -91,11 +91,11 @@ jobs:
         run: pip install -e test
 
       - name: Run tests
-        run: python3 -m coverage run --source drenv -m pytest
+        run: make test
         working-directory: test
 
       - name: Report test coverage
-        run: python3 -m coverage report
+        run: make coverage
         working-directory: test
 
   build-image-and-ensure-clean-branch:

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ config/hub/bundle
 test/drenv.egg-info/
 test/**/__pycache__/
 test/.coverage
+test/.vimrc

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ test-drpc: generate manifests setup-envtest
 	go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus DRPlacementControl
 
 test-drenv:
-	cd test; pytest
+	$(MAKE) -C test
 
 ##@ Build
 

--- a/test/.flake8
+++ b/test/.flake8
@@ -1,7 +1,8 @@
 [flake8]
 # TODO: modify the code to elimiante the ignores.
 # E501: line to long.
-ignore = E501
+# E203 whitespace before ':' to accept black code style
+ignore = E501,E203
 
 show_source = true
 statistics = true

--- a/test/.flake8
+++ b/test/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+# TODO: modify the code to elimiante the ignores.
+# E501: line to long.
+ignore = E501
+
+show_source = true
+statistics = true

--- a/test/.vimrc.example
+++ b/test/.vimrc.example
@@ -1,0 +1,16 @@
+" Local vim configuration for ramen
+"
+" Using this file in vim
+" -----------------------
+"
+" 1. Copy this file to .vimrc
+" 2. Enable loading vimrc from current directory in your ~/.vimrc
+"
+"    set exrc
+"    set secure
+"
+
+augroup black_on_save
+  autocmd!
+  autocmd BufWritePre *.py Black
+augroup end

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,11 @@
+all: test coverage
+
+test:
+	python3 -m coverage run --source drenv -m pytest
+
+coverage:
+	python3 -m coverage report
+
+coverage-html:
+	python3 -m coverage html
+	xdg-open htmlcov/index.html

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,10 +1,16 @@
-all: flake8 pylint test coverage
+all: flake8 pylint black test coverage
 
 flake8:
 	python3 -m flake8 drenv */start */test
 
 pylint:
 	python3 -m pylint --errors-only drenv */start */test
+
+black:
+	python3 -m black --check --diff drenv */start */test
+
+black-reformat:
+	python3 -m black drenv */start */test
 
 test:
 	python3 -m coverage run --source drenv -m pytest

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,10 @@
-all: flake8 test coverage
+all: flake8 pylint test coverage
 
 flake8:
 	python3 -m flake8 drenv */start */test
+
+pylint:
+	python3 -m pylint --errors-only drenv */start */test
 
 test:
 	python3 -m coverage run --source drenv -m pytest

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,4 +1,7 @@
-all: test coverage
+all: flake8 test coverage
+
+flake8:
+	python3 -m flake8 drenv */start */test
 
 test:
 	python3 -m coverage run --source drenv -m pytest

--- a/test/README.md
+++ b/test/README.md
@@ -511,3 +511,15 @@ Create an html report and open the report in a browser:
 ```
 make coverage-html
 ```
+
+Checking that code is formatted according to project style:
+
+```
+make black
+```
+
+Reformatting code to be compatible with project style:
+
+```
+make black-reformat
+```

--- a/test/README.md
+++ b/test/README.md
@@ -500,7 +500,7 @@ pip install -r requirements.txt
 
 ### Running the tests
 
-Run all tests and report test coverage:
+Run all linters and tests and report test coverage:
 
 ```
 make

--- a/test/README.md
+++ b/test/README.md
@@ -500,37 +500,14 @@ pip install -r requirements.txt
 
 ### Running the tests
 
-```
-pytest
-```
-
-### Checking coverage
-
-Running the tests collecting coverage data:
+Run all tests and report test coverage:
 
 ```
-python3 -m coverage run --source drenv -m pytest
+make
 ```
 
-Reporting coverage:
+Create an html report and open the report in a browser:
 
 ```
-$ python3 -m coverage report
-Name                    Stmts   Miss  Cover
--------------------------------------------
-drenv/__init__.py          82     62    24%
-drenv/__main__.py         114    114     0%
-drenv/envfile.py           61      0   100%
-drenv/envfile_test.py      67      0   100%
--------------------------------------------
-TOTAL                     324    176    46%
-```
-
-### Creating html coverage report
-
-This creates html report and open the report in a browser:
-
-```
-$ python3 -m coverage html
-xdg-open htmlcov/index.html
+make coverage-html
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -494,16 +494,6 @@ This is a configuration for testing regional DR using a hub cluster and
 
 ### Installing development tools
 
-On Fedora run:
-
-```
-dnf install pytest python3-coverage
-```
-
-If pytest is not packaged for your distribution or the packaged version
-is too old, you can install the latest version using pip - in the drenv
-virtual environment:
-
 ```
 pip install -r requirements.txt
 ```
@@ -511,7 +501,6 @@ pip install -r requirements.txt
 ### Running the tests
 
 ```
-cd test
 pytest
 ```
 
@@ -520,13 +509,13 @@ pytest
 Running the tests collecting coverage data:
 
 ```
-coverage run --source drenv -m pytest
+python3 -m coverage run --source drenv -m pytest
 ```
 
 Reporting coverage:
 
 ```
-$ coverage report
+$ python3 -m coverage report
 Name                    Stmts   Miss  Cover
 -------------------------------------------
 drenv/__init__.py          82     62    24%
@@ -537,14 +526,11 @@ drenv/envfile_test.py      67      0   100%
 TOTAL                     324    176    46%
 ```
 
-**Note**: if you installed coverage via pip, you will have to use
-`coverage3` instead of `coverage`.
-
 ### Creating html coverage report
 
 This creates html report and open the report in a browser:
 
 ```
-coverage html
+$ python3 -m coverage html
 xdg-open htmlcov/index.html
 ```

--- a/test/cert-manager/start
+++ b/test/cert-manager/start
@@ -19,10 +19,14 @@ def deploy(cluster):
 def wait(cluster):
     drenv.log_progress("Waiting until all deployments are available")
     drenv.kubectl(
-        "wait", "deploy", "--all",
+        "wait",
+        "deploy",
+        "--all",
         "--for=condition=Available",
-        "--namespace", "cert-manager",
-        "--timeout", "300s",
+        "--namespace",
+        "cert-manager",
+        "--timeout",
+        "300s",
         profile=cluster,
     )
 

--- a/test/csi-addons/start
+++ b/test/csi-addons/start
@@ -26,9 +26,13 @@ def wait(cluster):
         "Waiting until csi-addons-controller-manager is rolled out",
     )
     drenv.kubectl(
-        "rollout", "status", "deploy/csi-addons-controller-manager",
-        "--namespace", "csi-addons-system",
-        "--timeout", "300s",
+        "rollout",
+        "status",
+        "deploy/csi-addons-controller-manager",
+        "--namespace",
+        "csi-addons-system",
+        "--timeout",
+        "300s",
         profile=cluster,
     )
 

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -50,8 +50,13 @@ def kubectl(*args, profile=None, input=None, verbose=True):
     return run(*cmd, input=input, verbose=verbose)
 
 
-def wait_for(resource, output="jsonpath={.metadata.name}", timeout=300,
-             namespace=None, profile=None):
+def wait_for(
+    resource,
+    output="jsonpath={.metadata.name}",
+    timeout=300,
+    namespace=None,
+    profile=None,
+):
     """
     Wait until resource exists. Once the resource exists, wait for it
     using `kubectl wait`.
@@ -124,9 +129,12 @@ def cluster_status(cluster):
         return {}
 
     out = run(
-        "minikube", "status",
-        "--profile", cluster,
-        "--output", "json",
+        "minikube",
+        "status",
+        "--profile",
+        cluster,
+        "--output",
+        "json",
         verbose=False,
     )
 
@@ -164,7 +172,8 @@ def run(*args, input=None, verbose=True):
         args,
         input=input.encode() if input else None,
         stdout=subprocess.PIPE,
-        check=True)
+        check=True,
+    )
 
     out = cp.stdout.decode().rstrip()
 

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -21,29 +21,19 @@ CMD_PREFIX = "cmd_"
 
 
 def main():
-    commands = [n[len(CMD_PREFIX):] for n in globals()
-                if n.startswith(CMD_PREFIX)]
+    commands = [n[len(CMD_PREFIX) :] for n in globals() if n.startswith(CMD_PREFIX)]
 
     p = argparse.ArgumentParser(prog="drenv")
-    p.add_argument(
-        "-v", "--verbose",
-        action="store_true",
-        help="Be more verbose")
-    p.add_argument(
-        "command",
-        choices=commands,
-        help="Command to run")
-    p.add_argument(
-        "--name-prefix",
-        help="Prefix profile names")
-    p.add_argument(
-        "filename",
-        help="Environment filename")
+    p.add_argument("-v", "--verbose", action="store_true", help="Be more verbose")
+    p.add_argument("command", choices=commands, help="Command to run")
+    p.add_argument("--name-prefix", help="Prefix profile names")
+    p.add_argument("filename", help="Environment filename")
     args = p.parse_args()
 
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
-        format="%(asctime)s %(levelname)-7s %(message)s")
+        format="%(asctime)s %(levelname)-7s %(message)s",
+    )
 
     with open(args.filename) as f:
         env = envfile.load(f, name_prefix=args.name_prefix)
@@ -60,7 +50,8 @@ def cmd_start(env):
     execute(run_worker, env["workers"])
     logging.info(
         "[%s] Environment started in %.2f seconds",
-        env["name"], time.monotonic() - start,
+        env["name"],
+        time.monotonic() - start,
     )
 
 
@@ -70,7 +61,8 @@ def cmd_stop(env):
     execute(stop_cluster, env["profiles"])
     logging.info(
         "[%s] Environment stopped in %.2f seconds",
-        env["name"], time.monotonic() - start,
+        env["name"],
+        time.monotonic() - start,
     )
 
 
@@ -80,7 +72,8 @@ def cmd_delete(env):
     execute(delete_cluster, env["profiles"])
     logging.info(
         "[%s] Environment deleted in %.2f seconds",
-        env["name"], time.monotonic() - start,
+        env["name"],
+        time.monotonic() - start,
     )
 
 
@@ -115,21 +108,36 @@ def start_cluster(profile):
 
     is_restart = drenv.cluster_info(profile["name"]) != {}
 
-    minikube("start",
-             "--driver", "kvm2",
-             "--container-runtime", profile["container_runtime"],
-             "--extra-disks", str(profile["extra_disks"]),
-             "--disk-size", profile["disk_size"],
-             "--network", profile["network"],
-             "--nodes", str(profile["nodes"]),
-             "--cni", profile["cni"],
-             "--cpus", str(profile["cpus"]),
-             "--memory", profile["memory"],
-             "--addons", ",".join(profile["addons"]),
-             profile=profile["name"])
+    minikube(
+        "start",
+        "--driver",
+        "kvm2",
+        "--container-runtime",
+        profile["container_runtime"],
+        "--extra-disks",
+        str(profile["extra_disks"]),
+        "--disk-size",
+        profile["disk_size"],
+        "--network",
+        profile["network"],
+        "--nodes",
+        str(profile["nodes"]),
+        "--cni",
+        profile["cni"],
+        "--cpus",
+        str(profile["cpus"]),
+        "--memory",
+        profile["memory"],
+        "--addons",
+        ",".join(profile["addons"]),
+        profile=profile["name"],
+    )
 
-    logging.info("[%s] Cluster started in %.2f seconds",
-                 profile["name"], time.monotonic() - start)
+    logging.info(
+        "[%s] Cluster started in %.2f seconds",
+        profile["name"],
+        time.monotonic() - start,
+    )
 
     if is_restart:
         wait_for_deployments(profile)
@@ -141,8 +149,11 @@ def stop_cluster(profile):
     start = time.monotonic()
     logging.info("[%s] Stopping cluster", profile["name"])
     minikube("stop", profile=profile["name"])
-    logging.info("[%s] Cluster stopped in %.2f seconds",
-                 profile["name"], time.monotonic() - start)
+    logging.info(
+        "[%s] Cluster stopped in %.2f seconds",
+        profile["name"],
+        time.monotonic() - start,
+    )
 
 
 def delete_cluster(profile):
@@ -151,11 +162,13 @@ def delete_cluster(profile):
     minikube("delete", profile=profile["name"])
     profile_config = drenv.config_dir(profile["name"])
     if os.path.exists(profile_config):
-        logging.info("[%s] Removing config %s",
-                     profile["name"], profile_config)
+        logging.info("[%s] Removing config %s", profile["name"], profile_config)
         shutil.rmtree(profile_config)
-    logging.info("[%s] Cluster deleted in %.2f seconds",
-                 profile["name"], time.monotonic() - start)
+    logging.info(
+        "[%s] Cluster deleted in %.2f seconds",
+        profile["name"],
+        time.monotonic() - start,
+    )
 
 
 def wait_for_deployments(profile, initial_wait=30, timeout=300):
@@ -179,16 +192,21 @@ def wait_for_deployments(profile, initial_wait=30, timeout=300):
     time.sleep(initial_wait)
 
     kubectl(
-        "wait", "deploy", "--all",
-        "--for", "condition=available",
+        "wait",
+        "deploy",
+        "--all",
+        "--for",
+        "condition=available",
         "--all-namespaces",
-        "--timeout", f"{timeout}s",
+        "--timeout",
+        f"{timeout}s",
         profile=profile["name"],
     )
 
     logging.info(
         "[%s] Deployments are available in %.2f seconds",
-        profile["name"], time.monotonic() - start,
+        profile["name"],
+        time.monotonic() - start,
     )
 
 
@@ -216,8 +234,9 @@ def run_hook(hook, args, name):
     start = time.monotonic()
     logging.info("[%s] Running %s", name, hook)
     run(hook, *args, name=name)
-    logging.info("[%s] %s completed in %.2f seconds",
-                 name, hook, time.monotonic() - start)
+    logging.info(
+        "[%s] %s completed in %.2f seconds", name, hook, time.monotonic() - start
+    )
 
 
 def run(*cmd, name=None):
@@ -246,7 +265,8 @@ def run(*cmd, name=None):
             f"[{name}] Command {cmd} failed rc={p.returncode}\n"
             "\n"
             "Last messages:\n"
-            f"{last_messages}")
+            f"{last_messages}"
+        )
 
 
 if __name__ == "__main__":

--- a/test/drenv/envfile_test.py
+++ b/test/drenv/envfile_test.py
@@ -65,7 +65,7 @@ def test_valid():
 
     profile = env["profiles"][0]
     assert profile["name"] == "dr1"
-    assert profile["network"] == "default"   # From template
+    assert profile["network"] == "default"  # From template
     assert profile["memory"] == "8g"  # From profile
     assert profile["cpus"] == 2  # From defaults
 

--- a/test/example/start
+++ b/test/example/start
@@ -16,6 +16,7 @@ cluster = sys.argv[1]
 drenv.log_progress("Deploying example")
 drenv.kubectl(
     "apply",
-    "--filename", "example/deployment.yaml",
+    "--filename",
+    "example/deployment.yaml",
     profile=cluster,
 )

--- a/test/example/test
+++ b/test/example/test
@@ -15,7 +15,10 @@ cluster = sys.argv[1]
 
 drenv.log_progress("Testing example deployment")
 drenv.kubectl(
-    "rollout", "status", "deploy/example-deployment",
-    "--timeout", "60s",
+    "rollout",
+    "status",
+    "deploy/example-deployment",
+    "--timeout",
+    "60s",
     profile=cluster,
 )

--- a/test/minio/start
+++ b/test/minio/start
@@ -16,9 +16,13 @@ def deploy(cluster):
 def wait(cluster):
     drenv.log_progress("Waiting until minio is rolled out")
     drenv.kubectl(
-        "rollout", "status", "deployment/minio",
-        "--namespace", "minio",
-        "--timeout", "300s",
+        "rollout",
+        "status",
+        "deployment/minio",
+        "--namespace",
+        "minio",
+        "--timeout",
+        "300s",
         profile=cluster,
     )
 

--- a/test/ocm-cluster/start
+++ b/test/ocm-cluster/start
@@ -39,9 +39,13 @@ def wait(cluster):
         deployment = f"deploy/{name}"
         drenv.wait_for(deployment, namespace=ADDONS_NAMESPACE, profile=cluster)
         drenv.kubectl(
-            "rollout", "status", deployment,
-            "--namespace", ADDONS_NAMESPACE,
-            "--timeout", "300s",
+            "rollout",
+            "status",
+            deployment,
+            "--namespace",
+            ADDONS_NAMESPACE,
+            "--timeout",
+            "300s",
             profile=cluster,
         )
 
@@ -56,9 +60,13 @@ def wait_for_hub(hub):
         deployment = f"deploy/{name}"
         drenv.wait_for(deployment, namespace=HUB_NAMESPACE, profile=hub)
         drenv.kubectl(
-            "rollout", "status", deployment,
-            "--namespace", HUB_NAMESPACE,
-            "--timeout", "300s",
+            "rollout",
+            "status",
+            deployment,
+            "--namespace",
+            HUB_NAMESPACE,
+            "--timeout",
+            "300s",
             profile=hub,
         )
 
@@ -68,7 +76,11 @@ def join_cluster(cluster, hub):
 
     # We can get the token from the first line of the response.
     out = drenv.run(
-        "clusteradm", "get", "token", "--context", hub,
+        "clusteradm",
+        "get",
+        "token",
+        "--context",
+        hub,
         verbose=False,
     )
 
@@ -77,32 +89,45 @@ def join_cluster(cluster, hub):
     assert key == "token"
 
     drenv.run(
-        "clusteradm", "join",
-        "--hub-token", hub_token,
-        "--hub-apiserver", drenv.cluster_info(hub)["cluster"]["server"],
-        "--cluster-name", cluster,
+        "clusteradm",
+        "join",
+        "--hub-token",
+        hub_token,
+        "--hub-apiserver",
+        drenv.cluster_info(hub)["cluster"]["server"],
+        "--cluster-name",
+        cluster,
         "--wait",
-        "--context", cluster,
+        "--context",
+        cluster,
     )
 
 
 def accept_cluster(cluster, hub):
     drenv.log_progress("Accepting cluster")
     drenv.run(
-        "clusteradm", "accept",
-        "--clusters", cluster,
+        "clusteradm",
+        "accept",
+        "--clusters",
+        cluster,
         "--wait",
-        "--context", hub,
+        "--context",
+        hub,
     )
 
 
 def enable_addons(cluster, hub):
     drenv.log_progress("Enabling addons")
     drenv.run(
-        "clusteradm", "addon", "enable",
-        "--names", ",".join(ADDONS),
-        "--clusters", cluster,
-        "--context", hub,
+        "clusteradm",
+        "addon",
+        "enable",
+        "--names",
+        ",".join(ADDONS),
+        "--clusters",
+        cluster,
+        "--context",
+        hub,
     )
 
 

--- a/test/ocm-cluster/test
+++ b/test/ocm-cluster/test
@@ -14,14 +14,16 @@ def deploy_work(cluster, hub, work):
 
 
 def wait_for_work(cluster, hub):
-    drenv.log_progress(
-        f"Waiting until manifestwork is applied in namespace {cluster}"
-    )
+    drenv.log_progress(f"Waiting until manifestwork is applied in namespace {cluster}")
     drenv.kubectl(
-        "wait", "manifestwork/example-manifestwork",
-        "--for", "condition=applied",
-        "--namespace", cluster,
-        "--timeout", "60s",
+        "wait",
+        "manifestwork/example-manifestwork",
+        "--for",
+        "condition=applied",
+        "--namespace",
+        cluster,
+        "--timeout",
+        "60s",
         profile=hub,
     )
 
@@ -31,50 +33,58 @@ def wait_for_deployment(cluster, hub):
         f"Waiting until manifestwork is available in namespace {cluster}"
     )
     drenv.kubectl(
-        "wait", "manifestwork/example-manifestwork",
-        "--for", "condition=available",
-        "--namespace", cluster,
-        "--timeout", "60s",
+        "wait",
+        "manifestwork/example-manifestwork",
+        "--for",
+        "condition=available",
+        "--namespace",
+        cluster,
+        "--timeout",
+        "60s",
         profile=hub,
     )
 
-    drenv.log_progress(
-        f"Waiting until deployment is available in cluster {cluster}"
-    )
+    drenv.log_progress(f"Waiting until deployment is available in cluster {cluster}")
     drenv.kubectl(
-        "wait", "deploy/example-deployment",
-        "--for", "condition=available",
-        "--timeout", "60s",
+        "wait",
+        "deploy/example-deployment",
+        "--for",
+        "condition=available",
+        "--timeout",
+        "60s",
         profile=cluster,
     )
 
 
 def delete_work(cluster, hub, work):
-    drenv.log_progress(F"Deleting manifestwork from namespace {cluster}")
+    drenv.log_progress(f"Deleting manifestwork from namespace {cluster}")
     drenv.kubectl("delete", "--filename", "-", input=work, profile=hub)
 
 
 def wait_for_delete_work(cluster, hub):
-    drenv.log_progress(
-        f"Waiting until manifestwork is deleted from namspace {cluster}"
-    )
+    drenv.log_progress(f"Waiting until manifestwork is deleted from namspace {cluster}")
     drenv.kubectl(
-        "wait", "manifestwork/example-manifestwork",
-        "--for", "delete",
-        "--namespace", cluster,
-        "--timeout", "60s",
+        "wait",
+        "manifestwork/example-manifestwork",
+        "--for",
+        "delete",
+        "--namespace",
+        cluster,
+        "--timeout",
+        "60s",
         profile=hub,
     )
 
 
 def wait_for_delete_deployment(cluster):
-    drenv.log_progress(
-        f"Waiting until deployment is deleted from cluster {cluster}"
-    )
+    drenv.log_progress(f"Waiting until deployment is deleted from cluster {cluster}")
     drenv.kubectl(
-        "wait", "deploy/example-deployment",
-        "--for", "delete",
-        "--timeout", "60s",
+        "wait",
+        "deploy/example-deployment",
+        "--for",
+        "delete",
+        "--timeout",
+        "60s",
         profile=cluster,
     )
 

--- a/test/ocm-controller/start
+++ b/test/ocm-controller/start
@@ -23,9 +23,13 @@ def deploy(cluster):
 def wait(cluster):
     drenv.log_progress("Waiting for ocm controller rollout")
     drenv.kubectl(
-        "rollout", "status", "deploy/ocm-controller",
-        "--namespace", "open-cluster-management",
-        "--timeout", "300s",
+        "rollout",
+        "status",
+        "deploy/ocm-controller",
+        "--namespace",
+        "open-cluster-management",
+        "--timeout",
+        "300s",
         profile=cluster,
     )
 

--- a/test/ocm-hub/start
+++ b/test/ocm-hub/start
@@ -36,9 +36,13 @@ def deploy(cluster):
 
     drenv.log_progress("Installing hub addons")
     drenv.run(
-        "clusteradm", "install", "hub-addon",
-        "--names", ",".join(ADDONS),
-        "--context", cluster,
+        "clusteradm",
+        "install",
+        "hub-addon",
+        "--names",
+        ",".join(ADDONS),
+        "--context",
+        cluster,
     )
 
 
@@ -49,9 +53,13 @@ def wait(cluster):
             deployment = f"deploy/{name}"
             drenv.wait_for(deployment, namespace=ns, profile=cluster)
             drenv.kubectl(
-                "rollout", "status", deployment,
-                "--namespace", ns,
-                "--timeout", "300s",
+                "rollout",
+                "status",
+                deployment,
+                "--namespace",
+                ns,
+                "--timeout",
+                "300s",
                 profile=cluster,
             )
 

--- a/test/olm/start
+++ b/test/olm/start
@@ -21,7 +21,8 @@ def deploy(cluster):
     # See https://medium.com/pareture/kubectl-install-crd-failed-annotations-too-long-2ebc91b40c7d
     drenv.kubectl(
         "apply",
-        "--filename", f"{BASE_URL}/crds.yaml",
+        "--filename",
+        f"{BASE_URL}/crds.yaml",
         "--server-side=true",
         profile=cluster,
     )
@@ -29,15 +30,18 @@ def deploy(cluster):
     drenv.log_progress("Waiting until cdrs are established")
     drenv.kubectl(
         "wait",
-        "--for", "condition=established",
-        "--filename", f"{BASE_URL}/crds.yaml",
+        "--for",
+        "condition=established",
+        "--filename",
+        f"{BASE_URL}/crds.yaml",
         profile=cluster,
     )
 
     drenv.log_progress("Deploying olm")
     drenv.kubectl(
         "apply",
-        "--filename", f"{BASE_URL}/olm.yaml",
+        "--filename",
+        f"{BASE_URL}/olm.yaml",
         profile=cluster,
     )
 
@@ -46,8 +50,12 @@ def wait(cluster):
     for operator in "olm-operator", "catalog-operator":
         drenv.log_progress(f"Waiting until {operator} is rolled out")
         drenv.kubectl(
-            "rollout", "status", "deploy", operator,
-            "--namespace", NAMESPACE,
+            "rollout",
+            "status",
+            "deploy",
+            operator,
+            "--namespace",
+            NAMESPACE,
             profile=cluster,
         )
 
@@ -59,17 +67,24 @@ def wait(cluster):
         profile=cluster,
     )
     drenv.kubectl(
-        "wait", "csv/packageserver",
-        "--namespace", NAMESPACE,
-        "--for", 'jsonpath={.status.phase}=Succeeded',
-        "--timeout", "300s",
+        "wait",
+        "csv/packageserver",
+        "--namespace",
+        NAMESPACE,
+        "--for",
+        "jsonpath={.status.phase}=Succeeded",
+        "--timeout",
+        "300s",
         profile=cluster,
     )
 
     drenv.log_progress("Waiting for olm pakcage server rollout")
     drenv.kubectl(
-        "rollout", "status", "deploy/packageserver",
-        "--namespace", NAMESPACE,
+        "rollout",
+        "status",
+        "deploy/packageserver",
+        "--namespace",
+        NAMESPACE,
         profile=cluster,
     )
 

--- a/test/rbd-mirror/start
+++ b/test/rbd-mirror/start
@@ -17,25 +17,39 @@ def fetch_secret_info(cluster):
 
     drenv.log_progress(f"Getting mirroring info site name for cluster {cluster}")
     info["name"] = drenv.kubectl(
-        "get", "cephblockpools.ceph.rook.io", POOL_NAME,
-        "--output", "jsonpath={.status.mirroringInfo.site_name}",
-        "--namespace", "rook-ceph",
+        "get",
+        "cephblockpools.ceph.rook.io",
+        POOL_NAME,
+        "--output",
+        "jsonpath={.status.mirroringInfo.site_name}",
+        "--namespace",
+        "rook-ceph",
         profile=cluster,
     )
 
-    drenv.log_progress(f"Getting rbd mirror boostrap peer secret name for cluster {cluster}")
+    drenv.log_progress(
+        f"Getting rbd mirror boostrap peer secret name for cluster {cluster}"
+    )
     secret_name = drenv.kubectl(
-        "get", "cephblockpools.ceph.rook.io", POOL_NAME,
-        "--output", "jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}",
-        "--namespace", "rook-ceph",
+        "get",
+        "cephblockpools.ceph.rook.io",
+        POOL_NAME,
+        "--output",
+        "jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}",
+        "--namespace",
+        "rook-ceph",
         profile=cluster,
     )
 
     drenv.log_progress(f"Getting secret {secret_name} token for cluster {cluster}")
     info["token"] = drenv.kubectl(
-        "get", "secret", secret_name,
-        "--output", "jsonpath={.data.token}",
-        "--namespace", "rook-ceph",
+        "get",
+        "secret",
+        secret_name,
+        "--output",
+        "jsonpath={.data.token}",
+        "--namespace",
+        "rook-ceph",
         profile=cluster,
     )
 
@@ -52,61 +66,84 @@ def configure_rbd_mirroring(cluster, peer_info):
     yaml = template.substitute(peer_info)
     drenv.kubectl(
         "apply",
-        "--filename", "-",
-        "--namespace", "rook-ceph",
+        "--filename",
+        "-",
+        "--namespace",
+        "rook-ceph",
         input=yaml,
         profile=cluster,
     )
 
     drenv.log_progress(f"Configure peers for cluster {cluster}")
-    patch = {
-        "spec": {
-            "mirroring": {
-                "peers": {
-                    "secretNames": [
-                        peer_info["name"]]}}}}
+    patch = {"spec": {"mirroring": {"peers": {"secretNames": [peer_info["name"]]}}}}
     drenv.kubectl(
-        "patch", "cephblockpool", POOL_NAME,
-        "--type", "merge",
-        "--patch", json.dumps(patch),
-        "--namespace", "rook-ceph",
+        "patch",
+        "cephblockpool",
+        POOL_NAME,
+        "--type",
+        "merge",
+        "--patch",
+        json.dumps(patch),
+        "--namespace",
+        "rook-ceph",
         profile=cluster,
     )
 
     drenv.log_progress(f"Apply rbd mirror to cluster {cluster}")
     drenv.kubectl(
         "apply",
-        "--filename", "rbd-mirror/rbd-mirror.yaml",
-        "--namespace", "rook-ceph",
+        "--filename",
+        "rbd-mirror/rbd-mirror.yaml",
+        "--namespace",
+        "rook-ceph",
         profile=cluster,
     )
 
 
 def wait_until_pool_mirroring_is_healthy(cluster):
-    drenv.log_progress(f"Waiting until ceph mirror daemon is healthy in cluster {cluster}")
+    drenv.log_progress(
+        f"Waiting until ceph mirror daemon is healthy in cluster {cluster}"
+    )
     drenv.kubectl(
-        "wait", "cephblockpools.ceph.rook.io", POOL_NAME,
-        "--for", "jsonpath={.status.mirroringStatus.summary.daemon_health}=OK",
-        "--namespace", "rook-ceph",
-        "--timeout", "300s",
+        "wait",
+        "cephblockpools.ceph.rook.io",
+        POOL_NAME,
+        "--for",
+        "jsonpath={.status.mirroringStatus.summary.daemon_health}=OK",
+        "--namespace",
+        "rook-ceph",
+        "--timeout",
+        "300s",
         profile=cluster,
     )
 
     drenv.log_progress(f"Waiting until ceph mirror is healthy in cluster {cluster}")
     drenv.kubectl(
-        "wait", "cephblockpools.ceph.rook.io", POOL_NAME,
-        "--for", "jsonpath={.status.mirroringStatus.summary.health}=OK",
-        "--namespace", "rook-ceph",
-        "--timeout", "300s",
+        "wait",
+        "cephblockpools.ceph.rook.io",
+        POOL_NAME,
+        "--for",
+        "jsonpath={.status.mirroringStatus.summary.health}=OK",
+        "--namespace",
+        "rook-ceph",
+        "--timeout",
+        "300s",
         profile=cluster,
     )
 
-    drenv.log_progress(f"Waiting until ceph mirror image is healthy in cluster {cluster}")
+    drenv.log_progress(
+        f"Waiting until ceph mirror image is healthy in cluster {cluster}"
+    )
     drenv.kubectl(
-        "wait", "cephblockpools.ceph.rook.io", POOL_NAME,
-        "--for", "jsonpath={.status.mirroringStatus.summary.image_health}=OK",
-        "--namespace", "rook-ceph",
-        "--timeout", "300s",
+        "wait",
+        "cephblockpools.ceph.rook.io",
+        POOL_NAME,
+        "--for",
+        "jsonpath={.status.mirroringStatus.summary.image_health}=OK",
+        "--namespace",
+        "rook-ceph",
+        "--timeout",
+        "300s",
         profile=cluster,
     )
 
@@ -115,8 +152,10 @@ def deploy_vrc_sample(cluster):
     drenv.log_progress(f"Applying vrc sample in cluster {cluster}")
     drenv.kubectl(
         "apply",
-        "--filename", "rbd-mirror/vrc-sample.yaml",
-        "--namespace", "rook-ceph",
+        "--filename",
+        "rbd-mirror/vrc-sample.yaml",
+        "--namespace",
+        "rook-ceph",
         profile=cluster,
     )
 

--- a/test/rbd-mirror/test
+++ b/test/rbd-mirror/test
@@ -15,9 +15,18 @@ PVC_NAME = "rbd-pvc"
 
 def rbd_mirror_image_status(cluster, image):
     out = drenv.kubectl(
-        "exec", "deploy/rook-ceph-tools", "--namespace", "rook-ceph", "--",
-        "rbd", "mirror", "image", "status", f"{POOL_NAME}/{image}",
-        "--format", "json",
+        "exec",
+        "deploy/rook-ceph-tools",
+        "--namespace",
+        "rook-ceph",
+        "--",
+        "rbd",
+        "mirror",
+        "image",
+        "status",
+        f"{POOL_NAME}/{image}",
+        "--format",
+        "json",
         profile=cluster,
         verbose=False,
     )
@@ -40,81 +49,133 @@ def test_volume_replication(primary, secondary):
     drenv.log_progress(f"Deploying pvc {PVC_NAME} in cluster {primary}")
     drenv.kubectl(
         "apply",
-        "--filename", f"rbd-mirror/{PVC_NAME}.yaml",
-        "--namespace", "rook-ceph",
+        "--filename",
+        f"rbd-mirror/{PVC_NAME}.yaml",
+        "--namespace",
+        "rook-ceph",
         profile=primary,
     )
 
     drenv.log_progress(f"Waiting until pvc {PVC_NAME} is bound in cluster {primary}")
     drenv.kubectl(
-        "wait", "pvc", PVC_NAME,
-        "--for", "jsonpath={.status.phase}=Bound",
-        "--namespace", "rook-ceph",
-        "--timeout", "300s",
+        "wait",
+        "pvc",
+        PVC_NAME,
+        "--for",
+        "jsonpath={.status.phase}=Bound",
+        "--namespace",
+        "rook-ceph",
+        "--timeout",
+        "300s",
         profile=primary,
     )
 
     drenv.log_progress(f"Deploying vr vr-sample in cluster {primary}")
     drenv.kubectl(
         "apply",
-        "--filename", "rbd-mirror/vr-sample.yaml",
-        "--namespace", "rook-ceph",
+        "--filename",
+        "rbd-mirror/vr-sample.yaml",
+        "--namespace",
+        "rook-ceph",
         profile=primary,
     )
 
     drenv.log_progress(f"Waiting until vr vr-sample is completed in cluster {primary}")
     drenv.kubectl(
-        "wait", "volumereplication", "vr-sample",
-        "--for", "condition=Completed",
-        "--namespace", "rook-ceph",
-        "--timeout", "300s",
+        "wait",
+        "volumereplication",
+        "vr-sample",
+        "--for",
+        "condition=Completed",
+        "--namespace",
+        "rook-ceph",
+        "--timeout",
+        "300s",
         profile=primary,
     )
 
-    drenv.log_progress(f"Waiting until vr vr-sample state is primary in cluster {primary}")
+    drenv.log_progress(
+        f"Waiting until vr vr-sample state is primary in cluster {primary}"
+    )
     drenv.kubectl(
-        "wait", "volumereplication", "vr-sample",
-        "--for", "jsonpath={.status.state}=Primary",
-        "--namespace", "rook-ceph",
-        "--timeout", "300s",
+        "wait",
+        "volumereplication",
+        "vr-sample",
+        "--for",
+        "jsonpath={.status.state}=Primary",
+        "--namespace",
+        "rook-ceph",
+        "--timeout",
+        "300s",
         profile=primary,
     )
 
     drenv.log_progress(f"Looking up pvc {PVC_NAME} pv name in cluster {primary}")
     pv_name = drenv.kubectl(
-        "get", f"pvc/{PVC_NAME}",
-        "--output", "jsonpath={.spec.volumeName}",
-        "--namespace", "rook-ceph",
+        "get",
+        f"pvc/{PVC_NAME}",
+        "--output",
+        "jsonpath={.spec.volumeName}",
+        "--namespace",
+        "rook-ceph",
         profile=primary,
     )
 
     drenv.log_progress(f"Looking up rbd image for pv {pv_name} in cluster {primary}")
     rbd_image = drenv.kubectl(
-        "get", f"pv/{pv_name}",
-        "--output", "jsonpath={.spec.csi.volumeAttributes.imageName}",
-        "--namespace", "rook-ceph",
+        "get",
+        f"pv/{pv_name}",
+        "--output",
+        "jsonpath={.spec.csi.volumeAttributes.imageName}",
+        "--namespace",
+        "rook-ceph",
         profile=primary,
     )
 
     drenv.log_progress(f"rbd image {rbd_image} info in cluster {primary}")
     drenv.kubectl(
-        "exec", "deploy/rook-ceph-tools", "--namespace", "rook-ceph", "--",
-        "rbd", "info", rbd_image, "--pool", POOL_NAME,
+        "exec",
+        "deploy/rook-ceph-tools",
+        "--namespace",
+        "rook-ceph",
+        "--",
+        "rbd",
+        "info",
+        rbd_image,
+        "--pool",
+        POOL_NAME,
         profile=primary,
     )
 
-    drenv.log_progress(f"Waiting until rbd image {rbd_image} is created in cluster {secondary}")
+    drenv.log_progress(
+        f"Waiting until rbd image {rbd_image} is created in cluster {secondary}"
+    )
     for i in range(60):
         time.sleep(1)
         out = drenv.kubectl(
-            "exec", "deploy/rook-ceph-tools", "--namespace", "rook-ceph", "--",
-            "rbd", "list", "--pool", POOL_NAME,
+            "exec",
+            "deploy/rook-ceph-tools",
+            "--namespace",
+            "rook-ceph",
+            "--",
+            "rbd",
+            "list",
+            "--pool",
+            POOL_NAME,
             profile=secondary,
         )
         if rbd_image in out:
             drenv.kubectl(
-                "exec", "deploy/rook-ceph-tools", "--namespace", "rook-ceph", "--",
-                "rbd", "info", rbd_image, "--pool", POOL_NAME,
+                "exec",
+                "deploy/rook-ceph-tools",
+                "--namespace",
+                "rook-ceph",
+                "--",
+                "rbd",
+                "info",
+                rbd_image,
+                "--pool",
+                POOL_NAME,
                 profile=secondary,
             )
             break
@@ -123,9 +184,13 @@ def test_volume_replication(primary, secondary):
 
     drenv.log_progress(f"vr vr-sample info on primary cluster {primary}")
     drenv.kubectl(
-        "get", "volumereplication", "vr-sample",
-        "--output", "yaml",
-        "--namespace", "rook-ceph",
+        "get",
+        "volumereplication",
+        "vr-sample",
+        "--output",
+        "yaml",
+        "--namespace",
+        "rook-ceph",
         profile=primary,
     )
 
@@ -135,19 +200,27 @@ def test_volume_replication(primary, secondary):
 
     drenv.log_progress(f"Deleting vr vr-sample in primary cluster {primary}")
     drenv.kubectl(
-        "delete", "volumereplication", "vr-sample",
-        "--namespace", "rook-ceph",
+        "delete",
+        "volumereplication",
+        "vr-sample",
+        "--namespace",
+        "rook-ceph",
         profile=primary,
     )
 
     drenv.log_progress(f"Deleting pvc {PVC_NAME} in primary cluster {primary}")
     drenv.kubectl(
-        "delete", "pvc", PVC_NAME,
-        "--namespace", "rook-ceph",
+        "delete",
+        "pvc",
+        PVC_NAME,
+        "--namespace",
+        "rook-ceph",
         profile=primary,
     )
 
-    drenv.log_progress(f"Replication from cluster {primary} to cluster {secondary} successeded")
+    drenv.log_progress(
+        f"Replication from cluster {primary} to cluster {secondary} successeded"
+    )
 
 
 if len(sys.argv) != 3:

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 coverage
+flake8

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 coverage
 flake8
+pylint

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,3 +2,4 @@ pytest
 coverage
 flake8
 pylint
+black

--- a/test/rook-cluster/start
+++ b/test/rook-cluster/start
@@ -31,10 +31,15 @@ def wait(cluster):
         profile=cluster,
     )
     drenv.kubectl(
-        "wait", "CephCluster", "my-cluster",
-        "--for", "jsonpath={.status.phase}=Ready",
-        "--namespace", "rook-ceph",
-        "--timeout", "300s",
+        "wait",
+        "CephCluster",
+        "my-cluster",
+        "--for",
+        "jsonpath={.status.phase}=Ready",
+        "--namespace",
+        "rook-ceph",
+        "--timeout",
+        "300s",
         profile=cluster,
     )
 

--- a/test/rook-operator/start
+++ b/test/rook-operator/start
@@ -24,19 +24,28 @@ def deploy(cluster):
 def wait(cluster):
     drenv.log_progress("Waiting until rook ceph operator is rolled out")
     drenv.kubectl(
-        "rollout", "status", "deploy/rook-ceph-operator",
-        "--namespace", "rook-ceph",
-        "--timeout", "300s",
+        "rollout",
+        "status",
+        "deploy/rook-ceph-operator",
+        "--namespace",
+        "rook-ceph",
+        "--timeout",
+        "300s",
         profile=cluster,
     )
 
     drenv.log_progress("Waiting until rook ceph operator is ready")
     drenv.kubectl(
-        "wait", "pod",
-        "--for", "jsonpath={.status.phase}=Running",
-        "--namespace", "rook-ceph",
-        "--selector", "app=rook-ceph-operator",
-        "--timeout", "300s",
+        "wait",
+        "pod",
+        "--for",
+        "jsonpath={.status.phase}=Running",
+        "--namespace",
+        "rook-ceph",
+        "--selector",
+        "app=rook-ceph-operator",
+        "--timeout",
+        "300s",
         profile=cluster,
     )
 

--- a/test/rook-pool/start
+++ b/test/rook-pool/start
@@ -12,8 +12,10 @@ def deploy(cluster):
     drenv.log_progress("Creating rbd pool and storage class")
     drenv.kubectl(
         "apply",
-        "--filename", "rook-pool/replica-pool.yaml",
-        "--filename", "rook-pool/storage-class.yaml",
+        "--filename",
+        "rook-pool/replica-pool.yaml",
+        "--filename",
+        "rook-pool/storage-class.yaml",
         profile=cluster,
     )
 
@@ -28,19 +30,29 @@ def wait(cluster):
         profile=cluster,
     )
     drenv.kubectl(
-        "wait", "CephBlockPool", "replicapool",
-        "--for", "jsonpath={.status.phase}=Ready",
-        "--namespace", "rook-ceph",
-        "--timeout", "300s",
+        "wait",
+        "CephBlockPool",
+        "replicapool",
+        "--for",
+        "jsonpath={.status.phase}=Ready",
+        "--namespace",
+        "rook-ceph",
+        "--timeout",
+        "300s",
         profile=cluster,
     )
 
     drenv.log_progress("Waiting for replica pool peer token")
     drenv.kubectl(
-        "wait", "CephBlockPool", "replicapool",
-        "--for", "jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}=pool-peer-token-replicapool",
-        "--namespace", "rook-ceph",
-        "--timeout", "300s",
+        "wait",
+        "CephBlockPool",
+        "replicapool",
+        "--for",
+        "jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}=pool-peer-token-replicapool",
+        "--namespace",
+        "rook-ceph",
+        "--timeout",
+        "300s",
         profile=cluster,
     )
 

--- a/test/rook-toolbox/start
+++ b/test/rook-toolbox/start
@@ -16,7 +16,8 @@ def deploy(cluster):
     drenv.log_progress("Deploying rook ceph toolbox")
     drenv.kubectl(
         "apply",
-        "--filename", f"{BASE_URL}/toolbox.yaml",
+        "--filename",
+        f"{BASE_URL}/toolbox.yaml",
         profile=cluster,
     )
 
@@ -24,9 +25,13 @@ def deploy(cluster):
 def wait(cluster):
     drenv.log_progress("Waiting until rook-ceph-tools is rolled out")
     drenv.kubectl(
-        "rollout", "status", "deploy/rook-ceph-tools",
-        "--namespace", "rook-ceph",
-        "--timeout", "300s",
+        "rollout",
+        "status",
+        "deploy/rook-ceph-tools",
+        "--namespace",
+        "rook-ceph",
+        "--timeout",
+        "300s",
         profile=cluster,
     )
 


### PR DESCRIPTION
Integrate flake8 in the build.

- Simplify installation of pytest and coverage
- Add test Makfile
- Add flake8 target and CI step
- Add pylint target and CI step
- Add black target and CI step (not finished)

Currently we ignore line length checks. We can improve this later by
reformatting the code.

Fixes: #655 