### PR TITLE
VRG: Unprotect deleted PVCs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,9 @@ test: generate manifests envtest ## Run tests.
 test-pvrgl: generate manifests envtest
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus ProtectedVolumeReplicationGroupList
 
+test-obj: generate manifests envtest
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus FakeObjectStorer
+
 test-vrg: generate manifests envtest
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus VolumeReplicationGroup
 

--- a/controllers/s3utils.go
+++ b/controllers/s3utils.go
@@ -328,7 +328,7 @@ func S3KeyPrefix(namespacedName string) string {
 	return namespacedName + "/"
 }
 
-func typedObjectKey(prefix, suffix string, object interface{}) string {
+func TypedObjectKey(prefix, suffix string, object interface{}) string {
 	return typedKey(prefix, suffix, reflect.TypeOf(object))
 }
 
@@ -369,7 +369,7 @@ func uploadTypedObject(s ObjectStorer, keyPrefix, keySuffix string,
 	return s.UploadObject(key, uploadContent)
 }
 
-func downloadTypedObject(s ObjectStorer, keyPrefix, keySuffix string, objectPointer interface{},
+func DownloadTypedObject(s ObjectStorer, keyPrefix, keySuffix string, objectPointer interface{},
 ) error {
 	return s.DownloadObject(typedKey(keyPrefix, keySuffix, reflect.TypeOf(objectPointer).Elem()), objectPointer)
 }

--- a/controllers/s3utils.go
+++ b/controllers/s3utils.go
@@ -91,6 +91,7 @@ type ObjectStorer interface {
 	UploadObject(key string, object interface{}) error
 	DownloadObject(key string, objectPointer interface{}) error
 	ListKeys(keyPrefix string) (keys []string, err error)
+	DeleteObject(key string) error
 	DeleteObjects(keyPrefix string) error
 }
 
@@ -374,9 +375,9 @@ func DownloadTypedObject(s ObjectStorer, keyPrefix, keySuffix string, objectPoin
 	return s.DownloadObject(typedKey(keyPrefix, keySuffix, reflect.TypeOf(objectPointer).Elem()), objectPointer)
 }
 
-func DeleteTypedObjects(s ObjectStorer, keyPrefix, keySuffix string, object interface{},
+func DeleteTypedObject(s ObjectStorer, keyPrefix, keySuffix string, object interface{},
 ) error {
-	return s.DeleteObjects(typedKey(keyPrefix, keySuffix, reflect.TypeOf(object)))
+	return s.DeleteObject(typedKey(keyPrefix, keySuffix, reflect.TypeOf(object)))
 }
 
 // UploadObject uploads the given object to the bucket with the given key.
@@ -571,6 +572,15 @@ func (s *s3ObjectStore) DownloadObject(key string,
 	}
 
 	return nil
+}
+
+func (s *s3ObjectStore) DeleteObject(key string) error {
+	_, err := s.client.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(s.s3Bucket),
+		Key:    aws.String(key),
+	})
+
+	return err
 }
 
 // DeleteObjects() deletes from the bucket any objects that have the given

--- a/controllers/s3utils.go
+++ b/controllers/s3utils.go
@@ -328,6 +328,10 @@ func S3KeyPrefix(namespacedName string) string {
 	return namespacedName + "/"
 }
 
+func typedObjectKey(prefix, suffix string, object interface{}) string {
+	return typedKey(prefix, suffix, reflect.TypeOf(object))
+}
+
 func typedKey(prefix, suffix string, typ reflect.Type) string {
 	return prefix + typ.String() + "/" + suffix
 }

--- a/controllers/s3utils_test.go
+++ b/controllers/s3utils_test.go
@@ -134,7 +134,15 @@ func (f fakeObjectStorer) DeleteObject(key string) error {
 	return nil
 }
 
