### PR TITLE
Improve error messages

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -27,6 +27,9 @@ environment.
    You need `minikube` version supporting the `--extra-disks` option.
    The tool was tested with `minikube` v1.26.1.
 
+1. Install the kubectl tool. See
+   [Install and Set Up kubectl on Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
+
 1. Install `clusteradm` tool. See
    [Open Cluster Management Quick Start guide](https://open-cluster-management.io/getting-started/quick-start/#install-clusteradm-cli-tool)
    for the details.

--- a/test/cert-manager/start
+++ b/test/cert-manager/start
@@ -6,6 +6,7 @@
 import sys
 
 import drenv
+from drenv import kubectl
 
 VERSION = "v1.10.0"
 URL = f"https://github.com/cert-manager/cert-manager/releases/download/{VERSION}/cert-manager.yaml"
@@ -13,12 +14,12 @@ URL = f"https://github.com/cert-manager/cert-manager/releases/download/{VERSION}
 
 def deploy(cluster):
     drenv.log_progress("Deploying cert-manager")
-    drenv.kubectl_apply("--filename", URL, profile=cluster)
+    kubectl.apply("--filename", URL, profile=cluster)
 
 
 def wait(cluster):
     drenv.log_progress("Waiting until all deployments are available")
-    drenv.kubectl_wait(
+    kubectl.wait(
         "deploy",
         "--all",
         "--for=condition=Available",

--- a/test/cert-manager/start
+++ b/test/cert-manager/start
@@ -13,7 +13,7 @@ URL = f"https://github.com/cert-manager/cert-manager/releases/download/{VERSION}
 
 def deploy(cluster):
     drenv.log_progress("Deploying cert-manager")
-    drenv.kubectl("apply", "--filename", URL, profile=cluster)
+    drenv.kubectl_apply("--filename", URL, profile=cluster)
 
 
 def wait(cluster):

--- a/test/cert-manager/start
+++ b/test/cert-manager/start
@@ -18,8 +18,7 @@ def deploy(cluster):
 
 def wait(cluster):
     drenv.log_progress("Waiting until all deployments are available")
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "deploy",
         "--all",
         "--for=condition=Available",

--- a/test/csi-addons/start
+++ b/test/csi-addons/start
@@ -6,6 +6,7 @@
 import sys
 
 import drenv
+from drenv import kubectl
 
 # Using main till a release is available with lastSyncTime.
 VERSION = "main"
@@ -18,14 +19,14 @@ def deploy(cluster):
         "csi-addons/kustomization.yaml",
         base_url=BASE_URL,
     ) as kustomization:
-        drenv.kubectl_apply("--kustomize", kustomization, profile=cluster)
+        kubectl.apply("--kustomize", kustomization, profile=cluster)
 
 
 def wait(cluster):
     drenv.log_progress(
         "Waiting until csi-addons-controller-manager is rolled out",
     )
-    drenv.kubectl_rollout(
+    kubectl.rollout(
         "status",
         "deploy/csi-addons-controller-manager",
         "--namespace",

--- a/test/csi-addons/start
+++ b/test/csi-addons/start
@@ -25,8 +25,7 @@ def wait(cluster):
     drenv.log_progress(
         "Waiting until csi-addons-controller-manager is rolled out",
     )
-    drenv.kubectl(
-        "rollout",
+    drenv.kubectl_rollout(
         "status",
         "deploy/csi-addons-controller-manager",
         "--namespace",

--- a/test/csi-addons/start
+++ b/test/csi-addons/start
@@ -18,7 +18,7 @@ def deploy(cluster):
         "csi-addons/kustomization.yaml",
         base_url=BASE_URL,
     ) as kustomization:
-        drenv.kubectl("apply", "--kustomize", kustomization, profile=cluster)
+        drenv.kubectl_apply("--kustomize", kustomization, profile=cluster)
 
 
 def wait(cluster):

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -42,12 +42,28 @@ def kubectl_exec(*args, profile=None):
     return _kubectl_run("exec", *args, profile=profile)
 
 
+def kubectl_apply(*args, input=None, profile=None):
+    """
+    Run kubectl apply ... logging progress messages.
+    """
+    _kubectl_watch("apply", *args, input=input, profile=profile)
+
+
 def _kubectl_run(cmd, *args, profile=None):
     cmd = ["kubectl", cmd]
     if profile:
         cmd.extend(("--context", profile))
     cmd.extend(args)
     return commands.run(*cmd)
+
+
+def _kubectl_watch(cmd, *args, input=None, profile=None):
+    cmd = ["kubectl", cmd]
+    if profile:
+        cmd.extend(("--context", profile))
+    cmd.extend(args)
+    for line in commands.watch(*cmd, input=input):
+        log_detail(line)
 
 
 def kubectl(*args, profile=None, input=None, verbose=True):

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -49,6 +49,13 @@ def kubectl_apply(*args, input=None, profile=None):
     _kubectl_watch("apply", *args, input=input, profile=profile)
 
 
+def kubectl_rollout(*args, profile=None):
+    """
+    Run kubectl rollout ... logging progress messages.
+    """
+    _kubectl_watch("rollout", *args, profile=profile)
+
+
 def _kubectl_run(cmd, *args, profile=None):
     cmd = ["kubectl", cmd]
     if profile:

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -49,6 +49,13 @@ def kubectl_apply(*args, input=None, profile=None):
     _kubectl_watch("apply", *args, input=input, profile=profile)
 
 
+def kubectl_patch(*args, profile=None):
+    """
+    Run kubectl patch ... logging progress messages.
+    """
+    _kubectl_watch("patch", *args, profile=profile)
+
+
 def kubectl_delete(*args, input=None, profile=None):
     """
     Run kubectl delete ... logging progress messages.

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -28,10 +28,7 @@ def log_detail(text):
 
 def kubectl(*args, profile=None, input=None, verbose=True):
     """
-    Run `minikube kubectl` command for profile.
-
-    Some kubectl commands (e.g. config) do not work with profile and require
-    `--context profile` in the command arguments.
+    Run `kubectl` command for profile.
 
     To pipe yaml into the kubectl command, use `--filename -` and pass the yaml
     to the input argument.
@@ -41,10 +38,9 @@ def kubectl(*args, profile=None, input=None, verbose=True):
 
     Returns the underlying command output.
     """
-    cmd = ["minikube", "kubectl"]
+    cmd = ["kubectl"]
     if profile:
-        cmd.extend(("--profile", profile))
-    cmd.append("--")
+        cmd.extend(("--context", profile))
     cmd.extend(args)
 
     return run(*cmd, input=input, verbose=verbose)

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -4,7 +4,6 @@
 import json
 import os
 import string
-import subprocess
 import tempfile
 import textwrap
 import time
@@ -107,13 +106,20 @@ def cluster_status(cluster):
     if not cluster_info(cluster):
         return {}
 
-    out = run("minikube", "status", "--profile", cluster, "--output", "json")
+    out = commands.run(
+        "minikube",
+        "status",
+        "--profile",
+        cluster,
+        "--output",
+        "json",
+    )
 
     return json.loads(out)
 
 
 def cluster_exists(cluster):
-    out = run("minikube", "profile", "list", "--output=json")
+    out = commands.run("minikube", "profile", "list", "--output=json")
     profiles = json.loads(out)
     for profile in profiles["valid"]:
         if profile["Name"] == cluster:
@@ -138,23 +144,6 @@ def cluster_info(cluster):
             return c
 
     return {}
-
-
-def run(*args, input=None):
-    """
-    Run a command and return the output. You can set input to the text to pipe
-    into the commnad stdin.
-    """
-    return commands.run(*args, input=input)
-
-
-def watch(*args, input=None):
-    """
-    Run a command and log progress messages. You can set input to the text to
-    pipe into the commnad stdin.
-    """
-    for line in commands.watch(*args, input=input):
-        log_detail(line)
 
 
 def template(path):

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -35,6 +35,13 @@ def kubectl_get(*args, profile=None):
     return _kubectl_run("get", *args, profile=profile)
 
 
+def kubectl_exec(*args, profile=None):
+    """
+    Run kubectl get ... and return the output.
+    """
+    return _kubectl_run("exec", *args, profile=profile)
+
+
 def _kubectl_run(cmd, *args, profile=None):
     cmd = ["kubectl", cmd]
     if profile:

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -56,6 +56,13 @@ def kubectl_rollout(*args, profile=None):
     _kubectl_watch("rollout", *args, profile=profile)
 
 
+def kubectl_wait(*args, profile=None):
+    """
+    Run kubectl wait ... logging progress messages.
+    """
+    _kubectl_watch("wait", *args, profile=profile)
+
+
 def _kubectl_run(cmd, *args, profile=None):
     cmd = ["kubectl", cmd]
     if profile:

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -49,6 +49,13 @@ def kubectl_apply(*args, input=None, profile=None):
     _kubectl_watch("apply", *args, input=input, profile=profile)
 
 
+def kubectl_delete(*args, input=None, profile=None):
+    """
+    Run kubectl delete ... logging progress messages.
+    """
+    _kubectl_watch("delete", *args, input=input, profile=profile)
+
+
 def kubectl_rollout(*args, profile=None):
     """
     Run kubectl rollout ... logging progress messages.

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -28,6 +28,13 @@ def log_detail(text):
     print(textwrap.indent(text, "  "))
 
 
+def kubectl_config(*args, profile=None):
+    """
+    Run kubectl config ... and return the output.
+    """
+    return _kubectl_run("config", *args, profile=profile)
+
+
 def kubectl_get(*args, profile=None):
     """
     Run kubectl get ... and return the output.
@@ -220,7 +227,7 @@ def cluster_info(cluster):
     Return cluster info from kubectl config. Returns empty dict if the cluster
     is not configured with kubectl yet.
     """
-    out = kubectl("config", "view", "--output", "json", verbose=False)
+    out = kubectl_config("view", "--output", "json", verbose=False)
     config = json.loads(out)
 
     # We get null instead of [].

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -208,8 +208,8 @@ def wait_for_deployments(profile, initial_wait=30, timeout=300):
     )
 
 
-def kubectl(cmd, *args, profile=None):
-    minikube("kubectl", "--", cmd, *args, profile=profile)
+def kubectl(*args, profile=None):
+    run("kubectl", "--context", profile, *args, name=profile)
 
 
 def minikube(cmd, *args, profile=None):

--- a/test/drenv/clusteradm.py
+++ b/test/drenv/clusteradm.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import drenv
+from . import commands
+
+
+def init(wait=False, context=None):
+    """
+    Initialize a Kubernetes cluster into an OCM hub cluster.
+    """
+    cmd = ["clusteradm", "init"]
+    if wait:
+        cmd.append("--wait")
+    if context:
+        cmd.extend(("--context", context))
+    _watch(*cmd)
+
+
+def get(what, context=None):
+    """
+    Get information from the cluster.
+    """
+    cmd = ["clusteradm", "get", what]
+    if context:
+        cmd.extend(("--context", context))
+    return commands.run(*cmd)
+
+
+def install(what, names, context=None):
+    """
+    Install a feature.
+    """
+    cmd = ["clusteradm", "install", what, "--names", ",".join(names)]
+    if context:
+        cmd.extend(("--context", context))
+    _watch(*cmd)
+
+
+def join(hub_token, hub_apiserver, cluster_name, wait=False, context=None):
+    """
+    Join a cluster to the hub.
+    """
+    cmd = [
+        "clusteradm",
+        "join",
+        "--hub-token",
+        hub_token,
+        "--hub-apiserver",
+        hub_apiserver,
+        "--cluster-name",
+        cluster_name,
+    ]
+    if wait:
+        cmd.append("--wait")
+    if context:
+        cmd.extend(("--context", context))
+    _watch(*cmd)
+
+
+def accept(clusters, wait=False, context=None):
+    """
+    Accept clusters to the hub.
+    """
+    cmd = ["clusteradm", "accept", "--clusters", ",".join(clusters)]
+    if wait:
+        cmd.append("--wait")
+    if context:
+        cmd.extend(("--context", context))
+    _watch(*cmd)
+
+
+def addon(action, names, clusters, context=None):
+    """
+    Enable or disable addons on clusters.
+    """
+    cmd = [
+        "clusteradm",
+        "addon",
+        action,
+        "--names",
+        ",".join(names),
+        "--clusters",
+        ",".join(clusters),
+    ]
+    if context:
+        cmd.extend(("--context", context))
+    _watch(*cmd)
+
+
+def _watch(*cmd):
+    for line in commands.watch(*cmd):
+        drenv.log_detail(line)

--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -74,7 +74,7 @@ def run(*args, input=None):
     return output
 
 
-def watch(*args):
+def watch(*args, input=None):
     """
     Run command args, iterating over lines read from the child process stdout.
 
@@ -95,6 +95,7 @@ def watch(*args):
 
     with subprocess.Popen(
         args,
+        stdin=subprocess.PIPE if input else None,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         env=env,
@@ -102,7 +103,7 @@ def watch(*args):
         error = bytearray()
         partial = bytearray()
 
-        for src, data in stream(p):
+        for src, data in stream(p, input=input):
             if src is ERR:
                 error += data
             else:

--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -3,11 +3,84 @@
 
 import os
 import selectors
+import subprocess
+import textwrap
 
 OUT = "out"
 ERR = "err"
 
 _Selector = getattr(selectors, "PollSelector", selectors.SelectSelector)
+
+
+class Error(Exception):
+    INDENT = 3 * " "
+
+    def __init__(self, command, exitcode, error):
+        self.command = command
+        self.exitcode = exitcode
+        self.error = error
+
+    def __str__(self):
+        error = textwrap.indent(self.error.rstrip(), self.INDENT * 2)
+        return f"""\
+Command failed:
+   command: {self.command}
+   exitcode: {self.exitcode}
+   error:
+{error}
+"""
+
+
+def watch(*args):
+    """
+    Run command args, iterating over lines read from the child process stdout.
+
+    Assumes that the child process output UTF-8. Will raise if the command
+    outputs binary data. This is not a problem in this projects since all our
+    commands are text based.
+
+    Invalid UTF-8 in child process stderr is handled gracefully so we don't
+    fail to raise an error about the failing command. Invalid characters will
+    be replaced with unicode replacement character (U+FFFD).
+
+    Raises Error if the child process terminated with non-zero exit code. The
+    error includes all data read from the child process stderr.
+    """
+    # Avoid delays in python child process logs.
+    env = dict(os.environ)
+    env["PYTHONUNBUFFERED"] = "1"
+
+    with subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    ) as p:
+        error = bytearray()
+        partial = bytearray()
+
+        for src, data in stream(p):
+            if src is ERR:
+                error += data
+            else:
+                for line in data.splitlines(keepends=True):
+                    if not line.endswith(b"\n"):
+                        partial += line
+                        break
+
+                    if partial:
+                        line = bytes(partial) + line
+                        del partial[:]
+
+                    yield line.rstrip().decode()
+
+        if partial:
+            yield partial.rstrip().decode()
+            del partial[:]
+
+    if p.returncode != 0:
+        error = error.decode(errors="replace")
+        raise Error(args, p.returncode, error)
 
 
 def stream(proc, bufsize=32 << 10):

--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -15,20 +15,30 @@ _Selector = getattr(selectors, "PollSelector", selectors.SelectSelector)
 class Error(Exception):
     INDENT = 3 * " "
 
-    def __init__(self, command, exitcode, error):
+    def __init__(self, command, exitcode, error, output=None):
         self.command = command
         self.exitcode = exitcode
         self.error = error
+        self.output = output
+
+    def _indent(self, s):
+        return textwrap.indent(s, self.INDENT)
 
     def __str__(self):
-        error = textwrap.indent(self.error.rstrip(), self.INDENT * 2)
-        return f"""\
-Command failed:
-   command: {self.command}
-   exitcode: {self.exitcode}
-   error:
-{error}
-"""
+        lines = [
+            "Command failed:\n",
+            self._indent(f"command: {self.command}\n"),
+            self._indent(f"exitcode: {self.exitcode}\n"),
+        ]
+
+        if self.output:
+            output = self._indent(self.output.rstrip())
+            lines.append(self._indent(f"output:\n{output}\n"))
+
+        error = self._indent(self.error.rstrip())
+        lines.append(self._indent(f"error:\n{error}\n"))
+
+        return "".join(lines)
 
 
 def watch(*args):

--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -7,31 +7,31 @@ from contextlib import contextmanager
 from drenv import commands
 
 
-def test_nothing():
+def test_stream_nothing():
     with run("true") as p:
         stream = list(commands.stream(p))
     assert stream == []
 
 
-def test_stdout():
+def test_stream_stdout():
     with run("echo", "-n", "output") as p:
         stream = list(commands.stream(p))
     assert stream == [(commands.OUT, b"output")]
 
 
-def test_stderr():
+def test_stream_stderr():
     with run("sh", "-c", "echo -n error >&2") as p:
         stream = list(commands.stream(p))
     assert stream == [(commands.ERR, b"error")]
 
 
-def test_both():
+def test_stream_both():
     with run("sh", "-c", "echo -n output; echo -n error >&2") as p:
         stream = list(commands.stream(p))
     assert stream == [(commands.OUT, b"output"), (commands.ERR, b"error")]
 
 
-def test_large_output():
+def test_stream_output_large():
     out = err = 0
     with run("dd", "if=/dev/zero", "bs=1M", "count=100", "status=none") as p:
         for src, data in commands.stream(p):
@@ -43,21 +43,21 @@ def test_large_output():
     assert err == 0
 
 
-def test_no_stdout():
+def test_stream_no_stdout():
     # No reason to stream with one pipe, but it works.
     with run("sh", "-c", "echo -n error >&2", stdout=None) as p:
         stream = list(commands.stream(p))
     assert stream == [(commands.ERR, b"error")]
 
 
-def test_no_stderr():
+def test_stream_no_stderr():
     # No reason to stream with one pipe, but it works.
     with run("sh", "-c", "echo -n output", stderr=None) as p:
         stream = list(commands.stream(p))
     assert stream == [(commands.OUT, b"output")]
 
 
-def test_no_streams():
+def test_stream_no_stdout_stderr():
     # No reason without pipes, but it works.
     with run("true", stdout=None, stderr=None) as p:
         stream = list(commands.stream(p))

--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -130,6 +130,22 @@ def test_watch_no_output():
     assert output == []
 
 
+def test_watch_with_input():
+    output = list(commands.watch("cat", input="input"))
+    assert output == ["input"]
+
+
+def test_watch_with_input_non_ascii():
+    output = list(commands.watch("cat", input="\u05d0"))
+    assert output == ["\u05d0"]
+
+
+def test_watch_with_input_large():
+    text = "A" * (1 << 20)
+    output = list(commands.watch("cat", input=text))
+    assert output == [text]
+
+
 def test_watch_lines():
     script = """
 for i in range(10):

--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -4,7 +4,11 @@
 import subprocess
 from contextlib import contextmanager
 
+import pytest
+
 from drenv import commands
+
+# Streaming data from commands.
 
 
 def test_stream_nothing():
@@ -62,6 +66,111 @@ def test_stream_no_stdout_stderr():
     with run("true", stdout=None, stderr=None) as p:
         stream = list(commands.stream(p))
     assert stream == []
+
+
+# Watching commands.
+
+
+def test_watch_no_output():
+    output = list(commands.watch("true"))
+    assert output == []
+
+
+def test_watch_lines():
+    script = """
+for i in range(10):
+    print(f"line {i}", flush=True)
+"""
+    output = list(commands.watch("python3", "-c", script))
+    assert output == ["line %d" % i for i in range(10)]
+
+
+def test_watch_partial_lines():
+    script = """
+import time
+
+print("first ", end="", flush=True);
+time.sleep(0.02)
+print("line\\nsecond ", end="", flush=True);
+time.sleep(0.02)
+print("line\\n", end="", flush=True);
+"""
+    output = list(commands.watch("python3", "-c", script))
+    assert output == ["first line", "second line"]
+
+
+def test_watch_no_newline():
+    script = """
+import time
+
+print("first ", end="", flush=True);
+time.sleep(0.02)
+print("second ", end="", flush=True);
+time.sleep(0.02)
+print("last", end="", flush=True);
+"""
+    output = list(commands.watch("python3", "-c", script))
+    assert output == ["first second last"]
+
+
+def test_watch_error_empty():
+    cmd = ("false",)
+    output = []
+
+    with pytest.raises(commands.Error) as e:
+        for line in commands.watch(*cmd):
+            output.append(line)
+
+    assert output == []
+
+    assert e.value.command == cmd
+    assert e.value.exitcode == 1
+    assert e.value.error == ""
+
+
+def test_watch_error():
+    cmd = ("sh", "-c", "echo -n output >&1; echo -n error >&2; exit 1")
+    output = []
+
+    with pytest.raises(commands.Error) as e:
+        for line in commands.watch(*cmd):
+            output.append(line)
+
+    # All output is always reported to the caller, even if the command failed.
+    assert output == ["output"]
+
+    # Errors are buffered and reported only if the command failed.
+    assert e.value.command == cmd
+    assert e.value.exitcode == 1
+    assert e.value.error == "error"
+
+
+def test_watch_non_ascii():
+    script = 'print("\u05d0")'  # Hebrew Letter Alef (U+05D0)
+    output = list(commands.watch("python3", "-c", script))
+    assert output == ["\u05d0"]
+
+
+def test_watch_invalid_utf8():
+    script = """
+import os
+os.write(1, bytes([0xff]))
+"""
+    with pytest.raises(UnicodeDecodeError):
+        list(commands.watch("python3", "-c", script))
+
+
+def test_error():
+    e = commands.Error(("arg1", "arg2"), exitcode=2, error="err 1\nerr 2\n")
+    expected = """\
+Command failed:
+   command: ('arg1', 'arg2')
+   exitcode: 2
+   error:
+      err 1
+      err 2
+"""
+    assert str(e) == expected
 
 
 @contextmanager

--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -160,12 +160,33 @@ os.write(1, bytes([0xff]))
         list(commands.watch("python3", "-c", script))
 
 
+# Formatting errors.
+
+
 def test_error():
     e = commands.Error(("arg1", "arg2"), exitcode=2, error="err 1\nerr 2\n")
     expected = """\
 Command failed:
    command: ('arg1', 'arg2')
    exitcode: 2
+   error:
+      err 1
+      err 2
+"""
+    assert str(e) == expected
+
+
+def test_error_with_output():
+    e = commands.Error(
+        ("arg1", "arg2"), exitcode=3, error="err 1\nerr 2\n", output="out 1\nout 2\n"
+    )
+    expected = """\
+Command failed:
+   command: ('arg1', 'arg2')
+   exitcode: 3
+   output:
+      out 1
+      out 2
    error:
       err 1
       err 2

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import drenv
+from . import commands
+
+
+def config(*args, profile=None):
+    """
+    Run kubectl config ... and return the output.
+    """
+    return _run("config", *args, profile=profile)
+
+
+def get(*args, profile=None):
+    """
+    Run kubectl get ... and return the output.
+    """
+    return _run("get", *args, profile=profile)
+
+
+def exec(*args, profile=None):
+    """
+    Run kubectl get ... and return the output.
+    """
+    return _run("exec", *args, profile=profile)
+
+
+def apply(*args, input=None, profile=None):
+    """
+    Run kubectl apply ... logging progress messages.
+    """
+    _watch("apply", *args, input=input, profile=profile)
+
+
+def patch(*args, profile=None):
+    """
+    Run kubectl patch ... logging progress messages.
+    """
+    _watch("patch", *args, profile=profile)
+
+
+def delete(*args, input=None, profile=None):
+    """
+    Run kubectl delete ... logging progress messages.
+    """
+    _watch("delete", *args, input=input, profile=profile)
+
+
+def rollout(*args, profile=None):
+    """
+    Run kubectl rollout ... logging progress messages.
+    """
+    _watch("rollout", *args, profile=profile)
+
+
+def wait(*args, profile=None):
+    """
+    Run kubectl wait ... logging progress messages.
+    """
+    _watch("wait", *args, profile=profile)
+
+
+def _run(cmd, *args, profile=None):
+    cmd = ["kubectl", cmd]
+    if profile:
+        cmd.extend(("--context", profile))
+    cmd.extend(args)
+    return commands.run(*cmd)
+
+
+def _watch(cmd, *args, input=None, profile=None):
+    cmd = ["kubectl", cmd]
+    if profile:
+        cmd.extend(("--context", profile))
+    cmd.extend(args)
+    for line in commands.watch(*cmd, input=input):
+        drenv.log_detail(line)

--- a/test/example/start
+++ b/test/example/start
@@ -14,9 +14,4 @@ if len(sys.argv) != 2:
 cluster = sys.argv[1]
 
 drenv.log_progress("Deploying example")
-drenv.kubectl(
-    "apply",
-    "--filename",
-    "example/deployment.yaml",
-    profile=cluster,
-)
+drenv.kubectl_apply("--filename", "example/deployment.yaml", profile=cluster)

--- a/test/example/start
+++ b/test/example/start
@@ -6,6 +6,7 @@
 import sys
 
 import drenv
+from drenv import kubectl
 
 if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
@@ -14,4 +15,4 @@ if len(sys.argv) != 2:
 cluster = sys.argv[1]
 
 drenv.log_progress("Deploying example")
-drenv.kubectl_apply("--filename", "example/deployment.yaml", profile=cluster)
+kubectl.apply("--filename", "example/deployment.yaml", profile=cluster)

--- a/test/example/test
+++ b/test/example/test
@@ -14,8 +14,7 @@ if len(sys.argv) != 2:
 cluster = sys.argv[1]
 
 drenv.log_progress("Testing example deployment")
-drenv.kubectl(
-    "rollout",
+drenv.kubectl_rollout(
     "status",
     "deploy/example-deployment",
     "--timeout",

--- a/test/example/test
+++ b/test/example/test
@@ -6,6 +6,7 @@
 import sys
 
 import drenv
+from drenv import kubectl
 
 if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
@@ -14,7 +15,7 @@ if len(sys.argv) != 2:
 cluster = sys.argv[1]
 
 drenv.log_progress("Testing example deployment")
-drenv.kubectl_rollout(
+kubectl.rollout(
     "status",
     "deploy/example-deployment",
     "--timeout",

--- a/test/minio/start
+++ b/test/minio/start
@@ -15,8 +15,7 @@ def deploy(cluster):
 
 def wait(cluster):
     drenv.log_progress("Waiting until minio is rolled out")
-    drenv.kubectl(
-        "rollout",
+    drenv.kubectl_rollout(
         "status",
         "deployment/minio",
         "--namespace",

--- a/test/minio/start
+++ b/test/minio/start
@@ -10,7 +10,7 @@ import drenv
 
 def deploy(cluster):
     drenv.log_progress("Deploying minio")
-    drenv.kubectl("apply", "--filename", "minio/minio.yaml", profile=cluster)
+    drenv.kubectl_apply("--filename", "minio/minio.yaml", profile=cluster)
 
 
 def wait(cluster):

--- a/test/minio/start
+++ b/test/minio/start
@@ -6,16 +6,17 @@
 import sys
 
 import drenv
+from drenv import kubectl
 
 
 def deploy(cluster):
     drenv.log_progress("Deploying minio")
-    drenv.kubectl_apply("--filename", "minio/minio.yaml", profile=cluster)
+    kubectl.apply("--filename", "minio/minio.yaml", profile=cluster)
 
 
 def wait(cluster):
     drenv.log_progress("Waiting until minio is rolled out")
-    drenv.kubectl_rollout(
+    kubectl.rollout(
         "status",
         "deployment/minio",
         "--namespace",

--- a/test/ocm-cluster/start
+++ b/test/ocm-cluster/start
@@ -6,6 +6,7 @@
 import sys
 
 import drenv
+from drenv import kubectl
 
 ADDONS = (
     "application-manager",
@@ -38,7 +39,7 @@ def wait(cluster):
     for name in ADDONS:
         deployment = f"deploy/{name}"
         drenv.wait_for(deployment, namespace=ADDONS_NAMESPACE, profile=cluster)
-        drenv.kubectl_rollout(
+        kubectl.rollout(
             "status",
             deployment,
             "--namespace",
@@ -58,7 +59,7 @@ def wait_for_hub(hub):
     for name in HUB_DEPLOYMENTS:
         deployment = f"deploy/{name}"
         drenv.wait_for(deployment, namespace=HUB_NAMESPACE, profile=hub)
-        drenv.kubectl_rollout(
+        kubectl.rollout(
             "status",
             deployment,
             "--namespace",

--- a/test/ocm-cluster/start
+++ b/test/ocm-cluster/start
@@ -6,6 +6,7 @@
 import sys
 
 import drenv
+from drenv import clusteradm
 from drenv import kubectl
 
 ADDONS = (
@@ -74,53 +75,29 @@ def join_cluster(cluster, hub):
     drenv.log_progress(f"Joining to cluster {hub}")
 
     # We can get the token from the first line of the response.
-    out = drenv.run("clusteradm", "get", "token", "--context", hub)
+    out = clusteradm.get("token", context=hub)
 
     token_line = out.splitlines()[0]
     key, hub_token = token_line.split("=", 1)
     assert key == "token"
 
-    drenv.watch(
-        "clusteradm",
-        "join",
-        "--hub-token",
-        hub_token,
-        "--hub-apiserver",
-        drenv.cluster_info(hub)["cluster"]["server"],
-        "--cluster-name",
-        cluster,
-        "--wait",
-        "--context",
-        cluster,
+    clusteradm.join(
+        hub_token=hub_token,
+        hub_apiserver=drenv.cluster_info(hub)["cluster"]["server"],
+        cluster_name=cluster,
+        wait=True,
+        context=cluster,
     )
 
 
 def accept_cluster(cluster, hub):
     drenv.log_progress("Accepting cluster")
-    drenv.watch(
-        "clusteradm",
-        "accept",
-        "--clusters",
-        cluster,
-        "--wait",
-        "--context",
-        hub,
-    )
+    clusteradm.accept([cluster], wait=True, context=hub)
 
 
 def enable_addons(cluster, hub):
     drenv.log_progress("Enabling addons")
-    drenv.watch(
-        "clusteradm",
-        "addon",
-        "enable",
-        "--names",
-        ",".join(ADDONS),
-        "--clusters",
-        cluster,
-        "--context",
-        hub,
-    )
+    clusteradm.addon("enable", names=ADDONS, clusters=[cluster], context=hub)
 
 
 if len(sys.argv) != 3:

--- a/test/ocm-cluster/start
+++ b/test/ocm-cluster/start
@@ -38,8 +38,7 @@ def wait(cluster):
     for name in ADDONS:
         deployment = f"deploy/{name}"
         drenv.wait_for(deployment, namespace=ADDONS_NAMESPACE, profile=cluster)
-        drenv.kubectl(
-            "rollout",
+        drenv.kubectl_rollout(
             "status",
             deployment,
             "--namespace",
@@ -59,8 +58,7 @@ def wait_for_hub(hub):
     for name in HUB_DEPLOYMENTS:
         deployment = f"deploy/{name}"
         drenv.wait_for(deployment, namespace=HUB_NAMESPACE, profile=hub)
-        drenv.kubectl(
-            "rollout",
+        drenv.kubectl_rollout(
             "status",
             deployment,
             "--namespace",

--- a/test/ocm-cluster/start
+++ b/test/ocm-cluster/start
@@ -74,20 +74,13 @@ def join_cluster(cluster, hub):
     drenv.log_progress(f"Joining to cluster {hub}")
 
     # We can get the token from the first line of the response.
-    out = drenv.run(
-        "clusteradm",
-        "get",
-        "token",
-        "--context",
-        hub,
-        verbose=False,
-    )
+    out = drenv.run("clusteradm", "get", "token", "--context", hub)
 
     token_line = out.splitlines()[0]
     key, hub_token = token_line.split("=", 1)
     assert key == "token"
 
-    drenv.run(
+    drenv.watch(
         "clusteradm",
         "join",
         "--hub-token",
@@ -104,7 +97,7 @@ def join_cluster(cluster, hub):
 
 def accept_cluster(cluster, hub):
     drenv.log_progress("Accepting cluster")
-    drenv.run(
+    drenv.watch(
         "clusteradm",
         "accept",
         "--clusters",
@@ -117,7 +110,7 @@ def accept_cluster(cluster, hub):
 
 def enable_addons(cluster, hub):
     drenv.log_progress("Enabling addons")
-    drenv.run(
+    drenv.watch(
         "clusteradm",
         "addon",
         "enable",

--- a/test/ocm-cluster/test
+++ b/test/ocm-cluster/test
@@ -15,8 +15,7 @@ def deploy_work(cluster, hub, work):
 
 def wait_for_work(cluster, hub):
     drenv.log_progress(f"Waiting until manifestwork is applied in namespace {cluster}")
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "manifestwork/example-manifestwork",
         "--for",
         "condition=applied",
@@ -32,8 +31,7 @@ def wait_for_deployment(cluster, hub):
     drenv.log_progress(
         f"Waiting until manifestwork is available in namespace {cluster}"
     )
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "manifestwork/example-manifestwork",
         "--for",
         "condition=available",
@@ -45,8 +43,7 @@ def wait_for_deployment(cluster, hub):
     )
 
     drenv.log_progress(f"Waiting until deployment is available in cluster {cluster}")
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "deploy/example-deployment",
         "--for",
         "condition=available",
@@ -63,8 +60,7 @@ def delete_work(cluster, hub, work):
 
 def wait_for_delete_work(cluster, hub):
     drenv.log_progress(f"Waiting until manifestwork is deleted from namspace {cluster}")
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "manifestwork/example-manifestwork",
         "--for",
         "delete",
@@ -78,8 +74,7 @@ def wait_for_delete_work(cluster, hub):
 
 def wait_for_delete_deployment(cluster):
     drenv.log_progress(f"Waiting until deployment is deleted from cluster {cluster}")
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "deploy/example-deployment",
         "--for",
         "delete",

--- a/test/ocm-cluster/test
+++ b/test/ocm-cluster/test
@@ -6,16 +6,17 @@
 import sys
 
 import drenv
+from drenv import kubectl
 
 
 def deploy_work(cluster, hub, work):
     drenv.log_progress(f"Applying manifestwork to namespace {cluster}")
-    drenv.kubectl_apply("--filename", "-", input=work, profile=hub)
+    kubectl.apply("--filename", "-", input=work, profile=hub)
 
 
 def wait_for_work(cluster, hub):
     drenv.log_progress(f"Waiting until manifestwork is applied in namespace {cluster}")
-    drenv.kubectl_wait(
+    kubectl.wait(
         "manifestwork/example-manifestwork",
         "--for",
         "condition=applied",
@@ -31,7 +32,7 @@ def wait_for_deployment(cluster, hub):
     drenv.log_progress(
         f"Waiting until manifestwork is available in namespace {cluster}"
     )
-    drenv.kubectl_wait(
+    kubectl.wait(
         "manifestwork/example-manifestwork",
         "--for",
         "condition=available",
@@ -43,7 +44,7 @@ def wait_for_deployment(cluster, hub):
     )
 
     drenv.log_progress(f"Waiting until deployment is available in cluster {cluster}")
-    drenv.kubectl_wait(
+    kubectl.wait(
         "deploy/example-deployment",
         "--for",
         "condition=available",
@@ -55,12 +56,12 @@ def wait_for_deployment(cluster, hub):
 
 def delete_work(cluster, hub, work):
     drenv.log_progress(f"Deleting manifestwork from namespace {cluster}")
-    drenv.kubectl_delete("--filename", "-", input=work, profile=hub)
+    kubectl.delete("--filename", "-", input=work, profile=hub)
 
 
 def wait_for_delete_work(cluster, hub):
     drenv.log_progress(f"Waiting until manifestwork is deleted from namspace {cluster}")
-    drenv.kubectl_wait(
+    kubectl.wait(
         "manifestwork/example-manifestwork",
         "--for",
         "delete",
@@ -74,7 +75,7 @@ def wait_for_delete_work(cluster, hub):
 
 def wait_for_delete_deployment(cluster):
     drenv.log_progress(f"Waiting until deployment is deleted from cluster {cluster}")
-    drenv.kubectl_wait(
+    kubectl.wait(
         "deploy/example-deployment",
         "--for",
         "delete",

--- a/test/ocm-cluster/test
+++ b/test/ocm-cluster/test
@@ -55,7 +55,7 @@ def wait_for_deployment(cluster, hub):
 
 def delete_work(cluster, hub, work):
     drenv.log_progress(f"Deleting manifestwork from namespace {cluster}")
-    drenv.kubectl("delete", "--filename", "-", input=work, profile=hub)
+    drenv.kubectl_delete("--filename", "-", input=work, profile=hub)
 
 
 def wait_for_delete_work(cluster, hub):

--- a/test/ocm-cluster/test
+++ b/test/ocm-cluster/test
@@ -10,7 +10,7 @@ import drenv
 
 def deploy_work(cluster, hub, work):
     drenv.log_progress(f"Applying manifestwork to namespace {cluster}")
-    drenv.kubectl("apply", "--filename", "-", input=work, profile=hub)
+    drenv.kubectl_apply("--filename", "-", input=work, profile=hub)
 
 
 def wait_for_work(cluster, hub):

--- a/test/ocm-controller/start
+++ b/test/ocm-controller/start
@@ -17,7 +17,7 @@ def deploy(cluster):
         "ocm-controller/kustomization.yaml",
         base_url=BASE_URL,
     ) as kustomization:
-        drenv.kubectl("apply", "--kustomize", kustomization, profile=cluster)
+        drenv.kubectl_apply("--kustomize", kustomization, profile=cluster)
 
 
 def wait(cluster):

--- a/test/ocm-controller/start
+++ b/test/ocm-controller/start
@@ -6,6 +6,7 @@
 import sys
 
 import drenv
+from drenv import kubectl
 
 VERSION = "v2.4.4-ACM"
 BASE_URL = f"https://raw.githubusercontent.com/stolostron/multicloud-operators-foundation/{VERSION}/deploy/foundation/hub"
@@ -17,12 +18,12 @@ def deploy(cluster):
         "ocm-controller/kustomization.yaml",
         base_url=BASE_URL,
     ) as kustomization:
-        drenv.kubectl_apply("--kustomize", kustomization, profile=cluster)
+        kubectl.apply("--kustomize", kustomization, profile=cluster)
 
 
 def wait(cluster):
     drenv.log_progress("Waiting for ocm controller rollout")
-    drenv.kubectl_rollout(
+    kubectl.rollout(
         "status",
         "deploy/ocm-controller",
         "--namespace",

--- a/test/ocm-controller/start
+++ b/test/ocm-controller/start
@@ -22,8 +22,7 @@ def deploy(cluster):
 
 def wait(cluster):
     drenv.log_progress("Waiting for ocm controller rollout")
-    drenv.kubectl(
-        "rollout",
+    drenv.kubectl_rollout(
         "status",
         "deploy/ocm-controller",
         "--namespace",

--- a/test/ocm-hub/start
+++ b/test/ocm-hub/start
@@ -33,10 +33,10 @@ DEPLOYMENTS = {
 
 def deploy(cluster):
     drenv.log_progress("Initializing hub")
-    drenv.run("clusteradm", "init", "--wait", "--context", cluster)
+    drenv.watch("clusteradm", "init", "--wait", "--context", cluster)
 
     drenv.log_progress("Installing hub addons")
-    drenv.run(
+    drenv.watch(
         "clusteradm",
         "install",
         "hub-addon",

--- a/test/ocm-hub/start
+++ b/test/ocm-hub/start
@@ -52,8 +52,7 @@ def wait(cluster):
         for name in names:
             deployment = f"deploy/{name}"
             drenv.wait_for(deployment, namespace=ns, profile=cluster)
-            drenv.kubectl(
-                "rollout",
+            drenv.kubectl_rollout(
                 "status",
                 deployment,
                 "--namespace",

--- a/test/ocm-hub/start
+++ b/test/ocm-hub/start
@@ -7,6 +7,7 @@ import sys
 
 import drenv
 from drenv import kubectl
+from drenv import clusteradm
 
 ADDONS = (
     "application-manager",
@@ -33,18 +34,10 @@ DEPLOYMENTS = {
 
 def deploy(cluster):
     drenv.log_progress("Initializing hub")
-    drenv.watch("clusteradm", "init", "--wait", "--context", cluster)
+    clusteradm.init(wait=True, context=cluster)
 
     drenv.log_progress("Installing hub addons")
-    drenv.watch(
-        "clusteradm",
-        "install",
-        "hub-addon",
-        "--names",
-        ",".join(ADDONS),
-        "--context",
-        cluster,
-    )
+    clusteradm.install("hub-addon", names=ADDONS, context=cluster)
 
 
 def wait(cluster):

--- a/test/ocm-hub/start
+++ b/test/ocm-hub/start
@@ -6,6 +6,7 @@
 import sys
 
 import drenv
+from drenv import kubectl
 
 ADDONS = (
     "application-manager",
@@ -52,7 +53,7 @@ def wait(cluster):
         for name in names:
             deployment = f"deploy/{name}"
             drenv.wait_for(deployment, namespace=ns, profile=cluster)
-            drenv.kubectl_rollout(
+            kubectl.rollout(
                 "status",
                 deployment,
                 "--namespace",

--- a/test/olm/start
+++ b/test/olm/start
@@ -43,8 +43,7 @@ def deploy(cluster):
 def wait(cluster):
     for operator in "olm-operator", "catalog-operator":
         drenv.log_progress(f"Waiting until {operator} is rolled out")
-        drenv.kubectl(
-            "rollout",
+        drenv.kubectl_rollout(
             "status",
             "deploy",
             operator,
@@ -73,8 +72,7 @@ def wait(cluster):
     )
 
     drenv.log_progress("Waiting for olm pakcage server rollout")
-    drenv.kubectl(
-        "rollout",
+    drenv.kubectl_rollout(
         "status",
         "deploy/packageserver",
         "--namespace",

--- a/test/olm/start
+++ b/test/olm/start
@@ -6,6 +6,7 @@
 import sys
 
 import drenv
+from drenv import kubectl
 
 VERSION = "v0.22.0"
 BASE_URL = f"https://github.com/operator-framework/operator-lifecycle-manager/releases/download/{VERSION}"
@@ -19,7 +20,7 @@ def deploy(cluster):
     #   The CustomResourceDefinition "clusterserviceversions.operators.coreos.com"
     #   is invalid: metadata.annotations: Too long: must have at most 262144 bytes
     # See https://medium.com/pareture/kubectl-install-crd-failed-annotations-too-long-2ebc91b40c7d
-    drenv.kubectl_apply(
+    kubectl.apply(
         "--filename",
         f"{BASE_URL}/crds.yaml",
         "--server-side=true",
@@ -27,7 +28,7 @@ def deploy(cluster):
     )
 
     drenv.log_progress("Waiting until cdrs are established")
-    drenv.kubectl_wait(
+    kubectl.wait(
         "--for",
         "condition=established",
         "--filename",
@@ -36,13 +37,13 @@ def deploy(cluster):
     )
 
     drenv.log_progress("Deploying olm")
-    drenv.kubectl_apply("--filename", f"{BASE_URL}/olm.yaml", profile=cluster)
+    kubectl.apply("--filename", f"{BASE_URL}/olm.yaml", profile=cluster)
 
 
 def wait(cluster):
     for operator in "olm-operator", "catalog-operator":
         drenv.log_progress(f"Waiting until {operator} is rolled out")
-        drenv.kubectl_rollout(
+        kubectl.rollout(
             "status",
             "deploy",
             operator,
@@ -58,7 +59,7 @@ def wait(cluster):
         namespace=NAMESPACE,
         profile=cluster,
     )
-    drenv.kubectl_wait(
+    kubectl.wait(
         "csv/packageserver",
         "--namespace",
         NAMESPACE,
@@ -70,7 +71,7 @@ def wait(cluster):
     )
 
     drenv.log_progress("Waiting for olm pakcage server rollout")
-    drenv.kubectl_rollout(
+    kubectl.rollout(
         "status",
         "deploy/packageserver",
         "--namespace",

--- a/test/olm/start
+++ b/test/olm/start
@@ -19,8 +19,7 @@ def deploy(cluster):
     #   The CustomResourceDefinition "clusterserviceversions.operators.coreos.com"
     #   is invalid: metadata.annotations: Too long: must have at most 262144 bytes
     # See https://medium.com/pareture/kubectl-install-crd-failed-annotations-too-long-2ebc91b40c7d
-    drenv.kubectl(
-        "apply",
+    drenv.kubectl_apply(
         "--filename",
         f"{BASE_URL}/crds.yaml",
         "--server-side=true",
@@ -38,12 +37,7 @@ def deploy(cluster):
     )
 
     drenv.log_progress("Deploying olm")
-    drenv.kubectl(
-        "apply",
-        "--filename",
-        f"{BASE_URL}/olm.yaml",
-        profile=cluster,
-    )
+    drenv.kubectl_apply("--filename", f"{BASE_URL}/olm.yaml", profile=cluster)
 
 
 def wait(cluster):

--- a/test/olm/start
+++ b/test/olm/start
@@ -27,8 +27,7 @@ def deploy(cluster):
     )
 
     drenv.log_progress("Waiting until cdrs are established")
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "--for",
         "condition=established",
         "--filename",
@@ -59,8 +58,7 @@ def wait(cluster):
         namespace=NAMESPACE,
         profile=cluster,
     )
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "csv/packageserver",
         "--namespace",
         NAMESPACE,

--- a/test/rbd-mirror/start
+++ b/test/rbd-mirror/start
@@ -72,8 +72,7 @@ def configure_rbd_mirroring(cluster, peer_info):
 
     drenv.log_progress(f"Configure peers for cluster {cluster}")
     patch = {"spec": {"mirroring": {"peers": {"secretNames": [peer_info["name"]]}}}}
-    drenv.kubectl(
-        "patch",
+    drenv.kubectl_patch(
         "cephblockpool",
         POOL_NAME,
         "--type",

--- a/test/rbd-mirror/start
+++ b/test/rbd-mirror/start
@@ -8,6 +8,7 @@ import json
 import sys
 
 import drenv
+from drenv import kubectl
 
 POOL_NAME = "replicapool"
 
@@ -16,7 +17,7 @@ def fetch_secret_info(cluster):
     info = {}
 
     drenv.log_progress(f"Getting mirroring info site name for cluster {cluster}")
-    info["name"] = drenv.kubectl_get(
+    info["name"] = kubectl.get(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
         "--output",
@@ -29,7 +30,7 @@ def fetch_secret_info(cluster):
     drenv.log_progress(
         f"Getting rbd mirror boostrap peer secret name for cluster {cluster}"
     )
-    secret_name = drenv.kubectl_get(
+    secret_name = kubectl.get(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
         "--output",
@@ -40,7 +41,7 @@ def fetch_secret_info(cluster):
     )
 
     drenv.log_progress(f"Getting secret {secret_name} token for cluster {cluster}")
-    info["token"] = drenv.kubectl_get(
+    info["token"] = kubectl.get(
         "secret",
         secret_name,
         "--output",
@@ -61,7 +62,7 @@ def configure_rbd_mirroring(cluster, peer_info):
 
     template = drenv.template("rbd-mirror/rbd-mirror-secret.yaml")
     yaml = template.substitute(peer_info)
-    drenv.kubectl_apply(
+    kubectl.apply(
         "--filename",
         "-",
         "--namespace",
@@ -72,7 +73,7 @@ def configure_rbd_mirroring(cluster, peer_info):
 
     drenv.log_progress(f"Configure peers for cluster {cluster}")
     patch = {"spec": {"mirroring": {"peers": {"secretNames": [peer_info["name"]]}}}}
-    drenv.kubectl_patch(
+    kubectl.patch(
         "cephblockpool",
         POOL_NAME,
         "--type",
@@ -85,7 +86,7 @@ def configure_rbd_mirroring(cluster, peer_info):
     )
 
     drenv.log_progress(f"Apply rbd mirror to cluster {cluster}")
-    drenv.kubectl_apply(
+    kubectl.apply(
         "--filename",
         "rbd-mirror/rbd-mirror.yaml",
         "--namespace",
@@ -98,7 +99,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
     drenv.log_progress(
         f"Waiting until ceph mirror daemon is healthy in cluster {cluster}"
     )
-    drenv.kubectl_wait(
+    kubectl.wait(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
         "--for",
@@ -111,7 +112,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
     )
 
     drenv.log_progress(f"Waiting until ceph mirror is healthy in cluster {cluster}")
-    drenv.kubectl_wait(
+    kubectl.wait(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
         "--for",
@@ -126,7 +127,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
     drenv.log_progress(
         f"Waiting until ceph mirror image is healthy in cluster {cluster}"
     )
-    drenv.kubectl_wait(
+    kubectl.wait(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
         "--for",
@@ -141,7 +142,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
 
 def deploy_vrc_sample(cluster):
     drenv.log_progress(f"Applying vrc sample in cluster {cluster}")
-    drenv.kubectl_apply(
+    kubectl.apply(
         "--filename",
         "rbd-mirror/vrc-sample.yaml",
         "--namespace",

--- a/test/rbd-mirror/start
+++ b/test/rbd-mirror/start
@@ -61,8 +61,7 @@ def configure_rbd_mirroring(cluster, peer_info):
 
     template = drenv.template("rbd-mirror/rbd-mirror-secret.yaml")
     yaml = template.substitute(peer_info)
-    drenv.kubectl(
-        "apply",
+    drenv.kubectl_apply(
         "--filename",
         "-",
         "--namespace",
@@ -87,8 +86,7 @@ def configure_rbd_mirroring(cluster, peer_info):
     )
 
     drenv.log_progress(f"Apply rbd mirror to cluster {cluster}")
-    drenv.kubectl(
-        "apply",
+    drenv.kubectl_apply(
         "--filename",
         "rbd-mirror/rbd-mirror.yaml",
         "--namespace",
@@ -147,8 +145,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
 
 def deploy_vrc_sample(cluster):
     drenv.log_progress(f"Applying vrc sample in cluster {cluster}")
-    drenv.kubectl(
-        "apply",
+    drenv.kubectl_apply(
         "--filename",
         "rbd-mirror/vrc-sample.yaml",
         "--namespace",

--- a/test/rbd-mirror/start
+++ b/test/rbd-mirror/start
@@ -16,8 +16,7 @@ def fetch_secret_info(cluster):
     info = {}
 
     drenv.log_progress(f"Getting mirroring info site name for cluster {cluster}")
-    info["name"] = drenv.kubectl(
-        "get",
+    info["name"] = drenv.kubectl_get(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
         "--output",
@@ -30,8 +29,7 @@ def fetch_secret_info(cluster):
     drenv.log_progress(
         f"Getting rbd mirror boostrap peer secret name for cluster {cluster}"
     )
-    secret_name = drenv.kubectl(
-        "get",
+    secret_name = drenv.kubectl_get(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
         "--output",
@@ -42,8 +40,7 @@ def fetch_secret_info(cluster):
     )
 
     drenv.log_progress(f"Getting secret {secret_name} token for cluster {cluster}")
-    info["token"] = drenv.kubectl(
-        "get",
+    info["token"] = drenv.kubectl_get(
         "secret",
         secret_name,
         "--output",

--- a/test/rbd-mirror/start
+++ b/test/rbd-mirror/start
@@ -99,8 +99,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
     drenv.log_progress(
         f"Waiting until ceph mirror daemon is healthy in cluster {cluster}"
     )
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
         "--for",
@@ -113,8 +112,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
     )
 
     drenv.log_progress(f"Waiting until ceph mirror is healthy in cluster {cluster}")
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
         "--for",
@@ -129,8 +127,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
     drenv.log_progress(
         f"Waiting until ceph mirror image is healthy in cluster {cluster}"
     )
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
         "--for",

--- a/test/rbd-mirror/test
+++ b/test/rbd-mirror/test
@@ -45,8 +45,7 @@ def rbd_mirror_image_status(cluster, image):
 
 def test_volume_replication(primary, secondary):
     drenv.log_progress(f"Deploying pvc {PVC_NAME} in cluster {primary}")
-    drenv.kubectl(
-        "apply",
+    drenv.kubectl_apply(
         "--filename",
         f"rbd-mirror/{PVC_NAME}.yaml",
         "--namespace",
@@ -69,8 +68,7 @@ def test_volume_replication(primary, secondary):
     )
 
     drenv.log_progress(f"Deploying vr vr-sample in cluster {primary}")
-    drenv.kubectl(
-        "apply",
+    drenv.kubectl_apply(
         "--filename",
         "rbd-mirror/vr-sample.yaml",
         "--namespace",

--- a/test/rbd-mirror/test
+++ b/test/rbd-mirror/test
@@ -188,8 +188,7 @@ def test_volume_replication(primary, secondary):
     drenv.log_detail(json.dumps(image_status, indent=2))
 
     drenv.log_progress(f"Deleting vr vr-sample in primary cluster {primary}")
-    drenv.kubectl(
-        "delete",
+    drenv.kubectl_delete(
         "volumereplication",
         "vr-sample",
         "--namespace",
@@ -198,8 +197,7 @@ def test_volume_replication(primary, secondary):
     )
 
     drenv.log_progress(f"Deleting pvc {PVC_NAME} in primary cluster {primary}")
-    drenv.kubectl(
-        "delete",
+    drenv.kubectl_delete(
         "pvc",
         PVC_NAME,
         "--namespace",

--- a/test/rbd-mirror/test
+++ b/test/rbd-mirror/test
@@ -14,8 +14,7 @@ PVC_NAME = "rbd-pvc"
 
 
 def rbd_mirror_image_status(cluster, image):
-    out = drenv.kubectl(
-        "exec",
+    out = drenv.kubectl_exec(
         "deploy/rook-ceph-tools",
         "--namespace",
         "rook-ceph",
@@ -28,7 +27,6 @@ def rbd_mirror_image_status(cluster, image):
         "--format",
         "json",
         profile=cluster,
-        verbose=False,
     )
     status = json.loads(out)
 
@@ -131,8 +129,7 @@ def test_volume_replication(primary, secondary):
     )
 
     drenv.log_progress(f"rbd image {rbd_image} info in cluster {primary}")
-    drenv.kubectl(
-        "exec",
+    out = drenv.kubectl_exec(
         "deploy/rook-ceph-tools",
         "--namespace",
         "rook-ceph",
@@ -144,14 +141,14 @@ def test_volume_replication(primary, secondary):
         POOL_NAME,
         profile=primary,
     )
+    drenv.log_detail(out)
 
     drenv.log_progress(
         f"Waiting until rbd image {rbd_image} is created in cluster {secondary}"
     )
     for i in range(60):
         time.sleep(1)
-        out = drenv.kubectl(
-            "exec",
+        out = drenv.kubectl_exec(
             "deploy/rook-ceph-tools",
             "--namespace",
             "rook-ceph",
@@ -163,8 +160,7 @@ def test_volume_replication(primary, secondary):
             profile=secondary,
         )
         if rbd_image in out:
-            drenv.kubectl(
-                "exec",
+            out = drenv.kubectl_exec(
                 "deploy/rook-ceph-tools",
                 "--namespace",
                 "rook-ceph",
@@ -176,6 +172,7 @@ def test_volume_replication(primary, secondary):
                 POOL_NAME,
                 profile=secondary,
             )
+            drenv.log_detail(out)
             break
     else:
         raise RuntimeError(f"Timeout waiting for image {rbd_image}")

--- a/test/rbd-mirror/test
+++ b/test/rbd-mirror/test
@@ -8,13 +8,14 @@ import sys
 import time
 
 import drenv
+from drenv import kubectl
 
 POOL_NAME = "replicapool"
 PVC_NAME = "rbd-pvc"
 
 
 def rbd_mirror_image_status(cluster, image):
-    out = drenv.kubectl_exec(
+    out = kubectl.exec(
         "deploy/rook-ceph-tools",
         "--namespace",
         "rook-ceph",
@@ -45,7 +46,7 @@ def rbd_mirror_image_status(cluster, image):
 
 def test_volume_replication(primary, secondary):
     drenv.log_progress(f"Deploying pvc {PVC_NAME} in cluster {primary}")
-    drenv.kubectl_apply(
+    kubectl.apply(
         "--filename",
         f"rbd-mirror/{PVC_NAME}.yaml",
         "--namespace",
@@ -54,7 +55,7 @@ def test_volume_replication(primary, secondary):
     )
 
     drenv.log_progress(f"Waiting until pvc {PVC_NAME} is bound in cluster {primary}")
-    drenv.kubectl_wait(
+    kubectl.wait(
         "pvc",
         PVC_NAME,
         "--for",
@@ -67,7 +68,7 @@ def test_volume_replication(primary, secondary):
     )
 
     drenv.log_progress(f"Deploying vr vr-sample in cluster {primary}")
-    drenv.kubectl_apply(
+    kubectl.apply(
         "--filename",
         "rbd-mirror/vr-sample.yaml",
         "--namespace",
@@ -76,7 +77,7 @@ def test_volume_replication(primary, secondary):
     )
 
     drenv.log_progress(f"Waiting until vr vr-sample is completed in cluster {primary}")
-    drenv.kubectl_wait(
+    kubectl.wait(
         "volumereplication",
         "vr-sample",
         "--for",
@@ -91,7 +92,7 @@ def test_volume_replication(primary, secondary):
     drenv.log_progress(
         f"Waiting until vr vr-sample state is primary in cluster {primary}"
     )
-    drenv.kubectl_wait(
+    kubectl.wait(
         "volumereplication",
         "vr-sample",
         "--for",
@@ -104,7 +105,7 @@ def test_volume_replication(primary, secondary):
     )
 
     drenv.log_progress(f"Looking up pvc {PVC_NAME} pv name in cluster {primary}")
-    pv_name = drenv.kubectl_get(
+    pv_name = kubectl.get(
         f"pvc/{PVC_NAME}",
         "--output",
         "jsonpath={.spec.volumeName}",
@@ -114,7 +115,7 @@ def test_volume_replication(primary, secondary):
     )
 
     drenv.log_progress(f"Looking up rbd image for pv {pv_name} in cluster {primary}")
-    rbd_image = drenv.kubectl_get(
+    rbd_image = kubectl.get(
         f"pv/{pv_name}",
         "--output",
         "jsonpath={.spec.csi.volumeAttributes.imageName}",
@@ -124,7 +125,7 @@ def test_volume_replication(primary, secondary):
     )
 
     drenv.log_progress(f"rbd image {rbd_image} info in cluster {primary}")
-    out = drenv.kubectl_exec(
+    out = kubectl.exec(
         "deploy/rook-ceph-tools",
         "--namespace",
         "rook-ceph",
@@ -143,7 +144,7 @@ def test_volume_replication(primary, secondary):
     )
     for i in range(60):
         time.sleep(1)
-        out = drenv.kubectl_exec(
+        out = kubectl.exec(
             "deploy/rook-ceph-tools",
             "--namespace",
             "rook-ceph",
@@ -155,7 +156,7 @@ def test_volume_replication(primary, secondary):
             profile=secondary,
         )
         if rbd_image in out:
-            out = drenv.kubectl_exec(
+            out = kubectl.exec(
                 "deploy/rook-ceph-tools",
                 "--namespace",
                 "rook-ceph",
@@ -173,7 +174,7 @@ def test_volume_replication(primary, secondary):
         raise RuntimeError(f"Timeout waiting for image {rbd_image}")
 
     drenv.log_progress(f"vr vr-sample info on primary cluster {primary}")
-    drenv.kubectl_get(
+    kubectl.get(
         "volumereplication",
         "vr-sample",
         "--output",
@@ -188,7 +189,7 @@ def test_volume_replication(primary, secondary):
     drenv.log_detail(json.dumps(image_status, indent=2))
 
     drenv.log_progress(f"Deleting vr vr-sample in primary cluster {primary}")
-    drenv.kubectl_delete(
+    kubectl.delete(
         "volumereplication",
         "vr-sample",
         "--namespace",
@@ -197,7 +198,7 @@ def test_volume_replication(primary, secondary):
     )
 
     drenv.log_progress(f"Deleting pvc {PVC_NAME} in primary cluster {primary}")
-    drenv.kubectl_delete(
+    kubectl.delete(
         "pvc",
         PVC_NAME,
         "--namespace",

--- a/test/rbd-mirror/test
+++ b/test/rbd-mirror/test
@@ -111,8 +111,7 @@ def test_volume_replication(primary, secondary):
     )
 
     drenv.log_progress(f"Looking up pvc {PVC_NAME} pv name in cluster {primary}")
-    pv_name = drenv.kubectl(
-        "get",
+    pv_name = drenv.kubectl_get(
         f"pvc/{PVC_NAME}",
         "--output",
         "jsonpath={.spec.volumeName}",
@@ -122,8 +121,7 @@ def test_volume_replication(primary, secondary):
     )
 
     drenv.log_progress(f"Looking up rbd image for pv {pv_name} in cluster {primary}")
-    rbd_image = drenv.kubectl(
-        "get",
+    rbd_image = drenv.kubectl_get(
         f"pv/{pv_name}",
         "--output",
         "jsonpath={.spec.csi.volumeAttributes.imageName}",
@@ -183,8 +181,7 @@ def test_volume_replication(primary, secondary):
         raise RuntimeError(f"Timeout waiting for image {rbd_image}")
 
     drenv.log_progress(f"vr vr-sample info on primary cluster {primary}")
-    drenv.kubectl(
-        "get",
+    drenv.kubectl_get(
         "volumereplication",
         "vr-sample",
         "--output",

--- a/test/rbd-mirror/test
+++ b/test/rbd-mirror/test
@@ -54,8 +54,7 @@ def test_volume_replication(primary, secondary):
     )
 
     drenv.log_progress(f"Waiting until pvc {PVC_NAME} is bound in cluster {primary}")
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "pvc",
         PVC_NAME,
         "--for",
@@ -77,8 +76,7 @@ def test_volume_replication(primary, secondary):
     )
 
     drenv.log_progress(f"Waiting until vr vr-sample is completed in cluster {primary}")
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "volumereplication",
         "vr-sample",
         "--for",
@@ -93,8 +91,7 @@ def test_volume_replication(primary, secondary):
     drenv.log_progress(
         f"Waiting until vr vr-sample state is primary in cluster {primary}"
     )
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "volumereplication",
         "vr-sample",
         "--for",

--- a/test/rook-cluster/start
+++ b/test/rook-cluster/start
@@ -18,7 +18,7 @@ def deploy(cluster):
         "rook-cluster/kustomization.yaml",
         base_url=BASE_URL,
     ) as kustomization:
-        drenv.kubectl("apply", "--kustomize", kustomization, profile=cluster)
+        drenv.kubectl_apply("--kustomize", kustomization, profile=cluster)
 
 
 def wait(cluster):

--- a/test/rook-cluster/start
+++ b/test/rook-cluster/start
@@ -6,6 +6,7 @@
 import sys
 
 import drenv
+from drenv import kubectl
 
 # Update this when upgrading rook.
 VERSION = "release-1.10"
@@ -18,7 +19,7 @@ def deploy(cluster):
         "rook-cluster/kustomization.yaml",
         base_url=BASE_URL,
     ) as kustomization:
-        drenv.kubectl_apply("--kustomize", kustomization, profile=cluster)
+        kubectl.apply("--kustomize", kustomization, profile=cluster)
 
 
 def wait(cluster):
@@ -30,7 +31,7 @@ def wait(cluster):
         timeout=60,
         profile=cluster,
     )
-    drenv.kubectl_wait(
+    kubectl.wait(
         "CephCluster",
         "my-cluster",
         "--for",

--- a/test/rook-cluster/start
+++ b/test/rook-cluster/start
@@ -30,8 +30,7 @@ def wait(cluster):
         timeout=60,
         profile=cluster,
     )
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "CephCluster",
         "my-cluster",
         "--for",

--- a/test/rook-operator/start
+++ b/test/rook-operator/start
@@ -23,8 +23,7 @@ def deploy(cluster):
 
 def wait(cluster):
     drenv.log_progress("Waiting until rook ceph operator is rolled out")
-    drenv.kubectl(
-        "rollout",
+    drenv.kubectl_rollout(
         "status",
         "deploy/rook-ceph-operator",
         "--namespace",

--- a/test/rook-operator/start
+++ b/test/rook-operator/start
@@ -18,7 +18,7 @@ def deploy(cluster):
         "rook-operator/kustomization.yaml",
         base_url=BASE_URL,
     ) as kustomization:
-        drenv.kubectl("apply", "--kustomize", kustomization, profile=cluster)
+        drenv.kubectl_apply("--kustomize", kustomization, profile=cluster)
 
 
 def wait(cluster):

--- a/test/rook-operator/start
+++ b/test/rook-operator/start
@@ -34,8 +34,7 @@ def wait(cluster):
     )
 
     drenv.log_progress("Waiting until rook ceph operator is ready")
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "pod",
         "--for",
         "jsonpath={.status.phase}=Running",

--- a/test/rook-operator/start
+++ b/test/rook-operator/start
@@ -6,6 +6,7 @@
 import sys
 
 import drenv
+from drenv import kubectl
 
 # Update this when upgrading rook.
 VERSION = "release-1.10"
@@ -18,12 +19,12 @@ def deploy(cluster):
         "rook-operator/kustomization.yaml",
         base_url=BASE_URL,
     ) as kustomization:
-        drenv.kubectl_apply("--kustomize", kustomization, profile=cluster)
+        kubectl.apply("--kustomize", kustomization, profile=cluster)
 
 
 def wait(cluster):
     drenv.log_progress("Waiting until rook ceph operator is rolled out")
-    drenv.kubectl_rollout(
+    kubectl.rollout(
         "status",
         "deploy/rook-ceph-operator",
         "--namespace",
@@ -34,7 +35,7 @@ def wait(cluster):
     )
 
     drenv.log_progress("Waiting until rook ceph operator is ready")
-    drenv.kubectl_wait(
+    kubectl.wait(
         "pod",
         "--for",
         "jsonpath={.status.phase}=Running",

--- a/test/rook-pool/start
+++ b/test/rook-pool/start
@@ -28,8 +28,7 @@ def wait(cluster):
         timeout=60,
         profile=cluster,
     )
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "CephBlockPool",
         "replicapool",
         "--for",
@@ -42,8 +41,7 @@ def wait(cluster):
     )
 
     drenv.log_progress("Waiting for replica pool peer token")
-    drenv.kubectl(
-        "wait",
+    drenv.kubectl_wait(
         "CephBlockPool",
         "replicapool",
         "--for",

--- a/test/rook-pool/start
+++ b/test/rook-pool/start
@@ -6,11 +6,12 @@
 import sys
 
 import drenv
+from drenv import kubectl
 
 
 def deploy(cluster):
     drenv.log_progress("Creating rbd pool and storage class")
-    drenv.kubectl_apply(
+    kubectl.apply(
         "--filename",
         "rook-pool/replica-pool.yaml",
         "--filename",
@@ -28,7 +29,7 @@ def wait(cluster):
         timeout=60,
         profile=cluster,
     )
-    drenv.kubectl_wait(
+    kubectl.wait(
         "CephBlockPool",
         "replicapool",
         "--for",
@@ -41,7 +42,7 @@ def wait(cluster):
     )
 
     drenv.log_progress("Waiting for replica pool peer token")
-    drenv.kubectl_wait(
+    kubectl.wait(
         "CephBlockPool",
         "replicapool",
         "--for",

--- a/test/rook-pool/start
+++ b/test/rook-pool/start
@@ -10,8 +10,7 @@ import drenv
 
 def deploy(cluster):
     drenv.log_progress("Creating rbd pool and storage class")
-    drenv.kubectl(
-        "apply",
+    drenv.kubectl_apply(
         "--filename",
         "rook-pool/replica-pool.yaml",
         "--filename",

--- a/test/rook-toolbox/start
+++ b/test/rook-toolbox/start
@@ -19,8 +19,7 @@ def deploy(cluster):
 
 def wait(cluster):
     drenv.log_progress("Waiting until rook-ceph-tools is rolled out")
-    drenv.kubectl(
-        "rollout",
+    drenv.kubectl_rollout(
         "status",
         "deploy/rook-ceph-tools",
         "--namespace",

--- a/test/rook-toolbox/start
+++ b/test/rook-toolbox/start
@@ -6,6 +6,7 @@
 import sys
 
 import drenv
+from drenv import kubectl
 
 # Update this when upgrading rook.
 VERSION = "release-1.10"
@@ -14,12 +15,12 @@ BASE_URL = f"https://raw.githubusercontent.com/rook/rook/{VERSION}/deploy/exampl
 
 def deploy(cluster):
     drenv.log_progress("Deploying rook ceph toolbox")
-    drenv.kubectl_apply("--filename", f"{BASE_URL}/toolbox.yaml", profile=cluster)
+    kubectl.apply("--filename", f"{BASE_URL}/toolbox.yaml", profile=cluster)
 
 
 def wait(cluster):
     drenv.log_progress("Waiting until rook-ceph-tools is rolled out")
-    drenv.kubectl_rollout(
+    kubectl.rollout(
         "status",
         "deploy/rook-ceph-tools",
         "--namespace",

--- a/test/rook-toolbox/start
+++ b/test/rook-toolbox/start
@@ -14,12 +14,7 @@ BASE_URL = f"https://raw.githubusercontent.com/rook/rook/{VERSION}/deploy/exampl
 
 def deploy(cluster):
     drenv.log_progress("Deploying rook ceph toolbox")
-    drenv.kubectl(
-        "apply",
-        "--filename",
-        f"{BASE_URL}/toolbox.yaml",
-        profile=cluster,
-    )
+    drenv.kubectl_apply("--filename", f"{BASE_URL}/toolbox.yaml", profile=cluster)
 
 
 def wait(cluster):


### PR DESCRIPTION
Add new helpers to the commands module:

- `commands.watch()` - helper for running commands reading both stdout and stderr, raising detailed errors. drenv tool uses commands.watch() to run all commands, improving error message in the tool.
- `commands.run()` - helper for running commands buffering stdout and stderr, raising detailed errors.

Add `drenv.kubectl` and `drenv.clusteradm` modules, using the `drenv.commands` module to run
commands.

Scripts updated to use the new modules instead of `drevn.kubectl()` and `drenv.run()`.

This change will enable also #664.

Fixes: #648