### PR TITLE
Improve error messages and logs when displaying cluster names

### DIFF
--- a/test/drenv/cluster.py
+++ b/test/drenv/cluster.py
@@ -43,14 +43,14 @@ def wait_until_ready(name, timeout=300):
         current_status = status(name)
 
         if current_status != last_status:
-            print(f"Cluster {name} is {current_status}")
+            print(f"Cluster '{name}' is {current_status}")
             last_status = current_status
 
         if current_status == READY:
             break
 
         if time.monotonic() > deadline:
-            raise RuntimeError(f"Timeout waiting for cluster {name}")
+            raise RuntimeError(f"Timeout waiting for cluster '{name}'")
 
         time.sleep(delay)
 

--- a/test/ocm-cluster/start
+++ b/test/ocm-cluster/start
@@ -66,7 +66,7 @@ def wait(cluster):
 
 
 def wait_for_hub(hub):
-    print(f"Waiting until cluster {hub} is ready")
+    print(f"Waiting until cluster '{hub}' is ready")
 
     cluster.wait_until_ready(hub)
     drenv.wait_for(f"namespace/{HUB_NAMESPACE}", profile=hub)
@@ -84,7 +84,7 @@ def wait_for_hub(hub):
 
 
 def join_cluster(cluster, hub):
-    print(f"Joining to cluster {hub}")
+    print(f"Joining cluster '{hub}'")
 
     out = clusteradm.get("token", output="json", context=hub)
     hub_info = json.loads(out)

--- a/test/ocm-cluster/test
+++ b/test/ocm-cluster/test
@@ -10,12 +10,12 @@ from drenv import kubectl
 
 
 def deploy_work(cluster, hub, work):
-    print(f"Applying manifestwork to namespace {cluster}")
+    print(f"Applying manifestwork to namespace '{cluster}'")
     kubectl.apply("--filename", "-", input=work, context=hub)
 
 
 def wait_for_work(cluster, hub):
