### PR TITLE
Replace drenv.log_* functions with print()

### DIFF
--- a/test/cert-manager/start
+++ b/test/cert-manager/start
@@ -5,7 +5,6 @@
 
 import sys
 
-import drenv
 from drenv import kubectl
 
 VERSION = "v1.10.0"
@@ -13,12 +12,12 @@ URL = f"https://github.com/cert-manager/cert-manager/releases/download/{VERSION}
 
 
 def deploy(cluster):
-    drenv.log_progress("Deploying cert-manager")
+    print("Deploying cert-manager")
     kubectl.apply("--filename", URL, profile=cluster)
 
 
 def wait(cluster):
-    drenv.log_progress("Waiting until all deployments are available")
+    print("Waiting until all deployments are available")
     kubectl.wait(
         "deploy",
         "--all",

--- a/test/csi-addons/start
+++ b/test/csi-addons/start
@@ -14,7 +14,7 @@ BASE_URL = f"https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/
 
 
 def deploy(cluster):
-    drenv.log_progress("Deploying csi addon for volume replication")
+    print("Deploying csi addon for volume replication")
     with drenv.kustomization(
         "csi-addons/kustomization.yaml",
         base_url=BASE_URL,
@@ -23,7 +23,7 @@ def deploy(cluster):
 
 
 def wait(cluster):
-    drenv.log_progress("Waiting until csi-addons-controller-manager is rolled out")
+    print("Waiting until csi-addons-controller-manager is rolled out")
     kubectl.rollout(
         "status",
         "deploy/csi-addons-controller-manager",

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -5,27 +5,12 @@ import json
 import os
 import string
 import tempfile
-import textwrap
 import time
 
 from contextlib import contextmanager
 
 from . import commands
 from . import kubectl
-
-
-def log_progress(msg):
-    """
-    Logs progress mesage to stdout.
-    """
-    print(f"* {msg}")
-
-
-def log_detail(text):
-    """
-    Logs details for the last progress message to stdout.
-    """
-    print(textwrap.indent(text, "  "))
 
 
 def wait_for(
@@ -59,7 +44,7 @@ def wait_for(
     while True:
         out = kubectl.get(*args, profile=profile)
         if out:
-            log_detail(f"{resource} exists")
+            print(f"{resource} exists")
             return out
 
         if time.monotonic() > deadline:
@@ -84,7 +69,7 @@ def wait_for_cluster(cluster, timeout=300):
         current_status = status.get("APIServer", "Unknown")
 
         if current_status != last_status:
-            log_detail(f"cluster {cluster} status is {current_status}")
+            print(f"cluster {cluster} status is {current_status}")
             last_status = current_status
 
         if current_status == "Running":

--- a/test/drenv/clusteradm.py
+++ b/test/drenv/clusteradm.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-import drenv
 from . import commands
 
 
@@ -90,4 +89,4 @@ def addon(action, names, clusters, context=None):
 
 def _watch(*cmd):
     for line in commands.watch(*cmd):
-        drenv.log_detail(line)
+        print(line)

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-import drenv
 from . import commands
 
 
@@ -75,4 +74,4 @@ def _watch(cmd, *args, input=None, profile=None):
         cmd.extend(("--context", profile))
     cmd.extend(args)
     for line in commands.watch(*cmd, input=input):
-        drenv.log_detail(line)
+        print(line)

--- a/test/example/start
+++ b/test/example/start
@@ -5,7 +5,6 @@
 
 import sys
 
-import drenv
 from drenv import kubectl
 
 if len(sys.argv) != 2:
@@ -14,5 +13,5 @@ if len(sys.argv) != 2:
 
 cluster = sys.argv[1]
 
-drenv.log_progress("Deploying example")
+print("Deploying example")
 kubectl.apply("--filename", "example/deployment.yaml", profile=cluster)

--- a/test/example/test
+++ b/test/example/test
@@ -5,7 +5,6 @@
 
 import sys
 
-import drenv
 from drenv import kubectl
 
 if len(sys.argv) != 2:
@@ -14,7 +13,7 @@ if len(sys.argv) != 2:
 
 cluster = sys.argv[1]
 
-drenv.log_progress("Testing example deployment")
+print("Testing example deployment")
 kubectl.rollout(
     "status",
     "deploy/example-deployment",

--- a/test/minio/start
+++ b/test/minio/start
@@ -5,17 +5,16 @@
 
 import sys
 
-import drenv
 from drenv import kubectl
 
 
 def deploy(cluster):
-    drenv.log_progress("Deploying minio")
+    print("Deploying minio")
     kubectl.apply("--filename", "minio/minio.yaml", profile=cluster)
 
 
 def wait(cluster):
-    drenv.log_progress("Waiting until minio is rolled out")
+    print("Waiting until minio is rolled out")
     kubectl.rollout(
         "status",
         "deployment/minio",

--- a/test/ocm-cluster/start
+++ b/test/ocm-cluster/start
@@ -36,7 +36,7 @@ def deploy(cluster, hub):
 
 
 def wait(cluster):
-    drenv.log_progress("Waiting until deployments are rolled out")
+    print("Waiting until deployments are rolled out")
     for name in ADDONS:
         deployment = f"deploy/{name}"
         drenv.wait_for(deployment, namespace=ADDONS_NAMESPACE, profile=cluster)
@@ -50,7 +50,7 @@ def wait(cluster):
 
 
 def wait_for_hub(hub):
-    drenv.log_progress(f"Waiting until cluster {hub} is ready")
+    print(f"Waiting until cluster {hub} is ready")
 
     drenv.wait_for_cluster(hub)
     drenv.wait_for(f"namespace/{HUB_NAMESPACE}", profile=hub)
@@ -68,7 +68,7 @@ def wait_for_hub(hub):
 
 
 def join_cluster(cluster, hub):
-    drenv.log_progress(f"Joining to cluster {hub}")
+    print(f"Joining to cluster {hub}")
 
     # We can get the token from the first line of the response.
     out = clusteradm.get("token", context=hub)
@@ -87,12 +87,12 @@ def join_cluster(cluster, hub):
 
 
 def accept_cluster(cluster, hub):
-    drenv.log_progress("Accepting cluster")
+    print("Accepting cluster")
     clusteradm.accept([cluster], wait=True, context=hub)
 
 
 def enable_addons(cluster, hub):
-    drenv.log_progress("Enabling addons")
+    print("Enabling addons")
     clusteradm.addon("enable", names=ADDONS, clusters=[cluster], context=hub)
 
 

--- a/test/ocm-cluster/test
+++ b/test/ocm-cluster/test
@@ -10,12 +10,12 @@ from drenv import kubectl
 
 
 def deploy_work(cluster, hub, work):
-    drenv.log_progress(f"Applying manifestwork to namespace {cluster}")
+    print(f"Applying manifestwork to namespace {cluster}")
     kubectl.apply("--filename", "-", input=work, profile=hub)
 
 
 def wait_for_work(cluster, hub):
-    drenv.log_progress(f"Waiting until manifestwork is applied in namespace {cluster}")
+    print(f"Waiting until manifestwork is applied in namespace {cluster}")
     kubectl.wait(
         "manifestwork/example-manifestwork",
         "--for=condition=applied",
@@ -26,9 +26,7 @@ def wait_for_work(cluster, hub):
 
 
 def wait_for_deployment(cluster, hub):
-    drenv.log_progress(
-        f"Waiting until manifestwork is available in namespace {cluster}"
-    )
+    print(f"Waiting until manifestwork is available in namespace {cluster}")
     kubectl.wait(
         "manifestwork/example-manifestwork",
         "--for=condition=available",
@@ -37,7 +35,7 @@ def wait_for_deployment(cluster, hub):
         profile=hub,
     )
 
-    drenv.log_progress(f"Waiting until deployment is available in cluster {cluster}")
+    print(f"Waiting until deployment is available in cluster {cluster}")
     kubectl.wait(
         "deploy/example-deployment",
         "--for=condition=available",
@@ -47,12 +45,12 @@ def wait_for_deployment(cluster, hub):
 
 
 def delete_work(cluster, hub, work):
-    drenv.log_progress(f"Deleting manifestwork from namespace {cluster}")
+    print(f"Deleting manifestwork from namespace {cluster}")
     kubectl.delete("--filename", "-", input=work, profile=hub)
 
 
 def wait_for_delete_work(cluster, hub):
-    drenv.log_progress(f"Waiting until manifestwork is deleted from namspace {cluster}")
+    print(f"Waiting until manifestwork is deleted from namspace {cluster}")
     kubectl.wait(
         "manifestwork/example-manifestwork",
         "--for=delete",
@@ -63,7 +61,7 @@ def wait_for_delete_work(cluster, hub):
 
 
 def wait_for_delete_deployment(cluster):
-    drenv.log_progress(f"Waiting until deployment is deleted from cluster {cluster}")
+    print(f"Waiting until deployment is deleted from cluster {cluster}")
     kubectl.wait(
         "deploy/example-deployment",
         "--for=delete",

--- a/test/ocm-controller/start
+++ b/test/ocm-controller/start
@@ -13,7 +13,7 @@ BASE_URL = f"https://raw.githubusercontent.com/stolostron/multicloud-operators-f
 
 
 def deploy(cluster):
-    drenv.log_progress("Deploying ocm controller")
+    print("Deploying ocm controller")
     with drenv.kustomization(
         "ocm-controller/kustomization.yaml",
         base_url=BASE_URL,
@@ -22,7 +22,7 @@ def deploy(cluster):
 
 
 def wait(cluster):
-    drenv.log_progress("Waiting for ocm controller rollout")
+    print("Waiting for ocm controller rollout")
     kubectl.rollout(
         "status",
         "deploy/ocm-controller",

--- a/test/ocm-hub/start
+++ b/test/ocm-hub/start
@@ -33,15 +33,15 @@ DEPLOYMENTS = {
 
 
 def deploy(cluster):
-    drenv.log_progress("Initializing hub")
+    print("Initializing hub")
     clusteradm.init(wait=True, context=cluster)
 
-    drenv.log_progress("Installing hub addons")
+    print("Installing hub addons")
     clusteradm.install("hub-addon", names=ADDONS, context=cluster)
 
 
 def wait(cluster):
-    drenv.log_progress("Waiting until deployments are rolled out")
+    print("Waiting until deployments are rolled out")
     for ns, names in DEPLOYMENTS.items():
         for name in names:
             deployment = f"deploy/{name}"

--- a/test/olm/start
+++ b/test/olm/start
@@ -14,7 +14,7 @@ NAMESPACE = "olm"
 
 
 def deploy(cluster):
-    drenv.log_progress("Deploying olm crds")
+    print("Deploying olm crds")
 
     # Using Server-side Apply to avoid this failure:
     #   The CustomResourceDefinition "clusterserviceversions.operators.coreos.com"
@@ -26,20 +26,20 @@ def deploy(cluster):
         profile=cluster,
     )
 
-    drenv.log_progress("Waiting until cdrs are established")
+    print("Waiting until cdrs are established")
     kubectl.wait(
         "--for=condition=established",
         f"--filename={BASE_URL}/crds.yaml",
         profile=cluster,
     )
 
-    drenv.log_progress("Deploying olm")
+    print("Deploying olm")
     kubectl.apply("--filename", f"{BASE_URL}/olm.yaml", profile=cluster)
 
 
 def wait(cluster):
     for operator in "olm-operator", "catalog-operator":
-        drenv.log_progress(f"Waiting until {operator} is rolled out")
+        print(f"Waiting until {operator} is rolled out")
         kubectl.rollout(
             "status",
             "deploy",
@@ -48,7 +48,7 @@ def wait(cluster):
             profile=cluster,
         )
 
-    drenv.log_progress("Waiting until olm packageserver succeeds")
+    print("Waiting until olm packageserver succeeds")
     drenv.wait_for(
         "csv/packageserver",
         output="jsonpath={.status.phase}",
@@ -63,7 +63,7 @@ def wait(cluster):
         profile=cluster,
     )
 
-    drenv.log_progress("Waiting for olm pakcage server rollout")
+    print("Waiting for olm pakcage server rollout")
     kubectl.rollout(
         "status",
         "deploy/packageserver",

--- a/test/rbd-mirror/start
+++ b/test/rbd-mirror/start
@@ -16,7 +16,7 @@ POOL_NAME = "replicapool"
 def fetch_secret_info(cluster):
     info = {}
 
-    drenv.log_progress(f"Getting mirroring info site name for cluster {cluster}")
+    print(f"Getting mirroring info site name for cluster {cluster}")
     info["name"] = kubectl.get(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
@@ -25,9 +25,7 @@ def fetch_secret_info(cluster):
         profile=cluster,
     )
 
-    drenv.log_progress(
-        f"Getting rbd mirror boostrap peer secret name for cluster {cluster}"
-    )
+    print(f"Getting rbd mirror boostrap peer secret name for cluster {cluster}")
     secret_name = kubectl.get(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
@@ -36,7 +34,7 @@ def fetch_secret_info(cluster):
         profile=cluster,
     )
 
-    drenv.log_progress(f"Getting secret {secret_name} token for cluster {cluster}")
+    print(f"Getting secret {secret_name} token for cluster {cluster}")
     info["token"] = kubectl.get(
         "secret",
         secret_name,
@@ -52,7 +50,7 @@ def fetch_secret_info(cluster):
 
 
 def configure_rbd_mirroring(cluster, peer_info):
-    drenv.log_progress(f"Applying rbd mirror secret in cluster {cluster}")
+    print(f"Applying rbd mirror secret in cluster {cluster}")
 
     template = drenv.template("rbd-mirror/rbd-mirror-secret.yaml")
     yaml = template.substitute(peer_info)
@@ -63,7 +61,7 @@ def configure_rbd_mirroring(cluster, peer_info):
         profile=cluster,
     )
 
-    drenv.log_progress(f"Configure peers for cluster {cluster}")
+    print(f"Configure peers for cluster {cluster}")
     patch = {"spec": {"mirroring": {"peers": {"secretNames": [peer_info["name"]]}}}}
     kubectl.patch(
         "cephblockpool",
@@ -74,7 +72,7 @@ def configure_rbd_mirroring(cluster, peer_info):
         profile=cluster,
     )
 
-    drenv.log_progress(f"Apply rbd mirror to cluster {cluster}")
+    print(f"Apply rbd mirror to cluster {cluster}")
     kubectl.apply(
         "--filename=rbd-mirror/rbd-mirror.yaml",
         "--namespace=rook-ceph",
@@ -83,9 +81,7 @@ def configure_rbd_mirroring(cluster, peer_info):
 
 
 def wait_until_pool_mirroring_is_healthy(cluster):
-    drenv.log_progress(
-        f"Waiting until ceph mirror daemon is healthy in cluster {cluster}"
-    )
+    print(f"Waiting until ceph mirror daemon is healthy in cluster {cluster}")
     kubectl.wait(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
@@ -95,7 +91,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
         profile=cluster,
     )
 
-    drenv.log_progress(f"Waiting until ceph mirror is healthy in cluster {cluster}")
+    print(f"Waiting until ceph mirror is healthy in cluster {cluster}")
     kubectl.wait(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
@@ -105,9 +101,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
         profile=cluster,
     )
 
-    drenv.log_progress(
-        f"Waiting until ceph mirror image is healthy in cluster {cluster}"
-    )
+    print(f"Waiting until ceph mirror image is healthy in cluster {cluster}")
     kubectl.wait(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
@@ -119,7 +113,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
 
 
 def deploy_vrc_sample(cluster):
-    drenv.log_progress(f"Applying vrc sample in cluster {cluster}")
+    print(f"Applying vrc sample in cluster {cluster}")
     kubectl.apply(
         "--filename=rbd-mirror/vrc-sample.yaml",
         "--namespace=rook-ceph",
@@ -137,10 +131,10 @@ cluster2 = sys.argv[2]
 cluster1_info = fetch_secret_info(cluster1)
 cluster2_info = fetch_secret_info(cluster2)
 
-drenv.log_progress(f"Setting up mirroring from '{cluster2}' to '{cluster1}'")
+print(f"Setting up mirroring from '{cluster2}' to '{cluster1}'")
 configure_rbd_mirroring(cluster1, cluster2_info)
 
-drenv.log_progress(f"Setting up mirroring from '{cluster1}' to '{cluster2}'")
+print(f"Setting up mirroring from '{cluster1}' to '{cluster2}'")
 configure_rbd_mirroring(cluster2, cluster1_info)
 
 wait_until_pool_mirroring_is_healthy(cluster1)
@@ -149,4 +143,4 @@ wait_until_pool_mirroring_is_healthy(cluster2)
 deploy_vrc_sample(cluster1)
 deploy_vrc_sample(cluster2)
 
-drenv.log_progress("Mirroring was setup successfully")
+print("Mirroring was setup successfully")

--- a/test/rbd-mirror/test
+++ b/test/rbd-mirror/test
@@ -7,7 +7,6 @@ import json
 import sys
 import time
 
-import drenv
 from drenv import kubectl
 
 POOL_NAME = "replicapool"
@@ -43,14 +42,14 @@ def rbd_mirror_image_status(cluster, image):
 
 
 def test_volume_replication(primary, secondary):
-    drenv.log_progress(f"Deploying pvc {PVC_NAME} in cluster {primary}")
+    print(f"Deploying pvc {PVC_NAME} in cluster {primary}")
     kubectl.apply(
         f"--filename=rbd-mirror/{PVC_NAME}.yaml",
         "--namespace=rook-ceph",
         profile=primary,
     )
 
-    drenv.log_progress(f"Waiting until pvc {PVC_NAME} is bound in cluster {primary}")
+    print(f"Waiting until pvc {PVC_NAME} is bound in cluster {primary}")
     kubectl.wait(
         f"pvc/{PVC_NAME}",
         "--for=jsonpath={.status.phase}=Bound",
@@ -59,14 +58,14 @@ def test_volume_replication(primary, secondary):
         profile=primary,
     )
 
-    drenv.log_progress(f"Deploying vr vr-sample in cluster {primary}")
+    print(f"Deploying vr vr-sample in cluster {primary}")
     kubectl.apply(
         "--filename=rbd-mirror/vr-sample.yaml",
         "--namespace=rook-ceph",
         profile=primary,
     )
 
-    drenv.log_progress(f"Waiting until vr vr-sample is completed in cluster {primary}")
+    print(f"Waiting until vr vr-sample is completed in cluster {primary}")
     kubectl.wait(
         "volumereplication/vr-sample",
         "--for=condition=Completed",
@@ -75,9 +74,7 @@ def test_volume_replication(primary, secondary):
         profile=primary,
     )
 
-    drenv.log_progress(
-        f"Waiting until vr vr-sample state is primary in cluster {primary}"
-    )
+    print(f"Waiting until vr vr-sample state is primary in cluster {primary}")
     kubectl.wait(
         "volumereplication/vr-sample",
         "--for=jsonpath={.status.state}=Primary",
@@ -86,7 +83,7 @@ def test_volume_replication(primary, secondary):
         profile=primary,
     )
 
-    drenv.log_progress(f"Looking up pvc {PVC_NAME} pv name in cluster {primary}")
+    print(f"Looking up pvc {PVC_NAME} pv name in cluster {primary}")
     pv_name = kubectl.get(
         f"pvc/{PVC_NAME}",
         "--output=jsonpath={.spec.volumeName}",
@@ -94,7 +91,7 @@ def test_volume_replication(primary, secondary):
         profile=primary,
     )
 
-    drenv.log_progress(f"Looking up rbd image for pv {pv_name} in cluster {primary}")
+    print(f"Looking up rbd image for pv {pv_name} in cluster {primary}")
     rbd_image = kubectl.get(
         f"pv/{pv_name}",
         "--output=jsonpath={.spec.csi.volumeAttributes.imageName}",
@@ -102,7 +99,7 @@ def test_volume_replication(primary, secondary):
         profile=primary,
     )
 
-    drenv.log_progress(f"rbd image {rbd_image} info in cluster {primary}")
+    print(f"rbd image {rbd_image} info in cluster {primary}")
     out = kubectl.exec(
         "deploy/rook-ceph-tools",
         "--namespace=rook-ceph",
@@ -113,11 +110,9 @@ def test_volume_replication(primary, secondary):
         f"--pool={POOL_NAME}",
         profile=primary,
     )
-    drenv.log_detail(out)
+    print(out)
 
-    drenv.log_progress(
-        f"Waiting until rbd image {rbd_image} is created in cluster {secondary}"
-    )
+    print(f"Waiting until rbd image {rbd_image} is created in cluster {secondary}")
     for i in range(60):
         time.sleep(1)
         out = kubectl.exec(
@@ -140,12 +135,12 @@ def test_volume_replication(primary, secondary):
                 f"--pool={POOL_NAME}",
                 profile=secondary,
             )
-            drenv.log_detail(out)
+            print(out)
             break
     else:
         raise RuntimeError(f"Timeout waiting for image {rbd_image}")
 
-    drenv.log_progress(f"vr vr-sample info on primary cluster {primary}")
+    print(f"vr vr-sample info on primary cluster {primary}")
     kubectl.get(
         "volumereplication/vr-sample",
         "--output=yaml",
@@ -153,27 +148,25 @@ def test_volume_replication(primary, secondary):
         profile=primary,
     )
 
-    drenv.log_progress(f"rbd mirror image status in cluster {primary}")
+    print(f"rbd mirror image status in cluster {primary}")
     image_status = rbd_mirror_image_status(primary, rbd_image)
-    drenv.log_detail(json.dumps(image_status, indent=2))
+    print(json.dumps(image_status, indent=2))
 
-    drenv.log_progress(f"Deleting vr vr-sample in primary cluster {primary}")
+    print(f"Deleting vr vr-sample in primary cluster {primary}")
     kubectl.delete(
         "volumereplication/vr-sample",
         "--namespace=rook-ceph",
         profile=primary,
     )
 
-    drenv.log_progress(f"Deleting pvc {PVC_NAME} in primary cluster {primary}")
+    print(f"Deleting pvc {PVC_NAME} in primary cluster {primary}")
     kubectl.delete(
         f"pvc/{PVC_NAME}",
         "--namespace=rook-ceph",
         profile=primary,
     )
 
-    drenv.log_progress(
-        f"Replication from cluster {primary} to cluster {secondary} successeded"
-    )
+    print(f"Replication from cluster {primary} to cluster {secondary} successeded")
 
 
 if len(sys.argv) != 3:

--- a/test/rook-cluster/start
+++ b/test/rook-cluster/start
@@ -14,7 +14,7 @@ BASE_URL = f"https://raw.githubusercontent.com/rook/rook/{VERSION}/deploy/exampl
 
 
 def deploy(cluster):
-    drenv.log_progress("Deploying rook ceph cluster")
+    print("Deploying rook ceph cluster")
     with drenv.kustomization(
         "rook-cluster/kustomization.yaml",
         base_url=BASE_URL,
@@ -23,7 +23,7 @@ def deploy(cluster):
 
 
 def wait(cluster):
-    drenv.log_progress("Waiting until rook ceph cluster is ready")
+    print("Waiting until rook ceph cluster is ready")
     drenv.wait_for(
         "cephcluster/my-cluster",
         output="jsonpath={.status.phase}",

--- a/test/rook-operator/start
+++ b/test/rook-operator/start
@@ -14,7 +14,7 @@ BASE_URL = f"https://raw.githubusercontent.com/rook/rook/{VERSION}/deploy/exampl
 
 
 def deploy(cluster):
-    drenv.log_progress("Deploying rook ceph operator")
+    print("Deploying rook ceph operator")
     with drenv.kustomization(
         "rook-operator/kustomization.yaml",
         base_url=BASE_URL,
@@ -23,7 +23,7 @@ def deploy(cluster):
 
 
 def wait(cluster):
-    drenv.log_progress("Waiting until rook ceph operator is rolled out")
+    print("Waiting until rook ceph operator is rolled out")
     kubectl.rollout(
         "status",
         "deploy/rook-ceph-operator",
@@ -32,7 +32,7 @@ def wait(cluster):
         profile=cluster,
     )
 
-    drenv.log_progress("Waiting until rook ceph operator is ready")
+    print("Waiting until rook ceph operator is ready")
     kubectl.wait(
         "pod",
         "--for=jsonpath={.status.phase}=Running",

--- a/test/rook-pool/start
+++ b/test/rook-pool/start
@@ -10,7 +10,7 @@ from drenv import kubectl
 
 
 def deploy(cluster):
-    drenv.log_progress("Creating rbd pool and storage class")
+    print("Creating rbd pool and storage class")
     kubectl.apply(
         "--filename=rook-pool/replica-pool.yaml",
         "--filename=rook-pool/storage-class.yaml",
@@ -19,7 +19,7 @@ def deploy(cluster):
 
 
 def wait(cluster):
-    drenv.log_progress("Waiting until ceph block pool is ready")
+    print("Waiting until ceph block pool is ready")
     drenv.wait_for(
         "cephblockpool/replicapool",
         output="jsonpath={.status.phase}",
@@ -35,7 +35,7 @@ def wait(cluster):
         profile=cluster,
     )
 
-    drenv.log_progress("Waiting for replica pool peer token")
+    print("Waiting for replica pool peer token")
     kubectl.wait(
         "cephblockpool/replicapool",
         "--for=jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}=pool-peer-token-replicapool",

--- a/test/rook-toolbox/start
+++ b/test/rook-toolbox/start
@@ -5,7 +5,6 @@
 
 import sys
 
-import drenv
 from drenv import kubectl
 
 # Update this when upgrading rook.
@@ -14,12 +13,12 @@ BASE_URL = f"https://raw.githubusercontent.com/rook/rook/{VERSION}/deploy/exampl
 
 
 def deploy(cluster):
-    drenv.log_progress("Deploying rook ceph toolbox")
+    print("Deploying rook ceph toolbox")
     kubectl.apply("--filename", f"{BASE_URL}/toolbox.yaml", profile=cluster)
 
 
 def wait(cluster):
-    drenv.log_progress("Waiting until rook-ceph-tools is rolled out")
+    print("Waiting until rook-ceph-tools is rolled out")
     kubectl.rollout(
         "status",
         "deploy/rook-ceph-tools",


### PR DESCRIPTION
The logging functions makes the debug output little nicer, but they are not standard and make it harder to learn for new contributors.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>