### PR TITLE
Label managed cluster

### DIFF
--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -39,6 +39,16 @@ def patch(*args, context=None):
     _watch("patch", *args, context=context)
 
 
+def label(name, value, overwrite=False, context=None):
+    """
+    Run kubectl label ... logging progress messages.
+    """
+    args = ["label", name, value]
+    if overwrite:
+        args.append("--overwrite")
+    _watch(*args, context=context)
+
+
 def delete(*args, input=None, context=None):
     """
     Run kubectl delete ... logging progress messages.

--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import secrets
 
 from drenv import kubectl
 
@@ -64,6 +65,19 @@ def test_patch(tmpenv, capsys):
     )
     out, err = capsys.readouterr()
     assert out.strip() == f"{pod} patched"
+
+
+def test_label(tmpenv, capsys):
+    pod = kubectl.get("pod", "--output=name", context=tmpenv.profile).strip()
+    name = f"test-{secrets.token_hex(8)}"
+
+    kubectl.label(pod, f"{name}=old", context=tmpenv.profile)
+    out, err = capsys.readouterr()
+    assert out.strip() == f"{pod} labeled"
+
+    kubectl.label(pod, f"{name}=new", overwrite=True, context=tmpenv.profile)
+    out, err = capsys.readouterr()
+    assert out.strip() == f"{pod} labeled"
 
 
 def test_delete(tmpenv, capsys):

--- a/test/ocm-cluster/start
+++ b/test/ocm-cluster/start
@@ -46,6 +46,7 @@ def deploy(cluster, hub):
     wait_for_hub(hub)
     join_cluster(cluster, hub)
     accept_cluster(cluster, hub)
+    label_cluster(cluster, hub)
     enable_addons(cluster, hub)
 
 
@@ -99,6 +100,19 @@ def join_cluster(cluster, hub):
 def accept_cluster(cluster, hub):
     print("Accepting cluster")
     clusteradm.accept([cluster], wait=True, context=hub)
+
+
+def label_cluster(cluster, hub):
+    # Managed cluster must have name=cluster label in addition to
+    # metadata.name.
+    # https://github.com/open-cluster-management-io/multicloud-operators-subscription/issues/16
+    print("Labelling cluster")
+    kubectl.label(
+        f"managedclusters/{cluster}",
+        f"name={cluster}",
+        overwrite=True,
+        context=hub,
+    )
 
 
 def enable_addons(cluster, hub):


### PR DESCRIPTION
Managed clusters need a label name={cluster} to work with PlacementRule. This
smells like a bug in clusteradm but lets fix it here first to unlock e2e tests.
