### PR TITLE
Cleanup setting of KUBEBUILDER_ASSETS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,9 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 envtest:
 	mkdir -p $(ENVTEST_ASSETS_DIR)
 	test -s $(ENVTEST_ASSETS_DIR)/setup-envtest || GOBIN=$(ENVTEST_ASSETS_DIR) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-	$(ENVTEST_ASSETS_DIR)/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR)
+	current="$$($(ENVTEST_ASSETS_DIR)/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR) --print path)"; \
+			rm -f "$(ENVTEST_ASSETS_DIR)/current"; \
+			ln -s "$$current" "$(ENVTEST_ASSETS_DIR)/current"
 
 test: generate manifests envtest ## Run tests.
 	go test ./... -coverprofile cover.out $(GO_TEST_GINKGO_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -166,11 +166,11 @@ test-vrg-kubeobjects: generate manifests setup-envtest
 test-drpc: generate manifests setup-envtest
 	go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus DRPlacementControl
 
-test-drenv:
-	$(MAKE) -C test
-	
 test-util-pvc: generate manifests setup-envtest
 	go test ./controllers/util -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus PVCS_Util
+
+test-drenv:
+	$(MAKE) -C test
 
 ##@ Build
 

--- a/Makefile
+++ b/Makefile
@@ -141,32 +141,30 @@ ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
 envtest:
 	mkdir -p $(ENVTEST_ASSETS_DIR)
 	test -s $(ENVTEST_ASSETS_DIR)/setup-envtest || GOBIN=$(ENVTEST_ASSETS_DIR) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	$(ENVTEST_ASSETS_DIR)/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR)
 
-setup-envtest: envtest
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST_ASSETS_DIR)/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR) -p path)"
-
-test: generate manifests setup-envtest ## Run tests.
+test: generate manifests envtest ## Run tests.
 	go test ./... -coverprofile cover.out $(GO_TEST_GINKGO_ARGS)
 
-test-pvrgl: generate manifests setup-envtest
+test-pvrgl: generate manifests envtest
 	go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus ProtectedVolumeReplicationGroupList
 
-test-vrg: generate manifests setup-envtest
+test-vrg: generate manifests envtest
 	go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus VolumeReplicationGroup
 
-test-vrg-vr: generate manifests setup-envtest
+test-vrg-vr: generate manifests envtest
 	go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus VolumeReplicationGroupVolRep
 
-test-vrg-vs: generate manifests setup-envtest
+test-vrg-vs: generate manifests envtest
 	go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus VolumeReplicationGroupVolSync
 
-test-vrg-kubeobjects: generate manifests setup-envtest
+test-vrg-kubeobjects: generate manifests envtest
 	go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus VRG_KubeObjectProtection
 
-test-drpc: generate manifests setup-envtest
+test-drpc: generate manifests envtest
 	go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus DRPlacementControl
 
-test-util-pvc: generate manifests setup-envtest
+test-util-pvc: generate manifests envtest
 	go test ./controllers/util -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus PVCS_Util
 
 test-drenv:

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -5,10 +5,8 @@ package controllers_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -116,8 +114,7 @@ var _ = BeforeSuite(func() {
 	ramencontrollers.ControllerType = ramendrv1alpha1.DRHubType
 
 	if _, set := os.LookupEnv("KUBEBUILDER_ASSETS"); !set {
-		Expect(os.Setenv("KUBEBUILDER_ASSETS",
-			fmt.Sprintf("../testbin/k8s/1.25.0-%s-%s", runtime.GOOS, runtime.GOARCH))).To(Succeed())
+		Expect(os.Setenv("KUBEBUILDER_ASSETS", "../testbin/current")).To(Succeed())
 	}
 
 	rNs, set := os.LookupEnv("POD_NAMESPACE")

--- a/controllers/util/util_suite_test.go
+++ b/controllers/util/util_suite_test.go
@@ -5,10 +5,8 @@ package util_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -59,8 +57,7 @@ var _ = BeforeSuite(func() {
 
 	By("Setting up KUBEBUILDER_ASSETS for envtest")
 	if _, set := os.LookupEnv("KUBEBUILDER_ASSETS"); !set {
-		Expect(os.Setenv("KUBEBUILDER_ASSETS",
-			fmt.Sprintf("../../testbin/k8s/1.25.0-%s-%s", runtime.GOOS, runtime.GOARCH))).To(Succeed())
+		Expect(os.Setenv("KUBEBUILDER_ASSETS", "../../testbin/current")).To(Succeed())
 	}
 
 	By("Bootstrapping test environment")

--- a/controllers/volsync/volsync_suite_test.go
+++ b/controllers/volsync/volsync_suite_test.go
@@ -5,10 +5,8 @@ package volsync_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -76,8 +74,7 @@ var _ = BeforeSuite(func() {
 
 	By("Setting up KUBEBUILDER_ASSETS for envtest")
 	if _, set := os.LookupEnv("KUBEBUILDER_ASSETS"); !set {
-		Expect(os.Setenv("KUBEBUILDER_ASSETS",
-			fmt.Sprintf("../../testbin/k8s/1.25.0-%s-%s", runtime.GOOS, runtime.GOARCH))).To(Succeed())
+		Expect(os.Setenv("KUBEBUILDER_ASSETS", "../../testbin/current")).To(Succeed())
 	}
 
 	By("bootstrapping test environment")


### PR DESCRIPTION
Was duplicated 4 times in different files. Replace with a symlink created when setting
envtest.