### PR TITLE
Fix PV reclaim policy when VRG is deleting

### DIFF
--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -324,8 +324,7 @@ func (v *VRGInstance) preparePVCForVRDeletion(pvc *corev1.PersistentVolumeClaim,
 	// to the current cluster, in case the PVC has been deleted (cases like STS the
 	// PVC may not be deleted). This is achieved by clearing the required claim ref.
 	// such that the PV can bind back to a recreated PVC. func ref.: updateExistingPVForSync
-	if v.instance.Spec.ReplicationState == ramendrv1alpha1.Secondary &&
-		v.instance.Spec.Async != nil {
+	if v.instance.Spec.Async != nil || v.instance.Spec.ReplicationState == ramendrv1alpha1.Primary {
 		if err := v.undoPVRetentionForPVC(*pvc, log); err != nil {
 			return err
 		}


### PR DESCRIPTION
BZ: #2155976 was filed due to leaving the PV in a *Reclaim Policy* `Retain` when the application is deleted.
The fix in this PR is to ALWAYS change the Reclaim Policy to `Delete` when VRG is being deleted on RDR workload.
On MDR workload, only make the modification if the ReplicationState is `Primary`.

Signed-off-by: Benamar Mekhissi <bmekhiss@redhat.com>