### PR TITLE
Install missing volsync and velero crds

### DIFF
--- a/test/ocm-cluster/example-manifestwork.yaml
+++ b/test/ocm-cluster/example-manifestwork.yaml
@@ -35,5 +35,5 @@ spec:
               serviceAccountName: example-sa
               containers:
                 - name: busybox
-                  image: quay.io/quay/busybox
+                  image: docker.io/library/busybox:stable
                   command: ["sleep", "60"]

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -28,6 +28,7 @@ templates:
           - name: olm
           - name: minio
           - name: velero
+          - name: volsync
   - name: "hub-cluster"
     driver: kvm2
     container_runtime: containerd

--- a/test/regional-dr.yaml
+++ b/test/regional-dr.yaml
@@ -27,6 +27,7 @@ templates:
           - name: csi-addons
           - name: olm
           - name: minio
+          - name: velero
   - name: "hub-cluster"
     driver: kvm2
     container_runtime: containerd

--- a/test/velero/start
+++ b/test/velero/start
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+from drenv import kubectl
+
+CRDS = [
+    "../hack/test/velero.io_backups.yaml",
+    "../hack/test/velero.io_restores.yaml",
+]
+
+
+def deploy(cluster):
+    print("Deploying velero crds")
+    for crd in CRDS:
+        kubectl.apply(f"--filename={crd}", context=cluster)
+
+
+def wait(cluster):
+    print("Waiting until cdrs are established")
+    for crd in CRDS:
+        kubectl.wait(
+            "--for=condition=established",
+            f"--filename={crd}",
+            context=cluster,
+        )
+
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} cluster")
+    sys.exit(1)
+
+cluster = sys.argv[1]
+
+deploy(cluster)
+wait(cluster)

--- a/test/volsync/start
+++ b/test/volsync/start
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+from drenv import kubectl
+
+CRDS = [
+    "../hack/test/volsync.backube_replicationsources.yaml",
+    "../hack/test/volsync.backube_replicationdestinations.yaml",
+]
+
+
+def deploy(cluster):
+    print("Deploying volsync crds")
+    for crd in CRDS:
+        kubectl.apply(f"--filename={crd}", context=cluster)
+
+
+def wait(cluster):
+    print("Waiting until cdrs are established")
+    for crd in CRDS:
+        kubectl.wait(
+            "--for=condition=established",
+            f"--filename={crd}",
+            context=cluster,
+        )
+
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} cluster")
+    sys.exit(1)
+
+cluster = sys.argv[1]
+
+deploy(cluster)
+wait(cluster)


### PR DESCRIPTION
This is a quick workaround to get ramen running without disbaling volsync and velero
in ramen config map.

We will improve this later to actually install the operators so we can test also
kube object protection and volsync.

Part of: #661, #662