### PR TITLE
Add ramen configuration for drenv

### DIFF
--- a/docs/devel-quick-start.md
+++ b/docs/devel-quick-start.md
@@ -148,12 +148,26 @@ kubectl get deploy -A --context dr2
    done
    ```
 
+## Configure the ramen operator on the hub
+
+Ramen need to be configured to know about the managed clusters and the
+s3 endpoints. To configure the test environment, run this script:
+
+```
+test/ramen-config/deploy regional-dr
+```
+
+If you need to remove your configuration, use:
+
+```
+test/ramen-config/undeploy regional-dr
+```
+
 ## The next steps
 
-At this point *Ramen* is running in your cluster, and you are ready for
-the next steps:
+At this point *Ramen* is ready to protect workloads in your cluster, and
+you are ready for the next steps:
 
-- Configuring *Ramen*
 - Enable disaster recovery for an application
 - Failing over the application to another cluster
 - Relocating an application back to the original cluster

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,19 +1,21 @@
+sources := $(wildcard drenv *.py */start */test */stop */deploy */undeploy)
+
 all: flake8 pylint black test coverage
 
 venv:
 	scripts/make-venv.sh
 
 flake8:
-	python3 -m flake8 drenv */start */test
+	python3 -m flake8 $(sources)
 
 pylint:
-	python3 -m pylint --errors-only drenv */start */test
+	python3 -m pylint --errors-only $(sources)
 
 black:
-	python3 -m black --check --diff drenv */start */test
+	python3 -m black --check --diff $(sources)
 
 black-reformat:
-	python3 -m black drenv */start */test
+	python3 -m black $(sources)
 
 test:
 	rm -f .coverage.*

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
 sources := $(wildcard drenv *.py */start */test */stop */deploy */undeploy)
 
 all: flake8 pylint black test coverage

--- a/test/ramen-config/README.md
+++ b/test/ramen-config/README.md
@@ -1,0 +1,32 @@
+<!--
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Ramen configuration for test environment
+
+This directory configures *Ramen* for drenv based test environment.
+
+## Assumptions
+
+- You have 3 clusters "hub", "dr1", and "dr2"
+- The cluster "hub" is the hub cluster
+- Clusters "dr1" and "dr2" are managed clusters
+- *Ramen* was deployed using `make deploy-hub`
+
+## Configuring
+
+```
+ramen-config/deploy regional-dr
+```
+
+## Removing the configuration
+
+```
+ramen-config/undeploy regional-dr
+```
+
+Notes:
+
+- The ramen configmap is not removed. If you want to restore it to
+  default value, run `make deploy-hub` again.

--- a/test/ramen-config/config.py
+++ b/test/ramen-config/config.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+HUB = "hub"
+CLUSTERS = ["dr1", "dr2"]
+NAMESPACE = "ramen-system"
+ENV_TYPES = ["regional-dr"]

--- a/test/ramen-config/configmap.yaml
+++ b/test/ramen-config/configmap.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ramen-hub-operator-config
+  namespace: ramen-system
+data:
+  ramen_manager_config.yaml: |
+    apiVersion: ramendr.openshift.io/v1alpha1
+    kind: RamenConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:9289
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: hub.ramendr.openshift.io
+    ramenControllerType: dr-hub
+    maxConcurrentReconciles: 50
+    drClusterOperator:
+      deploymentAutomationEnabled: $auto_deploy
+      s3SecretDistributionEnabled: true
+      channelName: alpha
+      packageName: ramen-dr-cluster-operator
+      namespaceName: ramen-system
+      catalogSourceName: ramen-catalog
+      catalogSourceNamespaceName: ramen-system
+      clusterServiceVersionName: ramen-dr-cluster-operator.v0.0.1
+    s3StoreProfiles:
+    - s3ProfileName: minio-on-dr1
+      s3Bucket: bucket
+      s3CompatibleEndpoint: $minio_url_dr1
+      s3Region: us-west-1
+      s3SecretRef:
+        name: s3secret
+        namespace: ramen-system
+    - s3ProfileName: minio-on-dr2
+      s3Bucket: bucket
+      s3CompatibleEndpoint: $minio_url_dr2
+      s3Region: us-east-1
+      s3SecretRef:
+        name: s3secret
+        namespace: ramen-system

--- a/test/ramen-config/deploy
+++ b/test/ramen-config/deploy
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+
+import drenv
+from drenv import kubectl
+
+import config
+import minio
+
+parser = argparse.ArgumentParser("deploy")
+parser.add_argument("env_type", choices=config.ENV_TYPES)
+args = parser.parse_args()
+
+print(f"Configuring ramen for {args.env_type}")
+
+os.chdir(os.path.dirname(__file__))
+
+print("Waiting until ramen-hub-operator is rolled out")
+kubectl.rollout(
+    "status",
+    "deploy/ramen-hub-operator",
+    f"--namespace={config.NAMESPACE}",
+    "--timeout=180s",
+    context=config.HUB,
+)
+
+print("Creating s3 secret in ramen hub namespace")
+kubectl.apply("--filename=s3-secret.yaml", context=config.HUB)
+
+print("Updating ramen config map")
+template = drenv.template("configmap.yaml")
+yaml = template.substitute(
+    # Auto deploy is needed only for olm install.
+    auto_deploy=False,
+    minio_url_dr1=minio.service_url(config.CLUSTERS[0]),
+    minio_url_dr2=minio.service_url(config.CLUSTERS[1]),
+)
+kubectl.apply("--filename=-", input=yaml, context=config.HUB)
+
+print(f"Creating DRClusters and DRPolicy for {args.env_type}")
+kubectl.apply("--kustomize", args.env_type, context=config.HUB)
+
+print("Waiting until DRClusters report phase")
+for name in config.CLUSTERS:
+    drenv.wait_for(
+        f"drcluster/{name}",
+        output="jsonpath={.status.phase}",
+        namespace=config.NAMESPACE,
+        timeout=180,
+        profile=config.HUB,
+    )
+
+print("Waiting until DRClusters phase is available")
+kubectl.wait(
+    "drcluster",
+    "--all",
+    "--for=jsonpath={.status.phase}=Available",
+    f"--namespace={config.NAMESPACE}",
+    context=config.HUB,
+)
+
+print("Waiting until DRPolicy is validated")
+kubectl.wait(
+    "drpolicy/dr-policy",
+    "--for=condition=Validated",
+    f"--namespace={config.NAMESPACE}",
+    context=config.HUB,
+)
+
+print("Creating channel")
+kubectl.apply("--filename", "samples-channel.yaml", context=config.HUB)
+
+print("Ramen was configured successfully")

--- a/test/ramen-config/minio.py
+++ b/test/ramen-config/minio.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+from drenv import kubectl
+
+
+def service_url(cluster):
+    """
+    Find minio service url.
+    """
+    host_ip = kubectl.get(
+        "pod",
+        "--selector=component=minio",
+        "--namespace=minio",
+        "--output=jsonpath={.items[0].status.hostIP}",
+        context=cluster,
+    )
+    service_port = kubectl.get(
+        "service/minio",
+        "--namespace=minio",
+        "--output=jsonpath={.spec.ports[0].nodePort}",
+        context=cluster,
+    )
+    return f"http://{host_ip}:{service_port}"

--- a/test/ramen-config/regional-dr/dr-clusters.yaml
+++ b/test/ramen-config/regional-dr/dr-clusters.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: DRCluster
+metadata:
+  name: dr1
+spec:
+  s3ProfileName: minio-on-dr1
+  region: west
+---
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: DRCluster
+metadata:
+  name: dr2
+spec:
+  s3ProfileName: minio-on-dr2
+  region: east

--- a/test/ramen-config/regional-dr/dr-policy.yaml
+++ b/test/ramen-config/regional-dr/dr-policy.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: DRPolicy
+metadata:
+  name: dr-policy
+spec:
+  drClusters:
+  - dr1
+  - dr2
+  schedulingInterval: 1m

--- a/test/ramen-config/regional-dr/kustomization.yaml
+++ b/test/ramen-config/regional-dr/kustomization.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+---
+resources:
+  - dr-clusters.yaml
+  - dr-policy.yaml

--- a/test/ramen-config/s3-secret.yaml
+++ b/test/ramen-config/s3-secret.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: s3secret
+  namespace: ramen-system
+stringData:
+  AWS_ACCESS_KEY_ID: minio
+  AWS_SECRET_ACCESS_KEY: minio123

--- a/test/ramen-config/samples-channel.yaml
+++ b/test/ramen-config/samples-channel.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ramen-samples
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: Channel
+metadata:
+  name: ramen-gitops
+  namespace: ramen-samples
+spec:
+  type: GitHub
+  pathname: https://github.com/RamenDR/ocm-ramen-samples.git

--- a/test/ramen-config/undeploy
+++ b/test/ramen-config/undeploy
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+
+from drenv import kubectl
+import config
+
+parser = argparse.ArgumentParser("undeploy")
+parser.add_argument("env_type", choices=config.ENV_TYPES)
+args = parser.parse_args()
+
+print(f"Unconfiguring Ramen for {args.env_type}")
+
+os.chdir(os.path.dirname(__file__))
+
+print("Deleting samples channel")
+kubectl.delete(
+    "--filename",
+    "samples-channel.yaml",
+    "--ignore-not-found",
+    context=config.HUB,
+)
+
+print("Deleting DRClusters and DRPolicy")
+kubectl.delete(
+    "--kustomize",
+    args.env_type,
+    "--ignore-not-found",
+    context=config.HUB,
+)
+
+# We keep the ramen config map since we do not own it.
+
+print("Deleting s3 secret in ramen hub namespace")
+kubectl.delete(
+    "--filename",
+    "s3-secret.yaml",
+    "--ignore-not-found",
+    context=config.HUB,
+)
+
+print("Ramen was unconfigured successfully")

--- a/test/setup.py
+++ b/test/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Topic :: Software Development :: Testing",
     ],
-    entry_points = {
-        'console_scripts': ['drenv=drenv.__main__:main'],
-    }
+    entry_points={
+        "console_scripts": ["drenv=drenv.__main__:main"],
+    },
 )


### PR DESCRIPTION
This is the simplest way to configure *Ramen* assuming that we installed it using `make deploy-*` with drenv based environment such as `regional-dr.yaml`

Issues:
- Does not support installing the bundles and catalog.

I'm not sure yet how we are going to use with the e2e framework, but let's start with a simple working solution and iterate from there.