### PR TITLE
Work In Progress for Discussion: cooler example of drenv

### DIFF
--- a/test/example.yaml
+++ b/test/example.yaml
@@ -8,6 +8,7 @@ templates:
   - name: "example-cluster"
     driver: podman
     container_runtime: cri-o
+    addons: 'ingress'
     workers:
       - scripts:
           - name: example

--- a/test/example/deployment.yaml
+++ b/test/example/deployment.yaml
@@ -1,6 +1,18 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginxservice
+  labels:
+    app: nginx
+spec:
+  ports:
+  - port: 80
+  selector:
+    app: nginx
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,14 +31,6 @@ spec:
     spec:
       containers:
       - name: example
-        image: docker.io/library/busybox:stable
-        command:
-        - sh
-        - -c
-        - |
-          trap exit TERM
-          while true; do
-              date
-              sleep 10 &
-              wait  # interrupted quickly on signal.
-          done
+        image: docker.io/library/nginx:stable
+        ports:
+          - containerPort: 80

--- a/test/example/ingress.yaml
+++ b/test/example/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+spec:
+  ingressClassName: nginx-example
+  rules:
+  - host: localhost
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: nginexservice
+            port:
+              number: 80

--- a/test/example/start
+++ b/test/example/start
@@ -15,3 +15,5 @@ cluster = sys.argv[1]
 
 print("Deploying example")
 kubectl.apply("--filename", "example/deployment.yaml", context=cluster)
+print("Creating ingress")
+kubectl.apply("--filename", "example/ingress.yaml")


### PR DESCRIPTION
I am trying to access the nginx server page with this code changes.

Issues I am facing:
1. Image pull for nginx is contantly failing from 1+ days Events:
   Type     Reason            Age                    From               Message
   ----     ------            ----                   ----               -------
   Warning  FailedScheduling  8m28s                  default-scheduler  0/1 nodes are available: 1 node(s) had untolerated taint {node.kubernetes.io/not-ready: }. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling..
   Normal   Scheduled         8m26s                  default-scheduler  Successfully assigned default/example-deployment-84f999657d-pmxrb to ex2
   Normal   Pulling           4m (x4 over 8m25s)     kubelet            Pulling image "docker.io/library/nginx:stable"
   Warning  Failed            3m28s (x4 over 6m31s)  kubelet            Failed to pull image "docker.io/library/nginx:stable": rpc error: code = Unknown desc = writing blob: adding layer with blob "sha256:1c3cdc1adeef9cbd6fd04801bf2b50e410555a227dd942052fd10e00e273cd5a": Error processing tar file(exit status 1): operation not permitted
   Warning  Failed            3m28s (x4 over 6m31s)  kubelet            Error: ErrImagePull
   Normal   BackOff           2m53s (x7 over 6m31s)  kubelet            Back-off pulling image "docker.io/library/nginx:stable"
   Warning  Failed            2m53s (x7 over 6m31s)  kubelet            Error: ImagePullBackOff

   (ramen) [sacharya@fedora test]$ kubectl describe nodes | grep -i taint
   Taints:             <none>
   (ramen) [sacharya@fedora test]$

   I am able to do both docker pull and podman pull from terminal with the same user, without even password.

   (ramen) [sacharya@fedora test]$ podman pull docker.io/library/nginx:stable Trying to pull docker.io/library/nginx:stable... Getting image source signatures Copying blob 3f9582a2cbe7 done   Copying blob 1c3cdc1adeef done   Copying blob 0d20c7b11e51 done   Copying blob 2f98bdf28b77 done   Copying blob 66350be01a8b done   Copying blob 90f8f705fe4d done   Copying config 8c9eabeac4 done   Writing manifest to image destination Storing signatures 8c9eabeac475449c72ad457ccbc014788a02dbbc64f24158b0a40fdc5def2dc9 (ramen) [sacharya@fedora test]$

   Permissions on my user are as follows: $ id uid=1000(sacharya) gid=1000(sacharya) groups=1000(sacharya),10(wheel),63(audio),973(docker) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023

   PS: I am also able to pull busybox image when I run the deployment in older example/deplyment.yaml with the existing permissions.

   2. I might also want to ensure ingress is properly enabled, any suggestions to check it at this stage?