### PR TITLE
report drcluster deploy status using manifestwork

### DIFF
--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -818,6 +818,7 @@ func createDRClusters(inClusters []*spokeClusterV1.ManagedCluster) {
 			if managedCluster.Name == drClusters[idx].Name {
 				err := k8sClient.Create(context.TODO(), &drClusters[idx])
 				Expect(err).NotTo(HaveOccurred())
+				updateDRClusterManifestWorkStatus(drClusters[idx].Name)
 			}
 		}
 	}

--- a/controllers/drpolicy_controller_test.go
+++ b/controllers/drpolicy_controller_test.go
@@ -175,6 +175,7 @@ var _ = Describe("DrpolicyController", func() {
 				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: drcluster.Name}},
 			)).To(Succeed())
 			Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
+			updateDRClusterManifestWorkStatus(drcluster.Name)
 			drclusterConditionExpectEventually(
 				drcluster,
 				!ramenConfig.DrClusterOperator.DeploymentAutomationEnabled,


### PR DESCRIPTION
Read DRCluster manifest-work status and report if not successful and fix unit tests intermittent failures on an update of an object. 