### PR TITLE
Add missing ocm-controller to the hub

### DIFF
--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -35,6 +35,7 @@ templates:
     workers:
       - scripts:
           - name: ocm-hub
+          - name: ocm-controller
           - name: cert-manager
           - name: olm
 


### PR DESCRIPTION
The ocm-controller is missing from regional-dr yaml. I suspect that it was dropped by mistake recently.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>