### PR TITLE
Nicer kubectl calls

### DIFF
--- a/test/cert-manager/start
+++ b/test/cert-manager/start
@@ -23,10 +23,8 @@ def wait(cluster):
         "deploy",
         "--all",
         "--for=condition=Available",
-        "--namespace",
-        "cert-manager",
-        "--timeout",
-        "300s",
+        "--namespace=cert-manager",
+        "--timeout=300s",
         profile=cluster,
     )
 

--- a/test/csi-addons/start
+++ b/test/csi-addons/start
@@ -23,16 +23,12 @@ def deploy(cluster):
 
 
 def wait(cluster):
-    drenv.log_progress(
-        "Waiting until csi-addons-controller-manager is rolled out",
-    )
+    drenv.log_progress("Waiting until csi-addons-controller-manager is rolled out")
     kubectl.rollout(
         "status",
         "deploy/csi-addons-controller-manager",
-        "--namespace",
-        "csi-addons-system",
-        "--timeout",
-        "300s",
+        "--namespace=csi-addons-system",
+        "--timeout=300s",
         profile=cluster,
     )
 

--- a/test/example/test
+++ b/test/example/test
@@ -18,7 +18,6 @@ drenv.log_progress("Testing example deployment")
 kubectl.rollout(
     "status",
     "deploy/example-deployment",
-    "--timeout",
-    "180s",
+    "--timeout=180s",
     profile=cluster,
 )

--- a/test/minio/start
+++ b/test/minio/start
@@ -19,10 +19,8 @@ def wait(cluster):
     kubectl.rollout(
         "status",
         "deployment/minio",
-        "--namespace",
-        "minio",
-        "--timeout",
-        "300s",
+        "--namespace=minio",
+        "--timeout=300s",
         profile=cluster,
     )
 

--- a/test/ocm-cluster/start
+++ b/test/ocm-cluster/start
@@ -43,10 +43,8 @@ def wait(cluster):
         kubectl.rollout(
             "status",
             deployment,
-            "--namespace",
-            ADDONS_NAMESPACE,
-            "--timeout",
-            "300s",
+            f"--namespace={ADDONS_NAMESPACE}",
+            "--timeout=300s",
             profile=cluster,
         )
 
@@ -63,10 +61,8 @@ def wait_for_hub(hub):
         kubectl.rollout(
             "status",
             deployment,
-            "--namespace",
-            HUB_NAMESPACE,
-            "--timeout",
-            "300s",
+            f"--namespace={HUB_NAMESPACE}",
+            "--timeout=300s",
             profile=hub,
         )
 

--- a/test/ocm-cluster/test
+++ b/test/ocm-cluster/test
@@ -18,12 +18,9 @@ def wait_for_work(cluster, hub):
     drenv.log_progress(f"Waiting until manifestwork is applied in namespace {cluster}")
     kubectl.wait(
         "manifestwork/example-manifestwork",
-        "--for",
-        "condition=applied",
-        "--namespace",
-        cluster,
-        "--timeout",
-        "60s",
+        "--for=condition=applied",
+        f"--namespace={cluster}",
+        "--timeout=60s",
         profile=hub,
     )
 
@@ -34,22 +31,17 @@ def wait_for_deployment(cluster, hub):
     )
     kubectl.wait(
         "manifestwork/example-manifestwork",
-        "--for",
-        "condition=available",
-        "--namespace",
-        cluster,
-        "--timeout",
-        "60s",
+        "--for=condition=available",
+        f"--namespace={cluster}",
+        "--timeout=60s",
         profile=hub,
     )
 
     drenv.log_progress(f"Waiting until deployment is available in cluster {cluster}")
     kubectl.wait(
         "deploy/example-deployment",
-        "--for",
-        "condition=available",
-        "--timeout",
-        "60s",
+        "--for=condition=available",
+        "--timeout=60s",
         profile=cluster,
     )
 
@@ -63,12 +55,9 @@ def wait_for_delete_work(cluster, hub):
     drenv.log_progress(f"Waiting until manifestwork is deleted from namspace {cluster}")
     kubectl.wait(
         "manifestwork/example-manifestwork",
-        "--for",
-        "delete",
-        "--namespace",
-        cluster,
-        "--timeout",
-        "60s",
+        "--for=delete",
+        f"--namespace={cluster}",
+        "--timeout=60s",
         profile=hub,
     )
 
