### PR TITLE
Fix vrg namespace everywhere

### DIFF
--- a/controllers/drcluster_controller.go
+++ b/controllers/drcluster_controller.go
@@ -96,7 +96,7 @@ func (r *DRClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("get: %w", err))
 	}
 
-	manifestWorkUtil := &util.MWUtil{Client: r.Client, Ctx: ctx, Log: log, InstName: drcluster.Name, InstNamespace: ""}
+	manifestWorkUtil := &util.MWUtil{Client: r.Client, Ctx: ctx, Log: log, InstName: drcluster.Name, TargetNamespace: ""}
 
 	u := &drclusterInstance{
 		ctx: ctx, object: drcluster, client: r.Client, log: log, reconciler: r,

--- a/controllers/drcluster_controller_test.go
+++ b/controllers/drcluster_controller_test.go
@@ -163,11 +163,11 @@ func validateClusterManifest(drcluster *ramen.DRCluster, disabled bool) {
 
 func inspectClusterManifestSubscriptionCSV(match bool, value string, drcluster *ramen.DRCluster) {
 	mwu := &util.MWUtil{
-		Client:        k8sClient,
-		Ctx:           context.TODO(),
-		Log:           ctrl.Log.WithName("MWUtilTest"),
-		InstName:      "",
-		InstNamespace: "",
+		Client:          k8sClient,
+		Ctx:             context.TODO(),
+		Log:             ctrl.Log.WithName("MWUtilTest"),
+		InstName:        "",
+		TargetNamespace: "",
 	}
 
 	sub, err := controllers.SubscriptionFromDrClusterManifestWork(mwu, drcluster.Name)

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -1083,9 +1083,7 @@ func (d *DRPCInstance) updateUserPlacementRule(homeCluster, reason string) error
 func (d *DRPCInstance) clearUserPlacementRuleStatus() error {
 	d.log.Info("Clearing user Placement", "name", d.userPlacement.GetName())
 
-	newPD := &clrapiv1beta1.ClusterDecision{}
-
-	return d.reconciler.updateUserPlacementStatusDecision(d.ctx, d.userPlacement, newPD)
+	return d.reconciler.updateUserPlacementStatusDecision(d.ctx, d.userPlacement, nil)
 }
 
 func (d *DRPCInstance) updatePreferredDecision() {

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1322,13 +1322,17 @@ func (r *DRPlacementControlReconciler) updateUserPlacementStatusDecision(ctx con
 func (r *DRPlacementControlReconciler) createOrUpdatePlacementRuleDecision(ctx context.Context,
 	plRule *plrv1.PlacementRule, newCD *clrapiv1beta1.ClusterDecision,
 ) error {
-	newStatus := plrv1.PlacementRuleStatus{
-		Decisions: []plrv1.PlacementDecision{
-			{
-				ClusterName:      newCD.ClusterName,
-				ClusterNamespace: newCD.ClusterName,
+	newStatus := plrv1.PlacementRuleStatus{}
+
+	if newCD != nil {
+		newStatus = plrv1.PlacementRuleStatus{
+			Decisions: []plrv1.PlacementDecision{
+				{
+					ClusterName:      newCD.ClusterName,
+					ClusterNamespace: newCD.ClusterName,
+				},
 			},
-		},
+		}
 	}
 
 	if !reflect.DeepEqual(newStatus, plRule.Status) {
@@ -1380,12 +1384,18 @@ func (r *DRPlacementControlReconciler) createOrUpdatePlacementDecision(ctx conte
 	}
 
 	plDecision.Status = clrapiv1beta1.PlacementDecisionStatus{
-		Decisions: []clrapiv1beta1.ClusterDecision{
-			{
-				ClusterName: newCD.ClusterName,
-				Reason:      newCD.Reason,
+		Decisions: []clrapiv1beta1.ClusterDecision{},
+	}
+
+	if newCD != nil {
+		plDecision.Status = clrapiv1beta1.PlacementDecisionStatus{
+			Decisions: []clrapiv1beta1.ClusterDecision{
+				{
+					ClusterName: newCD.ClusterName,
+					Reason:      newCD.Reason,
+				},
 			},
-		},
+		}
 	}
 
 	if err := r.Status().Update(ctx, plDecision); err != nil {

--- a/controllers/drplacementcontrolvolsync.go
+++ b/controllers/drplacementcontrolvolsync.go
@@ -302,17 +302,12 @@ func (d *DRPCInstance) createVolSyncDestManifestWork(srcCluster string) error {
 				d.instance.Namespace, dstCluster)
 		}
 
-		objMeta, err := d.generateObjectMetaForVRG()
-		if err != nil {
-			return err
-		}
-
 		annotations := make(map[string]string)
 
-		annotations[DRPCNameAnnotation] = d.mwu.InstName
-		annotations[DRPCNamespaceAnnotation] = d.mwu.InstNamespace
+		annotations[DRPCNameAnnotation] = d.instance.Name
+		annotations[DRPCNamespaceAnnotation] = d.instance.Namespace
 
-		vrg := d.generateVRG(rmn.Secondary, objMeta)
+		vrg := d.generateVRG(rmn.Secondary)
 		if err := d.mwu.CreateOrUpdateVRGManifestWork(
 			d.instance.Name, d.instance.Namespace,
 			dstCluster, vrg, annotations); err != nil {

--- a/controllers/util/mw_util.go
+++ b/controllers/util/mw_util.go
@@ -47,10 +47,10 @@ const (
 
 type MWUtil struct {
 	client.Client
-	Ctx           context.Context
-	Log           logr.Logger
-	InstName      string
-	InstNamespace string
+	Ctx             context.Context
+	Log             logr.Logger
+	InstName        string
+	TargetNamespace string
 }
 
 func ManifestWorkName(name, namespace, mwType string) string {
@@ -58,7 +58,7 @@ func ManifestWorkName(name, namespace, mwType string) string {
 }
 
 func (mwu *MWUtil) BuildManifestWorkName(mwType string) string {
-	return ManifestWorkName(mwu.InstName, mwu.InstNamespace, mwType)
+	return ManifestWorkName(mwu.InstName, mwu.TargetNamespace, mwType)
 }
 
 func (mwu *MWUtil) FindManifestWork(mwName, managedCluster string) (*ocmworkv1.ManifestWork, error) {


### PR DESCRIPTION
When using ApplicationSet, the VRG namespace is taken from the Application resource belonging to the ApplicationSet. However, this can cause issues when the DRPC is deleted, as we can't depend on the ApplicationSet/Application to be around for selecting the VRG namespace in order to clean up the related resources. Additionally, the order of deletion is to delete the ManifestWork first in order to verify that the VRG is deleted, making it impossible to select the VRG namespace from the ManifestWork.
To solve this problem, the following changes have been made
1. To avoid selecting the VRG namespace from the ApplicationSet/Application on every reconciliation, we have reused the ClusterNamespace field in the DRPC.Status.PreferredDecision. This field is unused in DRPC, and it maps perfectly to hold the destination namespace for the VRG. Moreover, Using this field allows us to have the VRG namespace even when the ApplicationSet resources have been deleted.
2. The namespace on the Managed Cluster where the VRG will be created needs to be created beforehand using the same namespace name that the VRG will be deployed on instead of the DRPC namespace.
3. Renamed the InstNamespace to TargetNamespace in MWUtil and set it to the VRG namespace.
4. Now the cached VRG namespace is used rather than selecting it from the ApplicationSet/Application in every reconciliation.
5. Updated the MCV utility function to use the correct VRG as the resource namespace instead of using the DRPC namespace.