### PR TITLE
VRG Relocate: expect dataReady on "from" not "to" cluster

### DIFF
--- a/docs/vrg-usage.md
+++ b/docs/vrg-usage.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: Apache-2.0
 
 1. Deploy **cluster1** VRG with `Spec.ReplicationState: primary` in
  application's namespace
-1. Wait for **cluster1** VRG `Status.Conditions.ClusterDataProtected: true`
+1. Wait for **cluster1** VRG condition `ClusterDataProtected`
  indicating application's Kube objects have been protected
 
 ## Unprotect application
@@ -30,39 +30,42 @@ SPDX-License-Identifier: Apache-2.0
  `Namespace` it was in and with the `Name` it had on **cluster1**
    - Kube objects are recovered from the first available replica store specified
  in VRG's `Spec.S3Profiles` containing a replica for its `Namespace` and `Name`
-1. Wait for **cluster2** VRG `Status.Condtions`:
-   - `ClusterDataReady: true` indicating its Kube objects have been recovered
-   - `DataReady: true` indicating its volumes have been recovered
+1. Wait for **cluster2** VRG condition
+   - `ClusterDataReady` indicating its Kube objects have been recovered
+   - `DataReady` indicating its volumes have been recovered
 1. **cluster2** application protection resumes automatically
 
 ## Failback/Relocate application from cluster2 to cluster1
 
 1. Set **cluster1** VRG `Spec.ReplicationState: secondary`
+   - This disables its Kube object replication and preserves its Kube object
+ replicas when VRG is deleted in a subsequent step
 1. Undeploy **cluster1** application
    - Its PVCs can finally be deleted once VRG is deleted in a subsequent step
    - This allows its Kube objects to be recovered in a subsequent step
+1. Wait for **cluster1** VRG `Status.State: Secondary` indicating volume data
+  and Kube object replication can resume from **cluster2** to **cluster1**
 1. Delete **cluster1** VRG
    - This allows its PVCs to finally be deleted
 1. Unfence **cluster1** and **cluster2** VRGs from each other's Kube object
  replicas
    - This is typically accomplished by network unfencing
 1. Unfence **cluster1** and **cluster2** VRGs from each other's volume data
-   - For `Async` mode, this is typically accomplished by setting **cluster1**
- VRG `Spec.ReplicationState: secondary`
+   - For `Async` mode, this is accomplished when **cluster1** VRG
+ `Status.State: Secondary`
    - For `Sync` mode, this is typically accomplished by network unfencing
-1. Wait for **cluster2** VRG `Status.Conditions.ClusterDataProtected: true`
+1. Wait for **cluster2** VRG condition `ClusterDataProtected` indicating
+ Kube objects have been replicated to **cluster1**
 1. Set **cluster2** VRG `Spec.ReplicationState: secondary`
 1. Undeploy **cluster2** application
    - Its PVCs can finally be deleted once VRG is deleted in a subsequent step
-1. For `Async` mode, synchronize volume data:
-   1. Deploy **cluster1** VRG with `Spec.ReplicationState: secondary`
-   1. Wait for **cluster1** VRG `Status.Conditions.DataReady: true` indicating its
- volume data are in-sync with **cluster2**'s
+1. Wait for **cluster2** VRG `Status.State: Secondary`
+1. Wait for **cluster2** VRG condition `DataReady` indicating **cluster1**'s
+  volume data are synchronized with **cluster2**'s
+1. Deploy **cluster1** VRG with `Spec.ReplicationState: primary`
+1. Wait for **cluster1** VRG condition
+   - `ClusterDataReady` indicating its Kube objects have been recovered
+   - `DataReady` indicating its volumes have been recovered
+1. **cluster1** application protection resumes automatically
 1. Delete **cluster2** VRG
    - This allows its PVCs to finally be deleted
-1. Set, for `Async` mode, or deploy, for `Sync` mode, **cluster1** VRG
- `Spec.ReplicationState: primary` to recover its volumes and Kube objects
-1. Wait for **cluster1** VRG `Status.Condtions`:
-   - `ClusterDataReady: true` indicating its Kube objects have been recovered
-   - `DataReady: true` indicating its volumes have been recovered
-1. **cluster1** application protection resumes automatically


### PR DESCRIPTION
- Add some waits for `Status.State: Secondary`