### PR TITLE
Use separate storage for minio

### DIFF
--- a/test/minio.yaml
+++ b/test/minio.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Enviroment for testing minio deployment with both podman and kvm2 drivers.
+---
+name: "minio"
+
+templates:
+  - name: base
+    memory: 2g
+    workers:
+      - scripts:
+          - name: minio
+
+profiles:
+  - name: c1
+    template: base
+    driver: podman
+    container_runtime: cri-o
+  - name: c2
+    template: base
+    driver: kvm2
+    container_runtime: containerd

--- a/test/minio/minio.yaml
+++ b/test/minio/minio.yaml
@@ -17,7 +17,7 @@ metadata:
     component: minio
 spec:
   accessModes: ["ReadWriteOnce"]
-  storageClassName: "rook-ceph-block"
+  storageClassName: "standard"
   resources:
     requests:
       storage: 10Gi
@@ -31,7 +31,7 @@ metadata:
     component: minio
 spec:
   accessModes: ["ReadWriteOnce"]
-  storageClassName: "rook-ceph-block"
+  storageClassName: "standard"
   resources:
     requests:
       storage: 10Gi

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -20,13 +20,13 @@ templates:
           - name: rook-cluster
           - name: rook-pool
           - name: rook-toolbox
-          - name: minio
       - scripts:
           - name: ocm-cluster
             args: ["$name", "hub"]
       - scripts:
           - name: csi-addons
           - name: olm
+          - name: minio
   - name: "hub-cluster"
     driver: kvm2
     container_runtime: containerd


### PR DESCRIPTION
Use "standard" storage class for minio, so it does not depend on rook, and
we can install it in parallel.

This also helps to use external storage since minio uses now the builtin
standard storage (hostPath).