### PR TITLE
Add drenv integration tests using podman driver

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -100,6 +100,9 @@ jobs:
       - name: Install tools
         run: pip install -r test/requirements.txt
 
+      - name: Enable coverage for child processes
+        run: cp test/coverage.pth $(python -m site --user-site)
+
       - name: Install drenv
         run: pip install -e test
 

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -84,6 +84,19 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
 
+      - name: Install minikube
+        run: |
+          curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+          sudo install minikube-linux-amd64 /usr/local/bin/minikube
+          minikube version
+          mkdir "$HOME/.minikube/profiles"
+
+      - name: Install kubectl
+        run: |
+          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          sudo install ./kubectl /usr/local/bin/
+          kubectl version --client --output=yaml
+
       - name: Install tools
         run: pip install -r test/requirements.txt
 

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ config/hub/bundle
 test/drenv.egg-info/
 test/**/__pycache__/
 test/.coverage
+test/.coverage.*
 test/.vimrc

--- a/test/.coveragerc
+++ b/test/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+parallel = True
+source = drenv
+omit = drenv/*_test.py

--- a/test/Makefile
+++ b/test/Makefile
@@ -13,7 +13,9 @@ black-reformat:
 	python3 -m black drenv */start */test
 
 test:
-	python3 -m coverage run --source drenv -m pytest
+	rm -f .coverage.*
+	COVERAGE_PROCESS_START=.coveragerc python3 -m coverage run -m pytest
+	python3 -m coverage combine --quiet
 
 coverage:
 	python3 -m coverage report

--- a/test/README.md
+++ b/test/README.md
@@ -423,6 +423,8 @@ $ drenv delete example.yaml
 
 - `templates`: templates for creating new profiles.
     - `name`: profile name.
+    - `driver`: The minikube driver. Tested with "kvm2" and "podman"
+      (default "kvm2")
     - `container_runtime`: The container runtime to be used. Valid
       options: "docker", "cri-o", "containerd" (default: "containerd")
     - `network`: The network to run minikube with. If left empty,

--- a/test/README.md
+++ b/test/README.md
@@ -509,6 +509,15 @@ This is a configuration for testing regional DR using a hub cluster and
 pip install -r requirements.txt
 ```
 
+### Enabling full test coverage
+
+To enable test coverage for child processes, copy the `coverage.pth`
+file to the python installation:
+
+```
+cp coverage.pth ~/.venv/ramen/lib/python*/site-packages
+```
+
 ### Running the tests
 
 Run all linters and tests and report test coverage:

--- a/test/README.md
+++ b/test/README.md
@@ -132,6 +132,8 @@ clusters and how to deploy them.
 name: example
 templates:
   - name: "example-cluster"
+    driver: podman
+    container_runtime: cri-o
     workers:
       - scripts:
           - name: example
@@ -155,20 +157,20 @@ the deployment is available on both clusters.
 
 ```
 $ drenv start example.yaml
-2022-12-01 23:30:25,294 INFO    [example] Starting environment
-2022-12-01 23:30:25,295 INFO    [ex1] Starting cluster
-2022-12-01 23:30:26,296 INFO    [ex2] Starting cluster
-2022-12-01 23:31:04,112 INFO    [ex1] Cluster started in 38.82 seconds
-2022-12-01 23:31:04,113 INFO    [ex1/0] Running example/start
-2022-12-01 23:31:04,366 INFO    [ex1/0] example/start completed in 0.25 seconds
-2022-12-01 23:31:04,366 INFO    [ex1/0] Running example/test
-2022-12-01 23:31:18,404 INFO    [ex1/0] example/test completed in 14.04 seconds
-2022-12-01 23:31:18,925 INFO    [ex2] Cluster started in 52.63 seconds
-2022-12-01 23:31:18,925 INFO    [ex2/0] Running example/start
-2022-12-01 23:31:19,152 INFO    [ex2/0] example/start completed in 0.23 seconds
-2022-12-01 23:31:19,152 INFO    [ex2/0] Running example/test
-2022-12-01 23:31:34,413 INFO    [ex2/0] example/test completed in 15.26 seconds
-2022-12-01 23:31:34,414 INFO    [example] Environment started in 69.12 seconds
+2023-01-03 23:20:17,822 INFO    [example] Starting environment
+2023-01-03 23:20:17,823 INFO    [ex1] Starting cluster
+2023-01-03 23:20:18,824 INFO    [ex2] Starting cluster
+2023-01-03 23:20:41,037 INFO    [ex1] Cluster started in 23.21 seconds
+2023-01-03 23:20:41,038 INFO    [ex1/0] Running example/start
+2023-01-03 23:20:41,200 INFO    [ex1/0] example/start completed in 0.16 seconds
+2023-01-03 23:20:41,200 INFO    [ex1/0] Running example/test
+2023-01-03 23:20:42,212 INFO    [ex2] Cluster started in 23.39 seconds
+2023-01-03 23:20:42,212 INFO    [ex2/0] Running example/start
+2023-01-03 23:20:42,387 INFO    [ex2/0] example/start completed in 0.17 seconds
+2023-01-03 23:20:42,387 INFO    [ex2/0] Running example/test
+2023-01-03 23:20:59,249 INFO    [ex1/0] example/test completed in 18.05 seconds
+2023-01-03 23:21:01,474 INFO    [ex2/0] example/test completed in 19.09 seconds
+2023-01-03 23:21:01,474 INFO    [example] Environment started in 43.65 seconds
 ```
 
 #### Inspecting the clusters with minikube
@@ -177,12 +179,12 @@ We can use minikube to inspect or access the clusters:
 
 ```
 $ minikube profile list
