### PR TITLE
Use podman for ocm environment

### DIFF
--- a/test/ocm.yaml
+++ b/test/ocm.yaml
@@ -7,16 +7,16 @@ name: "ocm"
 
 templates:
   - name: "hub-cluster"
-    driver: kvm2
-    container_runtime: containerd
+    driver: podman
+    container_runtime: cri-o
     network: default
     workers:
       - scripts:
           - name: ocm-hub
           - name: ocm-controller
   - name: "dr-cluster"
-    driver: kvm2
-    container_runtime: containerd
+    driver: podman
+    container_runtime: cri-o
     network: default
     workers:
       - scripts:


### PR DESCRIPTION
Does not work yet, posting for discussion.

This may make it possible to test the ocm environment in github actions, or in a developer machine with limited resources. With this we can test the environment and the cluster module which is not tested today.

With this change clusters are stuck in this state:

    $ kubectl get node --context hub
    NAME   STATUS     ROLES           AGE     VERSION
    hub    NotReady   control-plane   2m17s   v1.26.1

And we can see this warning:

    $ kubectl describe node --context hub
    Ready            False   Sun, 12 Mar 2023 15:39:55 +0200   Sun, 12
    Mar 2023 15:39:51 +0200   KubeletNotReady   container runtime
    network not ready: NetworkReady=false reason:NetworkPluginNotReady
    message:Network plugin returns error: No CNI configuration file in
    /etc/cni/net.d/. Has your network provider started?

I tried to remove --cni=auto but it does not change anything.

The test.yaml and example.yaml do work with podman - maybe this is a bug with podman
or minikube starting more than 2 clusters at the same time.