### PR TITLE
Fix: set Reason and Message fields to none when empty

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -569,7 +569,7 @@ func (r *DRPlacementControlReconciler) reconcileDRPCInstance(d *DRPCInstance, lo
 		r.Callback(d.instance.Name, string(d.getLastDRState()))
 	}
 
-	if d.mcvRequestInProgress {
+	if d.mcvRequestInProgress && d.getLastDRState() != "" {
 		duration := d.getRequeueDuration()
 		log.Info(fmt.Sprintf("Requeing after %v", duration))
 

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -360,7 +360,7 @@ func setStatusCondition(existingConditions *[]metav1.Condition, newCondition met
 	if newCondition.Message == "" {
 		newCondition.Message = defaultValue
 	}
-	
+
 	existingCondition.Reason = newCondition.Reason
 	existingCondition.Message = newCondition.Message
 

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -352,6 +352,15 @@ func setStatusCondition(existingConditions *[]metav1.Condition, newCondition met
 		existingCondition.LastTransitionTime = metav1.NewTime(time.Now())
 	}
 
+	defaultValue := "none"
+	if newCondition.Reason == "" {
+		newCondition.Reason = defaultValue
+	}
+
+	if newCondition.Message == "" {
+		newCondition.Message = defaultValue
+	}
+	
 	existingCondition.Reason = newCondition.Reason
 	existingCondition.Message = newCondition.Message
 


### PR DESCRIPTION
The `Reason` field and the `Message` in the status condition must contain at least one character, as per the Kubernetes documentation. This was causing status updates to be rejected when the field was empty. To address this issue, this fix sets the `Reason` and `Message` fields to the string `none` when it is empty. This ensures that in the event of hub recovery where the DRPC status is empty, the status condition is updated accordingly.

Additionally, when the `Phase` status is empty, DRPC logs are being spammed. This fix ensures that the high requeue frequency is only applied where there is an in-progress MCV and only when the Phase status is not empty.