-|---------|-----------|------------|----------------|------|---------|---------|-------|--------|
-| Profile | VM Driver |  Runtime   |       IP       | Port | Version | Status  | Nodes | Active |
-|---------|-----------|------------|----------------|------|---------|---------|-------|--------|
-| ex1     | kvm2      | containerd | 192.168.39.198 | 8443 | v1.25.3 | Running |     1 |        |
-| ex2     | kvm2      | containerd | 192.168.50.184 | 8443 | v1.25.3 | Running |     1 |        |
-|---------|-----------|------------|----------------|------|---------|---------|-------|--------|
+|---------|-----------|---------|--------------|------|---------|---------|-------|--------|
+| Profile | VM Driver | Runtime |      IP      | Port | Version | Status  | Nodes | Active |
+|---------|-----------|---------|--------------|------|---------|---------|-------|--------|
+| ex1     | podman    | crio    | 192.168.49.2 | 8443 | v1.25.3 | Running |     1 |        |
+| ex2     | podman    | crio    | 10.88.0.166  | 8443 | v1.25.3 | Running |     1 |        |
+|---------|-----------|---------|--------------|------|---------|---------|-------|--------|
 ```
 
 #### Inspecting the clusters with kubectl
@@ -191,14 +193,14 @@ We can use kubectl to access the clusters:
 
 ```
 $ kubectl logs deploy/example-deployment --context ex1
-Thu Dec  1 21:31:18 UTC 2022
-Thu Dec  1 21:31:28 UTC 2022
-Thu Dec  1 21:31:38 UTC 2022
+Tue Jan  3 21:20:58 UTC 2023
+Tue Jan  3 21:21:08 UTC 2023
+Tue Jan  3 21:21:18 UTC 2023
 
 $ kubectl logs deploy/example-deployment --context ex2
-Thu Dec  1 21:31:34 UTC 2022
-Thu Dec  1 21:31:44 UTC 2022
-Thu Dec  1 21:31:54 UTC 2022
+Tue Jan  3 21:21:00 UTC 2023
+Tue Jan  3 21:21:10 UTC 2023
+Tue Jan  3 21:21:20 UTC 2023
 ```
 
 #### Isolating environments with --name-prefix
@@ -211,66 +213,66 @@ Start first instance:
 
 ```
 $ drenv start --name-prefix test1- example.yaml
-2022-12-01 23:35:39,919 INFO    [test1-example] Starting environment
-2022-12-01 23:35:39,921 INFO    [test1-ex1] Starting cluster
-2022-12-01 23:35:40,923 INFO    [test1-ex2] Starting cluster
-2022-12-01 23:36:19,035 INFO    [test1-ex1] Cluster started in 39.11 seconds
-2022-12-01 23:36:19,035 INFO    [test1-ex1/0] Running example/start
-2022-12-01 23:36:19,257 INFO    [test1-ex1/0] example/start completed in 0.22 seconds
-2022-12-01 23:36:19,257 INFO    [test1-ex1/0] Running example/test
-2022-12-01 23:36:34,458 INFO    [test1-ex1/0] example/test completed in 15.20 seconds
-2022-12-01 23:36:37,469 INFO    [test1-ex2] Cluster started in 56.55 seconds
-2022-12-01 23:36:37,469 INFO    [test1-ex2/0] Running example/start
-2022-12-01 23:36:37,737 INFO    [test1-ex2/0] example/start completed in 0.27 seconds
-2022-12-01 23:36:37,737 INFO    [test1-ex2/0] Running example/test
-2022-12-01 23:36:52,942 INFO    [test1-ex2/0] example/test completed in 15.21 seconds
-2022-12-01 23:36:52,942 INFO    [test1-example] Environment started in 73.02 seconds
+2023-01-03 23:35:38,328 INFO    [test1-example] Starting environment
+2023-01-03 23:35:38,330 INFO    [test1-ex1] Starting cluster
+2023-01-03 23:35:39,330 INFO    [test1-ex2] Starting cluster
+2023-01-03 23:36:01,923 INFO    [test1-ex1] Cluster started in 23.59 seconds
+2023-01-03 23:36:01,924 INFO    [test1-ex1/0] Running example/start
+2023-01-03 23:36:02,153 INFO    [test1-ex1/0] example/start completed in 0.23 seconds
+2023-01-03 23:36:02,153 INFO    [test1-ex1/0] Running example/test
+2023-01-03 23:36:02,428 INFO    [test1-ex2] Cluster started in 23.10 seconds
+2023-01-03 23:36:02,429 INFO    [test1-ex2/0] Running example/start
+2023-01-03 23:36:02,608 INFO    [test1-ex2/0] example/start completed in 0.18 seconds
+2023-01-03 23:36:02,608 INFO    [test1-ex2/0] Running example/test
+2023-01-03 23:36:21,114 INFO    [test1-ex1/0] example/test completed in 18.96 seconds
+2023-01-03 23:36:22,616 INFO    [test1-ex2/0] example/test completed in 20.01 seconds
+2023-01-03 23:36:22,616 INFO    [test1-example] Environment started in 44.29 seconds
 ```
 
 This creates:
 
 ```
 $ minikube profile list