@@ -77,10 +66,8 @@ def wait_for_delete_deployment(cluster):
     drenv.log_progress(f"Waiting until deployment is deleted from cluster {cluster}")
     kubectl.wait(
         "deploy/example-deployment",
-        "--for",
-        "delete",
-        "--timeout",
-        "60s",
+        "--for=delete",
+        "--timeout=60s",
         profile=cluster,
     )
 

--- a/test/ocm-controller/start
+++ b/test/ocm-controller/start
@@ -26,10 +26,8 @@ def wait(cluster):
     kubectl.rollout(
         "status",
         "deploy/ocm-controller",
-        "--namespace",
-        "open-cluster-management",
-        "--timeout",
-        "300s",
+        "--namespace=open-cluster-management",
+        "--timeout=300s",
         profile=cluster,
     )
 

--- a/test/ocm-hub/start
+++ b/test/ocm-hub/start
@@ -49,10 +49,8 @@ def wait(cluster):
             kubectl.rollout(
                 "status",
                 deployment,
-                "--namespace",
-                ns,
-                "--timeout",
-                "300s",
+                f"--namespace={ns}",
+                "--timeout=300s",
                 profile=cluster,
             )
 

--- a/test/olm/start
+++ b/test/olm/start
@@ -21,18 +21,15 @@ def deploy(cluster):
     #   is invalid: metadata.annotations: Too long: must have at most 262144 bytes
     # See https://medium.com/pareture/kubectl-install-crd-failed-annotations-too-long-2ebc91b40c7d
     kubectl.apply(
-        "--filename",
-        f"{BASE_URL}/crds.yaml",
+        f"--filename={BASE_URL}/crds.yaml",
         "--server-side=true",
         profile=cluster,
     )
 
     drenv.log_progress("Waiting until cdrs are established")
     kubectl.wait(
-        "--for",
-        "condition=established",
-        "--filename",
-        f"{BASE_URL}/crds.yaml",
+        "--for=condition=established",
+        f"--filename={BASE_URL}/crds.yaml",
         profile=cluster,
     )
 
@@ -47,8 +44,7 @@ def wait(cluster):
             "status",
             "deploy",
             operator,
-            "--namespace",
-            NAMESPACE,
+            f"--namespace={NAMESPACE}",
             profile=cluster,
         )
 
@@ -61,12 +57,9 @@ def wait(cluster):
     )
     kubectl.wait(
         "csv/packageserver",
-        "--namespace",
-        NAMESPACE,
-        "--for",
-        "jsonpath={.status.phase}=Succeeded",
-        "--timeout",
-        "300s",
+        f"--namespace={NAMESPACE}",
+        "--for=jsonpath={.status.phase}=Succeeded",
+        "--timeout=300s",
         profile=cluster,
     )
 
@@ -74,8 +67,7 @@ def wait(cluster):
     kubectl.rollout(
         "status",
         "deploy/packageserver",
-        "--namespace",
-        NAMESPACE,
+        f"--namespace={NAMESPACE}",
         profile=cluster,
     )
 

--- a/test/rbd-mirror/start
+++ b/test/rbd-mirror/start
@@ -20,10 +20,8 @@ def fetch_secret_info(cluster):
     info["name"] = kubectl.get(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
-        "--output",
-        "jsonpath={.status.mirroringInfo.site_name}",
-        "--namespace",
-        "rook-ceph",
+        "--output=jsonpath={.status.mirroringInfo.site_name}",
+        "--namespace=rook-ceph",
         profile=cluster,
     )
 
@@ -33,10 +31,8 @@ def fetch_secret_info(cluster):
     secret_name = kubectl.get(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
-        "--output",
-        "jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}",
-        "--namespace",
-        "rook-ceph",
+        "--output=jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}",
+        "--namespace=rook-ceph",
         profile=cluster,
     )
 
@@ -44,10 +40,8 @@ def fetch_secret_info(cluster):
     info["token"] = kubectl.get(
         "secret",
         secret_name,
-        "--output",
-        "jsonpath={.data.token}",
-        "--namespace",
-        "rook-ceph",
+        "--output=jsonpath={.data.token}",
+        "--namespace=rook-ceph",
         profile=cluster,
     )
 
@@ -63,10 +57,8 @@ def configure_rbd_mirroring(cluster, peer_info):
     template = drenv.template("rbd-mirror/rbd-mirror-secret.yaml")
     yaml = template.substitute(peer_info)
     kubectl.apply(
-        "--filename",
-        "-",
-        "--namespace",
-        "rook-ceph",
+        "--filename=-",
+        "--namespace=rook-ceph",
         input=yaml,
         profile=cluster,
     )
