### PR TITLE
Conditional publish image job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -294,6 +294,7 @@ jobs:
       IMAGE_NAME: ${{needs.definevars.outputs.imagename}}
       OPERATOR_SUGGESTED_NAMESPACE: ${{needs.definevars.outputs.operatorsuggestednamespace}}
     if: >
+      (vars.PUBLISH_IMAGES == 'true') &&
       (github.event_name == 'push') &&
       (github.ref == 'refs/heads/main' ||
        startsWith(github.ref, 'refs/heads/release-') ||


### PR DESCRIPTION
Now that every fork can publish images, the build fail since forks do not have the required secrets to push to `quay.io/ramendr/`. Enable the publish job only if the variable PUBLISH_IMAGES is true.

Forks that want to publish images must define PUBLISH_IMAGES variable and configure the required secrets.

Fixes: 974ac0af4c53