-|-----------|-----------|------------|---------------|------|---------|---------|-------|--------|
-|  Profile  | VM Driver |  Runtime   |      IP       | Port | Version | Status  | Nodes | Active |
-|-----------|-----------|------------|---------------|------|---------|---------|-------|--------|
-| test1-ex1 | kvm2      | containerd | 192.168.39.54 | 8443 | v1.25.3 | Running |     1 |        |
-| test1-ex2 | kvm2      | containerd | 192.168.50.76 | 8443 | v1.25.3 | Running |     1 |        |
-|-----------|-----------|------------|---------------|------|---------|---------|-------|--------|
+|-----------|-----------|---------|--------------|------|---------|---------|-------|--------|
+|  Profile  | VM Driver | Runtime |      IP      | Port | Version | Status  | Nodes | Active |
+|-----------|-----------|---------|--------------|------|---------|---------|-------|--------|
+| test1-ex1 | podman    | crio    | 192.168.49.2 | 8443 | v1.25.3 | Running |     1 |        |
+| test1-ex2 | podman    | crio    | 10.88.0.196  | 8443 | v1.25.3 | Running |     1 |        |
+|-----------|-----------|---------|--------------|------|---------|---------|-------|--------|
 ```
 
 Start second instance:
 
 ```
 $ drenv start --name-prefix test2- example.yaml
-2022-12-01 23:38:01,812 INFO    [test2-example] Starting environment
-2022-12-01 23:38:01,814 INFO    [test2-ex1] Starting cluster
-2022-12-01 23:38:02,815 INFO    [test2-ex2] Starting cluster
-2022-12-01 23:38:40,707 INFO    [test2-ex1] Cluster started in 38.89 seconds
-2022-12-01 23:38:40,707 INFO    [test2-ex1/0] Running example/start
-2022-12-01 23:38:40,980 INFO    [test2-ex1/0] example/start completed in 0.27 seconds
-2022-12-01 23:38:40,980 INFO    [test2-ex1/0] Running example/test
-2022-12-01 23:38:54,988 INFO    [test2-ex1/0] example/test completed in 14.01 seconds
-2022-12-01 23:38:56,653 INFO    [test2-ex2] Cluster started in 53.84 seconds
-2022-12-01 23:38:56,653 INFO    [test2-ex2/0] Running example/start
-2022-12-01 23:38:56,890 INFO    [test2-ex2/0] example/start completed in 0.24 seconds
-2022-12-01 23:38:56,890 INFO    [test2-ex2/0] Running example/test
-2022-12-01 23:39:12,155 INFO    [test2-ex2/0] example/test completed in 15.26 seconds
-2022-12-01 23:39:12,156 INFO    [test2-example] Environment started in 70.34 seconds
+2023-01-03 23:36:44,181 INFO    [test2-example] Starting environment
+2023-01-03 23:36:44,182 INFO    [test2-ex1] Starting cluster
+2023-01-03 23:36:45,183 INFO    [test2-ex2] Starting cluster
+2023-01-03 23:37:08,685 INFO    [test2-ex2] Cluster started in 23.50 seconds
+2023-01-03 23:37:08,686 INFO    [test2-ex2/0] Running example/start
+2023-01-03 23:37:08,901 INFO    [test2-ex2/0] example/start completed in 0.22 seconds
+2023-01-03 23:37:08,901 INFO    [test2-ex2/0] Running example/test
+2023-01-03 23:37:08,969 INFO    [test2-ex1] Cluster started in 24.79 seconds
+2023-01-03 23:37:08,969 INFO    [test2-ex1/0] Running example/start
+2023-01-03 23:37:09,132 INFO    [test2-ex1/0] example/start completed in 0.16 seconds
+2023-01-03 23:37:09,132 INFO    [test2-ex1/0] Running example/test
+2023-01-03 23:37:26,811 INFO    [test2-ex2/0] example/test completed in 17.91 seconds
+2023-01-03 23:37:27,119 INFO    [test2-ex1/0] example/test completed in 17.99 seconds
+2023-01-03 23:37:27,119 INFO    [test2-example] Environment started in 42.94 seconds
 ```
 
 This adds new profiles:
 
 ```
 $ minikube profile list
-|-----------|-----------|------------|----------------|------|---------|---------|-------|--------|
-|  Profile  | VM Driver |  Runtime   |       IP       | Port | Version | Status  | Nodes | Active |
-|-----------|-----------|------------|----------------|------|---------|---------|-------|--------|
-| test1-ex1 | kvm2      | containerd | 192.168.39.54  | 8443 | v1.25.3 | Running |     1 |        |
-| test1-ex2 | kvm2      | containerd | 192.168.50.76  | 8443 | v1.25.3 | Running |     1 |        |
-| test2-ex1 | kvm2      | containerd | 192.168.72.116 | 8443 | v1.25.3 | Running |     1 |        |
-| test2-ex2 | kvm2      | containerd | 192.168.83.20  | 8443 | v1.25.3 | Running |     1 |        |
-|-----------|-----------|------------|----------------|------|---------|---------|-------|--------|
+|-----------|-----------|---------|--------------|------|---------|---------|-------|--------|
+|  Profile  | VM Driver | Runtime |      IP      | Port | Version | Status  | Nodes | Active |
+|-----------|-----------|---------|--------------|------|---------|---------|-------|--------|
+| test1-ex1 | podman    | crio    | 192.168.49.2 | 8443 | v1.25.3 | Running |     1 |        |
+| test1-ex2 | podman    | crio    | 10.88.0.196  | 8443 | v1.25.3 | Running |     1 |        |
+| test2-ex1 | podman    | crio    | 192.168.58.2 | 8443 | v1.25.3 | Running |     1 |        |
+| test2-ex2 | podman    | crio    | 10.88.0.201  | 8443 | v1.25.3 | Running |     1 |        |
+|-----------|-----------|---------|--------------|------|---------|---------|-------|--------|
 ```
 
 You must use the same `--name-prefix` when stopping or deleting the
@@ -298,24 +300,24 @@ scratch.
 
 ```
 $ drenv start example.yaml