@@ -76,21 +68,16 @@ def configure_rbd_mirroring(cluster, peer_info):
     kubectl.patch(
         "cephblockpool",
         POOL_NAME,
-        "--type",
-        "merge",
-        "--patch",
-        json.dumps(patch),
-        "--namespace",
-        "rook-ceph",
+        "--type=merge",
+        f"--patch={json.dumps(patch)}",
+        "--namespace=rook-ceph",
         profile=cluster,
     )
 
     drenv.log_progress(f"Apply rbd mirror to cluster {cluster}")
     kubectl.apply(
-        "--filename",
-        "rbd-mirror/rbd-mirror.yaml",
-        "--namespace",
-        "rook-ceph",
+        "--filename=rbd-mirror/rbd-mirror.yaml",
+        "--namespace=rook-ceph",
         profile=cluster,
     )
 
@@ -102,12 +89,9 @@ def wait_until_pool_mirroring_is_healthy(cluster):
     kubectl.wait(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
-        "--for",
-        "jsonpath={.status.mirroringStatus.summary.daemon_health}=OK",
-        "--namespace",
-        "rook-ceph",
-        "--timeout",
-        "300s",
+        "--for=jsonpath={.status.mirroringStatus.summary.daemon_health}=OK",
+        "--namespace=rook-ceph",
+        "--timeout=300s",
         profile=cluster,
     )
 
@@ -115,12 +99,9 @@ def wait_until_pool_mirroring_is_healthy(cluster):
     kubectl.wait(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
-        "--for",
-        "jsonpath={.status.mirroringStatus.summary.health}=OK",
-        "--namespace",
-        "rook-ceph",
-        "--timeout",
-        "300s",
+        "--for=jsonpath={.status.mirroringStatus.summary.health}=OK",
+        "--namespace=rook-ceph",
+        "--timeout=300s",
         profile=cluster,
     )
 
@@ -130,12 +111,9 @@ def wait_until_pool_mirroring_is_healthy(cluster):
     kubectl.wait(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
-        "--for",
-        "jsonpath={.status.mirroringStatus.summary.image_health}=OK",
-        "--namespace",
-        "rook-ceph",
-        "--timeout",
-        "300s",
+        "--for=jsonpath={.status.mirroringStatus.summary.image_health}=OK",
+        "--namespace=rook-ceph",
+        "--timeout=300s",
         profile=cluster,
     )
 
@@ -143,10 +121,8 @@ def wait_until_pool_mirroring_is_healthy(cluster):
 def deploy_vrc_sample(cluster):
     drenv.log_progress(f"Applying vrc sample in cluster {cluster}")
     kubectl.apply(
-        "--filename",
-        "rbd-mirror/vrc-sample.yaml",
-        "--namespace",
-        "rook-ceph",
+        "--filename=rbd-mirror/vrc-sample.yaml",
+        "--namespace=rook-ceph",
         profile=cluster,
     )
 

--- a/test/rbd-mirror/test
+++ b/test/rbd-mirror/test
@@ -17,16 +17,14 @@ PVC_NAME = "rbd-pvc"
 def rbd_mirror_image_status(cluster, image):
     out = kubectl.exec(
         "deploy/rook-ceph-tools",
-        "--namespace",
-        "rook-ceph",
+        "--namespace=rook-ceph",
         "--",
         "rbd",
         "mirror",
         "image",
         "status",
         f"{POOL_NAME}/{image}",
-        "--format",
-        "json",
+        "--format=json",
         profile=cluster,
     )
     status = json.loads(out)
