### PR TITLE
Remove leftover `scripts`

### DIFF
--- a/test/drenv/envfile.py
+++ b/test/drenv/envfile.py
@@ -74,7 +74,6 @@ def _validate_profile(profile):
     profile.setdefault("cpus", 2)
     profile.setdefault("memory", "4g")
     profile.setdefault("network", "")
-    profile.setdefault("scripts", [])
     profile.setdefault("addons", [])
     profile.setdefault("workers", [])
 


### PR DESCRIPTION
When adding `workers` we forgot to remove `scripts` which are never used now.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>