### PR TITLE
Finally fix .vimrc.example

### DIFF
--- a/test/.vimrc.example
+++ b/test/.vimrc.example
@@ -12,5 +12,5 @@
 
 augroup black_on_save
   autocmd!
-  autocmd FileType python autocmd BufWritePre * Black
+  autocmd BufWritePre * if &filetype == 'python'|execute ':Black'|endif
 augroup end


### PR DESCRIPTION
Nesting autocmd works, but it has the unwanted effect of adding the same autocmd to all buffers multiple times, so when we edit multiple files we reformat the file multiple times on save.

Change to install a conditional command that formats the file with black only if the current file type is python.