### PR TITLE
drenv: Fix broken drenv dump

### DIFF
--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -84,7 +84,7 @@ def cmd_delete(env, args):
     )
 
 
-def cmd_dump(env):
+def cmd_dump(env, args):
     yaml.dump(env, sys.stdout)
 
 

--- a/test/drenv/drenv_test.py
+++ b/test/drenv/drenv_test.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import yaml
 import pytest
 
 from drenv import cluster
@@ -16,6 +17,20 @@ def test_start_unknown():
 def test_start(tmpenv):
     commands.run("drenv", "start", "--name-prefix", tmpenv.prefix, "external.yaml")
     assert cluster.status(tmpenv.prefix + "cluster") == cluster.READY
+
+
+def test_dump_without_prefix():
+    out = commands.run("drenv", "dump", "example.yaml")
+    dump = yaml.safe_load(out)
+    assert dump["profiles"][0]["name"] == "ex1"
+    assert dump["profiles"][1]["name"] == "ex2"
+
+
+def test_dump_with_prefix():
+    out = commands.run("drenv", "dump", "--name-prefix", "test-", "example.yaml")
+    dump = yaml.safe_load(out)
+    assert dump["profiles"][0]["name"] == "test-ex1"
+    assert dump["profiles"][1]["name"] == "test-ex2"
 
 
 def test_stop_unknown():

--- a/test/external.yaml
+++ b/test/external.yaml
@@ -15,6 +15,7 @@
 # Stopping will run the stop script, but will not stop the external minikube
 # cluster. Deleting does nothing.
 #
+# https://github.com/RamenDR/ramen/commit/a54bb25dc5cf8882347de1cce8a2318b8b6a58b5
 ---
 name: external
 profiles:


### PR DESCRIPTION
drenv cmd_dump() errors out with the following message: 
cmd_dump() takes 1 positional argument but 2 were given

Passing args to cmd_dump function resolves this issue. 
Updates:  #797
Signed-off-by: Shwetha K Acharya <sacharya@redhat.com>