### PR TITLE
Ignore placement missing during DRPC deletion

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -391,7 +391,7 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	placementObj, err := r.getPlacementOrPlacementRule(ctx, drpc, logger)
-	if err != nil {
+	if err != nil && !(errors.IsNotFound(err) && !drpc.GetDeletionTimestamp().IsZero()) {
 		r.recordFailure(drpc, placementObj, "Error", err.Error(), nil, logger)
 
 		return ctrl.Result{}, err


### PR DESCRIPTION
Deletion order can be DRPC post Placement deletion and as a result if we do not find the Placement and DRPC is being deleted, then ignore the error and
proceed with deletion processing.