### PR TITLE
devel-quick-guide: update podman save cmd

### DIFF
--- a/docs/devel-quick-start.md
+++ b/docs/devel-quick-start.md
@@ -118,7 +118,7 @@ kubectl get deploy -A --context dr2
     - Loading the `ramen-operator` image into the clusters
 
       ```
-      podman save quay.io/nirsof/ramen-operator:canary \
+      podman save quay.io/$IMAGE_REPOSITORY/ramen-operator:$IMAGE_TAG \
           -o /tmp/ramen-operator.tar
 
       for p in hub dr1 dr2; do


### PR DESCRIPTION
instead of using hardcoded image repo and image tag in the command example, 
it's better to use the env variables defined in the section