### PR TITLE
Improve reliability or starting and stopping the enviroment

### DIFF
--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -141,6 +141,16 @@ def cluster_status(cluster):
     return json.loads(out)
 
 
+def cluster_exists(cluster):
+    out = run("minikube", "profile", "list", "--output=json", verbose=False)
+    profiles = json.loads(out)
+    for profile in profiles["valid"]:
+        if profile["Name"] == cluster:
+            return True
+
+    return False
+
+
 def cluster_info(cluster):
     """
     Return cluster info from kubectl config. Returns empty dict if the cluster

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -106,7 +106,7 @@ def start_cluster(profile):
     start = time.monotonic()
     logging.info("[%s] Starting cluster", profile["name"])
 
-    is_restart = drenv.cluster_info(profile["name"]) != {}
+    is_restart = drenv.cluster_exists(profile["name"])
 
     minikube(
         "start",

--- a/test/example/deployment.yaml
+++ b/test/example/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: example
-        image: quay.io/quay/busybox
+        image: docker.io/library/busybox:stable
         command:
         - sh
         - -c

--- a/test/example/deployment.yaml
+++ b/test/example/deployment.yaml
@@ -20,4 +20,13 @@ spec:
       containers:
       - name: example
         image: quay.io/quay/busybox
-        command: ["sh", "-c", "while true; do date; sleep 10; done"]
+        command:
+        - sh
+        - -c
+        - |
+          trap exit TERM
+          while true; do
+              date
+              sleep 10 &
+              wait  # interrupted quickly on signal.
+          done

--- a/test/example/test
+++ b/test/example/test
@@ -19,6 +19,6 @@ drenv.kubectl(
     "status",
     "deploy/example-deployment",
     "--timeout",
-    "60s",
+    "180s",
     profile=cluster,
 )


### PR DESCRIPTION
- Fix waiting for deployments when starting a stopped cluster
- Avoids delays when stopping the example environment (75x times faster)
- Avoids unwanted network access in example deployment by using busybox:stable
- Avoids timeouts when testing the example deployment
