### PR TITLE
Instructions to enable metrics on k8s 

### DIFF
--- a/config/hub/default/k8s/kustomization.yaml
+++ b/config/hub/default/k8s/kustomization.yaml
@@ -32,12 +32,6 @@ transformers:
   - kind: Service
     path: spec/selector
 
-# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#-../prometheus
-
-# Protect the /metrics endpoint by putting it behind auth.
-# If you want your controller-manager to expose the /metrics
-# endpoint w/o any authn/z, please comment the following line.
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
@@ -86,6 +80,11 @@ resources:
 - ../../manager
 - ../../../webhook
 - ../../../certmanager
+
+# uncomment the following lines to enable scraping the metrics using prometheus
+# - ../../../prometheus
+# - metrics_role_binding.yaml
+
 images:
 - name: kube-rbac-proxy
   newName: gcr.io/kubebuilder/kube-rbac-proxy

--- a/config/hub/default/k8s/metrics_role_binding.yaml
+++ b/config/hub/default/k8s/metrics_role_binding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: metrics
+  namespace: system
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: metrics

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -5,76 +5,63 @@ SPDX-License-Identifier: Apache-2.0
 
 # Metrics
 
-Metrics are collected using Prometheus, and registered with its global metrics
-registry in each controller. The endpoint exposed is `localhost:9289/metrics`.
+Metrics are collected using Prometheus, and registered with its global
+metrics registry in each controller. There are two ways where you can
+look at the metrics in ramen. One way is use prometheus stack(recommended)
+and the other way is to use curl or postman. More details on
+each of these in the below sections.
+
+More information on metrics is [here](https://book.kubebuilder.io/reference/metrics.html)
+
+## 1. Using Prometheus Stack
+
+We recommend to use [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus).
+Installing this will give you a containerized stack that
+includes Prometheus, AlertManager and Grafana.
+
+For more detailed information and querying,
+consider using the Prometheus Operator, but in summary:
+
+### Setup
+
+Follow the next steps before configuring ramen.
+
+#### Installing kube-prometheus
+
+Quickstart instructions are [here](https://github.com/prometheus-operator/kube-prometheus#quickstart).
+
+#### Grant permission for prometheus to scrape metrics
+
+Go to `ramen/config/hub/default/k8s/kustomizations.yaml`
+and uncomment `../../../prometheus`
+and `metrics_role_binding.yaml` under `Kustomization` section.
+Next is to install and configure ramen.
+
+#### Dashboard Access
+
+[Accessing Graphical User Interfaces](https://github.com/prometheus-operator/kube-prometheus/blob/main/docs/access-ui.md#access-uis)
+
+## 2. Basic testing (no Prometheus required)
+
 If running from minikube or a container, expose the port using `port-forward`
-on the hub:
+on the hub. The endpoint exposed is `localhost:8443/metrics`.
+
+>*This way does not use kube-rbac-proxy, use this method only for any quick debugging*
 
 ```bash
 kubectl port-forward -n ramen-system \
-  service/ramen-hub-operator-metrics-service 9289:9289
+deployment/ramen-hub-operator 8443:9289
 ```
 
-## Basic testing (no Prometheus required)
-
 Verify that the metrics endpoint is exposed with curl:
-`curl http://localhost:9289/metrics`
+`curl http://localhost:8443/metrics`.
 
 If curl can connect, search for your metrics in the output.
 
-## Metrics List
+### Metrics List
 
 All metrics are prefixed with `ramen_`. This makes them easier to find.
 
 To get the list of all the Ramen metrics available and their descriptions,
 run the Ramen code, then run this command:
-`curl http://localhost:9289/metrics -s | grep "# HELP ramen_"`
-
-## Prometheus Stack
-
-For more detailed information and querying, consider using the Prometheus
-Operator
-[kube-prometheus](https://github.com/prometheus-operator/kube-prometheus).
-Installing this will give you a containerized stack that
-includes Prometheus, AlertManager and Grafana. Quickstart instructions are
-[here](https://github.com/prometheus-operator/kube-prometheus#quickstart),
-but in summary:
-
-Setup and create:
-
-```bash
-git clone https://github.com/prometheus-operator/kube-prometheus.git
-
-cd kube-prometheus
-
-# install CRDs
-kubectl create -f manifests/setup
-
-# install resources
-kubectl create -f manifests/
-
-# verify everything is running
-kubectl get all -n monitoring
-```
-
-Delete stack:
-
-```bash
-kubectl delete --ignore-not-found=true -f manifests/ -f manifests/setup
-```
-
-### Dashboard Access
-
-To access GUI dashboards for each component, use `port-forward`:
-
-* Prometheus:
- `$ kubectl --namespace monitoring port-forward svc/prometheus-k8s 9090`
-* Grafana: `$ kubectl --namespace monitoring port-forward svc/grafana 3000`
-* Alert Manager:
- `$ kubectl --namespace monitoring port-forward svc/alertmanager-main 9093`
-
-Then navigate to the appropriate port on localhost, e.g.
-[http://localhost:9090](http://localhost:9090) for Prometheus.
-
-Ramen metrics can be found in namespace "ramen-system"; e.g. PromQL query
-`{namespace="ramen-system"}`
+`curl http://localhost:8443/metrics -s | grep "# HELP ramen_"`.


### PR DESCRIPTION
* Added sections to un-comment in `config/hub/default/k8s/kustomizations.yaml` to enable metrics scrapping using Prometheus 
* metrics.md doc corrected as per the current implementation. 