### PR TITLE
Backup and restore PVCs and PVs to/from S3 store

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -901,7 +901,7 @@ func (d *DRPCInstance) switchToCluster(targetCluster, targetClusterNamespace str
 
 	// already a primary
 	if restoreAppResources {
-		vrg, restored, err := d.getAndEnsureClusterDataRestored(targetCluster)
+		vrg, restored, err := d.ensureClusterDataRestored(targetCluster)
 		if err != nil {
 			return err
 		}
@@ -1296,7 +1296,7 @@ func (d *DRPCInstance) isVRGSecondary(vrg *rmn.VolumeReplicationGroup) bool {
 	return (vrg.Spec.ReplicationState == rmn.Secondary)
 }
 
-func (d *DRPCInstance) getAndEnsureClusterDataRestored(homeCluster string) (*rmn.VolumeReplicationGroup, bool, error) {
+func (d *DRPCInstance) ensureClusterDataRestored(homeCluster string) (*rmn.VolumeReplicationGroup, bool, error) {
 	d.log.Info("Checking if PVs have been restored", "cluster", homeCluster)
 
 	annotations := make(map[string]string)

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -908,15 +908,6 @@ func (d *DRPCInstance) switchToCluster(targetCluster, targetClusterNamespace str
 
 		d.log.Info(fmt.Sprintf("PVs/PVCs have been Restored? %v", restored))
 
-		// FIXME
-		//
-		// If C1, the preferred cluster, is running on version 4.12 while C2, the failover cluster, has
-		// been upgraded to 4.13, failing over from C1 to C2 would result in an indefinite stall as it
-		// waits for the ProtectedPVCs to become available. However, in such a scenario, it is desirable
-		// to proceed with the restoration of the PVs rather than getting stuck at the DRPC level.
-		// To address this issue, one possible solution is to add an annotation to the RamenConfig, which
-		// would tell DRPC that an upgrade is in progress. While this scenario may not occur in a production
-		// environment, it is likely to fail during QA testing.
 		if !restored || vrg == nil || vrg.Status.State != rmn.PrimaryState {
 			d.setProgression(rmn.ProgressionWaitingForResourceRestore)
 

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -288,7 +288,7 @@ func (f FakeMCVGetter) GetVRGFromManagedCluster(resourceName, resourceNamespace,
 		}
 
 		return vrg, nil
-	case "checkPVsHaveBeenRestored":
+	case "getAndEnsureClusterDataRestored":
 		if isRestorePVsComplete() {
 			vrg.Status.Conditions[0].Type = controllers.VRGConditionTypeClusterDataReady
 			vrg.Status.Conditions[0].Reason = controllers.VRGConditionReasonClusterDataRestored

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -288,7 +288,7 @@ func (f FakeMCVGetter) GetVRGFromManagedCluster(resourceName, resourceNamespace,
 		}
 
 		return vrg, nil
-	case "getAndEnsureClusterDataRestored":
+	case "ensureClusterDataRestored":
 		if isRestorePVsComplete() {
 			vrg.Status.Conditions[0].Type = controllers.VRGConditionTypeClusterDataReady
 			vrg.Status.Conditions[0].Reason = controllers.VRGConditionReasonClusterDataRestored

--- a/controllers/util/events.go
+++ b/controllers/util/events.go
@@ -37,8 +37,8 @@ const (
 	// EventReasonProtectPVCFailed is used when VRG fails to protect PVC
 	EventReasonProtectPVCFailed = "ProtectPVCFailed"
 
-	// EventReasonPVUploadFailed is used when VRG fails to upload PV cluster data
-	EventReasonPVUploadFailed = "PVUploadFailed"
+	// EventReasonUploadFailed is used when VRG fails to upload PV cluster data
+	EventReasonUploadFailed = "UploadFailed"
 
 	// EventReasonVrgUploadFailed is used when VRG fails to upload VRG object
 	EventReasonVrgUploadFailed = "VrgUploadFailed"

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -416,6 +416,7 @@ const (
 	pvVRAnnotationRetentionKey    = "volumereplicationgroups.ramendr.openshift.io/vr-retained"
 	pvVRAnnotationRetentionValue  = "retained"
 	RestoreAnnotation             = "volumereplicationgroups.ramendr.openshift.io/ramen-restore"
+	RestoredByRamen               = "True"
 )
 
 func (v *VRGInstance) processVRG() (ctrl.Result, error) {

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -721,6 +721,7 @@ func (v *vrgTest) VRGTestCaseStart() {
 
 	if v.vrgFirst {
 		v.createVRG()
+
 		if !v.skipCreationPVandPVC {
 			v.createPVCandPV(v.template.ClaimBindInfo, v.template.VolumeBindInfo)
 		}
@@ -728,6 +729,7 @@ func (v *vrgTest) VRGTestCaseStart() {
 		if !v.skipCreationPVandPVC {
 			v.createPVCandPV(v.template.ClaimBindInfo, v.template.VolumeBindInfo)
 		}
+
 		v.createVRG()
 	}
 
@@ -820,7 +822,9 @@ func (v *vrgTest) s3KeyPrefix() string {
 	return vrgController.S3KeyPrefix(v.vrgNamespacedName().String())
 }
 
-func populateS3Store(vrgNamespacedName string, pvList []corev1.PersistentVolume, pvcList []corev1.PersistentVolumeClaim) {
+func populateS3Store(vrgNamespacedName string, pvList []corev1.PersistentVolume,
+	pvcList []corev1.PersistentVolumeClaim,
+) {
 	for _, pv := range pvList {
 		Expect(
 			vrgController.UploadPV(*vrgObjectStorer, vrgNamespacedName, pv.Name, pv),
@@ -939,6 +943,7 @@ func (v *vrgTest) generatePVC(pvcName, namespace, volumeName string, labels map[
 	storageclass := v.storageClass
 
 	accessModes := []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+
 	return &corev1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This Pull Request adds support for backing up and restoring PVCs and PVs to/from an S3 store in the Kubernetes cluster. Previously, only PVs were backed up to the S3 store, but now PVCs will also be backed up to the same S3 stores alongside their associated PVs.

Additionally, this PR introduces a new feature that ensures the restore process is fully complete before allowing the application to be deployed. The new feature includes verifying that the VRG has transitioned to the desired state, which is Primary, before deploying the application. This step ensures that no contention occurs during the failover. Previously, the restore process only confirmed that the PVs were successfully restored to the new cluster, but this PR adds an additional step to ensure that the restore process has completed all the way to the storage system before proceeding with application deployment.

Furthermore, when the VRG restores the PVC, it will be responsible for deleting it when it's no longer needed. The deletion occurs either when the VRG is switched to secondary or when the workload associated with the PVC is deleted.

This PR does not handle upgrading from 4.12 to 4.13 well.  If C1, the preferred cluster, is running on version 4.12 while C2, the failover cluster, has been upgraded to 4.13, failing over from C1 to C2 would result in an indefinite stall as it waits for the ProtectedPVCs to become available. However, in such a scenario, it is desirable to proceed with the restoration of the PVs rather than getting stuck at the DRPC level. To address this issue, one possible solution is to add an annotation to the RamenConfig, which would tell DRPC that an upgrade is in progress. While this scenario may not occur in a production environment, it is likely to fail during QA testing.

Tasks to complete
=============

- [x] e2e tests
- [x] Ensure PVC is updated when its declarative source is updated when using a `Subscription`
- [ ] Ensure PVC is updated when its declarative source is updated when using `ApplicationSet`

Fixes: #644 