### PR TITLE
Enable deploymentAutomationEnabled

### DIFF
--- a/test/ramen-config/deploy
+++ b/test/ramen-config/deploy
@@ -36,7 +36,7 @@ print("Updating ramen config map")
 template = drenv.template("configmap.yaml")
 yaml = template.substitute(
     # Auto deploy is needed only for olm install.
-    auto_deploy=False,
+    auto_deploy="true",
     minio_url_dr1=minio.service_url(config.CLUSTERS[0]),
     minio_url_dr2=minio.service_url(config.CLUSTERS[1]),
 )


### PR DESCRIPTION
Without this the s3 secrets are not distributed to the managed clusters which will fail volume replication when deploying an app.

This looks like a bug in ramen since we already enable `s3SecretDistributionEnabled`. This need more investigation, but in downstream we always enable `deploymentAutomationEnabled` and it is also required for olm based install, so changing it seems to a good change even if we have a bug in ramen.

I tested with with a new environment by deploying the sample application right after configuring ramen:

    $ kubectl get drpc -A --context hub
    NAMESPACE        NAME           AGE   PREFERREDCLUSTER   FAILOVERCLUSTER   DESIREDSTATE   CURRENTSTATE
    busybox-sample   busybox-drpc   14s   dr1                                                 Deployed

    $ kubectl get vrg -A --context dr1
    NAMESPACE        NAME           DESIREDSTATE   CURRENTSTATE
    busybox-sample   busybox-drpc   primary        Primary

    $ kubectl get vr -A --context dr1
    NAMESPACE        NAME          AGE     VOLUMEREPLICATIONCLASS   PVCNAME       DESIREDSTATE   CURRENTSTATE
    busybox-sample   busybox-pvc   3m51s   vrc-sample               busybox-pvc   primary        Primary

    $ kubectl get secret  -n ramen-system --context dr1
    NAME       TYPE     DATA   AGE
    s3secret   Opaque   2      11m

Fixes: #818