-2022-12-01 23:41:15,543 INFO    [example] Starting environment
-2022-12-01 23:41:15,545 INFO    [ex1] Starting cluster
-2022-12-01 23:41:16,546 INFO    [ex2] Starting cluster
-2022-12-01 23:41:29,160 INFO    [ex1] Cluster started in 13.62 seconds
-2022-12-01 23:41:29,160 INFO    [ex1] Waiting until all deployments are available
-2022-12-01 23:41:29,874 INFO    [ex2] Cluster started in 13.33 seconds
-2022-12-01 23:41:29,874 INFO    [ex2] Waiting until all deployments are available
-2022-12-01 23:41:59,512 INFO    [ex1] Deployments are available in 30.35 seconds
-2022-12-01 23:41:59,513 INFO    [ex1/0] Running example/start
-2022-12-01 23:41:59,711 INFO    [ex1/0] example/start completed in 0.20 seconds
-2022-12-01 23:41:59,711 INFO    [ex1/0] Running example/test
-2022-12-01 23:41:59,839 INFO    [ex1/0] example/test completed in 0.13 seconds
-2022-12-01 23:42:00,228 INFO    [ex2] Deployments are available in 30.35 seconds
-2022-12-01 23:42:00,228 INFO    [ex2/0] Running example/start
-2022-12-01 23:42:00,431 INFO    [ex2/0] example/start completed in 0.20 seconds
-2022-12-01 23:42:00,431 INFO    [ex2/0] Running example/test
-2022-12-01 23:42:00,560 INFO    [ex2/0] example/test completed in 0.13 seconds
-2022-12-01 23:42:00,560 INFO    [example] Environment started in 45.02 seconds
+2023-01-03 23:40:25,451 INFO    [example] Starting environment
+2023-01-03 23:40:25,452 INFO    [ex1] Starting cluster
+2023-01-03 23:40:26,453 INFO    [ex2] Starting cluster
+2023-01-03 23:40:29,972 INFO    [ex1] Cluster started in 4.52 seconds
+2023-01-03 23:40:29,972 INFO    [ex1] Waiting until all deployments are available
+2023-01-03 23:40:30,658 INFO    [ex2] Cluster started in 4.20 seconds
+2023-01-03 23:40:30,658 INFO    [ex2] Waiting until all deployments are available
+2023-01-03 23:41:00,224 INFO    [ex1] Deployments are available in 30.25 seconds
+2023-01-03 23:41:00,225 INFO    [ex1/0] Running example/start
+2023-01-03 23:41:00,381 INFO    [ex1/0] example/start completed in 0.16 seconds
+2023-01-03 23:41:00,381 INFO    [ex1/0] Running example/test
+2023-01-03 23:41:00,467 INFO    [ex1/0] example/test completed in 0.09 seconds
+2023-01-03 23:41:00,925 INFO    [ex2] Deployments are available in 30.27 seconds
+2023-01-03 23:41:00,925 INFO    [ex2/0] Running example/start
+2023-01-03 23:41:01,080 INFO    [ex2/0] example/start completed in 0.15 seconds
+2023-01-03 23:41:01,080 INFO    [ex2/0] Running example/test
+2023-01-03 23:41:01,166 INFO    [ex2/0] example/test completed in 0.09 seconds
+2023-01-03 23:41:01,166 INFO    [example] Environment started in 35.71 seconds
 ```
 
 #### Using --verbose option
@@ -325,64 +327,68 @@ more details:
 
 ```
 $ drenv start example.yaml -v
