### PR TITLE
drenv: sensible defaults for various platforms

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -458,12 +458,16 @@ $ drenv delete envs/example.yaml
     - `external`: true if this is existing external cluster. In this
       case the tool will not start a minikube cluster and all other
       options are ignored.
-    - `driver`: The minikube driver. Tested with "kvm2" and "podman"
-      (default "kvm2")
+    - `driver`: The minikube driver. On Linux, the default drivers are kvm2 and
+      docker for VMs and containers. On MacOS, the defaults are hyperkit and
+      podman. Use "$vm" and "$container" values to use the recommended VM and
+      container drivers for the platform.
     - `container_runtime`: The container runtime to be used. Valid
       options: "docker", "cri-o", "containerd" (default: "containerd")
-    - `network`: The network to run minikube with. If left empty,
-      minikube will create a new isolated network.
+    - `network`: The network to run minikube with. If left empty, the behavior
+      is same as that of minikube for the platform. Use
+      "$network" value to use the recommended network configuration
+      for the platform.
     - `extra_disks`: Number of extra disks (default 0)
     - `disk_size`: Disk size string (default "50g")
     - `nodes`: Number of cluster nodes (default 1)

--- a/test/envs/demo.yaml
+++ b/test/envs/demo.yaml
@@ -6,9 +6,9 @@
 name: demo
 templates:
   - name: "demo-cluster"
-    driver: kvm2
+    driver: $vm
     container_runtime: containerd
-    network: default
+    network: $network
     addons:
       - ingress
     workers:

--- a/test/envs/example.yaml
+++ b/test/envs/example.yaml
@@ -6,7 +6,7 @@
 name: example
 templates:
   - name: "example-cluster"
-    driver: kvm2
+    driver: $vm
     container_runtime: containerd
     workers:
       - addons:

--- a/test/envs/minio.yaml
+++ b/test/envs/minio.yaml
@@ -15,9 +15,9 @@ templates:
 profiles:
   - name: c1
     template: base
-    driver: podman
+    driver: $container
     container_runtime: cri-o
   - name: c2
     template: base
-    driver: kvm2
+    driver: $vm
     container_runtime: containerd

--- a/test/envs/ocm.yaml
+++ b/test/envs/ocm.yaml
@@ -7,17 +7,17 @@ name: "ocm"
 
 templates:
   - name: "hub-cluster"
-    driver: kvm2
+    driver: "$vm"
     container_runtime: containerd
-    network: default
+    network: "$network"
     workers:
       - addons:
           - name: ocm-hub
           - name: ocm-controller
   - name: "dr-cluster"
-    driver: kvm2
+    driver: "$vm"
     container_runtime: containerd
-    network: default
+    network: "$network"
     workers:
       - addons:
           - name: ocm-cluster

--- a/test/envs/regional-dr-external.yaml.example
+++ b/test/envs/regional-dr-external.yaml.example
@@ -12,9 +12,9 @@ name: "rdr-external"
 
 templates:
   - name: "dr-cluster"
-    driver: kvm2
+    driver: $vm
     container_runtime: containerd
-    network: default
+    network: $network
     memory: "4g"
     workers:
       - addons:
@@ -28,9 +28,9 @@ templates:
       - addons:
           - name: my-external-storage
   - name: "hub-cluster"
-    driver: kvm2
+    driver: $vm
     container_runtime: containerd
-    network: default
+    network: $network
     memory: "4g"
     workers:
       - addons:

--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -12,9 +12,9 @@ ramen:
 
 templates:
   - name: "dr-cluster"
-    driver: kvm2
+    driver: "$vm"
     container_runtime: containerd
-    network: default
+    network: "$network"
     memory: "6g"
     extra_disks: 1
     disk_size: "50g"
@@ -37,9 +37,9 @@ templates:
           - name: minio
           - name: velero
   - name: "hub-cluster"
-    driver: kvm2
+    driver: "$vm"
     container_runtime: containerd
-    network: default
+    network: "$network"
     memory: "4g"
     workers:
       - addons:

--- a/test/envs/rook.yaml
+++ b/test/envs/rook.yaml
@@ -7,9 +7,9 @@ name: "rook"
 
 templates:
   - name: "dr-cluster"
-    driver: kvm2
+    driver: "$vm"
     container_runtime: containerd
-    network: default
+    network: "$network"
     memory: "6g"
     extra_disks: 1
     disk_size: "50g"

--- a/test/envs/submariner.yaml
+++ b/test/envs/submariner.yaml
@@ -7,9 +7,9 @@ name: submariner
 
 templates:
   - name: cluster
-    driver: kvm2
+    driver: $vm
     container_runtime: containerd
-    network: default
+    network: $network
     cni: kindnet
     memory: 3g
 

--- a/test/envs/test.yaml
+++ b/test/envs/test.yaml
@@ -6,7 +6,7 @@
 name: test
 profiles:
   - name: cluster
-    driver: docker
+    driver: $container
     memory: 2g
     workers:
       - addons:

--- a/test/envs/velero.yaml
+++ b/test/envs/velero.yaml
@@ -7,7 +7,7 @@ name: "velero"
 
 profiles:
   - name: velero
-    driver: kvm2
+    driver: $vm
     container_runtime: containerd
     memory: 2g
     workers:

--- a/test/envs/volsync.yaml
+++ b/test/envs/volsync.yaml
@@ -7,9 +7,9 @@ name: volsync
 
 templates:
   - name: hub
-    driver: kvm2
+    driver: $vm
     container_runtime: containerd
-    network: default
+    network: $network
     cni: kindnet
     memory: 2g
     workers:
@@ -17,9 +17,9 @@ templates:
           - name: submariner
             args: [hub, dr1, dr2]
   - name: cluster
-    driver: kvm2
+    driver: $vm
     container_runtime: containerd
-    network: default
+    network: $network
     cni: kindnet
     memory: 4g
     disk_size: 50g


### PR DESCRIPTION
We want drenv to use VM based driver in most cases. Also, the VM drivers
differ based on the OS. This commit introduces sensible defaults for
various platforms. To make it easy, higher level values like drenv-vm,
drenv-container and drenv-network-shared are introduced to abstract the
specifics from the user.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>