### PR TITLE
Developer quick start guide

### DIFF
--- a/docs/devel-quick-start.md
+++ b/docs/devel-quick-start.md
@@ -1,0 +1,159 @@
+<!--
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Ramen developer quick start guide
+
+This page will help you to set up a development environment for the
+*Ramen* project.
+
+## What you’ll need
+
+To set up a *Ramen* development environment you will need to run 3
+Kubernetes clusters. *Ramen* makes this easy using minikube, but you need
+enough resources:
+
+- Bare metal or virtual machine with nested virtualization enabled
+- 8 CPUs or more
+- 16 GiB of free memory
+- 20 GiB of free disk space
+- Internet connection
+- Linux - tested on *RHEL* 8.6 and *Fedora* 37.
+
+## Getting the source
+
+1. Fork the *Ramen* repository on github
+
+1. Clone the source locally
+
+   ```
+   git clone git@github.com:my-github-user/ramen.git
+   ```
+
+1. Add an `upstream` remote, to make it easy to sync your repo from
+   upstream.
+
+   ```
+   git remote add upstream https://github.com/RamenDR/ramen.git
+   ```
+
+1. Set up a commit-msg hook to sign off your commits
+
+   *Ramen* requires a `Signed-off-by: My Name <myemail@example.com>`
+   footer in the commit message. To add it automatically to all commits,
+   add this hook:
+
+   ```
+   $ cat .git/hooks/commit-msg
+   #!/bin/sh
+   # Add Signed-off-by trailer.
+   sob=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+   git interpret-trailers --in-place --trailer "$sob" "$1"
+   ```
+
+   And make the hook executable:
+
+   ```
+   chmod +x .git/hooks/commit-msg
+   ```
+
+That's all! You are ready to submit your first pull request!
+
+## Setting up the `drenv` tool
+
+*Ramen* uses the `drenv` tool to build a development environment
+quickly. Please follow the
+[Setup instructions](https://github.com/RamenDR/ramen/tree/main/test#setup)
+to set up the `drenv` tool.
+
+## Starting the test environment
+
+*Ramen* supports many configurations, but the only development
+environment available now is the `regional-dr.yaml`. This environment
+simulates a Regional DR setup, when the managed clusters are located in
+different zones (e.g. US, Europe) and storage is replicated
+asynchronously. This environment includes 3 clusters - a hub cluster
+(`hub`), and 2 managed clusters (`dr1`, `dr2`) using `Ceph` storage.
+
+To start the environment, run:
+
+```
+drenv start regional-dr.yaml
+```
+
+Starting takes at least 5 minutes, depending on your machine and
+internet connection.
+
+You can inspect the environment using kubectl, for example:
+
+```
+kubectl get deploy -A --context hub
+kubectl get deploy -A --context dr1
+kubectl get deploy -A --context dr2
+```
+
+## Building the Ramen operator
+
+1. Setup the environment variables for the Makefile
+
+   ```
+   export IMAGE_REPOSITORY=my-quay-user
+   export IMAGE_TAG=canary
+   ```
+
+1. Build the *Ramen* operator container:
+
+   ```
+   make docker-build
+   ```
+
+   This builds the image `quay.io/my-quay-user/ramen-operator:canary`
+
+1. Pushing the `ramen-operator` image to the clusters
+
+   You can push the container image to your private quay repo, or load
+   them into the clusters.
+
+    - Loading the `ramen-operator` image into the clusters
+
+      ```
+      podman save quay.io/nirsof/ramen-operator:canary \
+          -o /tmp/ramen-operator.tar
+
+      for p in hub dr1 dr2; do
+          minikube -p $p image load /tmp/ramen-operator.tar
+      done
+
+      rm /tmp/ramen-operator.tar
+      ```
+
+    - Pushing the `ramen-operator` image to your private repo
+
+      ```
+      make docker-push
+      ```
+
+      You may need to login first using `podman login quay.io`.
+
+1. Deploying to hub and cluster
+
+   ```
+   kubectl config use-context hub
+   make deploy-hub
+
+   for p in dr1 dr2; do
+       kubectl config use-context $p
+       make deploy-dr-cluster
+   done
+   ```
+
+## The next steps
+
+At this point *Ramen* is running in your cluster, and you are ready for
+the next steps:
+
+- Configuring *Ramen*
+- Enable disaster recovery for an application
+- Failing over the application to another cluster
+- Relocating an application back to the original cluster

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,8 @@
 all: flake8 pylint black test coverage
 
+venv:
+	scripts/make-venv.sh
+
 flake8:
 	python3 -m flake8 drenv */start */test
 

--- a/test/README.md
+++ b/test/README.md
@@ -66,8 +66,8 @@ environment.
    This installs a link file in the virtual environment:
 
    ```
-   $ cat /home/nsoffer/.venv/ramen/lib/python3.10/site-packages/drenv.egg-link
-   /home/nsoffer/src/ramen/test
+   $ cat ~/.venv/ramen/lib/python3.10/site-packages/drenv.egg-link
+   /home/myusername/src/ramen/test
    ```
 
    So changes in the `test/drenv` package are available immediately

--- a/test/README.md
+++ b/test/README.md
@@ -49,29 +49,26 @@ environment.
    myusername ALL=(ALL) NOPASSWD: /usr/bin/podman
    ```
 
-1. Install the `drenv` package in a virtual environment:
+1. Clone the `ramen` source
 
-   Run this once in the root of the source tree:
-
-   ```
-   python3 -m venv ~/.venv/ramen
-   source ~/.venv/ramen/bin/activate
-   pip install --upgrade pip
-   pip install -e ./test
-   ```
-
-   You can create the virtual environment anywhere, but keeping the
-   environment outside of the source tree is good practice.
-
-   This installs a link file in the virtual environment:
+   *Ramen* test environment is part of the ramen source. You need to
+   clone it locally to create a test environment and run the tests:
 
    ```
-   $ cat ~/.venv/ramen/lib/python3.10/site-packages/drenv.egg-link
-   /home/myusername/src/ramen/test
+   git clone https://github.com/RamenDR/ramen.git
    ```
 
-   So changes in the `test/drenv` package are available immediately
-   without installing the package again.
+1. Create a `ramen` virtual environment
+
+   Run this once from the root directory of the ramen source:
+
+   ```
+   make -C test venv
+   ```
+
+   This creates a python virtual environment in `~/.venv/ramen`, and
+   install the `drenv` tool using develop mode, so changes in `drenv`
+   source are available immediately without reinstalling the tool.
 
 ## Using the drenv tool
 

--- a/test/README.md
+++ b/test/README.md
@@ -60,15 +60,23 @@ environment.
 
 1. Create a `ramen` virtual environment
 
-   Run this once from the root directory of the ramen source:
+   Run this once in the ramen test directory
 
    ```
-   make -C test venv
+   make venv
    ```
 
    This creates a python virtual environment in `~/.venv/ramen`, and
    install the `drenv` tool using develop mode, so changes in `drenv`
    source are available immediately without reinstalling the tool.
+
+### Testing that drenv is healthy
+
+Run this script to make sure `drenv` works:
+
+```
+scripts/drenv-selftest
+```
 
 ## Using the drenv tool
 

--- a/test/README.md
+++ b/test/README.md
@@ -517,10 +517,28 @@ script/start cluster1 arg2
 script/test cluster1 arg2
 ```
 
-## The regional-dr environment
+## Environment files
 
-This is a configuration for testing regional DR using a hub cluster and
-2 managed clusters.
+### Ramen testing environments
+
+- `regional-dr.yaml` - for testing regional DR using a hub cluster and 2
+  managed clusters with Ceph storage.
+
+- `regional-dr-external.yaml` - A starting point for creating
+   environemnt for testing regional DR using with external storage.
+
+### drenv development environments
+
+These environments are useful for developing the `drenv` tool and
+scripts. When debugging an issue or adding a new component, it is much
+simpler and faster to work with a minimal environment.
+
+- `test.yaml` - for testing `drenv`
+- `example.yaml` - example for experimenting with the `drenv` tool
+- `external.yaml` - example for using external clusters
+- `minio.yaml` - for testing `minio` deployment
+- `ocm.yaml` - for testing `ocm` deployment
+- `rook.yaml` - for testing `rook` deployment
 
 ## Testing drenv
 

--- a/test/scripts/drenv-selftest
+++ b/test/scripts/drenv-selftest
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+# We must run in the test directory.
+cd $(dirname $(dirname $0))
+
+prefix="test-$(uuidgen)"
+
+echo
+echo "1. Activating the ramen virtual enviroment ..."
+echo
+
+source ~/.venv/ramen/bin/activate
+
+echo
+echo "2. Creating a test cluster ..."
+echo
+
+drenv start --name-prefix $prefix test.yaml
+
+echo
+echo "3. Deleting the test cluster ..."
+echo
+
+drenv delete --name-prefix $prefix test.yaml
+
+echo
+echo drenv is set up properly
+echo

--- a/test/scripts/make-venv.sh
+++ b/test/scripts/make-venv.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+
+venv=~/.venv/ramen
+
+if [ -d "$venv" ]; then
+    echo "venv $venv exists"
+    exit 0
+fi
+
+echo "Creating venv $venv"
+python3 -m venv $venv
+
+echo "Upgrading pip..."
+$venv/bin/pip install --upgrade pip
+
+echo "Installing drenv..."
+$venv/bin/pip install -e .
+
+echo
+echo "To activate the environment run:"
+echo
+echo "    source $venv/bin/activate"
+echo


### PR DESCRIPTION
Document how to set up a development enviroment, build ramen and deploy
it to the test environment. The document is intended to help new contributors to 
start quickly.

Notes:
- Addional steps discussed in #760 will be added later.
- The document is not linked yet from CONTRIBUITING. When this is finished I'll update
  CONTRIBUITING to link to this page and remove unneeded content.