### PR TITLE
Add rook-multi-node.yaml

### DIFF
--- a/test/rook-multi-node.yaml
+++ b/test/rook-multi-node.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Enviroment for testing rook ceph deployment with multiple nodes per cluster.
+---
+name: "rook"
+
+templates:
+  - name: "dr-cluster"
+    driver: kvm2
+    container_runtime: containerd
+    network: default
+    memory: "5g"
+    extra_disks: 1
+    disk_size: "50g"
+    nodes: 2
+    workers:
+      - scripts:
+          - name: rook-operator
+          - name: rook-cluster
+          - name: rook-pool
+          - name: rook-toolbox
+      - scripts:
+          - name: csi-addons
+
+profiles:
+  - name: "rook1"
+    template: "dr-cluster"
+  - name: "rook2"
+    template: "dr-cluster"
+
+workers:
+  - scripts:
+      - name: rbd-mirror
+        args: ["rook1", "rook2"]


### PR DESCRIPTION
This environment simulate a real cluster having multiple nodes. I'm using it to understand if our rook-cluster configuration can work for testing purposes on a multi node cluster.

Staring the environment creates 2 cluster:

    $ minikube profile list
    |---------|-----------|------------|-----------------|------|---------|---------|-------|--------|
    | Profile | VM Driver |  Runtime   |       IP        | Port | Version | Status  | Nodes | Active |
    |---------|-----------|------------|-----------------|------|---------|---------|-------|--------|
    | rook1   | kvm2      | containerd | 192.168.122.222 | 8443 | v1.26.1 | Running |     2 |        |
    | rook2   | kvm2      | containerd | 192.168.122.136 | 8443 | v1.26.1 | Running |     2 |        |
    |---------|-----------|------------|-----------------|------|---------|---------|-------|--------|

Each cluster have 2 vms, total 4 vms:

    $ virsh -c qemu:///system list
     Id   Name        State
    ---------------------------
     16   rook1       running
     17   rook2       running
     18   rook1-m02   running
     19   rook2-m02   running

On every cluster we have 2 disks and 2 Ceph osds:

    $ kubectl get deploy -n rook-ceph --context rook1
    NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
    csi-cephfsplugin-provisioner   2/2     2            2           29m
    csi-rbdplugin-provisioner      2/2     2            2           29m
    rook-ceph-mgr-a                1/1     1            1           26m
    rook-ceph-mon-a                1/1     1            1           27m
    rook-ceph-operator             1/1     1            1           30m
    rook-ceph-osd-0                1/1     1            1           25m
    rook-ceph-osd-1                1/1     1            1           25m
    rook-ceph-rbd-mirror-a         1/1     1            1           25m
    rook-ceph-tools                1/1     1            1           25m

So it looks like our test cluster works with existing clusters that have one disk per node. Move testing is needed with real clusters that don't have any disk.