### PR TITLE
Warn about missing scripts

### DIFF
--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -265,6 +265,14 @@ def run_worker(worker, hooks=(), reverse=False, allow_failure=False):
 
 
 def run_script(script, name, hooks=(), allow_failure=False):
+    if not os.path.isdir(script["name"]):
+        logging.warning(
+            "[%s] Script '%s' does not exist - skipping",
+            name,
+            script["name"],
+        )
+        return
+
     for filename in hooks:
         hook = os.path.join(script["name"], filename)
         if os.path.isfile(hook):


### PR DESCRIPTION
This is a partial fix for #809, warning about missing scripts. This should be good enough to help developer detect mismatch between the yaml and the script directory.

To test this I added a typo in external.yaml:

    --- a/test/external.yaml
    +++ b/test/external.yaml
    @@ -25,2 +25,2 @@ profiles:
           - scripts:
    -          - name: example
    +          - name: examplie

Staring and deleting the environment logs warnings about the missing script:

    $ drenv start external.yaml
    2023-03-27 19:13:48,539 INFO    [external] Starting environment
    2023-03-27 19:13:48,540 WARNING [cluster/0] Script 'examplie' does not exist - skipping
    2023-03-27 19:13:49,541 INFO    [external] Environment started in 1.00 seconds

Part-of: #809