### PR TITLE
Do not update drpc instance spec

### DIFF
--- a/api/v1alpha1/drplacementcontrol_webhook.go
+++ b/api/v1alpha1/drplacementcontrol_webhook.go
@@ -45,14 +45,26 @@ func (r *DRPlacementControl) ValidateUpdate(old runtime.Object) error {
 
 	// checks for immutability
 	if !reflect.DeepEqual(r.Spec.PlacementRef, oldDRPC.Spec.PlacementRef) {
+		drplacementcontrollog.Info("detected PlacementRef updates, which is disallowed", "name", r.Name,
+			"old", oldDRPC.Spec.PlacementRef,
+			"new", r.Spec.PlacementRef)
+
 		return fmt.Errorf("PlacementRef cannot be changed")
 	}
 
 	if !reflect.DeepEqual(r.Spec.DRPolicyRef, oldDRPC.Spec.DRPolicyRef) {
+		drplacementcontrollog.Info("detected DRPolicyRef updates, which is disallowed", "name", r.Name,
+			"old", oldDRPC.Spec.DRPolicyRef,
+			"new", r.Spec.DRPolicyRef)
+
 		return fmt.Errorf("DRPolicyRef cannot be changed")
 	}
 
 	if !reflect.DeepEqual(r.Spec.PVCSelector, oldDRPC.Spec.PVCSelector) {
+		drplacementcontrollog.Info("detected PVCSelector updates, which is disallowed", "name", r.Name,
+			"old", oldDRPC.Spec.PVCSelector,
+			"new", r.Spec.PVCSelector)
+
 		return fmt.Errorf("PVCSelector cannot be changed")
 	}
 

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -727,11 +727,12 @@ func (r *DRPlacementControlReconciler) getUserPlacementRule(ctx context.Context,
 ) (*plrv1.PlacementRule, error) {
 	log.Info("Getting User PlacementRule", "placement", drpc.Spec.PlacementRef)
 
-	if drpc.Spec.PlacementRef.Namespace == "" {
-		drpc.Spec.PlacementRef.Namespace = drpc.Namespace
+	plRuleNamespace := drpc.Spec.PlacementRef.Namespace
+	if plRuleNamespace == "" {
+		plRuleNamespace = drpc.Namespace
 	}
 
-	if drpc.Spec.PlacementRef.Namespace != drpc.Namespace {
+	if plRuleNamespace != drpc.Namespace {
 		return nil, fmt.Errorf("referenced PlacementRule namespace (%s)"+
 			" differs from DRPlacementControl resource namespace (%s)",
 			drpc.Spec.PlacementRef.Namespace, drpc.Namespace)
@@ -740,7 +741,7 @@ func (r *DRPlacementControlReconciler) getUserPlacementRule(ctx context.Context,
 	usrPlRule := &plrv1.PlacementRule{}
 
 	err := r.Client.Get(ctx,
-		types.NamespacedName{Name: drpc.Spec.PlacementRef.Name, Namespace: drpc.Spec.PlacementRef.Namespace},
+		types.NamespacedName{Name: drpc.Spec.PlacementRef.Name, Namespace: plRuleNamespace},
 		usrPlRule)
 	if err != nil {
 		if errors.IsNotFound(err) && !drpc.GetDeletionTimestamp().IsZero() {


### PR DESCRIPTION
While fetching the user placement rule, the drpc
instance spec.placementref.namespace was updated,
which causes a subsequent update of DRPC with its
finalizer to hit the webhook that prevents such an update.

The fix is to use a local namespace variable rather than update the drpc instance spec section for the same. This prevents the finalizer update to DRPC not failing at the webhook.

NOTE: Changing the DRPC webhook to ignore a namespace update is also a feasible fix, but that would update the user provided spec iadvertently, which is avoided here.