-    print(f"Waiting until manifestwork is applied in namespace {cluster}")
+    print(f"Waiting until manifestwork is applied in namespace '{cluster}'")
     kubectl.wait(
         "manifestwork/example-manifestwork",
         "--for=condition=applied",
@@ -26,7 +26,7 @@ def wait_for_work(cluster, hub):
 
 
 def wait_for_deployment(cluster, hub):
-    print(f"Waiting until manifestwork is available in namespace {cluster}")
+    print(f"Waiting until manifestwork is available in namespace '{cluster}'")
     kubectl.wait(
         "manifestwork/example-manifestwork",
         "--for=condition=available",
@@ -35,7 +35,7 @@ def wait_for_deployment(cluster, hub):
         context=hub,
     )
 
-    print(f"Waiting until deployment is available in cluster {cluster}")
+    print(f"Waiting until deployment is available in cluster '{cluster}'")
     kubectl.wait(
         "deploy/example-deployment",
         "--for=condition=available",
@@ -45,12 +45,12 @@ def wait_for_deployment(cluster, hub):
 
 
 def delete_work(cluster, hub, work):
-    print(f"Deleting manifestwork from namespace {cluster}")
+    print(f"Deleting manifestwork from namespace '{cluster}'")
     kubectl.delete("--filename", "-", input=work, context=hub)
 
 
 def wait_for_delete_work(cluster, hub):
-    print(f"Waiting until manifestwork is deleted from namspace {cluster}")
+    print(f"Waiting until manifestwork is deleted from namspace '{cluster}'")
     kubectl.wait(
         "manifestwork/example-manifestwork",
         "--for=delete",
@@ -61,7 +61,7 @@ def wait_for_delete_work(cluster, hub):
 
 
 def wait_for_delete_deployment(cluster):
-    print(f"Waiting until deployment is deleted from cluster {cluster}")
+    print(f"Waiting until deployment is deleted from cluster '{cluster}'")
     kubectl.wait(
         "deploy/example-deployment",
         "--for=delete",

--- a/test/rbd-mirror/start
+++ b/test/rbd-mirror/start
@@ -16,7 +16,7 @@ POOL_NAME = "replicapool"
 def fetch_secret_info(cluster):
     info = {}
 
-    print(f"Getting mirroring info site name for cluster {cluster}")
+    print(f"Getting mirroring info site name for cluster '{cluster}'")
     info["name"] = kubectl.get(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
@@ -25,7 +25,7 @@ def fetch_secret_info(cluster):
         context=cluster,
     )
 
-    print(f"Getting rbd mirror boostrap peer secret name for cluster {cluster}")
+    print(f"Getting rbd mirror boostrap peer secret name for cluster '{cluster}'")
     secret_name = kubectl.get(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
@@ -34,7 +34,7 @@ def fetch_secret_info(cluster):
         context=cluster,
     )
 
-    print(f"Getting secret {secret_name} token for cluster {cluster}")
+    print(f"Getting secret {secret_name} token for cluster '{cluster}'")
     info["token"] = kubectl.get(
         "secret",
         secret_name,
@@ -50,7 +50,7 @@ def fetch_secret_info(cluster):
 
 
 def configure_rbd_mirroring(cluster, peer_info):
-    print(f"Applying rbd mirror secret in cluster {cluster}")
+    print(f"Applying rbd mirror secret in cluster '{cluster}'")
 
     template = drenv.template("rbd-mirror/rbd-mirror-secret.yaml")
     yaml = template.substitute(peer_info)
@@ -61,7 +61,7 @@ def configure_rbd_mirroring(cluster, peer_info):
         context=cluster,
     )
 
-    print(f"Configure peers for cluster {cluster}")
+    print(f"Configure peers for cluster '{cluster}'")
     patch = {"spec": {"mirroring": {"peers": {"secretNames": [peer_info["name"]]}}}}
     kubectl.patch(
         "cephblockpool",
@@ -72,7 +72,7 @@ def configure_rbd_mirroring(cluster, peer_info):
         context=cluster,
     )
 
-    print(f"Apply rbd mirror to cluster {cluster}")
+    print(f"Apply rbd mirror to cluster '{cluster}'")
     kubectl.apply(
         "--filename=rbd-mirror/rbd-mirror.yaml",
         "--namespace=rook-ceph",
@@ -81,7 +81,7 @@ def configure_rbd_mirroring(cluster, peer_info):
 
 
 def wait_until_pool_mirroring_is_healthy(cluster):
-    print(f"Waiting until ceph mirror daemon is healthy in cluster {cluster}")
+    print(f"Waiting until ceph mirror daemon is healthy in cluster '{cluster}'")
     kubectl.wait(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
@@ -91,7 +91,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
         context=cluster,
     )
 
-    print(f"Waiting until ceph mirror is healthy in cluster {cluster}")
+    print(f"Waiting until ceph mirror is healthy in cluster '{cluster}'")
     kubectl.wait(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
@@ -101,7 +101,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
         context=cluster,
     )
 
-    print(f"Waiting until ceph mirror image is healthy in cluster {cluster}")
+    print(f"Waiting until ceph mirror image is healthy in cluster '{cluster}'")
     kubectl.wait(
         "cephblockpools.ceph.rook.io",
         POOL_NAME,
@@ -113,7 +113,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
 
 
 def deploy_vrc_sample(cluster):
-    print(f"Applying vrc sample in cluster {cluster}")
+    print(f"Applying vrc sample in cluster '{cluster}'")
     kubectl.apply(
         "--filename=rbd-mirror/vrc-sample.yaml",
         "--namespace=rook-ceph",

--- a/test/rbd-mirror/test
+++ b/test/rbd-mirror/test
@@ -54,14 +54,14 @@ def rbd_mirror_image_status(cluster, image):
 
 
 def test_volume_replication(primary, secondary):
-    print(f"Deploying pvc {PVC_NAME} in cluster {primary}")
+    print(f"Deploying pvc {PVC_NAME} in cluster '{primary}'")
     kubectl.apply(
         f"--filename=rbd-mirror/{PVC_NAME}.yaml",
         "--namespace=rook-ceph",
         context=primary,
     )
 
-    print(f"Waiting until pvc {PVC_NAME} is bound in cluster {primary}")
+    print(f"Waiting until pvc {PVC_NAME} is bound in cluster '{primary}'")
     kubectl.wait(
         f"pvc/{PVC_NAME}",
         "--for=jsonpath={.status.phase}=Bound",
@@ -70,14 +70,14 @@ def test_volume_replication(primary, secondary):
         context=primary,
     )
 
-    print(f"Deploying vr vr-sample in cluster {primary}")
+    print(f"Deploying vr vr-sample in cluster '{primary}'")
     kubectl.apply(
         "--filename=rbd-mirror/vr-sample.yaml",
         "--namespace=rook-ceph",
         context=primary,
     )
 
-    print(f"Waiting until vr vr-sample is completed in cluster {primary}")
+    print(f"Waiting until vr vr-sample is completed in cluster '{primary}'")
     kubectl.wait(
         "volumereplication/vr-sample",
         "--for=condition=Completed",
@@ -86,7 +86,7 @@ def test_volume_replication(primary, secondary):
         context=primary,
     )
 
-    print(f"Waiting until vr vr-sample state is primary in cluster {primary}")
+    print(f"Waiting until vr vr-sample state is primary in cluster '{primary}'")
     kubectl.wait(
         "volumereplication/vr-sample",
         "--for=jsonpath={.status.state}=Primary",
@@ -95,7 +95,7 @@ def test_volume_replication(primary, secondary):
         context=primary,
     )
 
-    print(f"Looking up pvc {PVC_NAME} pv name in cluster {primary}")
+    print(f"Looking up pvc {PVC_NAME} pv name in cluster '{primary}'")
     pv_name = kubectl.get(
         f"pvc/{PVC_NAME}",
         "--output=jsonpath={.spec.volumeName}",
@@ -103,7 +103,7 @@ def test_volume_replication(primary, secondary):
         context=primary,
     )
 
-    print(f"Looking up rbd image for pv {pv_name} in cluster {primary}")
+    print(f"Looking up rbd image for pv {pv_name} in cluster '{primary}'")
     rbd_image = kubectl.get(
         f"pv/{pv_name}",
         "--output=jsonpath={.spec.csi.volumeAttributes.imageName}",
@@ -111,11 +111,11 @@ def test_volume_replication(primary, secondary):
         context=primary,
     )
 
-    print(f"rbd image {rbd_image} info in cluster {primary}")
+    print(f"rbd image {rbd_image} info in cluster '{primary}'")
     out = rbd("info", rbd_image, cluster=primary)
     print(out)
 
-    print(f"Waiting until rbd image {rbd_image} is created in cluster {secondary}")
+    print(f"Waiting until rbd image {rbd_image} is created in cluster '{secondary}'")
     for i in range(60):
         time.sleep(1)
         out = rbd("list", cluster=primary)
@@ -126,7 +126,7 @@ def test_volume_replication(primary, secondary):
     else:
         raise RuntimeError(f"Timeout waiting for image {rbd_image}")
 
-    print(f"vr vr-sample info on primary cluster {primary}")
+    print(f"vr vr-sample info on primary cluster '{primary}'")
     kubectl.get(
         "volumereplication/vr-sample",
         "--output=yaml",
@@ -134,25 +134,25 @@ def test_volume_replication(primary, secondary):
         context=primary,
     )
 
-    print(f"rbd mirror image status in cluster {primary}")
+    print(f"rbd mirror image status in cluster '{primary}'")
     image_status = rbd_mirror_image_status(primary, rbd_image)
     print(json.dumps(image_status, indent=2))
 
-    print(f"Deleting vr vr-sample in primary cluster {primary}")
+    print(f"Deleting vr vr-sample in primary cluster '{primary}'")
     kubectl.delete(
         "volumereplication/vr-sample",
         "--namespace=rook-ceph",
         context=primary,
     )
 
-    print(f"Deleting pvc {PVC_NAME} in primary cluster {primary}")
+    print(f"Deleting pvc {PVC_NAME} in primary cluster '{primary}'")
     kubectl.delete(
         f"pvc/{PVC_NAME}",
         "--namespace=rook-ceph",
         context=primary,
     )
 
-    print(f"Replication from cluster {primary} to cluster {secondary} successeded")
+    print(f"Replication from cluster '{primary}' to cluster '{secondary}' successeded")
 
 
 if len(sys.argv) != 3:


### PR DESCRIPTION
Errors like "RuntimeError: Timeout waiting for cluster hub" can get confusing if a hub cluster is not named hub.

Resolve this issue with following improvisation:
RuntimeError: Timeout waiting for cluster 'hub'

Apply the same for all the instances cluster names in errors and logs.

Fixes: #795