### PR TITLE
Install ocm-controller from main

### DIFF
--- a/test/ocm-controller/kustomization.yaml
+++ b/test/ocm-controller/kustomization.yaml
@@ -1,34 +1,39 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-# Based on upstream deploy/foundation/hub/kustomization.yaml
-# excluding ocm proxyserver and webhook controllers.
+# yamllint disable rule:line-length
+
+# Based on https://github.com/stolostron/multicloud-operators-foundation/blob/main/deploy/foundation/hub/kustomization.yaml
+# including only what we need for ocm-controller.
 
 ---
-resources:
-- $base_url/resources/crds/action.open-cluster-management.io_managedclusteractions.yaml
-- $base_url/resources/crds/internal.open-cluster-management.io_managedclusterinfos.yaml
-- $base_url/resources/crds/imageregistry.open-cluster-management.io_managedclusterimageregistries.yaml
-- $base_url/resources/crds/inventory.open-cluster-management.io_baremetalassets.yaml
-- $base_url/resources/crds/view.open-cluster-management.io_managedclusterviews.yaml
-- $base_url/resources/crds/hive.openshift.io_syncsets.yaml
-- $base_url/resources/crds/hive.openshift.io_clusterdeployments.yaml
-- $base_url/resources/crds/hiveinternal.openshift.io_clustersyncs.yaml
-- $base_url/resources/crds/hive.openshift.io_clusterclaims.yaml
-- $base_url/resources/crds/hive.openshift.io_clusterpools.yaml
-- $base_url/resources/clusterrole.yaml
-- $base_url/resources/agent-clusterrole.yaml
-- $base_url/resources/controller.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 
+resources:
+- $base_url/resources/crds/action.open-cluster-management.io_managedclusteractions.crd.yaml
+- $base_url/resources/crds/hive.openshift.io_clusterclaims.yaml
+- $base_url/resources/crds/hive.openshift.io_clusterdeployments.yaml
+- $base_url/resources/crds/hive.openshift.io_clusterpools.yaml
+- $base_url/resources/crds/imageregistry.open-cluster-management.io_managedclusterimageregistries.crd.yaml
+- $base_url/resources/crds/internal.open-cluster-management.io_managedclusterinfos.crd.yaml
+- $base_url/resources/crds/view.open-cluster-management.io_managedclusterviews.crd.yaml
+- $base_url/resources/agent-clusterrole.yaml
+- $base_url/resources/clusterrole.yaml
+- $base_url/resources/controller.yaml
 
 images:
 - name: quay.io/stolostron/multicloud-manager
   newName: quay.io/stolostron/multicloud-manager
   newTag: latest
 
-
-patchesStrategicMerge:
-- $base_url/patches.yaml
-
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
+patches:
+# Replace upstream patches.yaml with version that does not need modification
+# before applying the patch.
+- target:
+    kind: Deployment
+    name: ocm-controller
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: "--agent-addon-image=quay.io/stolostron/multicloud-manager:latest"

--- a/test/ocm-controller/start
+++ b/test/ocm-controller/start
@@ -8,7 +8,10 @@ import sys
 import drenv
 from drenv import kubectl
 
-VERSION = "v2.4.4-ACM"
+# Using main since there are no releases, last tag is more than year old and
+# the image contains 36 vulnerabilities.
+VERSION = "main"
+
 BASE_URL = f"https://raw.githubusercontent.com/stolostron/multicloud-operators-foundation/{VERSION}/deploy/foundation/hub"
 
 


### PR DESCRIPTION
Recently we found the ocm-controller deployment is failing minutes after starting. The reason for the failure is not clear, but looking at the deployment I found some issues:

- We installed from the latest tag (2.4.4-ACM), but this tag is one year old.
- The yaml files from this tag reference the image with `latest` tag, and there is no image with 2.4.4-ACM tag.
- The latest related image is 2.4.4-SNAPSHOT-2022-05-03-14-05-24 that has 36 vulnerabilities.
- The upstream patches.yaml that we use does not tag the image in the container command line. In upstream this patch is modified before deployment in make `deploy-foundation`, but we applied it as is.

Since we don't have a release, recent tag, or maintained release image, we don't have a choice and must use main.

Update the version main, and update the resources for the current main branch content.

Replace the upstream patch with a json patch that tag the image correctly and embed the patch into the kustomization file, since our kustomization helper does not support additional files.

With this change ocm-controller looks stable, and I don't see the warnings and errors seen before, but I see new errors like:

    E0326 18:00:46.607916       1 clusterinfo_controller.go:256] failed to
    get log cert secret
    open-cluster-management/ocm-klusterlet-self-signed-secrets: secrets
    "ocm-klusterlet-self-signed-secrets" not found

    E0326 18:00:46.607974       1 clusterinfo_controller.go:179] failed to
    get log CA. secrets "ocm-klusterlet-self-signed-secrets" not found

Not tested otherwise, since we don't have a self test for ocm-controller, and I don't know how to test the behavior that ramen depends on.