-2022-12-01 23:42:38,883 INFO    [example] Starting environment
-2022-12-01 23:42:38,885 INFO    [ex1] Starting cluster
-2022-12-01 23:42:39,014 DEBUG   [ex1] * [ex1] minikube v1.28.0 on Fedora 36
-2022-12-01 23:42:39,017 DEBUG   [ex1]   - MINIKUBE_HOME=/data/minikube
-2022-12-01 23:42:39,263 DEBUG   [ex1] * Using the kvm2 driver based on user configuration
-2022-12-01 23:42:39,279 DEBUG   [ex1] * Starting control plane node ex1 in cluster ex1
-2022-12-01 23:42:39,283 DEBUG   [ex1] * Creating kvm2 VM (CPUs=2, Memory=4096MB, Disk=20480MB) ...
-2022-12-01 23:42:39,886 INFO    [ex2] Starting cluster
-2022-12-01 23:42:40,040 DEBUG   [ex2] * [ex2] minikube v1.28.0 on Fedora 36
-2022-12-01 23:42:40,041 DEBUG   [ex2]   - MINIKUBE_HOME=/data/minikube
-2022-12-01 23:42:40,336 DEBUG   [ex2] * Using the kvm2 driver based on user configuration
-2022-12-01 23:42:40,357 DEBUG   [ex2] * Starting control plane node ex2 in cluster ex2
-2022-12-01 23:42:55,748 DEBUG   [ex2] * Creating kvm2 VM (CPUs=2, Memory=4096MB, Disk=20480MB) ...
-2022-12-01 23:43:05,054 DEBUG   [ex1] * Preparing Kubernetes v1.25.3 on containerd 1.6.8 ...
-2022-12-01 23:43:06,214 DEBUG   [ex1]   - Generating certificates and keys ...
-2022-12-01 23:43:08,111 DEBUG   [ex1]   - Booting up control plane ...
-2022-12-01 23:43:15,196 DEBUG   [ex1]   - Configuring RBAC rules ...
-2022-12-01 23:43:15,622 DEBUG   [ex1] * Configuring bridge CNI (Container Networking Interface) ...
-2022-12-01 23:43:16,249 DEBUG   [ex1] * Verifying Kubernetes components...
-2022-12-01 23:43:16,327 DEBUG   [ex1]   - Using image gcr.io/k8s-minikube/storage-provisioner:v5
-2022-12-01 23:43:17,192 DEBUG   [ex1] * Enabled addons: storage-provisioner, default-storageclass
-2022-12-01 23:43:17,245 DEBUG   [ex1] * Done! kubectl is now configured to use "ex1" cluster and "default" namespace by default
-2022-12-01 23:43:17,269 INFO    [ex1] Cluster started in 38.38 seconds
-2022-12-01 23:43:17,270 INFO    [ex1/0] Running example/start
-2022-12-01 23:43:17,300 DEBUG   [ex1/0] * Deploying example
-2022-12-01 23:43:17,550 DEBUG   [ex1/0]   deployment.apps/example-deployment created
-2022-12-01 23:43:17,554 INFO    [ex1/0] example/start completed in 0.28 seconds
-2022-12-01 23:43:17,554 INFO    [ex1/0] Running example/test
-2022-12-01 23:43:17,580 DEBUG   [ex1/0] * Testing example deployment
-2022-12-01 23:43:21,066 DEBUG   [ex2] * Preparing Kubernetes v1.25.3 on containerd 1.6.8 ...
-2022-12-01 23:43:22,119 DEBUG   [ex2]   - Generating certificates and keys ...
-2022-12-01 23:43:24,112 DEBUG   [ex2]   - Booting up control plane ...
-2022-12-01 23:43:31,671 DEBUG   [ex2]   - Configuring RBAC rules ...
-2022-12-01 23:43:32,082 DEBUG   [ex2] * Configuring bridge CNI (Container Networking Interface) ...
-2022-12-01 23:43:32,706 DEBUG   [ex2] * Verifying Kubernetes components...
-2022-12-01 23:43:32,769 DEBUG   [ex2]   - Using image gcr.io/k8s-minikube/storage-provisioner:v5
-2022-12-01 23:43:33,553 DEBUG   [ex2] * Enabled addons: storage-provisioner, default-storageclass
-2022-12-01 23:43:33,601 DEBUG   [ex2] * Done! kubectl is now configured to use "ex2" cluster and "default" namespace by default
-2022-12-01 23:43:33,621 INFO    [ex2] Cluster started in 53.74 seconds
-2022-12-01 23:43:33,621 INFO    [ex2/0] Running example/start
-2022-12-01 23:43:33,624 DEBUG   [ex1/0]   Waiting for deployment spec update to be observed...
-2022-12-01 23:43:33,624 DEBUG   [ex1/0]   Waiting for deployment spec update to be observed...
-2022-12-01 23:43:33,624 DEBUG   [ex1/0]   Waiting for deployment "example-deployment" rollout to finish: 0 out of 1 new replicas have been updated...
-2022-12-01 23:43:33,624 DEBUG   [ex1/0]   Waiting for deployment "example-deployment" rollout to finish: 0 of 1 updated replicas are available...
-2022-12-01 23:43:33,624 DEBUG   [ex1/0]   deployment "example-deployment" successfully rolled out
-2022-12-01 23:43:33,629 INFO    [ex1/0] example/test completed in 16.08 seconds
-2022-12-01 23:43:33,651 DEBUG   [ex2/0] * Deploying example
-2022-12-01 23:43:33,853 DEBUG   [ex2/0]   deployment.apps/example-deployment created
-2022-12-01 23:43:33,857 INFO    [ex2/0] example/start completed in 0.24 seconds
-2022-12-01 23:43:33,857 INFO    [ex2/0] Running example/test
-2022-12-01 23:43:33,883 DEBUG   [ex2/0] * Testing example deployment
-2022-12-01 23:43:49,131 DEBUG   [ex2/0]   Waiting for deployment spec update to be observed...
-2022-12-01 23:43:49,131 DEBUG   [ex2/0]   Waiting for deployment spec update to be observed...
-2022-12-01 23:43:49,132 DEBUG   [ex2/0]   Waiting for deployment "example-deployment" rollout to finish: 0 out of 1 new replicas have been updated...
-2022-12-01 23:43:49,132 DEBUG   [ex2/0]   Waiting for deployment "example-deployment" rollout to finish: 0 of 1 updated replicas are available...
-2022-12-01 23:43:49,132 DEBUG   [ex2/0]   deployment "example-deployment" successfully rolled out
-2022-12-01 23:43:49,136 INFO    [ex2/0] example/test completed in 15.28 seconds
-2022-12-01 23:43:49,136 INFO    [example] Environment started in 70.25 seconds
+2023-01-03 23:41:53,414 INFO    [example] Starting environment
+2023-01-03 23:41:53,416 INFO    [ex1] Starting cluster
+2023-01-03 23:41:53,539 DEBUG   [ex1] * [ex1] minikube v1.28.0 on Fedora 37
+2023-01-03 23:41:53,540 DEBUG   [ex1]   - MINIKUBE_HOME=/data/minikube
+2023-01-03 23:41:53,582 DEBUG   [ex1] * Using the podman driver based on user configuration
+2023-01-03 23:41:53,664 DEBUG   [ex1] * Using Podman driver with root privileges
+2023-01-03 23:41:53,666 DEBUG   [ex1] * Starting control plane node ex1 in cluster ex1
+2023-01-03 23:41:53,669 DEBUG   [ex1] * Pulling base image ...
+2023-01-03 23:41:53,672 DEBUG   [ex1] * Creating podman container (CPUs=2, Memory=4096MB) ...
+2023-01-03 23:41:54,416 INFO    [ex2] Starting cluster
+2023-01-03 23:41:54,614 DEBUG   [ex2] * [ex2] minikube v1.28.0 on Fedora 37
+2023-01-03 23:41:54,617 DEBUG   [ex2]   - MINIKUBE_HOME=/data/minikube
+2023-01-03 23:41:54,665 DEBUG   [ex2] * Using the podman driver based on user configuration
+2023-01-03 23:41:54,768 DEBUG   [ex2] * Using Podman driver with root privileges
+2023-01-03 23:41:54,771 DEBUG   [ex2] * Starting control plane node ex2 in cluster ex2
+2023-01-03 23:41:54,774 DEBUG   [ex2] * Pulling base image ...
+2023-01-03 23:41:54,777 DEBUG   [ex2] * Creating podman container (CPUs=2, Memory=4096MB) ...
+2023-01-03 23:42:00,763 DEBUG   [ex1] * Preparing Kubernetes v1.25.3 on CRI-O 1.24.3 ...
+2023-01-03 23:42:01,814 DEBUG   [ex1]   - Generating certificates and keys ...
+2023-01-03 23:42:01,921 DEBUG   [ex2] * Preparing Kubernetes v1.25.3 on CRI-O 1.24.3 ...
+2023-01-03 23:42:02,808 DEBUG   [ex2]   - Generating certificates and keys ...
+2023-01-03 23:42:03,656 DEBUG   [ex1]   - Booting up control plane ...
+2023-01-03 23:42:05,617 DEBUG   [ex2]   - Booting up control plane ...
+2023-01-03 23:42:13,684 DEBUG   [ex1]   - Configuring RBAC rules ...
+2023-01-03 23:42:14,095 DEBUG   [ex1] * Configuring CNI (Container Networking Interface) ...
+2023-01-03 23:42:15,219 DEBUG   [ex1] * Verifying Kubernetes components...
+2023-01-03 23:42:15,380 DEBUG   [ex1]   - Using image gcr.io/k8s-minikube/storage-provisioner:v5
+2023-01-03 23:42:15,653 DEBUG   [ex2]   - Configuring RBAC rules ...
+2023-01-03 23:42:15,752 DEBUG   [ex1] * Enabled addons: storage-provisioner, default-storageclass
+2023-01-03 23:42:15,797 DEBUG   [ex1] * Done! kubectl is now configured to use "ex1" cluster and "default" namespace by default
+2023-01-03 23:42:15,809 INFO    [ex1] Cluster started in 22.39 seconds
+2023-01-03 23:42:15,809 INFO    [ex1/0] Running example/start
+2023-01-03 23:42:15,843 DEBUG   [ex1/0] * Deploying example
+2023-01-03 23:42:15,984 DEBUG   [ex1/0]   deployment.apps/example-deployment created
+2023-01-03 23:42:15,992 INFO    [ex1/0] example/start completed in 0.18 seconds
+2023-01-03 23:42:15,992 INFO    [ex1/0] Running example/test
+2023-01-03 23:42:16,026 DEBUG   [ex1/0] * Testing example deployment
+2023-01-03 23:42:16,067 DEBUG   [ex2] * Configuring CNI (Container Networking Interface) ...
+2023-01-03 23:42:16,083 DEBUG   [ex1/0]   Waiting for deployment spec update to be observed...
+2023-01-03 23:42:17,161 DEBUG   [ex2] * Verifying Kubernetes components...
+2023-01-03 23:42:17,216 DEBUG   [ex2]   - Using image gcr.io/k8s-minikube/storage-provisioner:v5
+2023-01-03 23:42:17,626 DEBUG   [ex2] * Enabled addons: storage-provisioner, default-storageclass
+2023-01-03 23:42:17,675 DEBUG   [ex2] * Done! kubectl is now configured to use "ex2" cluster and "default" namespace by default
+2023-01-03 23:42:17,688 INFO    [ex2] Cluster started in 23.27 seconds
+2023-01-03 23:42:17,688 INFO    [ex2/0] Running example/start
+2023-01-03 23:42:17,721 DEBUG   [ex2/0] * Deploying example
+2023-01-03 23:42:17,858 DEBUG   [ex2/0]   deployment.apps/example-deployment created
+2023-01-03 23:42:17,866 INFO    [ex2/0] example/start completed in 0.18 seconds
+2023-01-03 23:42:17,866 INFO    [ex2/0] Running example/test
+2023-01-03 23:42:17,900 DEBUG   [ex2/0] * Testing example deployment
+2023-01-03 23:42:17,954 DEBUG   [ex2/0]   Waiting for deployment spec update to be observed...
+2023-01-03 23:42:27,903 DEBUG   [ex1/0]   Waiting for deployment spec update to be observed...
+2023-01-03 23:42:27,909 DEBUG   [ex1/0]   Waiting for deployment "example-deployment" rollout to finish: 0 out of 1 new replicas have been updated...
+2023-01-03 23:42:28,021 DEBUG   [ex1/0]   Waiting for deployment "example-deployment" rollout to finish: 0 of 1 updated replicas are available...
+2023-01-03 23:42:28,992 DEBUG   [ex2/0]   Waiting for deployment spec update to be observed...
+2023-01-03 23:42:28,997 DEBUG   [ex2/0]   Waiting for deployment "example-deployment" rollout to finish: 0 out of 1 new replicas have been updated...
+2023-01-03 23:42:29,046 DEBUG   [ex2/0]   Waiting for deployment "example-deployment" rollout to finish: 0 of 1 updated replicas are available...
+2023-01-03 23:42:34,960 DEBUG   [ex1/0]   deployment "example-deployment" successfully rolled out
+2023-01-03 23:42:34,967 INFO    [ex1/0] example/test completed in 18.98 seconds
+2023-01-03 23:42:35,980 DEBUG   [ex2/0]   deployment "example-deployment" successfully rolled out
+2023-01-03 23:42:35,987 INFO    [ex2/0] example/test completed in 18.12 seconds
+2023-01-03 23:42:35,987 INFO    [example] Environment started in 42.57 seconds
 ```
 
 #### Stopping the environment
@@ -393,12 +399,12 @@ time.
 
 ```
 $ drenv stop example.yaml
