### PR TITLE
Simplify variables usage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,55 +13,20 @@ on:  # yamllint disable-line rule:truthy
   - pull_request
 
 env:
+  # Values can be overriden by repository variables.
+  IMAGE_TAG_BASE: ${{ vars.IMAGE_TAG_BASE || 'quay.io/ramendr/ramen' }}
+  IMAGE_REPOSITORY: ${{ vars.IMAGE_REPOSITORY || 'ramendr' }}
+  IMAGE_NAME: ${{ vars.IMAGE_NAME || 'ramen' }}
+  OPERATOR_SUGGESTED_NAMESPACE: ${{ vars.OPERATOR_SUGGESTED_NAMESPACE || 'ramen-system' }}
+  # Constants
   GO_VERSION: "1.18"
-  IMAGE_TAG_BASE: "quay.io/ramendr/ramen"
   IMAGE_REGISTRY: "quay.io"
-  IMAGE_REPOSITORY: "ramendr"
-  IMAGE_NAME: "ramen"
   IMAGE_TAG: "ci"
   DOCKERCMD: "podman"
-  OPERATOR_SUGGESTED_NAMESPACE: "ramen-system"
 defaults:
   run:
     shell: bash
 jobs:
-  definevars:
-    name: Define variables
-    runs-on: ubuntu-20.04
-    outputs:
-      imagetagbase: ${{ steps.imagetagbase.outputs.variable }}
-      imagerepository: ${{ steps.imagerepository.outputs.variable }}
-      imagename: ${{ steps.imagename.outputs.variable }}
-      operatorsuggestednamespace: ${{ steps.operatorsuggestednamespace.outputs.variable }}
-    steps:
-      - id: imagetagbase
-        run: |
-          if ${{ vars.IMAGE_TAG_BASE != '' }}; then
-            echo "variable=${{ vars.IMAGE_TAG_BASE }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "variable=$IMAGE_TAG_BASE" >> "$GITHUB_OUTPUT"
-          fi
-      - id: imagerepository
-        run: |
-          if ${{ vars.IMAGE_REPOSITORY != '' }}; then
-            echo "variable=${{ vars.IMAGE_REPOSITORY }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "variable=$IMAGE_REPOSITORY" >> "$GITHUB_OUTPUT"
-          fi
-      - id: imagename
-        run: |
-          if ${{ vars.IMAGE_NAME != '' }}; then
-            echo "variable=${{ vars.IMAGE_NAME }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "variable=$IMAGE_NAME" >> "$GITHUB_OUTPUT"
-          fi
-      - id: operatorsuggestednamespace
-        run: |
-          if ${{ vars.OPERATOR_SUGGESTED_NAMESPACE != '' }}; then
-            echo "variable=${{ vars.OPERATOR_SUGGESTED_NAMESPACE }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "variable=$OPERATOR_SUGGESTED_NAMESPACE" >> "$GITHUB_OUTPUT"
-          fi
 
   lint:
     name: Linters
@@ -167,11 +132,6 @@ jobs:
 
   build-image-and-ensure-clean-branch:
     name: Build image and ensure clean branch
-    needs: definevars
-    env:
-      IMAGE_TAG_BASE: ${{needs.definevars.outputs.imagetagbase}}
-      IMAGE_REPOSITORY: ${{needs.definevars.outputs.imagerepository}}
-      IMAGE_NAME: ${{needs.definevars.outputs.imagename}}
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source
@@ -206,7 +166,7 @@ jobs:
 
   deploy-check:
     name: Check artifacts and operator deployment
-    needs: [definevars, build-image-and-ensure-clean-branch]
+    needs: [build-image-and-ensure-clean-branch]
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -221,9 +181,6 @@ jobs:
       KIND_VERSION: ${{ matrix.kind_version }}
       KIND_IMAGE: ${{ matrix.kind_image }}
       KIND_CLUSTER_NAME: "ci"
-      IMAGE_TAG_BASE: ${{needs.definevars.outputs.imagetagbase}}
-      IMAGE_REPOSITORY: ${{needs.definevars.outputs.imagerepository}}
-      IMAGE_NAME: ${{needs.definevars.outputs.imagename}}
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -287,12 +244,7 @@ jobs:
 
   publish-image:
     name: Publish built image
-    needs: [definevars, deploy-check, lint, golangci, unit-test, build-image-and-ensure-clean-branch]
-    env:
-      IMAGE_TAG_BASE: ${{needs.definevars.outputs.imagetagbase}}
-      IMAGE_REPOSITORY: ${{needs.definevars.outputs.imagerepository}}
-      IMAGE_NAME: ${{needs.definevars.outputs.imagename}}
-      OPERATOR_SUGGESTED_NAMESPACE: ${{needs.definevars.outputs.operatorsuggestednamespace}}
+    needs: [deploy-check, lint, golangci, unit-test, build-image-and-ensure-clean-branch]
     if: >
       (vars.PUBLISH_IMAGES == 'true') &&
       (github.event_name == 'push') &&


### PR DESCRIPTION
We can inject the repository variables (vars.*) into the top level env. With this we don't need the definevars job.