### PR TITLE
Delete failed backups

### DIFF
--- a/controllers/kubeobjects/requests.go
+++ b/controllers/kubeobjects/requests.go
@@ -126,7 +126,7 @@ type RequestsManager interface {
 		annotations map[string]string,
 	) (ProtectRequest, error)
 	RecoverRequestCreate(
-		c context.Context, w client.Writer, r client.Reader, l logr.Logger,
+		c context.Context, w client.Writer, l logr.Logger,
 		s3Url string,
 		s3BucketName string,
 		s3RegionName string,
@@ -138,6 +138,7 @@ type RequestsManager interface {
 		recoverSpec RecoverSpec,
 		requestNamespaceName string,
 		protectRequestName string,
+		protectRequest ProtectRequest,
 		recoverRequestName string,
 		labels map[string]string,
 		annotations map[string]string,

--- a/controllers/kubeobjects/requests.go
+++ b/controllers/kubeobjects/requests.go
@@ -20,14 +20,27 @@ type (
 
 type Request interface {
 	Object() client.Object
+	Name() string
 	StartTime() metav1.Time
 	EndTime() metav1.Time
+	Status(logr.Logger) error
 	Deallocate(context.Context, client.Writer, logr.Logger) error
 }
 
 type Requests interface {
 	Count() int
 	Get(i int) Request
+}
+
+func RequestsMapKeyedByName(requestsStruct Requests) map[string]Request {
+	requests := make(map[string]Request, requestsStruct.Count())
+
+	for i := 0; i < requestsStruct.Count(); i++ {
+		request := requestsStruct.Get(i)
+		requests[request.Name()] = request
+	}
+
+	return requests
 }
 
 type RequestProcessingError struct{ string }
@@ -98,7 +111,7 @@ type RequestsManager interface {
 	ProtectRequestNew() ProtectRequest
 	RecoverRequestNew() RecoverRequest
 	ProtectRequestCreate(
-		c context.Context, w client.Writer, r client.Reader, l logr.Logger,
+		c context.Context, w client.Writer, l logr.Logger,
 		s3Url string,
 		s3BucketName string,
 		s3RegionName string,

--- a/controllers/kubeobjects/velero/requests.go
+++ b/controllers/kubeobjects/velero/requests.go
@@ -247,32 +247,26 @@ func backupDummyStatusProcessAndRestore(
 	backupStatusLog(backup, w.log)
 
 	switch backup.Status.Phase {
-	case velero.BackupPhaseCompleted:
-		fallthrough
-	case velero.BackupPhasePartiallyFailed:
-		fallthrough
-	case velero.BackupPhaseFailed:
+	case velero.BackupPhaseCompleted,
+		velero.BackupPhasePartiallyFailed,
+		velero.BackupPhaseFailed:
 		return backupRestore(
 			backup, w, sourceNamespaceName, targetNamespaceName,
 			recoverSpec,
 			restoreName,
 			labels,
 		)
-	case velero.BackupPhaseNew:
-		fallthrough
-	case velero.BackupPhaseInProgress:
-		fallthrough
-	case velero.BackupPhaseUploading:
-		fallthrough
-	case velero.BackupPhaseUploadingPartialFailure:
-		fallthrough
-	case velero.BackupPhaseDeleting:
+	case velero.BackupPhaseNew,
+		velero.BackupPhaseInProgress,
+		velero.BackupPhaseUploading,
+		velero.BackupPhaseUploadingPartialFailure,
+		velero.BackupPhaseDeleting:
 		return nil, kubeobjects.RequestProcessingErrorCreate("backup" + string(backup.Status.Phase))
 	case velero.BackupPhaseFailedValidation:
 		return nil, errors.New("backup" + string(backup.Status.Phase))
+	default:
+		return nil, kubeobjects.RequestProcessingErrorCreate("backup.status.phase absent")
 	}
-
-	return nil, kubeobjects.RequestProcessingErrorCreate("backup.status.phase absent")
 }
 
 func backupRestore(
@@ -302,15 +296,12 @@ func restoreStatusProcess(
 	switch restore.Status.Phase {
 	case velero.RestorePhaseCompleted:
 		return nil
-	case velero.RestorePhaseNew:
-		fallthrough
-	case velero.RestorePhaseInProgress:
+	case velero.RestorePhaseNew,
+		velero.RestorePhaseInProgress:
 		return kubeobjects.RequestProcessingErrorCreate("restore" + string(restore.Status.Phase))
-	case velero.RestorePhaseFailed:
-		fallthrough
-	case velero.RestorePhaseFailedValidation:
-		fallthrough
-	case velero.RestorePhasePartiallyFailed:
+	case velero.RestorePhaseFailed,
+		velero.RestorePhaseFailedValidation,
+		velero.RestorePhasePartiallyFailed:
 		return errors.New("restore" + string(restore.Status.Phase))
 	default:
 		return kubeobjects.RequestProcessingErrorCreate("restore.status.phase absent")
@@ -451,25 +442,19 @@ func backupRealStatusProcess(
 	switch backup.Status.Phase {
 	case velero.BackupPhaseCompleted:
 		return nil
-	case velero.BackupPhaseNew:
-		fallthrough
-	case velero.BackupPhaseInProgress:
-		fallthrough
-	case velero.BackupPhaseUploading:
-		fallthrough
-	case velero.BackupPhaseUploadingPartialFailure:
-		fallthrough
-	case velero.BackupPhaseDeleting:
+	case velero.BackupPhaseNew,
+		velero.BackupPhaseInProgress,
+		velero.BackupPhaseUploading,
+		velero.BackupPhaseUploadingPartialFailure,
+		velero.BackupPhaseDeleting:
 		return kubeobjects.RequestProcessingErrorCreate("backup" + string(backup.Status.Phase))
-	case velero.BackupPhaseFailedValidation:
-		fallthrough
-	case velero.BackupPhasePartiallyFailed:
-		fallthrough
-	case velero.BackupPhaseFailed:
+	case velero.BackupPhaseFailedValidation,
+		velero.BackupPhasePartiallyFailed,
+		velero.BackupPhaseFailed:
 		return errors.New("backup" + string(backup.Status.Phase))
+	default:
+		return kubeobjects.RequestProcessingErrorCreate("backup.status.phase absent")
 	}
-
-	return kubeobjects.RequestProcessingErrorCreate("backup.status.phase absent")
 }
 
 func (r BackupRequest) Deallocate(

--- a/controllers/kubeobjects/velero/requests.go
+++ b/controllers/kubeobjects/velero/requests.go
@@ -36,29 +36,26 @@ type (
 	RestoreRequest struct{ restore *velero.Restore }
 )
 
-func (r BackupRequest) Object() client.Object   { return r.backup }
-func (r RestoreRequest) Object() client.Object  { return r.restore }
-func (r BackupRequest) Name() string            { return r.backup.Name }
-func (r RestoreRequest) Name() string           { return r.restore.Name }
-func (r BackupRequest) StartTime() metav1.Time  { return *r.backup.Status.StartTimestamp }
-func (r RestoreRequest) StartTime() metav1.Time { return *r.restore.Status.StartTimestamp }
-func (r BackupRequest) EndTime() metav1.Time    { return *r.backup.Status.CompletionTimestamp }
-func (r RestoreRequest) EndTime() metav1.Time   { return *r.restore.Status.CompletionTimestamp }
+func (r BackupRequest) Object() client.Object         { return r.backup }
+func (r RestoreRequest) Object() client.Object        { return r.restore }
+func (r BackupRequest) Name() string                  { return r.backup.Name }
+func (r RestoreRequest) Name() string                 { return r.restore.Name }
+func (r BackupRequest) StartTime() metav1.Time        { return *r.backup.Status.StartTimestamp }
+func (r RestoreRequest) StartTime() metav1.Time       { return *r.restore.Status.StartTimestamp }
+func (r BackupRequest) EndTime() metav1.Time          { return *r.backup.Status.CompletionTimestamp }
+func (r RestoreRequest) EndTime() metav1.Time         { return *r.restore.Status.CompletionTimestamp }
+func (r BackupRequest) Status(log logr.Logger) error  { return backupRealStatusProcess(r.backup, log) }
+func (r RestoreRequest) Status(log logr.Logger) error { return restoreStatusProcess(r.restore, log) }
 
 type (
 	BackupRequests  struct{ backups *velero.BackupList }
 	RestoreRequests struct{ restores *velero.RestoreList }
 )
 
-func (r BackupRequests) Count() int  { return len(r.backups.Items) }
-func (r RestoreRequests) Count() int { return len(r.restores.Items) }
-func (r BackupRequests) Get(i int) kubeobjects.Request {
-	return BackupRequest{&r.backups.Items[i]}
-}
-
-func (r RestoreRequests) Get(i int) kubeobjects.Request {
-	return RestoreRequest{&r.restores.Items[i]}
-}
+func (r BackupRequests) Count() int                     { return len(r.backups.Items) }
+func (r RestoreRequests) Count() int                    { return len(r.restores.Items) }
+func (r BackupRequests) Get(i int) kubeobjects.Request  { return BackupRequest{&r.backups.Items[i]} }
+func (r RestoreRequests) Get(i int) kubeobjects.Request { return RestoreRequest{&r.restores.Items[i]} }
 
 type RequestsManager struct{}
 
@@ -211,9 +208,11 @@ func backupDummyCreateAndRestore(
 	labels map[string]string,
 	annotations map[string]string,
 ) (*velero.Restore, error) {
+	namespacedName := types.NamespacedName{Namespace: requestNamespaceName, Name: backupName}
+
 	backupLocation, backup, err := backupCreate(
-		types.NamespacedName{Namespace: requestNamespaceName, Name: backupName},
-		w, reader, s3Url, s3BucketName, s3RegionName, s3KeyPrefix, secretKeyRef,
+		namespacedName,
+		w, s3Url, s3BucketName, s3RegionName, s3KeyPrefix, secretKeyRef,
 		caCertificates,
 		backupSpecDummy(), sourceNamespaceName,
 		labels,
@@ -223,8 +222,12 @@ func backupDummyCreateAndRestore(
 		return nil, err
 	}
 
+	if err := reader.Get(w.ctx, namespacedName, backup); err != nil {
+		return nil, pkgerrors.Wrap(err, "backup dummy get")
+	}
+
 	return backupDummyStatusProcessAndRestore(
-		backupLocation, backup, w, reader,
+		backupLocation, backup, w,
 		sourceNamespaceName,
 		targetNamespaceName,
 		recoverSpec,
@@ -237,7 +240,6 @@ func backupDummyStatusProcessAndRestore(
 	backupLocation *velero.BackupStorageLocation,
 	backup *velero.Backup,
 	w objectWriter,
-	reader client.Reader,
 	sourceNamespaceName string,
 	targetNamespaceName string,
 	recoverSpec kubeobjects.RecoverSpec,
@@ -252,7 +254,8 @@ func backupDummyStatusProcessAndRestore(
 	case velero.BackupPhasePartiallyFailed:
 		fallthrough
 	case velero.BackupPhaseFailed:
-		return backupRestore(backupLocation, backup, w, reader, sourceNamespaceName, targetNamespaceName,
+		return backupRestore(
+			backup, w, sourceNamespaceName, targetNamespaceName,
 			recoverSpec,
 			restoreName,
 			labels,
@@ -275,10 +278,8 @@ func backupDummyStatusProcessAndRestore(
 }
 
 func backupRestore(
-	backupLocation *velero.BackupStorageLocation,
 	backup *velero.Backup,
 	w objectWriter,
-	reader client.Reader,
 	sourceNamespaceName string,
 	targetNamespaceName string,
 	recoverSpec kubeobjects.RecoverSpec,
@@ -287,56 +288,40 @@ func backupRestore(
 ) (*velero.Restore, error) {
 	restore := restore(backup.Namespace, restoreName, recoverSpec, backup.Name,
 		sourceNamespaceName, targetNamespaceName, labels)
-	if err := objectCreateAndGet(w, reader, restore); err != nil {
+	if err := w.objectCreate(restore); err != nil {
 		return nil, err
 	}
 
-	return restoreStatusProcess(backupLocation, backup, restore, w)
+	return restore, nil
 }
 
 func restoreStatusProcess(
-	backupLocation *velero.BackupStorageLocation,
-	backup *velero.Backup,
 	restore *velero.Restore,
-	w objectWriter,
-) (*velero.Restore, error) {
-	restoreStatusLog(restore, w.log)
+	log logr.Logger,
+) error {
+	restoreStatusLog(restore, log)
 
 	switch restore.Status.Phase {
 	case velero.RestorePhaseCompleted:
-		return restore, nil
+		return nil
 	case velero.RestorePhaseNew:
 		fallthrough
 	case velero.RestorePhaseInProgress:
-		return nil, kubeobjects.RequestProcessingErrorCreate("restore" + string(restore.Status.Phase))
+		return kubeobjects.RequestProcessingErrorCreate("restore" + string(restore.Status.Phase))
 	case velero.RestorePhaseFailed:
 		fallthrough
 	case velero.RestorePhaseFailedValidation:
 		fallthrough
 	case velero.RestorePhasePartiallyFailed:
-		return nil, restoreRequestFailedDelete(backupLocation, backup, restore, w)
+		return errors.New("restore" + string(restore.Status.Phase))
 	default:
-		return nil, kubeobjects.RequestProcessingErrorCreate("restore.status.phase absent")
+		return kubeobjects.RequestProcessingErrorCreate("restore.status.phase absent")
 	}
-}
-
-func restoreRequestFailedDelete(
-	backupLocation *velero.BackupStorageLocation,
-	backup *velero.Backup,
-	restore *velero.Restore,
-	w objectWriter,
-) error {
-	if err := w.restoreObjectsDelete(backupLocation, backup, restore); err != nil {
-		return err
-	}
-
-	return errors.New("restore" + string(restore.Status.Phase) + "; request deleted")
 }
 
 func (RequestsManager) ProtectRequestCreate(
 	ctx context.Context,
 	writer client.Writer,
-	reader client.Reader,
 	log logr.Logger,
 	s3Url string,
 	s3BucketName string,
@@ -365,9 +350,8 @@ func (RequestsManager) ProtectRequestCreate(
 		"annotations", annotations,
 	)
 
-	backup, err := backupRealCreate(
+	_, backup, err := backupRealCreate(
 		objectWriter{ctx: ctx, Writer: writer, log: log},
-		reader,
 		s3Url,
 		s3BucketName,
 		s3RegionName,
@@ -387,7 +371,6 @@ func (RequestsManager) ProtectRequestCreate(
 
 func backupRealCreate(
 	w objectWriter,
-	reader client.Reader,
 	s3Url string,
 	s3BucketName string,
 	s3RegionName string,
@@ -400,21 +383,16 @@ func backupRealCreate(
 	captureName string,
 	labels map[string]string,
 	annotations map[string]string,
-) (*velero.Backup, error) {
-	backupLocation, backup, err := backupCreate(
+) (*velero.BackupStorageLocation, *velero.Backup, error) {
+	return backupCreate(
 		types.NamespacedName{Namespace: requestNamespaceName, Name: captureName},
-		w, reader, s3Url, s3BucketName, s3RegionName, s3KeyPrefix, secretKeyRef,
+		w, s3Url, s3BucketName, s3RegionName, s3KeyPrefix, secretKeyRef,
 		caCertificates,
 		getBackupSpecFromObjectsSpec(objectsSpec),
 		sourceNamespaceName,
 		labels,
 		annotations,
 	)
-	if err != nil {
-		return nil, err
-	}
-
-	return backupRealStatusProcess(backupLocation, backup, w)
 }
 
 func getBackupSpecFromObjectsSpec(objectsSpec kubeobjects.Spec) velero.BackupSpec {
@@ -467,15 +445,14 @@ func dereferenceOrZeroValueIfNil[T any](pointer *T) (t T) {
 }
 
 func backupRealStatusProcess(
-	backupLocation *velero.BackupStorageLocation,
 	backup *velero.Backup,
-	w objectWriter,
-) (*velero.Backup, error) {
-	backupStatusLog(backup, w.log)
+	log logr.Logger,
+) error {
+	backupStatusLog(backup, log)
 
 	switch backup.Status.Phase {
 	case velero.BackupPhaseCompleted:
-		return backup, nil
+		return nil
 	case velero.BackupPhaseNew:
 		fallthrough
 	case velero.BackupPhaseInProgress:
@@ -485,16 +462,16 @@ func backupRealStatusProcess(
 	case velero.BackupPhaseUploadingPartialFailure:
 		fallthrough
 	case velero.BackupPhaseDeleting:
-		return nil, kubeobjects.RequestProcessingErrorCreate("backup" + string(backup.Status.Phase))
+		return kubeobjects.RequestProcessingErrorCreate("backup" + string(backup.Status.Phase))
 	case velero.BackupPhaseFailedValidation:
 		fallthrough
 	case velero.BackupPhasePartiallyFailed:
 		fallthrough
 	case velero.BackupPhaseFailed:
-		return nil, backupRequestFailedDelete(backupLocation, backup, w)
+		return errors.New("backup" + string(backup.Status.Phase))
 	}
 
-	return nil, kubeobjects.RequestProcessingErrorCreate("backup.status.phase absent")
+	return kubeobjects.RequestProcessingErrorCreate("backup.status.phase absent")
 }
 
 func backupRequestFailedDelete(
@@ -514,7 +491,10 @@ func (r BackupRequest) Deallocate(
 	writer client.Writer,
 	log logr.Logger,
 ) error {
-	return objectWriter{ctx: ctx, Writer: writer, log: log}.objectDelete(r.backup)
+	return objectWriter{ctx: ctx, Writer: writer, log: log}.backupObjectsDelete(
+		&velero.BackupStorageLocation{ObjectMeta: metav1.ObjectMeta{Namespace: r.backup.Namespace, Name: r.backup.Name}},
+		r.backup,
+	)
 }
 
 func (r RestoreRequest) Deallocate(
@@ -522,7 +502,13 @@ func (r RestoreRequest) Deallocate(
 	writer client.Writer,
 	log logr.Logger,
 ) error {
-	return objectWriter{ctx: ctx, Writer: writer, log: log}.objectDelete(r.restore)
+	backupObjectMeta := metav1.ObjectMeta{Namespace: r.restore.Namespace, Name: r.restore.Spec.BackupName}
+
+	return objectWriter{ctx: ctx, Writer: writer, log: log}.restoreObjectsDelete(
+		&velero.BackupStorageLocation{ObjectMeta: backupObjectMeta},
+		&velero.Backup{ObjectMeta: backupObjectMeta},
+		r.restore,
+	)
 }
 
 type objectWriter struct {
@@ -534,7 +520,6 @@ type objectWriter struct {
 func backupCreate(
 	backupNamespacedName types.NamespacedName,
 	w objectWriter,
-	reader client.Reader,
 	s3Url string,
 	s3BucketName string,
 	s3RegionName string,
@@ -560,7 +545,7 @@ func backupCreate(
 	backupSpec.SnapshotVolumes = new(bool)
 	backup := backup(backupNamespacedName, backupSpec, labels, annotations)
 
-	return backupLocation, backup, objectCreateAndGet(w, reader, backup)
+	return backupLocation, backup, w.objectCreate(backup)
 }
 
 func (w objectWriter) backupObjectsDelete(
@@ -612,18 +597,6 @@ func (w objectWriter) objectDelete(o client.Object) error {
 	}
 
 	return nil
-}
-
-func objectCreateAndGet(
-	w objectWriter,
-	reader client.Reader,
-	o client.Object,
-) error {
-	if err := w.objectCreate(o); err != nil {
-		return err
-	}
-
-	return reader.Get(w.ctx, types.NamespacedName{Namespace: o.GetNamespace(), Name: o.GetName()}, o)
 }
 
 func veleroTypeMeta(kind string) metav1.TypeMeta {

--- a/controllers/vrg_kubeobjects.go
+++ b/controllers/vrg_kubeobjects.go
@@ -652,15 +652,16 @@ func (v *VRGInstance) kubeObjectsRecoveryStartOrResume(
 			}
 		}
 
-		switch {
-		case errors.Is(err, kubeobjects.RequestProcessingError{}):
+		if errors.Is(err, kubeobjects.RequestProcessingError{}) {
 			log1.Info("Kube objects group recovering", "state", err.Error())
-		default:
-			log1.Error(err, "Kube objects group recover error")
-			cleanup(request)
 
-			result.Requeue = true
+			return err
 		}
+
+		log1.Error(err, "Kube objects group recover error")
+		cleanup(request)
+
+		result.Requeue = true
 
 		return err
 	}

--- a/controllers/vrg_kubeobjects.go
+++ b/controllers/vrg_kubeobjects.go
@@ -575,8 +575,7 @@ func (v *VRGInstance) getRecoverOrProtectRequest(
 		return request, ok, func() (kubeobjects.Request, error) {
 				return v.reconciler.kubeObjects.ProtectRequestCreate(
 					v.ctx, v.reconciler.Client, v.log,
-					s3StoreAccessor.S3CompatibleEndpoint, s3StoreAccessor.S3Bucket, s3StoreAccessor.S3Region,
-					pathName,
+					s3StoreAccessor.S3CompatibleEndpoint, s3StoreAccessor.S3Bucket, s3StoreAccessor.S3Region, pathName,
 					s3StoreAccessor.VeleroNamespaceSecretKeyRef,
 					s3StoreAccessor.CACertificates,
 					vrg.Namespace, recoverGroup.Spec, veleroNamespaceName,
@@ -600,8 +599,7 @@ func (v *VRGInstance) getRecoverOrProtectRequest(
 
 			return v.reconciler.kubeObjects.RecoverRequestCreate(
 				v.ctx, v.reconciler.Client, v.log,
-				s3StoreAccessor.S3CompatibleEndpoint, s3StoreAccessor.S3Bucket, s3StoreAccessor.S3Region,
-				pathName,
+				s3StoreAccessor.S3CompatibleEndpoint, s3StoreAccessor.S3Bucket, s3StoreAccessor.S3Region, pathName,
 				s3StoreAccessor.VeleroNamespaceSecretKeyRef,
 				s3StoreAccessor.CACertificates,
 				sourceVrgNamespaceName, vrg.Namespace, recoverGroup, veleroNamespaceName,

--- a/controllers/vrg_kubeobjects.go
+++ b/controllers/vrg_kubeobjects.go
@@ -572,23 +572,23 @@ func (v *VRGInstance) getRecoverOrProtectRequest(
 
 	recoverNamePrefix := kubeObjectsRecoverNamePrefix(vrg.Namespace, vrg.Name)
 	recoverName := kubeObjectsRecoverName(recoverNamePrefix, groupNumber)
-	// TODO pass backup request to recover request create
-	// captureRequest, ok := recoverRequests[recoverName]
-	request, ok := recoverRequests[recoverName]
+	recoverRequest, ok := recoverRequests[recoverName]
 
-	return request, ok, func() (kubeobjects.Request, error) {
+	return recoverRequest, ok, func() (kubeobjects.Request, error) {
 		capturePathName, captureNamePrefix := kubeObjectsCapturePathNameAndNamePrefix(
 			sourceVrgNamespaceName, sourceVrgName, captureToRecoverFromIdentifier.Number)
+		captureName := kubeObjectsCaptureName(captureNamePrefix, recoverGroup.BackupName, s3StoreAccessor.S3ProfileName)
+		captureRequest := captureRequests[captureName]
 
 		return v.reconciler.kubeObjects.RecoverRequestCreate(
-			v.ctx, v.reconciler.Client, v.reconciler.APIReader, v.log,
+			v.ctx, v.reconciler.Client, v.log,
 			s3StoreAccessor.S3CompatibleEndpoint, s3StoreAccessor.S3Bucket, s3StoreAccessor.S3Region,
 			capturePathName,
 			s3StoreAccessor.VeleroNamespaceSecretKeyRef,
 			s3StoreAccessor.CACertificates,
 			sourceVrgNamespaceName, vrg.Namespace, recoverGroup, veleroNamespaceName,
-			kubeObjectsCaptureName(captureNamePrefix, recoverGroup.BackupName, s3StoreAccessor.S3ProfileName),
-			kubeObjectsRecoverName(recoverNamePrefix, groupNumber),
+			captureName, captureRequest,
+			recoverName,
 			labels, annotations)
 	}
 }

--- a/hack/shio-demo.sh
+++ b/hack/shio-demo.sh
@@ -179,11 +179,18 @@ app_recipe_deploy() {
 	      container: busybox
 	      command:
 	      - date
+	    - name: fail-succeed
+	      container: busybox
+	      command:
+	      - sh
+	      - -c
+	      - "! rm /tmp/a&&touch /tmp/a"
 	  recoverWorkflow:
 	    sequence:
 	    - group: everything-but-deploy-po-pv-rs-vr-vrg
 	    - group: deployments-and-naked-pods
 	    - hook: busybox/date
+	    - hook: busybox/fail-succeed
 	a
 }; exit_stack_push unset -f app_recipe_deploy
 

--- a/hack/shio-demo.sh
+++ b/hack/shio-demo.sh
@@ -184,7 +184,7 @@ app_recipe_deploy() {
 	      command:
 	      - sh
 	      - -c
-	      - "! rm /tmp/a&&touch /tmp/a"
+	      - "rm /tmp/a||! touch /tmp/a"
 	  recoverWorkflow:
 	    sequence:
 	    - group: everything-but-deploy-po-pv-rs-vr-vrg


### PR DESCRIPTION
# Problem
If a normal backup or hook backup, but not a dummy backup, fails or partially fails then its request is deleted but its object store objects are not.  Subsequent retries fail due to backup already existing.

# Solution
If a backup fails or partially fails, delete backup in addition to its request.  Closes #807 

## Implementation details
### Background
- The `kubeobjects` requests interface `kubeobjects/requests.go` abstracts the Velero driver `kubeobjects/velero/requests.go` providing primitives to submit backup and restore requests, check their statuses, and delete them
  - The VRG controller `vrg_kubeobjects.go` uses these primitives

### Patch
-  Backup deletion is done via Ramen's S3 utility interface because it is synchronous (3rd commit)
   - Velero's undocumented `DeleteBackupRequest` API was also considered, but it requires managing another object asynchronously, one that deletes itself on successful completion!
   - Since the Velero driver is designed to be independent of Ramen, it cannot call Ramen's S3 delete function
     - Instead, the Velero driver returns the error and the VRG handles it by calling the Ramen S3 delete function
- About a year ago, I created a patch, but didn't submit a PR for it, that moves the backup and restore requests error handling, up from the Velero driver to the VRG controller, but for a different reason: to optimize API server queries
  - To determine whether a capture or recovery operation is in progress, the API server is **already** queried for Velero `Backup` and `Restore` request resources labeled as owned by the given VRG
    - Instead of re-querying them in the Velero driver, they are passed into the Velero driver (1st two commits)
    - This also moves the logic to create a request vs. query the status of an existing request up from the Velero driver to the VRG controller
      - This patch leverages the VRG controller's handling of an existing request's failure status to call the Ramen S3 delete routine (3rd commit)
- The 4th commit deletes the backup then the request instead of vice versa, in case of an interruption between the two, so the backup is deleted immediately instead of on a future recovery/backup
- The 5th commit fixes a test hook's logic to fail the first time and succeed the second
- The 6th commit reduces line count to pass linter
- The 7th commit changes a `switch` to an `if` based on a review comment

## End-to-end test results

```sh
$ kubectl logs -nvelero deploy/velero --context cluster2
$ hack/minikube-ramen.sh manager_log cluster2
```

Hook 1 fails due to issue #869 
```
time="2023-05-05T21:50:33Z" level=info msg="running exec hook" backup=velero/asdf--bb--0--use-backup-not-restore-restore-2--minio-on-cluster2 hookCommand="[date]" hookContainer=busybox hookName=date hookOnError=Fail hookPhase=post hookSource=backupSpec hookTimeout="{30s}" hookType=exec logSource="pkg/podexec/pod_command_executor.go:126" name=busybox-75666c475f-x62kg namespace=asdf resource=pods
time="2023-05-05T21:50:33Z" level=info msg="stdout: " backup=velero/asdf--bb--0--use-backup-not-restore-restore-2--minio-on-cluster2 hookCommand="[date]" hookContainer=busybox hookName=date hookOnError=Fail hookPhase=post hookSource=backupSpec hookTimeout="{30s}" hookType=exec logSource="pkg/podexec/pod_command_executor.go:173" name=busybox-75666c475f-x62kg namespace=asdf resource=pods
time="2023-05-05T21:50:33Z" level=info msg="stderr: " backup=velero/asdf--bb--0--use-backup-not-restore-restore-2--minio-on-cluster2 hookCommand="[date]" hookContainer=busybox hookName=date hookOnError=Fail hookPhase=post hookSource=backupSpec hookTimeout="{30s}" hookType=exec logSource="pkg/podexec/pod_command_executor.go:174" name=busybox-75666c475f-x62kg namespace=asdf resource=pods
time="2023-05-05T21:50:33Z" level=error msg="Error executing hook" backup=velero/asdf--bb--0--use-backup-not-restore-restore-2--minio-on-cluster2 error="unable to upgrade connection: container not found (\"busybox\")" hookPhase=post hookSource=backupSpec hookType=exec logSource="internal/hook/item_hook_handler.go:248" name=busybox-75666c475f-x62kg namespace=asdf resource=pods

2023-05-05T21:50:34.882Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:582      backup: use-backup-not-restore-restore-2, captureToRecoverFrom: 1       {"VolumeReplicationGroup": "asdf/bb", "rid": "70219aac-116d-4349-80f2-b81689e4d033", "State": "primary"}
2023-05-05T21:50:34.882Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:676  Backup  {"VolumeReplicationGroup": "asdf/bb", "rid": "70219aac-116d-4349-80f2-b81689e4d033", "State": "primary", "phase": "PartiallyFailed", "warnings": 0, "errors": 1, "failure": "", "validation errors": []}
2023-05-05T21:50:34.882Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:685  Backup  {"VolumeReplicationGroup": "asdf/bb", "rid": "70219aac-116d-4349-80f2-b81689e4d033", "State": "primary", "start": "2023-05-05 21:50:33 +0000 UTC"}
2023-05-05T21:50:34.882Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:689  Backup  {"VolumeReplicationGroup": "asdf/bb", "rid": "70219aac-116d-4349-80f2-b81689e4d033", "State": "primary", "finish": "2023-05-05 21:50:33 +0000 UTC"}
2023-05-05T21:50:34.882Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:693  Items   {"VolumeReplicationGroup": "asdf/bb", "rid": "70219aac-116d-4349-80f2-b81689e4d033", "State": "primary", "to be backed up": 1, "backed up": 1}
2023-05-05T21:50:34.882Z        ERROR   controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:662      Kube objects group recover error        {"VolumeReplicationGroup": "asdf/bb", "rid": "70219aac-116d-4349-80f2-b81689e4d033", "State": "primary", "number": 1, "profile": "minio-on-cluster2", "group": 2, "name": "use-backup-not-restore", "error": "backupPartiallyFailed"}
```
Manually create VR to workaround issue #869


Hook 1 succeeds
```
2023-05-05T21:50:34.997Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:582      backup: use-backup-not-restore-restore-2, captureToRecoverFrom: 1       {"VolumeReplicationGroup": "asdf/bb", "rid": "96536e2e-d343-4787-bccd-244404b8bb88", "State": "primary"}
2023-05-05T21:50:34.997Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:331  Kube objects protect    {"VolumeReplicationGroup": "asdf/bb", "rid": "96536e2e-d343-4787-bccd-244404b8bb88", "State": "primary", "s3 url": "http://192.168.39.123:30000", "s3 bucket": "bucket", "s3 region": "us-east-1", "s3 key prefix": "asdf/bb/kube-objects/0/", "secret key ref": "&SecretKeySelector{LocalObjectReference:LocalObjectReference{Name:s3secret,},Key:aws,Optional:nil,}", "source namespace": "asdf", "request namespace": "velero", "capture name": "asdf--bb--0--use-backup-not-restore-restore-2--minio-on-cluster2", "label set": {"ramendr.openshift.io/owner-name":"bb","ramendr.openshift.io/owner-namespace-name":"asdf"}, "annotations": {}}
2023-05-05T21:50:35.001Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:556  Object created successfully     {"VolumeReplicationGroup": "asdf/bb", "rid": "96536e2e-d343-4787-bccd-244404b8bb88", "State": "primary", "type": "&TypeMeta{Kind:,APIVersion:,}", "name": "asdf--bb--0--use-backup-not-restore-restore-2--minio-on-cluster2"}
2023-05-05T21:50:35.009Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:644      Kube objects group recover request submitted    {"VolumeReplicationGroup": "asdf/bb", "rid": "96536e2e-d343-4787-bccd-244404b8bb88", "State": "primary", "number": 1, "profile": "minio-on-cluster2", "group": 2, "name": "use-backup-not-restore"}
2023-05-05T21:50:35.009Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_volrep.go:1725  failed to restore PVs and PVCs using profile list ([minio-on-cluster2 minio-on-cluster1])       {"VolumeReplicationGroup": "asdf/bb", "rid": "96536e2e-d343-4787-bccd-244404b8bb88", "State": "primary"}

2023-05-05T21:50:35.258Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:582      backup: use-backup-not-restore-restore-2, captureToRecoverFrom: 1       {"VolumeReplicationGroup": "asdf/bb", "rid": "878abf7f-cf60-4bba-bad2-a4e69c5c3b97", "State": "primary"}
2023-05-05T21:50:35.258Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:676  Backup  {"VolumeReplicationGroup": "asdf/bb", "rid": "878abf7f-cf60-4bba-bad2-a4e69c5c3b97", "State": "primary", "phase": "InProgress", "warnings": 0, "errors": 0, "failure": "", "validation errors": []}
2023-05-05T21:50:35.259Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:685  Backup  {"VolumeReplicationGroup": "asdf/bb", "rid": "878abf7f-cf60-4bba-bad2-a4e69c5c3b97", "State": "primary", "start": "2023-05-05 21:50:35 +0000 UTC"}
2023-05-05T21:50:35.259Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:660      Kube objects group recovering   {"VolumeReplicationGroup": "asdf/bb", "rid": "878abf7f-cf60-4bba-bad2-a4e69c5c3b97", "State": "primary", "number": 1, "profile": "minio-on-cluster2", "group": 2, "name": "use-backup-not-restore", "state": "backupInProgress"}

time="2023-05-05T21:50:35Z" level=info msg="running exec hook" backup=velero/asdf--bb--0--use-backup-not-restore-restore-2--minio-on-cluster2 hookCommand="[date]" hookContainer=busybox hookName=date hookOnError=Fail hookPhase=post hookSource=backupSpec hookTimeout="{30s}" hookType=exec logSource="pkg/podexec/pod_command_executor.go:126" name=busybox-75666c475f-x62kg namespace=asdf resource=pods
time="2023-05-05T21:50:35Z" level=info msg="stdout: Fri May  5 21:50:35 UTC 2023\n" backup=velero/asdf--bb--0--use-backup-not-restore-restore-2--minio-on-cluster2 hookCommand="[date]" hookContainer=busybox hookName=date hookOnError=Fail hookPhase=post hookSource=backupSpec hookTimeout="{30s}" hookType=exec logSource="pkg/podexec/pod_command_executor.go:173" name=busybox-75666c475f-x62kg namespace=asdf resource=pods
time="2023-05-05T21:50:35Z" level=info msg="stderr: " backup=velero/asdf--bb--0--use-backup-not-restore-restore-2--minio-on-cluster2 hookCommand="[date]" hookContainer=busybox hookName=date hookOnError=Fail hookPhase=post hookSource=backupSpec hookTimeout="{30s}" hookType=exec logSource="pkg/podexec/pod_command_executor.go:174" name=busybox-75666c475f-x62kg namespace=asdf resource=pods
time="2023-05-05T21:50:35Z" level=info msg="Backed up 1 items out of an estimated total of 1 (estimate will change throughout the backup)" backup=velero/asdf--bb--0--use-backup-not-restore-restore-2--minio-on-cluster2 logSource="pkg/backup/backup.go:380" name=busybox-75666c475f-x62kg namespace=asdf progress= resource=pods

2023-05-05T21:50:36.353Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:582      backup: use-backup-not-restore-restore-2, captureToRecoverFrom: 1       {"VolumeReplicationGroup": "asdf/bb", "rid": "ca76d613-6776-4071-8f72-519613761a43", "State": "primary"}
2023-05-05T21:50:36.353Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:676  Backup  {"VolumeReplicationGroup": "asdf/bb", "rid": "ca76d613-6776-4071-8f72-519613761a43", "State": "primary", "phase": "Completed", "warnings": 0, "errors": 0, "failure": "", "validation errors": []}
2023-05-05T21:50:36.353Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:685  Backup  {"VolumeReplicationGroup": "asdf/bb", "rid": "ca76d613-6776-4071-8f72-519613761a43", "State": "primary", "start": "2023-05-05 21:50:35 +0000 UTC"}
2023-05-05T21:50:36.353Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:689  Backup  {"VolumeReplicationGroup": "asdf/bb", "rid": "ca76d613-6776-4071-8f72-519613761a43", "State": "primary", "finish": "2023-05-05 21:50:35 +0000 UTC"}
2023-05-05T21:50:36.353Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:693  Items   {"VolumeReplicationGroup": "asdf/bb", "rid": "ca76d613-6776-4071-8f72-519613761a43", "State": "primary", "to be backed up": 1, "backed up": 1}
2023-05-05T21:50:36.353Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:651      Kube objects group recovered    {"VolumeReplicationGroup": "as
```
Hook 2 succeeds
```
2023-05-05T21:50:36.353Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:582      backup: use-backup-not-restore-restore-3, captureToRecoverFrom: 1       {"VolumeReplicationGroup": "asdf/bb", "rid": "ca76d613-6776-4071-8f72-519613761a43", "State": "primary"}
2023-05-05T21:50:36.353Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:331  Kube objects protect    {"VolumeReplicationGroup": "asdf/bb", "rid": "ca76d613-6776-4071-8f72-519613761a43", "State": "primary", "s3 url": "http://192.168.39.123:30000", "s3 bucket": "bucket", "s3 region": "us-east-1", "s3 key prefix": "asdf/bb/kube-objects/0/", "secret key ref": "&SecretKeySelector{LocalObjectReference:LocalObjectReference{Name:s3secret,},Key:aws,Optional:nil,}", "source namespace": "asdf", "request namespace": "velero", "capture name": "asdf--bb--0--use-backup-not-restore-restore-3--minio-on-cluster2", "label set": {"ramendr.openshift.io/owner-name":"bb","ramendr.openshift.io/owner-namespace-name":"asdf"}, "annotations": {}}
2023-05-05T21:50:36.456Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:556  Object created successfully     {"VolumeReplicationGroup": "asdf/bb", "rid": "ca76d613-6776-4071-8f72-519613761a43", "State": "primary", "type": "&TypeMeta{Kind:,APIVersion:,}", "name": "asdf--bb--0--use-backup-not-restore-restore-3--minio-on-cluster2"}
2023-05-05T21:50:36.466Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:644      Kube objects group recover request submitted    {"VolumeReplicationGroup": "asdf/bb", "rid": "ca76d613-6776-4071-8f72-519613761a43", "State": "primary", "number": 1, "profile": "minio-on-cluster2", "group": 3, "name": "use-backup-not-restore"}

2023-05-05T21:50:36.647Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:582      backup: use-backup-not-restore-restore-3, captureToRecoverFrom: 1       {"VolumeReplicationGroup": "asdf/bb", "rid": "e1d9e8fe-484d-4211-b048-491744cd59e1", "State": "primary"}
2023-05-05T21:50:36.647Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:676  Backup  {"VolumeReplicationGroup": "asdf/bb", "rid": "e1d9e8fe-484d-4211-b048-491744cd59e1", "State": "primary", "phase": "InProgress", "warnings": 0, "errors": 0, "failure": "", "validation errors": []}
2023-05-05T21:50:36.647Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:685  Backup  {"VolumeReplicationGroup": "asdf/bb", "rid": "e1d9e8fe-484d-4211-b048-491744cd59e1", "State": "primary", "start": "2023-05-05 21:50:36 +0000 UTC"}
2023-05-05T21:50:36.647Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:660      Kube objects group recovering   {"VolumeReplicationGroup": "asdf/bb", "rid": "e1d9e8fe-484d-4211-b048-491744cd59e1", "State": "primary", "number": 1, "profile": "minio-on-cluster2", "group": 3, "name": "use-backup-not-restore", "state": "backupInProgress"}

time="2023-05-05T21:50:36Z" level=info msg="running exec hook" backup=velero/asdf--bb--0--use-backup-not-restore-restore-3--minio-on-cluster2 hookCommand="[sh -c ! rm /tmp/a&&touch /tmp/a]" hookContainer=busybox hookName=fail-succeed hookOnError=Fail hookPhase=post hookSource=backupSpec hookTimeout="{30s}" hookType=exec logSource="pkg/podexec/pod_command_executor.go:126" name=busybox-75666c475f-x62kg namespace=asdf resource=pods
time="2023-05-05T21:50:36Z" level=info msg="stdout: " backup=velero/asdf--bb--0--use-backup-not-restore-restore-3--minio-on-cluster2 hookCommand="[sh -c ! rm /tmp/a&&touch /tmp/a]" hookContainer=busybox hookName=fail-succeed hookOnError=Fail hookPhase=post hookSource=backupSpec hookTimeout="{30s}" hookType=exec logSource="pkg/podexec/pod_command_executor.go:173" name=busybox-75666c475f-x62kg namespace=asdf resource=pods
time="2023-05-05T21:50:36Z" level=info msg="stderr: rm: can't remove '/tmp/a': No such file or directory\n" backup=velero/asdf--bb--0--use-backup-not-restore-restore-3--minio-on-cluster2 hookCommand="[sh -c ! rm /tmp/a&&touch /tmp/a]" hookContainer=busybox hookName=fail-succeed hookOnError=Fail hookPhase=post hookSource=backupSpec hookTimeout="{30s}" hookType=exec logSource="pkg/podexec/pod_command_executor.go:174" name=busybox-75666c475f-x62kg namespace=asdf resource=pods
time="2023-05-05T21:50:36Z" level=info msg="Backed up 1 items out of an estimated total of 1 (estimate will change throughout the backup)" backup=velero/asdf--bb--0--use-backup-not-restore-restore-3--minio-on-cluster2 logSource="pkg/backup/backup.go:380" name=busybox-75666c475f-x62kg namespace=asdf progress= resource=pods

2023-05-05T21:50:37.549Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:582      backup: use-backup-not-restore-restore-3, captureToRecoverFrom: 1       {"VolumeReplicationGroup": "asdf/bb", "rid": "f139accd-5562-4ecf-ae51-738f3bb018c9", "State": "primary"}
2023-05-05T21:50:37.549Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:676  Backup  {"VolumeReplicationGroup": "asdf/bb", "rid": "f139accd-5562-4ecf-ae51-738f3bb018c9", "State": "primary", "phase": "Completed", "warnings": 0, "errors": 0, "failure": "", "validation errors": []}
2023-05-05T21:50:37.549Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:685  Backup  {"VolumeReplicationGroup": "asdf/bb", "rid": "f139accd-5562-4ecf-ae51-738f3bb018c9", "State": "primary", "start": "2023-05-05 21:50:36 +0000 UTC"}
2023-05-05T21:50:37.549Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:689  Backup  {"VolumeReplicationGroup": "asdf/bb", "rid": "f139accd-5562-4ecf-ae51-738f3bb018c9", "State": "primary", "finish": "2023-05-05 21:50:36 +0000 UTC"}
2023-05-05T21:50:37.549Z        INFO    controllers.VolumeReplicationGroup.vrginstance  velero/requests.go:693  Items   {"VolumeReplicationGroup": "asdf/bb", "rid": "f139accd-5562-4ecf-ae51-738f3bb018c9", "State": "primary", "to be backed up": 1, "backed up": 1}
2023-05-05T21:50:37.549Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:651      Kube objects group recovered    {"VolumeReplicationGroup": "asdf/bb", "rid": "f139accd-5562-4ecf-ae51-738f3bb018c9", "State": "primary", "number": 1, "profile": "minio-on-cluster2", "group": 3, "name": "use-backup-not-restore", "start": "2023-05-05 21:50:36 +0000 UTC", "end": "2023-05-05 21:50:36 +0000 UTC"}
2023-05-05T21:50:37.549Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:678      Kube objects recovered  {"VolumeReplicationGroup": "asdf/bb", "rid": "f139accd-5562-4ecf-ae51-738f3bb018c9", "State": "primary", "number": 1, "profile": "minio-on-cluster2", "groups": 4, "start": "2023-05-05 21:39:56 +0000 UTC", "duration": "10m41.549459484s"}
2023-05-05T21:50:37.682Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:696      Kube objects recover requests deleted   {"VolumeReplicationGroup": "asdf/bb", "rid": "f139accd-5562-4ecf-ae51-738f3bb018c9", "State": "primary"}
```

I was exepecting a non-zero return code to be considered a failure however it was not.  But issue #869 caused the first hook to fail allowing this fix to be validated.