### PR TITLE
Allow running scripts from any directory

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -525,6 +525,25 @@ script/start cluster1 arg2
 script/test cluster1 arg2
 ```
 
+#### Hook working directory
+
+Hook should not assume the current working directory. To make the hook
+runnable from any directory the hook can change the current working
+directory to the hook directory:
+
+```python
+import os
+
+os.chdir(os.path.dirname(__file__))
+```
+
+Now you can run the hook from any directory, and the hook can use
+relative path for resources in the same directory:
+
+```python
+kubectl.apply("--filename=deployment.yaml", context=cluster)
+```
+
 ## Environment files
 
 ### Ramen testing environments

--- a/test/README.md
+++ b/test/README.md
@@ -487,7 +487,7 @@ $ drenv delete example.yaml
 
 #### Scripts hooks
 
-The script direcotry may contain scripts to be run on certain events,
+The script directory may contain scripts to be run on certain events,
 based on the hook file name.
 
 | Event        | Scripts       | Comment                             |
@@ -533,7 +533,7 @@ script/test cluster1 arg2
   managed clusters with Ceph storage.
 
 - `regional-dr-external.yaml` - A starting point for creating
-   environemnt for testing regional DR using with external storage.
+   environment for testing regional DR using with external storage.
 
 ### drenv development environments
 

--- a/test/cert-manager/start
+++ b/test/cert-manager/start
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 from drenv import kubectl
@@ -32,6 +33,7 @@ if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 deploy(cluster)

--- a/test/csi-addons/start
+++ b/test/csi-addons/start
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 import drenv
@@ -16,7 +17,7 @@ BASE_URL = f"https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/
 def deploy(cluster):
     print("Deploying csi addon for volume replication")
     with drenv.kustomization(
-        "csi-addons/kustomization.yaml",
+        "kustomization.yaml",
         base_url=BASE_URL,
     ) as kustomization:
         kubectl.apply("--kustomize", kustomization, context=cluster)
@@ -37,6 +38,7 @@ if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 deploy(cluster)

--- a/test/example/start
+++ b/test/example/start
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 from drenv import kubectl
@@ -11,7 +12,8 @@ if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 print("Deploying example")
-kubectl.apply("--filename", "example/deployment.yaml", context=cluster)
+kubectl.apply("--filename", "deployment.yaml", context=cluster)

--- a/test/example/test
+++ b/test/example/test
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 from drenv import kubectl
@@ -11,6 +12,7 @@ if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 print("Testing example deployment")

--- a/test/minio/start
+++ b/test/minio/start
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 from drenv import kubectl
@@ -10,7 +11,7 @@ from drenv import kubectl
 
 def deploy(cluster):
     print("Deploying minio")
-    kubectl.apply("--filename", "minio/minio.yaml", context=cluster)
+    kubectl.apply("--filename", "minio.yaml", context=cluster)
 
 
 def wait(cluster):
@@ -28,6 +29,7 @@ if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 deploy(cluster)

--- a/test/ocm-cluster/start
+++ b/test/ocm-cluster/start
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import os
 import sys
 
 import drenv
@@ -126,6 +127,7 @@ if len(sys.argv) != 3:
     print(f"Usage: {sys.argv[0]} cluster hub")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster_name = sys.argv[1]
 hub_name = sys.argv[2]
 

--- a/test/ocm-cluster/test
+++ b/test/ocm-cluster/test
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 import drenv
@@ -74,10 +75,11 @@ if len(sys.argv) != 3:
     print(f"Usage: {sys.argv[0]} cluster hub")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 hub = sys.argv[2]
 
-template = drenv.template("ocm-cluster/example-manifestwork.yaml")
+template = drenv.template("example-manifestwork.yaml")
 work = template.substitute(namespace=cluster)
 
 deploy_work(cluster, hub, work)

--- a/test/ocm-controller/start
+++ b/test/ocm-controller/start
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 import drenv
@@ -18,7 +19,7 @@ BASE_URL = f"https://raw.githubusercontent.com/stolostron/multicloud-operators-f
 def deploy(cluster):
     print("Deploying ocm controller")
     with drenv.kustomization(
-        "ocm-controller/kustomization.yaml",
+        "kustomization.yaml",
         base_url=BASE_URL,
     ) as kustomization:
         kubectl.apply("--kustomize", kustomization, context=cluster)
@@ -39,6 +40,7 @@ if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 deploy(cluster)

--- a/test/ocm-hub/start
+++ b/test/ocm-hub/start
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 import drenv
@@ -71,6 +72,7 @@ if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 deploy(cluster)

--- a/test/olm/start
+++ b/test/olm/start
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 import drenv
@@ -76,6 +77,7 @@ if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 deploy(cluster)

--- a/test/rbd-mirror/start
+++ b/test/rbd-mirror/start
@@ -5,6 +5,7 @@
 
 import base64
 import json
+import os
 import sys
 
 import drenv
@@ -52,7 +53,7 @@ def fetch_secret_info(cluster):
 def configure_rbd_mirroring(cluster, peer_info):
     print(f"Applying rbd mirror secret in cluster '{cluster}'")
 
-    template = drenv.template("rbd-mirror/rbd-mirror-secret.yaml")
+    template = drenv.template("rbd-mirror-secret.yaml")
     yaml = template.substitute(peer_info)
     kubectl.apply(
         "--filename=-",
@@ -74,7 +75,7 @@ def configure_rbd_mirroring(cluster, peer_info):
 
     print(f"Apply rbd mirror to cluster '{cluster}'")
     kubectl.apply(
-        "--filename=rbd-mirror/rbd-mirror.yaml",
+        "--filename=rbd-mirror.yaml",
         "--namespace=rook-ceph",
         context=cluster,
     )
@@ -115,7 +116,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
 def deploy_vrc_sample(cluster):
     print(f"Applying vrc sample in cluster '{cluster}'")
     kubectl.apply(
-        "--filename=rbd-mirror/vrc-sample.yaml",
+        "--filename=vrc-sample.yaml",
         "--namespace=rook-ceph",
         context=cluster,
     )
@@ -125,6 +126,7 @@ if len(sys.argv) != 3:
     print(f"Usage: {sys.argv[0]} cluster1 cluster2")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster1 = sys.argv[1]
 cluster2 = sys.argv[2]
 

--- a/test/rbd-mirror/test
+++ b/test/rbd-mirror/test
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import os
 import sys
 import time
 
@@ -56,7 +57,7 @@ def rbd_mirror_image_status(cluster, image):
 def test_volume_replication(primary, secondary):
     print(f"Deploying pvc {PVC_NAME} in cluster '{primary}'")
     kubectl.apply(
-        f"--filename=rbd-mirror/{PVC_NAME}.yaml",
+        f"--filename={PVC_NAME}.yaml",
         "--namespace=rook-ceph",
         context=primary,
     )
@@ -72,7 +73,7 @@ def test_volume_replication(primary, secondary):
 
     print(f"Deploying vr vr-sample in cluster '{primary}'")
     kubectl.apply(
-        "--filename=rbd-mirror/vr-sample.yaml",
+        "--filename=vr-sample.yaml",
         "--namespace=rook-ceph",
         context=primary,
     )
@@ -159,6 +160,7 @@ if len(sys.argv) != 3:
     print(f"Usage: {sys.argv[0]} cluster1 cluster2")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster1 = sys.argv[1]
 cluster2 = sys.argv[2]
 

--- a/test/rook-cluster/start
+++ b/test/rook-cluster/start
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 import drenv
@@ -16,7 +17,7 @@ BASE_URL = f"https://raw.githubusercontent.com/rook/rook/{VERSION}/deploy/exampl
 def deploy(cluster):
     print("Deploying rook ceph cluster")
     with drenv.kustomization(
-        "rook-cluster/kustomization.yaml",
+        "kustomization.yaml",
         base_url=BASE_URL,
     ) as kustomization:
         kubectl.apply("--kustomize", kustomization, context=cluster)
@@ -44,6 +45,7 @@ if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 deploy(cluster)

--- a/test/rook-operator/start
+++ b/test/rook-operator/start
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 import drenv
@@ -16,7 +17,7 @@ BASE_URL = f"https://raw.githubusercontent.com/rook/rook/{VERSION}/deploy/exampl
 def deploy(cluster):
     print("Deploying rook ceph operator")
     with drenv.kustomization(
-        "rook-operator/kustomization.yaml",
+        "kustomization.yaml",
         base_url=BASE_URL,
     ) as kustomization:
         kubectl.apply("--kustomize", kustomization, context=cluster)
@@ -47,6 +48,7 @@ if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 deploy(cluster)

--- a/test/rook-pool/start
+++ b/test/rook-pool/start
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 import drenv
@@ -12,8 +13,8 @@ from drenv import kubectl
 def deploy(cluster):
     print("Creating rbd pool and storage class")
     kubectl.apply(
-        "--filename=rook-pool/replica-pool.yaml",
-        "--filename=rook-pool/storage-class.yaml",
+        "--filename=replica-pool.yaml",
+        "--filename=storage-class.yaml",
         context=cluster,
     )
 
@@ -49,6 +50,7 @@ if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 deploy(cluster)

--- a/test/rook-toolbox/start
+++ b/test/rook-toolbox/start
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 from drenv import kubectl
@@ -32,6 +33,7 @@ if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 deploy(cluster)

--- a/test/velero/start
+++ b/test/velero/start
@@ -3,13 +3,14 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 from drenv import kubectl
 
 CRDS = [
-    "../hack/test/velero.io_backups.yaml",
-    "../hack/test/velero.io_restores.yaml",
+    "../../hack/test/velero.io_backups.yaml",
+    "../../hack/test/velero.io_restores.yaml",
 ]
 
 
@@ -33,6 +34,7 @@ if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 deploy(cluster)

--- a/test/volsync/start
+++ b/test/volsync/start
@@ -3,13 +3,14 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import sys
 
 from drenv import kubectl
 
 CRDS = [
-    "../hack/test/volsync.backube_replicationsources.yaml",
-    "../hack/test/volsync.backube_replicationdestinations.yaml",
+    "../../hack/test/volsync.backube_replicationsources.yaml",
+    "../../hack/test/volsync.backube_replicationdestinations.yaml",
 ]
 
 
@@ -33,6 +34,7 @@ if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")
     sys.exit(1)
 
+os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 deploy(cluster)


### PR DESCRIPTION
Previously running a hook manually was possible only from the test directory:

    example/start ex1

Now you can run the hook from any directory. This makes it easier to maintain the scripts, since you don't need to repeat the name of the script in the hooks, and will make it possible to run drenv from any directory later.

Example usage that was not possible before:

    # From a script directory
    cd example
    ./start ex1

    # From source root directory
    test/example/start ex1

Part of #805 