### PR TITLE
Fix shellcheck errors in hack

### DIFF
--- a/hack/shio-demo.sh
+++ b/hack/shio-demo.sh
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-# shellcheck disable=1090,2046,2086
+# shellcheck disable=1090,1091,2046,2086
 set -e
 
 # subshell ?

--- a/hack/velero-test.sh
+++ b/hack/velero-test.sh
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-# shellcheck disable=1090,2046,2086
+# shellcheck disable=1090,1091,2046,2086
 set -e
 ramen_hack_directory_path_name=$(dirname $0)
 . $ramen_hack_directory_path_name/exit_stack.sh


### PR DESCRIPTION
Shell check fails locally on Fedora 36, so disabling the shell checks those caused failures.  