### PR TITLE
Fix handling of KUBEBUILDER_ASSETS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,11 +166,11 @@ test-vrg-kubeobjects: generate manifests setup-envtest
 test-drpc: generate manifests setup-envtest
 	go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus DRPlacementControl
 
-test-drenv:
-	$(MAKE) -C test
-	
 test-util-pvc: generate manifests setup-envtest
 	go test ./controllers/util -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus PVCS_Util
+
+test-drenv:
+	$(MAKE) -C test
 
 ##@ Build
 


### PR DESCRIPTION
It was added badly in b8617d8d8c47, which broke the tests on macOS/aarch64 (e6660972a765).
This change fix it so it is passed to `go test` and it can be overridden by the caller
for testing different versions.

This does not fix the duplication in the test suites recreating this variable if missing
(e.g. running `go test` directly).