### PR TITLE
Support using Placement in addition to PlacementRule with Subscription

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1432,7 +1432,12 @@ func (r *DRPlacementControlReconciler) getApplicationDestinationNamespace(placem
 		}
 	}
 
-	return "", fmt.Errorf("failed to find ApplicationSet/Application for Placement %s", placement.GetName())
+	r.Log.Info(fmt.Sprintf("Placement %s does not belong to any ApplicationSet. Defaulting the dest namespace to %s",
+		placement.GetName(), placement.GetNamespace()))
+
+	// Didn't find any ApplicationSet using this Placement. Assuming it is for Subscription.
+	// Returning its own namespace as the default namespace
+	return placement.GetNamespace(), nil
 }
 
 func (r *DRPlacementControlReconciler) selectVRGNamespace(drpc *rmn.DRPlacementControl, placementObj client.Object,


### PR DESCRIPTION
To avoid adding unnecessary dependencies on the soon-to-be-obsolete Subscription module. In this commit, we will default to using the Placement namespace instead when no ApplicationSet is found that references that Placement 

Note: The Placement namespace is the same as the DRPC namespace and when using Subscription, the VRG will have the same namespace as well.

Fixes #766 
