### PR TITLE
Fix to return RS when checking for pv inuse

### DIFF
--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -971,7 +971,7 @@ var _ = Describe("VolSync Handler", func() {
 									It("Should not complete the final sync", func() {
 										finalSyncDone, returnedRS, err := vsHandler.ReconcileRS(rsSpec, true)
 										Expect(err).NotTo(HaveOccurred()) // Not considered an error, we should just wait
-										Expect(returnedRS).To(BeNil())
+										Expect(returnedRS).NotTo(BeNil()) // Should return the existing RS
 										Expect(finalSyncDone).To(BeFalse())
 									})
 								})
@@ -1003,7 +1003,7 @@ var _ = Describe("VolSync Handler", func() {
 										It("Should not complete the final sync", func() {
 											finalSyncDone, returnedRS, err := vsHandler.ReconcileRS(rsSpec, true)
 											Expect(err).NotTo(HaveOccurred()) // Not considered an error, we should just wait
-											Expect(returnedRS).To(BeNil())
+											Expect(returnedRS).NotTo(BeNil()) // Should return existing RS
 											Expect(finalSyncDone).To(BeFalse())
 										})
 									})


### PR DESCRIPTION
- Small case where running final sync, if the pv is in use we return finalSyncComplete = false but then since the RS is nil, the "completed setup" status for the pv gets cleared