### PR TITLE
Support test environemnt using external storage and clusters

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -444,6 +444,9 @@ $ drenv delete example.yaml
 
 - `templates`: templates for creating new profiles.
     - `name`: profile name.
+    - `external`: true if this is existing external cluster. In this
+      case the tool will not start a minikube cluster and all other
+      options are ignored.
     - `driver`: The minikube driver. Tested with "kvm2" and "podman"
       (default "kvm2")
     - `container_runtime`: The container runtime to be used. Valid

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-import json
 import os
 import string
 import tempfile
@@ -10,7 +9,6 @@ import time
 from contextlib import contextmanager
 
 from . import kubectl
-from . import minikube
 
 
 def wait_for(
@@ -51,66 +49,6 @@ def wait_for(
             raise RuntimeError(f"Timeout waiting for {resource}")
 
         time.sleep(delay)
-
-
-def wait_for_cluster(cluster, timeout=300):
-    """
-    Wait until a cluster is available.
-
-    This is useful when starting profiles concurrently, when one profile needs
-    to wait for another profile.
-    """
-    deadline = time.monotonic() + timeout
-    delay = min(1.0, timeout / 60)
-    last_status = None
-
-    while True:
-        status = cluster_status(cluster)
-        current_status = status.get("APIServer", "Unknown")
-
-        if current_status != last_status:
-            print(f"cluster {cluster} status is {current_status}")
-            last_status = current_status
-
-        if current_status == "Running":
-            break
-
-        if time.monotonic() > deadline:
-            raise RuntimeError(f"Timeout waiting for {cluster}")
-
-        time.sleep(delay)
-
-
-def cluster_status(cluster):
-    """
-    Return minikube status for cluster or empty dict if the cluster does not
-    exist or not configured with kubectl yet.
-    """
-    # To avoid lot of noise in the logs, fetch status only if kubectl knows
-    # about this cluster.
-    if not cluster_info(cluster):
-        return {}
-
-    out = minikube.status(cluster, output="json")
-    return json.loads(out)
-
-
-def cluster_info(cluster):
-    """
-    Return cluster info from kubectl config. Returns empty dict if the cluster
-    is not configured with kubectl yet.
-    """
-    out = kubectl.config("view", "--output", "json")
-    config = json.loads(out)
-
-    # We get null instead of [].
-    clusters = config.get("clusters") or ()
-
-    for c in clusters:
-        if c["name"] == cluster:
-            return c
-
-    return {}
 
 
 def template(path):

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -9,8 +9,8 @@ import time
 
 from contextlib import contextmanager
 
-from . import commands
 from . import kubectl
+from . import minikube
 
 
 def wait_for(
@@ -91,26 +91,8 @@ def cluster_status(cluster):
     if not cluster_info(cluster):
         return {}
 
-    out = commands.run(
-        "minikube",
-        "status",
-        "--profile",
-        cluster,
-        "--output",
-        "json",
-    )
-
+    out = minikube.status(cluster, output="json")
     return json.loads(out)
-
-
-def cluster_exists(cluster):
-    out = commands.run("minikube", "profile", "list", "--output=json")
-    profiles = json.loads(out)
-    for profile in profiles["valid"]:
-        if profile["Name"] == cluster:
-            return True
-
-    return False
 
 
 def cluster_info(cluster):

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -13,6 +13,7 @@ import time
 import yaml
 
 import drenv
+from . import cluster
 from . import commands
 from . import envfile
 from . import minikube
@@ -129,9 +130,9 @@ def start_cluster(profile, hooks=(), **options):
 
 
 def stop_cluster(profile, **options):
-    cluster_status = drenv.cluster_status(profile["name"])
+    cluster_status = cluster.status(profile["name"])
 
-    if cluster_status.get("APIServer") == "Running":
+    if cluster_status == cluster.READY:
         execute(
             run_worker,
             profile["workers"],
@@ -142,7 +143,7 @@ def stop_cluster(profile, **options):
 
     if profile["external"]:
         logging.debug("[%s] Skipping external cluster", profile["name"])
-    elif cluster_status.get("Host") == "Running":
+    elif cluster_status != cluster.UNKNOWN:
         stop_minikube_cluster(profile)
 
 

--- a/test/drenv/cluster.py
+++ b/test/drenv/cluster.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import time
+
+from . import kubectl
+
+# Cluster does not have kubeconfig.
+UNKNOWN = "unknwon"
+
+# Cluster has kubeconfig.
+CONFIGURED = "configured"
+
+# APIServer is responding.
+READY = "ready"
+
+
+def status(name):
+    if not kubeconfig(name):
+        return UNKNOWN
+
+    out = kubectl.version(context=name, output="json")
+    version_info = json.loads(out)
+    if "serverVersion" not in version_info:
+        return CONFIGURED
+
+    return READY
+
+
+def wait_until_ready(name, timeout=300):
+    """
+    Wait until a cluster is ready.
+
+    This is useful when starting profiles concurrently, when one profile needs
+    to wait for another profile.
+    """
+    deadline = time.monotonic() + timeout
+    delay = min(1.0, timeout / 60)
+    last_status = None
+
+    while True:
+        current_status = status(name)
+
+        if current_status != last_status:
+            print(f"Cluster {name} is {current_status}")
+            last_status = current_status
+
+        if current_status == READY:
+            break
+
+        if time.monotonic() > deadline:
+            raise RuntimeError(f"Timeout waiting for cluster {name}")
+
+        time.sleep(delay)
+
+
+def kubeconfig(name):
+    """
+    Return cluster kubeconfig. Returns empty dict if the cluster is not
+    configured with kubectl yet.
+    """
+    out = kubectl.config("view", "--output", "json")
+    config = json.loads(out)
+
+    # We get null instead of [].
+    clusters = config.get("clusters") or ()
+
+    for c in clusters:
+        if c["name"] == name:
+            return c
+
+    return {}

--- a/test/drenv/cluster_test.py
+++ b/test/drenv/cluster_test.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from drenv import cluster
+
+
+def test_status_unknown():
+    assert cluster.status("no-such-profile") == cluster.UNKNOWN
+
+
+def test_status_ready(tmpenv):
+    assert cluster.status(tmpenv.profile) == cluster.READY
+
+
+def test_wait_until_ready_unknown():
+    with pytest.raises(RuntimeError):
+        cluster.wait_until_ready("no-such-profile", timeout=0)
+
+
+def test_wait_until_ready(tmpenv):
+    cluster.wait_until_ready(tmpenv.profile, timeout=0)
+
+
+def test_kubeconfig_unknown():
+    cluster.kubeconfig("no-such-profile") == {}
+
+
+def test_kubeconfig(tmpenv):
+    cfg = cluster.kubeconfig(tmpenv.profile)
+    assert cfg["name"] == tmpenv.profile
+    assert "cluster" in cfg

--- a/test/drenv/drenv_test.py
+++ b/test/drenv/drenv_test.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from drenv import cluster
+from drenv import commands
+
+
+def test_start_unknown():
+    # Cluster does not exists, so it should fail.
+    with pytest.raises(commands.Error):
+        commands.run("drenv", "start", "--name-prefix", "unknown-", "external.yaml")
+
+
+def test_start(tmpenv):
+    commands.run("drenv", "start", "--name-prefix", tmpenv.prefix, "external.yaml")
+    assert cluster.status(tmpenv.prefix + "cluster") == cluster.READY
+
+
+def test_stop_unknown():
+    # Does nothing, so should succeed.
+    commands.run("drenv", "stop", "--name-prefix", "unknown-", "external.yaml")
+
+
+def test_stop(tmpenv):
+    # Stop does nothing, so cluster must be ready.
+    commands.run("drenv", "stop", "--name-prefix", tmpenv.prefix, "external.yaml")
+    assert cluster.status(tmpenv.prefix + "cluster") == cluster.READY
+
+
+def test_delete_unknown():
+    # Does nothing, so should succeed.
+    commands.run("drenv", "delete", "--name-prefix", "unknown-", "external.yaml")
+
+
+def test_delete(tmpenv):
+    # Delete does nothing, so cluster must be ready.
+    commands.run("drenv", "delete", "--name-prefix", tmpenv.prefix, "external.yaml")
+    assert cluster.status(tmpenv.prefix + "cluster") == cluster.READY

--- a/test/drenv/envfile.py
+++ b/test/drenv/envfile.py
@@ -66,6 +66,10 @@ def _validate_profile(profile):
     if "name" not in profile:
         raise ValueError("Missing profile name")
 
+    # If True, this is an external cluster and we don't have to start it.
+    profile.setdefault("external", False)
+
+    # Properties for minikube created cluster.
     profile.setdefault("driver", "kvm2")
     profile.setdefault("container_runtime", "")
     profile.setdefault("extra_disks", 0)

--- a/test/drenv/envfile_test.py
+++ b/test/drenv/envfile_test.py
@@ -42,6 +42,7 @@ profiles:
   - name: dr2
     template: dr-cluster
   - name: hub
+    external: true
     template: hub-cluster
 
 workers:
@@ -65,6 +66,7 @@ def test_valid():
 
     profile = env["profiles"][0]
     assert profile["name"] == "dr1"
+    assert not profile["external"]
     assert profile["network"] == "default"  # From template
     assert profile["memory"] == "8g"  # From profile
     assert profile["cpus"] == 2  # From defaults
@@ -95,6 +97,7 @@ def test_valid():
 
     profile = env["profiles"][2]
     assert profile["name"] == "hub"
+    assert profile["external"]
     assert profile["memory"] == "4g"  # From template
 
     worker = profile["workers"][0]

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -4,6 +4,15 @@
 from . import commands
 
 
+def version(context=None, output=None):
+    """
+    Return local and server version info. Useful for testing connectivity to
+    APIServer.
+    """
+    args = ["--output", output] if output else []
+    return _run("version", *args, context=context)
+
+
 def config(*args, context=None):
     """
     Run kubectl config ... and return the output.

--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -6,6 +6,14 @@ import json
 from drenv import kubectl
 
 
+def test_version(tmpenv):
+    out = kubectl.version(output="json", context=tmpenv.profile)
+    info = json.loads(out)
+    # We care mostly about server version, but let's check also client version.
+    assert "serverVersion" in info
+    assert "clientVersion" in info
+
+
 def test_get(tmpenv):
     out = kubectl.get("deploy", "--output=name", context=tmpenv.profile)
     assert out.strip() == "deployment.apps/example-deployment"

--- a/test/drenv/minikube.py
+++ b/test/drenv/minikube.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+from . import commands
+
+
+def profile(command, output=None):
+    return _run("profile", command, output=output)
+
+
+def status(profile, output=None):
+    return _run("status", profile=profile, output=output)
+
+
+def start(
+    profile,
+    driver=None,
+    container_runtime=None,
+    extra_disks=None,
+    disk_size=None,
+    network=None,
+    nodes=None,
+    cni=None,
+    cpus=None,
+    memory=None,
+    addons=(),
+):
+    args = []
+
+    if driver:
+        args.extend(("--driver", driver))
+    if container_runtime:
+        args.extend(("--container-runtime", container_runtime))
+    if extra_disks:
+        args.extend(("--extra-disks", str(extra_disks)))
+    if disk_size:
+        args.extend(("--disk-size", disk_size))  # "4g"
+    if network:
+        args.extend(("--network", network))
+    if nodes:
+        args.extend(("--nodes", str(nodes)))
+    if cni:
+        args.extend(("--cni", cni))
+    if cpus:
+        args.extend(("--cpus", str(cpus)))
+    if memory:
+        args.extend(("--memory", memory))
+    if addons:
+        args.extend(("--addons", ",".join(addons)))
+
+    _watch("start", *args, profile=profile)
+
+
+def stop(profile):
+    _watch("stop", profile=profile)
+
+
+def delete(profile):
+    _watch("delete", profile=profile)
+
+
+def _run(command, *args, profile=None, output=None):
+    cmd = ["minikube", command]
+    if profile:
+        cmd.extend(("--profile", profile))
+    if output:
+        cmd.extend(("--output", output))
+    cmd.extend(args)
+    return commands.run(*cmd)
+
+
+def _watch(command, *args, profile=None):
+    cmd = ["minikube", command, "--profile", profile]
+    cmd.extend(args)
+    for line in commands.watch(*cmd):
+        logging.debug("[%s] %s", profile, line)

--- a/test/external.yaml
+++ b/test/external.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Example environment using external clusters. The cluster `test` must exist
+# when this environment is started.
+#
+# To try this example, create the cluster with:
+#
+#     drenv start test.yaml
+#
+# Now you can start this environment with:
+#
+#     drenv start external.yaml
+#
+# Stopping will run the stop script, but will not stop the external minikube
+# cluster. Deleting does nothing.
+#
+---
+name: external
+profiles:
+  - name: cluster
+    external: true
+    workers:
+      - scripts:
+          - name: example

--- a/test/external_test.py
+++ b/test/external_test.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+from drenv import envfile
+
+
+def test_load():
+    with open("external.yaml") as f:
+        envfile.load(f)
+
+
+def test_load_prefix():
+    with open("external.yaml") as f:
+        envfile.load(f, name_prefix="test-")

--- a/test/ocm-cluster/start
+++ b/test/ocm-cluster/start
@@ -7,6 +7,7 @@ import json
 import sys
 
 import drenv
+from drenv import cluster
 from drenv import clusteradm
 from drenv import kubectl
 
@@ -53,7 +54,7 @@ def wait(cluster):
 def wait_for_hub(hub):
     print(f"Waiting until cluster {hub} is ready")
 
-    drenv.wait_for_cluster(hub)
+    cluster.wait_until_ready(hub)
     drenv.wait_for(f"namespace/{HUB_NAMESPACE}", profile=hub)
 
     for name in HUB_DEPLOYMENTS:
@@ -97,8 +98,8 @@ if len(sys.argv) != 3:
     print(f"Usage: {sys.argv[0]} cluster hub")
     sys.exit(1)
 
-cluster = sys.argv[1]
-hub = sys.argv[2]
+cluster_name = sys.argv[1]
+hub_name = sys.argv[2]
 
-deploy(cluster, hub)
-wait(cluster)
+deploy(cluster_name, hub_name)
+wait(cluster_name)

--- a/test/regional-dr-external.yaml
+++ b/test/regional-dr-external.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# This is a starting point for developers that want to use ramen minikube based
+# test environment with extenral storage.
+#
+# You need to implement "my-external-storage" component, deploying the external
+# storage drivers in my-external-storage/start hook.
+#
+---
+name: "rdr-external"
+
+templates:
+  - name: "dr-cluster"
+    driver: kvm2
+    container_runtime: containerd
+    network: default
+    memory: "4g"
+    workers:
+      - scripts:
+          - name: ocm-cluster
+            args: ["$name", "hub"]
+      - scripts:
+          - name: cert-manager
+          - name: csi-addons
+          - name: olm
+          - name: minio
+      - scripts:
+          - name: my-external-storage
+  - name: "hub-cluster"
+    driver: kvm2
+    container_runtime: containerd
+    network: default
+    memory: "4g"
+    workers:
+      - scripts:
+          - name: ocm-hub
+          - name: ocm-controller
+          - name: cert-manager
+          - name: olm
+
+profiles:
+  - name: "dr1"
+    template: "dr-cluster"
+  - name: "dr2"
+    template: "dr-cluster"
+  - name: "hub"
+    template: "hub-cluster"

--- a/test/regional_dr_external_test.py
+++ b/test/regional_dr_external_test.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+from drenv import envfile
+
+
+def test_load():
+    with open("regional-dr-external.yaml") as f:
+        envfile.load(f)
+
+
+def test_load_prefix():
+    with open("regional-dr-external.yaml") as f:
+        envfile.load(f, name_prefix="test-")


### PR DESCRIPTION
Add `external` property to profile, to mark a clsuter as existing external cluster.
When set, we skip the minikube commands and only run the scripts. This allows using
existing clusters for install ramen for testing.

The new regional-dr-external.yaml can be used as starting point to create such test environemnt. The metro-dr.yaml will use similar setup.