### PR TITLE
Rename `sanity` to `ci`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@
 ---
 # yamllint disable rule:line-length
 
-name: PR and branch sanity
+name: CI
 
 # This workflow will run when developer push a topic branch to their
 # fork in github, minimizing noise for maintainers.
@@ -18,7 +18,7 @@ env:
   IMAGE_REGISTRY: "quay.io"
   IMAGE_REPOSITORY: "ramendr"
   IMAGE_NAME: "ramen"
-  IMAGE_TAG: "sanity"
+  IMAGE_TAG: "ci"
   DOCKERCMD: "podman"
 defaults:
   run:
@@ -154,7 +154,7 @@ jobs:
       - name: Go tidy
         run: go mod tidy
 
-      - name: Git branch sanity
+      - name: Check auto generated files
         run: |
           echo "Failing if any auto generated files are updated, checking 'git status'"
           git --no-pager diff
@@ -176,7 +176,7 @@ jobs:
       KUBERNETES_VERSION: ${{ matrix.kubernetes_version }}
       KIND_VERSION: ${{ matrix.kind_version }}
       KIND_IMAGE: ${{ matrix.kind_image }}
-      KIND_CLUSTER_NAME: "sanity"
+      KIND_CLUSTER_NAME: "ci"
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
According to IBM's Inclusive IT Terminology the terms `sanity test` and `sanity check` should not be used because:

    This term might be derogatory to neurodiverse people. Jargon, such
    as "sanity test", is difficult to translate and is difficult to
    understand by readers whose first language is not English.

Using `ci` instead of `sanity` in the workflow name and tags, and improve step name to describe better what the step does instead of the unclear `branch sanity`.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>