### PR TITLE
hack: require minimum linter versions

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           echo 'APT::Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/80-retries
           sudo apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip ruby
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip ruby shellcheck
           sudo gem install mdl
           sudo pip3 install yamllint
 

--- a/hack/version_test_ge_xyz.sh
+++ b/hack/version_test_ge_xyz.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+IFS=. read -r x y z <<-a
+$1
+a
+IFS=. read -r xx yy zz <<-a
+$2
+a
+printf "version: %s.%s.%s\nminimum: %s.%s.%s\n" "$x" "$y" "$z" "$xx" "$yy" "$zz" >&2
+test "$x" -gt "$xx" ||\
+{ test "$x" -eq "$xx" &&\
+        { test "$y" -gt "$yy" ||\
+        { test "$y" -eq "$yy" &&\
+                 test "$z" -ge "$zz";};};}
+set -- $?
+unset -v x y z xx yy zz
+exit "$1"


### PR DESCRIPTION
Require pre-commit linter versions be _greater than or equal to_ the following minimum values:

```sh
$ hack/pre-commit.sh
/tmp/tool-errors-llS3il
=====  mdl  =====
version: 0.12.0
minimum: 0.11.0


=====  shellcheck  =====
version: 0.7.2
minimum: 0.7.2


=====  yamllint  =====
version: 1.10.0
minimum: 1.10.0


```
Suppose `shellcheck` version is downgraded to one that is _less than_ the minimum:
```
$ hack/pre-commit.sh
/tmp/tool-errors-Hpg9wh
=====  mdl  =====
version: 0.12.0
minimum: 0.11.0


=====  shellcheck  =====
version: 0.4.6
minimum: 0.7.2
error: version precedes minimum
```