@@ -47,45 +45,33 @@ def rbd_mirror_image_status(cluster, image):
 def test_volume_replication(primary, secondary):
     drenv.log_progress(f"Deploying pvc {PVC_NAME} in cluster {primary}")
     kubectl.apply(
-        "--filename",
-        f"rbd-mirror/{PVC_NAME}.yaml",
-        "--namespace",
-        "rook-ceph",
+        f"--filename=rbd-mirror/{PVC_NAME}.yaml",
+        "--namespace=rook-ceph",
         profile=primary,
     )
 
     drenv.log_progress(f"Waiting until pvc {PVC_NAME} is bound in cluster {primary}")
     kubectl.wait(
-        "pvc",
-        PVC_NAME,
-        "--for",
-        "jsonpath={.status.phase}=Bound",
-        "--namespace",
-        "rook-ceph",
-        "--timeout",
-        "300s",
+        f"pvc/{PVC_NAME}",
+        "--for=jsonpath={.status.phase}=Bound",
+        "--namespace=rook-ceph",
+        "--timeout=300s",
         profile=primary,
     )
 
     drenv.log_progress(f"Deploying vr vr-sample in cluster {primary}")
     kubectl.apply(
-        "--filename",
-        "rbd-mirror/vr-sample.yaml",
-        "--namespace",
-        "rook-ceph",
+        "--filename=rbd-mirror/vr-sample.yaml",
+        "--namespace=rook-ceph",
         profile=primary,
     )
 
     drenv.log_progress(f"Waiting until vr vr-sample is completed in cluster {primary}")
     kubectl.wait(
-        "volumereplication",
-        "vr-sample",
-        "--for",
-        "condition=Completed",
-        "--namespace",
-        "rook-ceph",
-        "--timeout",
-        "300s",
+        "volumereplication/vr-sample",
+        "--for=condition=Completed",
+        "--namespace=rook-ceph",
+        "--timeout=300s",
         profile=primary,
     )
 
@@ -93,48 +79,38 @@ def test_volume_replication(primary, secondary):
         f"Waiting until vr vr-sample state is primary in cluster {primary}"
     )
     kubectl.wait(
-        "volumereplication",
-        "vr-sample",
-        "--for",
-        "jsonpath={.status.state}=Primary",
-        "--namespace",
-        "rook-ceph",
-        "--timeout",
-        "300s",
+        "volumereplication/vr-sample",
+        "--for=jsonpath={.status.state}=Primary",
+        "--namespace=rook-ceph",
+        "--timeout=300s",
         profile=primary,
     )
 
     drenv.log_progress(f"Looking up pvc {PVC_NAME} pv name in cluster {primary}")
     pv_name = kubectl.get(
         f"pvc/{PVC_NAME}",
-        "--output",
-        "jsonpath={.spec.volumeName}",
-        "--namespace",
-        "rook-ceph",
+        "--output=jsonpath={.spec.volumeName}",
+        "--namespace=rook-ceph",
         profile=primary,
     )
 
     drenv.log_progress(f"Looking up rbd image for pv {pv_name} in cluster {primary}")
     rbd_image = kubectl.get(
         f"pv/{pv_name}",
-        "--output",
-        "jsonpath={.spec.csi.volumeAttributes.imageName}",
-        "--namespace",
-        "rook-ceph",
+        "--output=jsonpath={.spec.csi.volumeAttributes.imageName}",
+        "--namespace=rook-ceph",
         profile=primary,
     )
 
     drenv.log_progress(f"rbd image {rbd_image} info in cluster {primary}")
     out = kubectl.exec(
         "deploy/rook-ceph-tools",
-        "--namespace",
-        "rook-ceph",
+        "--namespace=rook-ceph",
         "--",
         "rbd",
         "info",
         rbd_image,
-        "--pool",
-        POOL_NAME,
+        f"--pool={POOL_NAME}",
         profile=primary,
     )
     drenv.log_detail(out)
@@ -146,26 +122,22 @@ def test_volume_replication(primary, secondary):
         time.sleep(1)
         out = kubectl.exec(
             "deploy/rook-ceph-tools",
-            "--namespace",
-            "rook-ceph",
+            "--namespace=rook-ceph",
             "--",
             "rbd",
             "list",
-            "--pool",
-            POOL_NAME,
+            f"--pool={POOL_NAME}",
             profile=secondary,
         )
         if rbd_image in out:
             out = kubectl.exec(
                 "deploy/rook-ceph-tools",
-                "--namespace",
-                "rook-ceph",
+                "--namespace=rook-ceph",
                 "--",
                 "rbd",
                 "info",
                 rbd_image,
-                "--pool",
-                POOL_NAME,
+                f"--pool={POOL_NAME}",
                 profile=secondary,
             )
             drenv.log_detail(out)
@@ -175,12 +147,9 @@ def test_volume_replication(primary, secondary):
 
     drenv.log_progress(f"vr vr-sample info on primary cluster {primary}")
     kubectl.get(
-        "volumereplication",
-        "vr-sample",
-        "--output",
-        "yaml",
-        "--namespace",
-        "rook-ceph",
+        "volumereplication/vr-sample",
+        "--output=yaml",
+        "--namespace=rook-ceph",
         profile=primary,
     )
 
