### PR TITLE
cleanup existing metrics

### DIFF
--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -28,7 +28,6 @@ import (
 	ocmworkv1 "github.com/open-cluster-management/api/work/v1"
 	viewv1beta1 "github.com/stolostron/multicloud-operators-foundation/pkg/apis/view/v1beta1"
 
-	dto "github.com/prometheus/client_model/go"
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/controllers"
 	rmnutil "github.com/ramendr/ramen/controllers/util"
@@ -1199,10 +1198,6 @@ func runRelocateAction(userPlacementRule *plrv1.PlacementRule, fromCluster strin
 	userPlacementRule = getLatestUserPlacementRule(userPlacementRule.Name, userPlacementRule.Namespace)
 	Expect(userPlacementRule.Status.Decisions[0].ClusterName).To(Equal(toCluster1))
 	Expect(condition.Reason).To(Equal(string(rmn.Relocated)))
-
-	val, err := rmnutil.GetMetricValueSingle("ramen_relocate_time", dto.MetricType_GAUGE)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(val).NotTo(Equal(0.0)) // failover time should be non-zero
 }
 
 func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferredCluster, failoverCluster string) {
@@ -1419,10 +1414,6 @@ func verifyInitialDRPCDeployment(userPlacementRule *plrv1.PlacementRule, drpc *r
 	Expect(len(latestDRPC.Status.Conditions)).To(Equal(2))
 	_, condition := getDRPCCondition(&latestDRPC.Status, rmn.ConditionAvailable)
 	Expect(condition.Reason).To(Equal(string(rmn.Deployed)))
-
-	val, err := rmnutil.GetMetricValueSingle("ramen_initial_deploy_time", dto.MetricType_GAUGE)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(val).NotTo(Equal(0.0)) // failover time should be non-zero
 }
 
 func verifyFailoverToSecondary(userPlacementRule *plrv1.PlacementRule, toCluster string,
@@ -1441,10 +1432,6 @@ func verifyFailoverToSecondary(userPlacementRule *plrv1.PlacementRule, toCluster
 	}
 
 	Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1)) // Roles MW
-
-	val, err := rmnutil.GetMetricValueSingle("ramen_failover_time", dto.MetricType_GAUGE)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(val).NotTo(Equal(0.0)) // failover time should be non-zero
 
 	drpc := getLatestDRPC()
 	// At this point expect the DRPC status condition to have 2 types

--- a/controllers/util/mw_util_test.go
+++ b/controllers/util/mw_util_test.go
@@ -13,7 +13,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
@@ -288,73 +287,6 @@ var _ = Describe("IsManifestInAppliedState", func() {
 			}
 
 			Expect(rmnutil.IsManifestInAppliedState(mw)).To(Equal(false))
-		})
-	})
-
-	Context("GetMetricValueFromName tests Prometheus metrics", func() {
-		It("register custom metrics", func() {
-			// note: go_goroutines was picked because it's A) a supported type, B) does not use vector values
-			val, err := rmnutil.GetMetricValueSingle("ramen_test_gauge", dto.MetricType_GAUGE)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(val).To(Equal(0.0)) // unused: default to zero (float64)
-		})
-	})
-
-	Context("GetMetricValueFromName tests custom Prometheus metrics", func() {
-		It("basic timer functionality", func() {
-			timer := prometheus.NewTimer(prometheus.ObserverFunc(testGauge.Set))
-			time.Sleep(1 * time.Second) // let the observer gather some time
-			timer.ObserveDuration()     // stop timer when function returns (all cases)
-
-			val, err := rmnutil.GetMetricValueSingle("ramen_test_gauge", dto.MetricType_GAUGE)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(val).NotTo(Equal(0.0)) // should be some small but non-zero value
-		})
-
-		It("basic counter functionality", func() {
-			val, err := rmnutil.GetMetricValueSingle("ramen_test_counter", dto.MetricType_COUNTER)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(val).To(Equal(0.0))
-
-			testCounter.Inc()
-
-			val, err = rmnutil.GetMetricValueSingle("ramen_test_counter", dto.MetricType_COUNTER)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(val).To(Equal(1.0))
-		})
-
-		It("basic histogram functionality", func() {
-			val, err := rmnutil.GetMetricValueSingle("ramen_test_histogram", dto.MetricType_HISTOGRAM)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(val).To(Equal(0.0))
-
-			testHistogram.Observe(2.5) // add arbitrary observation
-
-			val, err = rmnutil.GetMetricValueSingle("ramen_test_histogram", dto.MetricType_HISTOGRAM)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(val).To(Equal(1.0)) // get observation count
-		})
-	})
-
-	Context("GetMetricValueFromName error checks", func() {
-		It("invalid name", func() {
-			val, err := rmnutil.GetMetricValueSingle("invalid_metric", dto.MetricType_GAUGE)
-
-			Expect(err).To(HaveOccurred())
-			Expect(val).To(Equal(0.0))
-		})
-
-		It("incorrect metric type", func() {
-			val, err := rmnutil.GetMetricValueSingle("ramen_test_gauge", dto.MetricType_HISTOGRAM)
-
-			Expect(err).To(HaveOccurred())
-			Expect(val).To(Equal(0.0))
 		})
 	})
 })


### PR DESCRIPTION
Removing current metrics that are not being used anymore. This is a precursor change to the new metrics that are being added to ramen. 