-2022-12-01 23:47:20,688 INFO    [example] Stopping environment
-2022-12-01 23:47:20,689 INFO    [ex1] Stopping cluster
-2022-12-01 23:47:20,689 INFO    [ex2] Stopping cluster
-2022-12-01 23:47:21,926 INFO    [ex2] Cluster stopped in 1.24 seconds
-2022-12-01 23:47:21,931 INFO    [ex1] Cluster stopped in 1.24 seconds
-2022-12-01 23:47:21,931 INFO    [example] Environment stopped in 1.24 seconds
+2023-01-03 23:43:09,169 INFO    [example] Stopping environment
+2023-01-03 23:43:09,171 INFO    [ex1] Stopping cluster
+2023-01-03 23:43:09,172 INFO    [ex2] Stopping cluster
+2023-01-03 23:43:13,829 INFO    [ex1] Cluster stopped in 4.66 seconds
+2023-01-03 23:43:14,032 INFO    [ex2] Cluster stopped in 4.86 seconds
+2023-01-03 23:43:14,033 INFO    [example] Environment stopped in 4.86 seconds
 ```
 
 We can start the environment later. This can be faster than recreating
@@ -411,12 +417,12 @@ changes made to the environment:
 
 ```
 $ drenv delete example.yaml
-2022-12-01 23:49:54,853 INFO    [example] Deleting environment
-2022-12-01 23:49:54,855 INFO    [ex1] Deleting cluster
-2022-12-01 23:49:54,855 INFO    [ex2] Deleting cluster
-2022-12-01 23:49:55,942 INFO    [ex1] Cluster deleted in 1.09 seconds
-2022-12-01 23:49:55,963 INFO    [ex2] Cluster deleted in 1.11 seconds
-2022-12-01 23:49:55,963 INFO    [example] Environment deleted in 1.11 seconds
+2023-01-03 23:43:36,601 INFO    [example] Deleting environment
+2023-01-03 23:43:36,602 INFO    [ex1] Deleting cluster
+2023-01-03 23:43:36,603 INFO    [ex2] Deleting cluster
+2023-01-03 23:43:43,645 INFO    [ex2] Cluster deleted in 7.04 seconds
+2023-01-03 23:43:43,897 INFO    [ex1] Cluster deleted in 7.29 seconds
+2023-01-03 23:43:43,897 INFO    [example] Environment deleted in 7.30 seconds
 ```
 
 ### The environment file format

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import secrets
+import subprocess
+
+import pytest
+
+from drenv import envfile
+
+
+class Env:
+    def __init__(self):
+        self.prefix = f"test-{secrets.token_hex(8)}-"
+        with open("test.yaml") as f:
+            env = envfile.load(f, name_prefix=self.prefix)
+        self.profile = env["profiles"][0]["name"]
+
+    def start(self):
+        self._run("start")
+
+    def delete(self):
+        self._run("delete")
+
+    def _run(self, cmd):
+        subprocess.run(
+            ["drenv", cmd, "--name-prefix", self.prefix, "test.yaml"],
+            check=True,
+        )
+
+
+@pytest.fixture(scope="session")
+def tmpenv():
+    env = Env()
+    env.start()
+    yield env
+    env.delete()

--- a/test/coverage.pth
+++ b/test/coverage.pth
@@ -1,0 +1,1 @@
+import coverage; coverage.process_startup()

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -109,7 +109,7 @@ def start_cluster(profile):
     minikube(
         "start",
         "--driver",
-        "kvm2",
+        profile["driver"],
         "--container-runtime",
         profile["container_runtime"],
         "--extra-disks",

--- a/test/drenv/envfile.py
+++ b/test/drenv/envfile.py
@@ -67,7 +67,7 @@ def _validate_profile(profile):
         raise ValueError("Missing profile name")
 
     profile.setdefault("driver", "kvm2")
-    profile.setdefault("container_runtime", "containerd")
+    profile.setdefault("container_runtime", "")
     profile.setdefault("extra_disks", 0)
     profile.setdefault("disk_size", "20g")
     profile.setdefault("nodes", 1)

--- a/test/drenv/envfile.py
+++ b/test/drenv/envfile.py
@@ -66,6 +66,7 @@ def _validate_profile(profile):
     if "name" not in profile:
         raise ValueError("Missing profile name")
 
+    profile.setdefault("driver", "kvm2")
     profile.setdefault("container_runtime", "containerd")
     profile.setdefault("extra_disks", 0)
     profile.setdefault("disk_size", "20g")

--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+from drenv import kubectl
+
+
+def test_get(tmpenv):
+    out = kubectl.get("deploy", "--output=name", profile=tmpenv.profile)
+    assert out.strip() == "deployment.apps/example-deployment"
+
+
+def test_config(tmpenv):
+    out = kubectl.config("view", "--output=json")
+    json.loads(out)
+
+
+def test_exec(tmpenv):
+    out = kubectl.exec(
+        "deploy/example-deployment",
+        "--",
+        "hostname",
+        profile=tmpenv.profile,
+    )
+    assert out.startswith("example-deployment-")
+
+
+def test_apply(tmpenv, capsys):
+    kubectl.apply("--filename=example/deployment.yaml", profile=tmpenv.profile)
+    out, err = capsys.readouterr()
+    assert out.strip() == "deployment.apps/example-deployment unchanged"
+
+
+def test_rollout(tmpenv, capsys):
+    kubectl.rollout(
+        "status",
+        "deploy/example-deployment",
+        "--timeout=10s",
+        profile=tmpenv.profile,
+    )
+    out, err = capsys.readouterr()
+    assert out.strip() == 'deployment "example-deployment" successfully rolled out'
+
+
+def test_wait(tmpenv, capsys):
+    kubectl.wait(
+        "deploy/example-deployment",
+        "--for=condition=available",
+        "--timeout=10s",
+        profile=tmpenv.profile,
+    )
+    out, err = capsys.readouterr()
+    assert out.strip() == "deployment.apps/example-deployment condition met"
+
+
+def test_patch(tmpenv, capsys):
+    pod = kubectl.get("pod", "--output=name", profile=tmpenv.profile).strip()
+    kubectl.patch(
+        pod,
+        "--type=merge",
+        '--patch={"metadata": {"labels": {"test": "yes"}}}',
+        profile=tmpenv.profile,
+    )
+    out, err = capsys.readouterr()
+    assert out.strip() == f"{pod} patched"
+
+
+def test_delete(tmpenv, capsys):
+    pod = kubectl.get("pod", "--output=name", profile=tmpenv.profile).strip()
+    kubectl.delete(pod, profile=tmpenv.profile)
+    out, err = capsys.readouterr()
+    _, name = pod.split("/", 1)
+    assert out.strip() == f'pod "{name}" deleted'

--- a/test/example.yaml
+++ b/test/example.yaml
@@ -6,6 +6,8 @@
 name: example
 templates:
   - name: "example-cluster"
+    driver: podman
+    container_runtime: cri-o
     workers:
       - scripts:
           - name: example

--- a/test/ocm.yaml
+++ b/test/ocm.yaml
@@ -8,6 +8,7 @@ name: "ocm"
 templates:
   - name: "hub-cluster"
     driver: kvm2
+    container_runtime: containerd
     network: default
     workers:
       - scripts:
@@ -15,6 +16,7 @@ templates:
           - name: ocm-controller
   - name: "dr-cluster"
     driver: kvm2
+    container_runtime: containerd
     network: default
     workers:
       - scripts:

--- a/test/ocm.yaml
+++ b/test/ocm.yaml
@@ -7,12 +7,14 @@ name: "ocm"
 
 templates:
   - name: "hub-cluster"
+    driver: kvm2
     network: default
     workers:
       - scripts:
           - name: ocm-hub
           - name: ocm-controller
   - name: "dr-cluster"
+    driver: kvm2
     network: default
     workers:
       - scripts:

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -7,6 +7,7 @@ name: "rdr"
 
 templates:
   - name: "dr-cluster"
+    driver: kvm2
     network: default
     memory: "6g"
     extra_disks: 1
@@ -26,8 +27,9 @@ templates:
           - name: csi-addons
           - name: olm
   - name: "hub-cluster"
-    memory: "4g"
+    driver: kvm2
     network: default
+    memory: "4g"
     workers:
       - scripts:
           - name: ocm-hub

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -8,6 +8,7 @@ name: "rdr"
 templates:
   - name: "dr-cluster"
     driver: kvm2
+    container_runtime: containerd
     network: default
     memory: "6g"
     extra_disks: 1
@@ -28,6 +29,7 @@ templates:
           - name: olm
   - name: "hub-cluster"
     driver: kvm2
+    container_runtime: containerd
     network: default
     memory: "4g"
     workers:

--- a/test/rook.yaml
+++ b/test/rook.yaml
@@ -7,6 +7,7 @@ name: "rook"
 
 templates:
   - name: "dr-cluster"
+    driver: kvm2
     network: default
     memory: "6g"
     extra_disks: 1

--- a/test/rook.yaml
+++ b/test/rook.yaml
@@ -8,6 +8,7 @@ name: "rook"
 templates:
   - name: "dr-cluster"
     driver: kvm2
+    container_runtime: containerd
     network: default
     memory: "6g"
     extra_disks: 1

--- a/test/test.yaml
+++ b/test/test.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Enviromemnt for testing the drenv package in github.
+---
+name: test
+profiles:
+  - name: cluster
+    driver: podman
+    container_runtime: cri-o
+    memory: 2g
+    workers:
+      - scripts:
+          - name: example


### PR DESCRIPTION
- Add support for podman driver
- Change default `container_runtime` to minikube default
- Add new minimal test environment using podamn driver
- Add test fixture running the test environment
- Add tests for the kubectl module using the fixture
- Collect coverage from drenv and scripts

The test fixture is using the drenv tool to start and stop the environment
covering most of the code in the tool.

Fixes #677