### PR TITLE
Update phase as Deployed unconditionally

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -148,13 +148,9 @@ func (d *DRPCInstance) RunInitialDeployment() (bool, error) {
 		return !done, err
 	}
 
-	// If for whatever reason, the DRPC status is missing (i.e. DRPC could have been deleted mistakingly and
-	// recreated again), we should update it with whatever status we are at.
-	if d.getLastDRState() == rmn.DRState("") {
-		// Update our 'well known' preferred placement
-		d.updatePreferredDecision()
-		d.setDRState(rmn.Deployed)
-	}
+	// Update our 'well known' preferred placement
+	d.updatePreferredDecision()
+	d.setDRState(rmn.Deployed)
 
 	d.setConditionOnInitialDeploymentCompletion()
 


### PR DESCRIPTION
During initial deployment, post a full reconcile
a subsequent reconcile found MW for VRG exists and attempted an update of the same. This failed as the cached MW was stale (with error, the object has been modified). This lef to phase being set to Deploying.

Future reconciles, established that workload was already deployed and phase was not empty, and failed to update it back to Deployed.

This fix updates the phase unconditionally at the end of DRPC reconcile.

Fixes: #742