### PR TITLE
docs: use internal references instead of github links

### DIFF
--- a/docs/devel-quick-start.md
+++ b/docs/devel-quick-start.md
@@ -64,7 +64,7 @@ That's all! You are ready to submit your first pull request!
 
 *Ramen* uses the `drenv` tool to build a development environment
 quickly. Please follow the
-[Setup instructions](https://github.com/RamenDR/ramen/tree/main/test#setup)
+[Setup instructions](../test/README.md#setup)
 to set up the `drenv` tool.
 
 ## Starting the test environment

--- a/hack/recipe_e2e/README.md
+++ b/hack/recipe_e2e/README.md
@@ -63,7 +63,8 @@ as Primary and restores the application as defined in the Recipe Restore Workflo
 The final test is the application running on Cluster2 and not Cluster1. Restore
 objects will be present in the S3 store from this sequence.
 
-Detailed steps can be found [here](https://github.com/RamenDR/ramen/blob/main/docs/vrg-usage.md#failover-application-from-cluster1-to-cluster2).
+Detailed steps can be found
+[here](../../docs/vrg-usage.md#failover-application-from-cluster1-to-cluster2).
 
 ```bash
 # failover from cluster1 to cluster2
@@ -79,7 +80,8 @@ Cluster2's VRG will be demoted to Secondary to enable a final sync of replicated
 data, then Cluster1's VRG will be promoted to Primary and the application will be
 restored.
 
-Detailed steps can be found [here](https://github.com/RamenDR/ramen/blob/main/docs/vrg-usage.md#failbackrelocate-application-from-cluster2-to-cluster1)
+Detailed steps can be found
+[here](../../docs/vrg-usage.md#failbackrelocate-application-from-cluster2-to-cluster1)
 
 ```bash
 # bash failback from cluster2 to cluster1


### PR DESCRIPTION
docs: use internal references instead of github links