-func (f fakeObjectStorer) DeleteObjects(keyPrefix string) error {
+func (f fakeObjectStorer) DeleteObjects(keys ...string) error {
+	for _, key := range keys {
+		delete(f.objects, key)
+	}
+
+	return nil
+}
+
+func (f fakeObjectStorer) DeleteObjectsWithKeyPrefix(keyPrefix string) error {
 	for key := range f.objects {
 		if strings.HasPrefix(key, keyPrefix) {
 			delete(f.objects, key)

--- a/controllers/s3utils_test.go
+++ b/controllers/s3utils_test.go
@@ -129,10 +129,6 @@ func (f fakeObjectStorer) ListKeys(keyPrefix string) ([]string, error) {
 }
 
 func (f fakeObjectStorer) DeleteObject(key string) error {
-	if _, ok := f.objects[key]; !ok {
-		return fs.ErrNotExist
-	}
-
 	delete(f.objects, key)
 
 	return nil
@@ -187,8 +183,8 @@ var _ = Describe("FakeObjectStorer", func() {
 			var object1 string
 			Expect(objectStorer.DownloadObject(key, &object1)).To(Succeed())
 		})
-		It("should return an error if an object with specified key was not uploaded", func() {
-			Expect(objectStorer.DeleteObject(key2)).To(MatchError(fs.ErrNotExist))
+		It("should return nil if an object with specified key was not uploaded", func() {
+			Expect(objectStorer.DeleteObject(key2)).To(Succeed())
 		})
 	})
 })

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -50,6 +50,7 @@ const (
 
 // VRG condition reasons
 const (
+	VRGConditionReasonDeleted                     = "Deleted"
 	VRGConditionReasonInitializing                = "Initializing"
 	VRGConditionReasonReplicating                 = "Replicating"
 	VRGConditionReasonReplicated                  = "Replicated"
@@ -309,14 +310,16 @@ func newVRGClusterDataProtectingCondition(observedGeneration int64, message stri
 }
 
 // sets conditions when PV cluster data failed to be protected
-func setVRGClusterDataUnprotectedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
-	setStatusCondition(conditions, *newVRGClusterDataUnprotectedCondition(observedGeneration, message))
+func setVRGClusterDataUnprotectedCondition(
+	conditions *[]metav1.Condition, observedGeneration int64, reason, message string,
+) {
+	setStatusCondition(conditions, *newVRGClusterDataUnprotectedCondition(observedGeneration, reason, message))
 }
 
-func newVRGClusterDataUnprotectedCondition(observedGeneration int64, message string) *metav1.Condition {
+func newVRGClusterDataUnprotectedCondition(observedGeneration int64, reason, message string) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               VRGConditionTypeClusterDataProtected,
-		Reason:             VRGConditionReasonUploadError,
+		Reason:             reason,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
 		Message:            message,

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -50,7 +50,6 @@ const (
 
 // VRG condition reasons
 const (
-	VRGConditionReasonDeleted                     = "Deleted"
 	VRGConditionReasonInitializing                = "Initializing"
 	VRGConditionReasonReplicating                 = "Replicating"
 	VRGConditionReasonReplicated                  = "Replicated"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -397,7 +397,7 @@ func objectDeletionTimestampRecentVerify(namespaceName, objectName string, objec
 
 		return object.GetDeletionTimestamp()
 	}).ShouldNot(BeNil())
-	Expect(object.GetDeletionTimestamp().Time).Should(BeTemporally("~", time.Now(), time.Second), "%#v", object)
+	Expect(object.GetDeletionTimestamp().Time).Should(BeTemporally("~", time.Now(), 2*time.Second), "%#v", object)
 }
 
 func objectNotFoundErrorMatch(groupResource schema.GroupResource, objectName string) gomegatypes.GomegaMatcher {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -427,26 +427,6 @@ func objectOrItsFinalizerAbsentVerify(namespaceName, objectName string, object c
 	return
 }
 
-func objectFinalizerPresentEventuallyVerify(namespaceName, objectName string, object client.Object,
-	finalizerName string,
-) {
-	Eventually(func() []string {
-		Expect(objectGet(namespaceName, objectName, object)).To(Succeed())
-
-		return object.GetFinalizers()
-	}).Should(ContainElement(finalizerName))
-}
-
-func objectFinalizerPresentConsistentlyVerify(namespaceName, objectName string, object client.Object,
-	finalizerName string,
-) {
-	Consistently(func() []string {
-		Expect(objectGet(namespaceName, objectName, object)).To(Succeed())
-
-		return object.GetFinalizers()
-	}).Should(ContainElement(finalizerName))
-}
-
 func conditionExpect(conditions []metav1.Condition, typ string) *metav1.Condition {
 	condition := meta.FindStatusCondition(conditions, typ)
 	Expect(condition).ToNot(BeNil())

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -427,7 +427,19 @@ func objectOrItsFinalizerAbsentVerify(namespaceName, objectName string, object c
 	return
 }
 
-func objectFinalizerPresentVerify(namespaceName, objectName string, object client.Object, finalizerName string) {
+func objectFinalizerPresentEventuallyVerify(namespaceName, objectName string, object client.Object,
+	finalizerName string,
+) {
+	Eventually(func() []string {
+		Expect(objectGet(namespaceName, objectName, object)).To(Succeed())
+
+		return object.GetFinalizers()
+	}).Should(ContainElement(finalizerName))
+}
+
+func objectFinalizerPresentConsistentlyVerify(namespaceName, objectName string, object client.Object,
+	finalizerName string,
+) {
 	Consistently(func() []string {
 		Expect(objectGet(namespaceName, objectName, object)).To(Succeed())
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -16,9 +16,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
+	gomegatypes "github.com/onsi/gomega/types"
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -54,6 +58,17 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
+const (
+	vrgS3ProfileNumber = iota
+	objS3ProfileNumber
+	bucketInvalidS3ProfileNumber1
+	bucketInvalidS3ProfileNumber2
+	listErrorS3ProfileNumber
+	drClusterS3ProfileNumber
+	uploadErrorS3ProfileNumber
+	s3ProfileCount
+)
+
 var (
 	cfg         *rest.Config
 	apiReader   client.Reader
@@ -75,7 +90,7 @@ var (
 	plRuleNames map[string]struct{}
 
 	s3Secrets     [1]corev1.Secret
-	s3Profiles    [7]ramendrv1alpha1.S3StoreProfile
+	s3Profiles    [s3ProfileCount]ramendrv1alpha1.S3StoreProfile
 	objectStorers [2]ramencontrollers.ObjectStorer
 
 	ramenNamespace = "ns-envtest"
@@ -229,9 +244,9 @@ var _ = BeforeSuite(func() {
 			"AWS_SECRET_ACCESS_KEY": "",
 		},
 	}
-	s3ProfileNew := func(profileNameSuffix, bucketName string) ramendrv1alpha1.S3StoreProfile {
+	s3ProfileNew := func(profileNamePrefix, profileNameSuffix, bucketName string) ramendrv1alpha1.S3StoreProfile {
 		return ramendrv1alpha1.S3StoreProfile{
-			S3ProfileName:        "s3profile" + profileNameSuffix,
+			S3ProfileName:        profileNamePrefix + "s3profile" + profileNameSuffix,
 			S3Bucket:             bucketName,
 			S3CompatibleEndpoint: "http://192.168.39.223:30000",
 			S3Region:             "us-east-1",
@@ -239,13 +254,13 @@ var _ = BeforeSuite(func() {
 		}
 	}
 
-	s3Profiles[0] = s3ProfileNew("0", bucketNameSucc)
-	s3Profiles[1] = s3ProfileNew("1", bucketNameSucc2)
-	s3Profiles[2] = s3ProfileNew("2", bucketNameFail)
-	s3Profiles[3] = s3ProfileNew("3", bucketNameFail2)
-	s3Profiles[4] = s3ProfileNew("4", bucketListFail)
-	// s3Profiles[5] used and modified in DRCluster tests
-	s3Profiles[6] = s3ProfileNew("6", bucketNameUploadAwsErr)
+	s3Profiles[vrgS3ProfileNumber] = s3ProfileNew("", "0", bucketNameSucc)
+	s3Profiles[objS3ProfileNumber] = s3ProfileNew("", "1", bucketNameSucc2)
+	s3Profiles[bucketInvalidS3ProfileNumber1] = s3ProfileNew("", "2", bucketNameFail)
+	s3Profiles[bucketInvalidS3ProfileNumber2] = s3ProfileNew("", "3", bucketNameFail2)
+	s3Profiles[listErrorS3ProfileNumber] = s3ProfileNew("", "4", bucketListFail)
+	s3Profiles[drClusterS3ProfileNumber] = s3ProfileNew("drc-", "", bucketNameSucc)
+	s3Profiles[uploadErrorS3ProfileNumber] = s3ProfileNew("", "6", bucketNameUploadAwsErr)
 
 	s3SecretsPolicyNamesSet := func() {
 		plRuleNames = make(map[string]struct{}, len(s3Secrets))
@@ -267,13 +282,6 @@ var _ = BeforeSuite(func() {
 		for i := range s3Profiles {
 			s3Profiles[i].S3SecretRef.Namespace = namespaceName
 		}
-	}
-	s3Profiles[5] = ramendrv1alpha1.S3StoreProfile{
-		S3ProfileName:        "drc-s3profile",
-		S3Bucket:             bucketNameSucc,
-		S3CompatibleEndpoint: "http://192.168.39.223:30000",
-		S3Region:             "us-east-1",
-		S3SecretRef:          corev1.SecretReference{Name: s3Secrets[0].Name},
 	}
 	s3ProfilesUpdate := func() {
 		s3ProfilesStore(s3Profiles[0:])
@@ -378,3 +386,58 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
+
+func objectGet(namespaceName, objectName string, object client.Object) error {
+	return apiReader.Get(context.TODO(), types.NamespacedName{Namespace: namespaceName, Name: objectName}, object)
+}
+
+func objectDeletionTimestampRecentVerify(namespaceName, objectName string, object client.Object) {
+	Eventually(func() *metav1.Time {
+		Expect(objectGet(namespaceName, objectName, object)).To(Succeed())
+
+		return object.GetDeletionTimestamp()
+	}).ShouldNot(BeNil())
+	Expect(object.GetDeletionTimestamp().Time).Should(BeTemporally("~", time.Now(), time.Second), "%#v", object)
+}
+
+func objectNotFoundErrorMatch(groupResource schema.GroupResource, objectName string) gomegatypes.GomegaMatcher {
+	return MatchError(errors.NewNotFound(groupResource, objectName))
+}
+
+func objectAbsentVerify(namespaceName, objectName string, object client.Object, groupResource schema.GroupResource) {
+	Eventually(func() error {
+		return objectGet(namespaceName, objectName, object)
+	}).Should(objectNotFoundErrorMatch(groupResource, objectName), "%#v", object)
+}
+
+func objectOrItsFinalizerAbsentVerify(namespaceName, objectName string, object client.Object,
+	groupResource schema.GroupResource, finalizerName string,
+) (objectAbsent bool) {
+	Eventually(func() []string {
+		if err := objectGet(namespaceName, objectName, object); err != nil {
+			Expect(err).To(objectNotFoundErrorMatch(groupResource, objectName), "%#v", object)
+			objectAbsent = true
+
+			return nil
+		}
+
+		return object.GetFinalizers()
+	}).ShouldNot(ContainElement(finalizerName))
+
+	return
+}
+
+func objectFinalizerPresentVerify(namespaceName, objectName string, object client.Object, finalizerName string) {
+	Consistently(func() []string {
+		Expect(objectGet(namespaceName, objectName, object)).To(Succeed())
+
+		return object.GetFinalizers()
+	}).Should(ContainElement(finalizerName))
+}
+
+func conditionExpect(conditions []metav1.Condition, typ string) *metav1.Condition {
+	condition := meta.FindStatusCondition(conditions, typ)
+	Expect(condition).ToNot(BeNil())
+
+	return condition
+}

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -440,7 +440,7 @@ type VRGInstance struct {
 const (
 	// Finalizers
 	vrgFinalizerName        = "volumereplicationgroups.ramendr.openshift.io/vrg-protection"
-	pvcVRFinalizerProtected = "volumereplicationgroups.ramendr.openshift.io/pvc-vr-protection"
+	PvcVRFinalizerProtected = "volumereplicationgroups.ramendr.openshift.io/pvc-vr-protection"
 	pvcInUse                = "kubernetes.io/pvc-protection"
 
 	// Annotations

--- a/controllers/vrg_kubeobjects.go
+++ b/controllers/vrg_kubeobjects.go
@@ -212,7 +212,7 @@ func (v *VRGInstance) kubeObjectsCapturesDelete(
 ) error {
 	// current s3 profiles may differ from those at capture time
 	for _, s3StoreAccessor := range s3StoreAccessors {
-		if err := s3StoreAccessor.ObjectStorer.DeleteObjects(pathName); err != nil {
+		if err := s3StoreAccessor.ObjectStorer.DeleteObjectsWithKeyPrefix(pathName); err != nil {
 			v.log.Error(err, "Kube objects capture s3 objects delete error",
 				"number", captureNumber,
 				"profile", s3StoreAccessor.S3ProfileName,

--- a/controllers/vrg_kubeobjects.go
+++ b/controllers/vrg_kubeobjects.go
@@ -358,8 +358,7 @@ func (v *VRGInstance) kubeObjectsCaptureAndCaptureRequestDelete(
 func (v *VRGInstance) kubeObjectsCaptureDeleteAndLog(
 	s3StoreAccessor s3StoreAccessor, pathName, requestName string, log logr.Logger,
 ) {
-	// TODO Rename DeleteObjectsWithKeyPrefix after merging PR #828
-	if err := s3StoreAccessor.ObjectStorer.DeleteObjects /*WithKeyPrefix*/ (pathName + requestName + "/"); err != nil {
+	if err := s3StoreAccessor.ObjectStorer.DeleteObjectsWithKeyPrefix(pathName + requestName + "/"); err != nil {
 		log.Error(err, "Kube objects capture delete error")
 	}
 }

--- a/controllers/vrg_kubeobjects.go
+++ b/controllers/vrg_kubeobjects.go
@@ -137,7 +137,7 @@ func (v *VRGInstance) kubeObjectsCaptureStartOrResumeOrDelay(
 		v.ctx, v.reconciler.APIReader, veleroNamespaceName, labels)
 	if err != nil {
 		log.Error(err, "Kube objects capture in-progress query error")
-		v.kubeObjectsCaptureFailed(err.Error())
+		v.kubeObjectsCaptureFailed("KubeObjectsCaptureRequestsQueryError", err.Error())
 
 		result.Requeue = true
 
@@ -217,7 +217,7 @@ func (v *VRGInstance) kubeObjectsCapturesDelete(
 				"number", captureNumber,
 				"profile", s3StoreAccessor.S3ProfileName,
 			)
-			v.kubeObjectsCaptureFailed(err.Error())
+			v.kubeObjectsCaptureFailed("KubeObjectsReplicaDeleteError", err.Error())
 
 			result.Requeue = true
 
@@ -316,21 +316,26 @@ func (v *VRGInstance) kubeObjectsGroupCapture(
 		} else {
 			err := request.Status(v.log)
 
-			switch {
-			case err == nil:
+			if err == nil {
 				log1.Info("Kube objects group captured", "start", request.StartTime(), "end", request.EndTime())
 				requestsCompletedCount++
-			case errors.Is(err, kubeobjects.RequestProcessingError{}):
-				log1.Info("Kube objects group capturing", "state", err.Error())
-			default:
-				log1.Error(err, "Kube objects group capture error")
-				v.kubeObjectsCaptureAndCaptureRequestDelete(request, s3StoreAccessor, capturePathName, log1)
-				v.kubeObjectsCaptureStatusFalse("KubeObjectsCaptureError", err.Error())
 
-				result.Requeue = true
-
-				return
+				continue
 			}
+
+			if errors.Is(err, kubeobjects.RequestProcessingError{}) {
+				log1.Info("Kube objects group capturing", "state", err.Error())
+
+				continue
+			}
+
+			log1.Error(err, "Kube objects group capture error")
+			v.kubeObjectsCaptureAndCaptureRequestDelete(request, s3StoreAccessor, capturePathName, log1)
+			v.kubeObjectsCaptureStatusFalse("KubeObjectsCaptureError", err.Error())
+
+			result.Requeue = true
+
+			return
 		}
 
 		captureInProgressStatusUpdate()
@@ -414,7 +419,7 @@ func (v *VRGInstance) kubeObjectsCaptureIdentifierUpdateComplete(
 	); err != nil {
 		v.log.Error(err, "Kube objects capture requests delete error",
 			"number", captureToRecoverFromIdentifier.Number)
-		v.kubeObjectsCaptureFailed(err.Error())
+		v.kubeObjectsCaptureFailed("KubeObjectsCaptureRequestsDeleteError", err.Error())
 
 		result.Requeue = true
 
@@ -435,8 +440,8 @@ func (v *VRGInstance) kubeObjectsCaptureIdentifierUpdateComplete(
 	)
 }
 
-func (v *VRGInstance) kubeObjectsCaptureFailed(message string) {
-	v.kubeObjectsCaptureStatusFalse(VRGConditionReasonUploadError, message)
+func (v *VRGInstance) kubeObjectsCaptureFailed(reason, message string) {
+	v.kubeObjectsCaptureStatusFalse(reason, message)
 }
 
 func (v *VRGInstance) kubeObjectsCaptureStatusFalse(reason, message string) {

--- a/controllers/vrg_status_pvcs.go
+++ b/controllers/vrg_status_pvcs.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"github.com/go-logr/logr"
+	ramen "github.com/ramendr/ramen/api/v1alpha1"
+)
+
+// findProtectedPVC returns the &VRG.Status.ProtectedPVC[x] for the given pvcName
+func (v *VRGInstance) findProtectedPVC(pvcName string) *ramen.ProtectedPVC {
+	return FindProtectedPVC(v.instance, pvcName)
+}
+
+func FindProtectedPVC(vrg *ramen.VolumeReplicationGroup, pvcName string) *ramen.ProtectedPVC {
+	protectedPvc, _ := FindProtectedPvcAndIndex(vrg, pvcName)
+
+	return protectedPvc
+}
+
+func (v *VRGInstance) pvcStatusDeleteIfPresent(pvcName string, log logr.Logger) {
+	pvcStatus, i := FindProtectedPvcAndIndex(v.instance, pvcName)
+	if pvcStatus == nil {
+		log.Info("PVC status absent already")
+
+		return
+	}
+
+	log.Info("PVC status delete", "index", i)
+	v.instance.Status.ProtectedPVCs = sliceUnorderedElementDelete(v.instance.Status.ProtectedPVCs, i)
+}
+
+func sliceUnorderedElementDelete[T any](s []T, i int) []T {
+	s[i] = s[len(s)-1]
+
+	return s[:len(s)-1]
+}
+
+func FindProtectedPvcAndIndex(vrg *ramen.VolumeReplicationGroup, pvcName string) (*ramen.ProtectedPVC, int) {
+	for index := range vrg.Status.ProtectedPVCs {
+		protectedPVC := &vrg.Status.ProtectedPVCs[index]
+		if protectedPVC.Name == pvcName {
+			return protectedPVC, index
+		}
+	}
+
+	return nil, len(vrg.Status.ProtectedPVCs)
+}

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -719,20 +719,17 @@ func (v *VRGInstance) pvcUnprotectIfDeleted(
 		return
 	}
 
-	const message = "PVC deletion timestamp non-zero"
-
-	log.Info(message)
-	v.updatePVCClusterDataProtectedCondition(pvc.Name, VRGConditionReasonDeleted, message)
+	log.Info("PVC deletion timestamp non-zero")
 
 	if err := v.pvAndPvcObjectReplicasDelete(pvc, log); err != nil {
 		log.Error(err, "PersistentVolume and PersistentVolumeClaim replicas deletion failed")
 
 		*requeue = true
-
-		return
+	} else {
+		v.pvcsUnprotect([]corev1.PersistentVolumeClaim{pvc}, requeue)
 	}
 
-	v.pvcsUnprotect([]corev1.PersistentVolumeClaim{pvc}, requeue)
+	v.pvcStatusDeleteIfPresent(pvc.Name, log)
 
 	return
 }
@@ -1644,7 +1641,7 @@ func setPVCClusterDataProtectedCondition(protectedPVC *ramendrv1alpha1.Protected
 		setVRGClusterDataProtectedCondition(&protectedPVC.Conditions, observedGeneration, message)
 	case VRGConditionReasonUploading:
 		setVRGClusterDataProtectingCondition(&protectedPVC.Conditions, observedGeneration, message)
-	case VRGConditionReasonUploadError, VRGConditionReasonDeleted, VRGConditionReasonClusterDataAnnotationFailed:
+	case VRGConditionReasonUploadError, VRGConditionReasonClusterDataAnnotationFailed:
 		setVRGClusterDataUnprotectedCondition(&protectedPVC.Conditions, observedGeneration, reason, message)
 	default:
 		// if appropriate reason is not provided, then treat it as an unknown condition.
@@ -1817,22 +1814,6 @@ func (v *VRGInstance) addArchivedAnnotationForPVC(pvc *corev1.PersistentVolumeCl
 		return fmt.Errorf("failed to update PersistentVolume (%s) annotation (%s) belonging to"+
 			"VolumeReplicationGroup (%s/%s), %w",
 			pvc.Name, pvcVRAnnotationArchivedKey, v.instance.Namespace, v.instance.Name, err)
-	}
-
-	return nil
-}
-
-// findProtectedPVC returns the &VRG.Status.ProtectedPVC[x] for the given pvcName
-func (v *VRGInstance) findProtectedPVC(pvcName string) *ramendrv1alpha1.ProtectedPVC {
-	return FindProtectedPVC(v.instance, pvcName)
-}
-
-func FindProtectedPVC(vrg *ramendrv1alpha1.VolumeReplicationGroup, pvcName string) *ramendrv1alpha1.ProtectedPVC {
-	for index := range vrg.Status.ProtectedPVCs {
-		protectedPVC := &vrg.Status.ProtectedPVCs[index]
-		if protectedPVC.Name == pvcName {
-			return protectedPVC
-		}
 	}
 
 	return nil

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -711,7 +711,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		// It("protects kube objects", func() { kubeObjectProtectionValidate(vrgScheduleTests) })
 		It("cleans up after testing", func() {
 			v := vrgScheduleTests[0]
-			v.cleanupButPvcFinalizerPresent()
+			v.cleanup()
 		})
 	})
 
@@ -745,7 +745,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		// It("protects kube objects", func() { kubeObjectProtectionValidate(vrgSchedule2Tests) })
 		It("cleans up after testing", func() {
 			v := vrgSchedule2Tests[0]
-			v.cleanupButPvcFinalizerPresent()
+			v.cleanup()
 		})
 	})
 
@@ -779,7 +779,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		// It("protects kube objects", func() { kubeObjectProtectionValidate(vrgSchedule3Tests) })
 		It("cleans up after testing", func() {
 			v := vrgSchedule3Tests[0]
-			v.cleanupButPvcFinalizerPresent()
+			v.cleanup()
 		})
 	})
 	// TODO: Add tests to move VRG to Secondary
@@ -1468,15 +1468,6 @@ func kubeObjectProtectionValidate(tests []*vrgTest) {
 
 func (v *vrgTest) cleanup() {
 	v.cleanupPVCs(vrAndPvcFinalizerOrPvcAndPvAbsentVerify)
-	v.cleanupVrgAndNamespaceAndScAndVrc()
-}
-
-func (v *vrgTest) cleanupButPvcFinalizerPresent() {
-	v.cleanupPVCs(vrAbsentAndPvcFinalizerPresentVerify)
-	v.cleanupVrgAndNamespaceAndScAndVrc()
-}
-
-func (v *vrgTest) cleanupVrgAndNamespaceAndScAndVrc() {
 	v.cleanupVRG()
 	v.cleanupNamespace()
 	v.cleanupSC()
@@ -1543,24 +1534,12 @@ func vrAndPvcFinalizerOrPvcAndPvAbsentVerify(namespaceName string, pvc *corev1.P
 	}
 }
 
-func vrAbsentAndPvcFinalizerPresentVerify(namespaceName string, pvc *corev1.PersistentVolumeClaim) {
-	vrAbsentVerify(namespaceName, pvc.Name)
-	pvcFinalizerPresentVerify(namespaceName, pvc.Name)
-}
-
 func vrAbsentVerify(namespaceName, pvcName string) {
 	objectAbsentVerify(namespaceName, pvcName, &volrep.VolumeReplication{}, vrGroupResource())
 }
 
 func pvcAbsentVerify(namespaceName, pvcName string) {
 	objectAbsentVerify(namespaceName, pvcName, &corev1.PersistentVolumeClaim{}, pvcGroupResource())
-}
-
-func pvcFinalizerPresentVerify(namespaceName, pvcName string) {
-	objectFinalizerPresentEventuallyVerify(namespaceName, pvcName, &corev1.PersistentVolumeClaim{},
-		vrgController.PvcVRFinalizerProtected)
-	objectFinalizerPresentConsistentlyVerify(namespaceName, pvcName, &corev1.PersistentVolumeClaim{},
-		vrgController.PvcVRFinalizerProtected)
 }
 
 func pvAbsentVerify(pvName string) {

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -1557,7 +1557,9 @@ func pvcAbsentVerify(namespaceName, pvcName string) {
 }
 
 func pvcFinalizerPresentVerify(namespaceName, pvcName string) {
-	objectFinalizerPresentVerify(namespaceName, pvcName, &corev1.PersistentVolumeClaim{},
+	objectFinalizerPresentEventuallyVerify(namespaceName, pvcName, &corev1.PersistentVolumeClaim{},
+		vrgController.PvcVRFinalizerProtected)
+	objectFinalizerPresentConsistentlyVerify(namespaceName, pvcName, &corev1.PersistentVolumeClaim{},
 		vrgController.PvcVRFinalizerProtected)
 }
 

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"math/rand"
+	"strconv"
 	"strings"
 	"time"
 
@@ -897,10 +898,9 @@ func (v *vrgTest) createPVCandPV(claimBindInfo corev1.PersistentVolumeClaimPhase
 	volumeBindInfo corev1.PersistentVolumePhase,
 ) {
 	// Create the requested number of PVs and corresponding PVCs
-	for i := 0; i < v.pvcCount; i++ {
-		pvName := fmt.Sprintf("pv-%v-%02d", v.uniqueID, i)
-		pvcName := fmt.Sprintf("pvc-%v-%02d", v.uniqueID, i)
-
+	for i, volumeNameSuffix := 0, "-"+v.uniqueID+"-"; i < v.pvcCount; i++ {
+		volumeNameSuffix := volumeNameSuffix + strconv.Itoa(i)
+		pvName, pvcName := "pv"+volumeNameSuffix, "pvc"+volumeNameSuffix
 		// Create PV first and then PVC. This is important to ensure that there
 		// is no race between the unit test and VRG reconciler in modifying PV.
 		// i.e. suppose VRG is already created and then this function is run,

--- a/controllers/vrg_vrgobject.go
+++ b/controllers/vrg_vrgobject.go
@@ -71,7 +71,7 @@ func VrgObjectProtect(objectStorer ObjectStorer, vrg ramen.VolumeReplicationGrou
 }
 
 func VrgObjectUnprotect(objectStorer ObjectStorer, vrg ramen.VolumeReplicationGroup) error {
-	return DeleteTypedObjects(objectStorer, s3PathNamePrefix(vrg.Namespace, vrg.Name), vrgS3ObjectNameSuffix, vrg)
+	return DeleteTypedObject(objectStorer, s3PathNamePrefix(vrg.Namespace, vrg.Name), vrgS3ObjectNameSuffix, vrg)
 }
 
 func vrgObjectDownload(objectStorer ObjectStorer, pathName string, vrg *ramen.VolumeReplicationGroup) error {

--- a/controllers/vrg_vrgobject.go
+++ b/controllers/vrg_vrgobject.go
@@ -46,7 +46,8 @@ func (v *VRGInstance) vrgObjectProtectThrottled(result *ctrl.Result, s3StoreAcce
 
 			log1.Error(err, message)
 
-			v.vrgObjectProtected = newVRGClusterDataUnprotectedCondition(vrg.Generation, message)
+			v.vrgObjectProtected = newVRGClusterDataUnprotectedCondition(vrg.Generation,
+				"VolumeReplicationGroupObjectCaptureError", message)
 			result.Requeue = true
 
 			failure()
@@ -74,5 +75,5 @@ func VrgObjectUnprotect(objectStorer ObjectStorer, vrg ramen.VolumeReplicationGr
 }
 
 func vrgObjectDownload(objectStorer ObjectStorer, pathName string, vrg *ramen.VolumeReplicationGroup) error {
-	return downloadTypedObject(objectStorer, pathName, vrgS3ObjectNameSuffix, vrg)
+	return DownloadTypedObject(objectStorer, pathName, vrgS3ObjectNameSuffix, vrg)
 }


### PR DESCRIPTION
Unprotect a PVC if the following conditions are satisfied:
- PVC matches VRG's `Spec.PVCSelector`
- VRG's `Spec.ReplicationState` is `primary`
- PVC's `ObjectMeta.DeletionTimestamp` is non-zero

PVC unprotection steps:
- Delete its `PersistentVolume` and `PersistentVolumeClaim` object replicas from the stores specified in VRG's `Spec.S3Profiles`
- Delete its `VolumeReplication` object
- Change PV's `ReclaimPolicy` to `Delete` if `volumereplicationgroups.ramendr.openshift.io/vr-retained` annotation present
- Remove `volumereplicationgroups.ramendr.openshift.io/pvc-protection` finalizer from PVC
- Remove its `protectedPVC` from VRG's status

In addition to the above, test the following:
- Deleting PV object replica named with common prefix of another, e.g., `a` is deleted but `aa` remains

Closes #697 from VRG perspective