### PR TITLE
Fix .vimrc.example for script hooks

### DIFF
--- a/test/.vimrc.example
+++ b/test/.vimrc.example
@@ -12,5 +12,5 @@
 
 augroup black_on_save
   autocmd!
-  autocmd BufWritePre *.py Black
+  autocmd FileType python autocmd BufWritePre * Black
 augroup end


### PR DESCRIPTION
Run black for buffer with python file type instead of matching on the file name, which works only for modules.