@@ -190,19 +159,15 @@ def test_volume_replication(primary, secondary):
 
     drenv.log_progress(f"Deleting vr vr-sample in primary cluster {primary}")
     kubectl.delete(
-        "volumereplication",
-        "vr-sample",
-        "--namespace",
-        "rook-ceph",
+        "volumereplication/vr-sample",
+        "--namespace=rook-ceph",
         profile=primary,
     )
 
     drenv.log_progress(f"Deleting pvc {PVC_NAME} in primary cluster {primary}")
     kubectl.delete(
-        "pvc",
-        PVC_NAME,
-        "--namespace",
-        "rook-ceph",
+        f"pvc/{PVC_NAME}",
+        "--namespace=rook-ceph",
         profile=primary,
     )
 

--- a/test/rook-cluster/start
+++ b/test/rook-cluster/start
@@ -32,14 +32,10 @@ def wait(cluster):
         profile=cluster,
     )
     kubectl.wait(
-        "CephCluster",
-        "my-cluster",
-        "--for",
-        "jsonpath={.status.phase}=Ready",
-        "--namespace",
-        "rook-ceph",
-        "--timeout",
-        "300s",
+        "cephcluster/my-cluster",
+        "--for=jsonpath={.status.phase}=Ready",
+        "--namespace=rook-ceph",
+        "--timeout=300s",
         profile=cluster,
     )
 

--- a/test/rook-operator/start
+++ b/test/rook-operator/start
@@ -27,24 +27,18 @@ def wait(cluster):
     kubectl.rollout(
         "status",
         "deploy/rook-ceph-operator",
-        "--namespace",
-        "rook-ceph",
-        "--timeout",
-        "300s",
+        "--namespace=rook-ceph",
+        "--timeout=300s",
         profile=cluster,
     )
 
     drenv.log_progress("Waiting until rook ceph operator is ready")
     kubectl.wait(
         "pod",
-        "--for",
-        "jsonpath={.status.phase}=Running",
-        "--namespace",
-        "rook-ceph",
-        "--selector",
-        "app=rook-ceph-operator",
-        "--timeout",
-        "300s",
+        "--for=jsonpath={.status.phase}=Running",
+        "--namespace=rook-ceph",
+        "--selector=app=rook-ceph-operator",
+        "--timeout=300s",
         profile=cluster,
     )
 

--- a/test/rook-pool/start
+++ b/test/rook-pool/start
@@ -12,10 +12,8 @@ from drenv import kubectl
 def deploy(cluster):
     drenv.log_progress("Creating rbd pool and storage class")
     kubectl.apply(
-        "--filename",
-        "rook-pool/replica-pool.yaml",
-        "--filename",
-        "rook-pool/storage-class.yaml",
+        "--filename=rook-pool/replica-pool.yaml",
+        "--filename=rook-pool/storage-class.yaml",
         profile=cluster,
     )
 
@@ -30,27 +28,19 @@ def wait(cluster):
         profile=cluster,
     )
     kubectl.wait(
-        "CephBlockPool",
-        "replicapool",
-        "--for",
-        "jsonpath={.status.phase}=Ready",
-        "--namespace",
-        "rook-ceph",
-        "--timeout",
-        "300s",
+        "cephblockpool/replicapool",
+        "--for=jsonpath={.status.phase}=Ready",
+        "--namespace=rook-ceph",
+        "--timeout=300s",
         profile=cluster,
     )
 
     drenv.log_progress("Waiting for replica pool peer token")
     kubectl.wait(
-        "CephBlockPool",
-        "replicapool",
-        "--for",
-        "jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}=pool-peer-token-replicapool",
-        "--namespace",
-        "rook-ceph",
-        "--timeout",
-        "300s",
+        "cephblockpool/replicapool",
+        "--for=jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}=pool-peer-token-replicapool",
+        "--namespace=rook-ceph",
+        "--timeout=300s",
         profile=cluster,
     )
 

--- a/test/rook-toolbox/start
+++ b/test/rook-toolbox/start
@@ -23,10 +23,8 @@ def wait(cluster):
     kubectl.rollout(
         "status",
         "deploy/rook-ceph-tools",
-        "--namespace",
-        "rook-ceph",
-        "--timeout",
-        "300s",
+        "--namespace=rook-ceph",
+        "--timeout=300s",
         profile=cluster,
     )
 


### PR DESCRIPTION
Always use `--key=value` format for shorter, more consistent, and easier to grep code.

This does not give us all the benefits of a complete python wrapper like the `clusteradm` module, but it is a very quick change, so lets start with this. We can improve the kubectl wrappers later.

Part-of: #664
Signed-off-by: Nir Soffer <nsoffer@redhat.com>