### PR TITLE
Support stop hook

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -488,6 +488,12 @@ based on the hook file name.
 | stop         | stop          | before cluster is stopped           |
 | delete       | -             |                                     |
 
+The `start` and `test` scripts are not allowed to fail. If a script
+fail, execution stops and the entire command will fail.
+
+The `stop` script is allowed to fail. The failure is logged but the
+`stop` command will not fail.
+
 #### Script arguments
 
 When specifying script `args`, you can use the special variable `$name`.

--- a/test/README.md
+++ b/test/README.md
@@ -482,11 +482,11 @@ $ drenv delete example.yaml
 The script direcotry may contain scripts to be run on certain events,
 based on the hook file name.
 
-| Event        | Scripts       |
-|--------------|---------------|
-| start        | start, test   |
-| stop         | -             |
-| delete       | -             |
+| Event        | Scripts       | Comment                             |
+|--------------|---------------|-------------------------------------|
+| start        | start, test   | after cluster was started           |
+| stop         | stop          | before cluster is stopped           |
+| delete       | -             |                                     |
 
 #### Script arguments
 


### PR DESCRIPTION
Add support for stop hook, running before stopping the clusters with minikube.

Tested manully by adding a working and broken stop hook to the example env.