### PR TITLE
Fix misidentification of setup type in Failover scenario

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -347,6 +347,10 @@ func (d *DRPCInstance) RunFailover() (bool, error) {
 		d.setActionDuration()
 
 		return done, nil
+	} else if yes, err := d.mwExistsAndPlacementUpdated(d.instance.Spec.FailoverCluster); yes || err != nil {
+		// We have to wait for the VRG to appear on the failoverCluster or
+		// in case of an error, try again later
+		return !done, err
 	}
 
 	d.setStatusInitiating()
@@ -391,7 +395,6 @@ func (d *DRPCInstance) switchToFailoverCluster() (bool, error) {
 		fmt.Sprintf("Started failover to cluster %q", d.instance.Spec.FailoverCluster))
 	d.setProgression(rmn.ProgressionCheckingFailoverPrequisites)
 
-	// Save the current home cluster
 	curHomeCluster := d.getCurrentHomeClusterName(d.instance.Spec.FailoverCluster, d.drClusters)
 
 	if curHomeCluster == "" {
@@ -772,7 +775,7 @@ func (d *DRPCInstance) ensureCleanupAndVolSyncReplicationSetup(srcCluster string
 	}
 
 	// Check if the reset has already been applied. ResetVolSyncRDOnPrimary resets the VRG
-	// in the MW, but the VRGs in the vrgs slice are fetched using using MCV.
+	// in the MW, but the VRGs in the vrgs slice are fetched using MCV.
 	vrg, ok := d.vrgs[srcCluster]
 	if !ok || len(vrg.Spec.VolSync.RDSpec) != 0 {
 		return fmt.Errorf(fmt.Sprintf("Waiting for RDSpec count on cluster %s to go to zero. VRG OK? %v",
@@ -1200,6 +1203,27 @@ func (d *DRPCInstance) vrgExistsAndPrimary(targetCluster string) bool {
 	}
 
 	return false
+}
+
+func (d *DRPCInstance) mwExistsAndPlacementUpdated(targetCluster string) (bool, error) {
+	vrgMWName := d.mwu.BuildManifestWorkName(rmnutil.MWTypeVRG)
+
+	_, err := d.mwu.FindManifestWork(vrgMWName, targetCluster)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	clusterDecision := d.reconciler.getClusterDecision(d.userPlacement)
+	if clusterDecision.ClusterName == "" ||
+		clusterDecision.ClusterName != targetCluster {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func (d *DRPCInstance) moveVRGToSecondaryEverywhere() bool {
@@ -1658,7 +1682,7 @@ func (d *DRPCInstance) ensureVRGManifestWorkOnClusterDeleted(clusterName string)
 	}
 
 	if !mw.GetDeletionTimestamp().IsZero() {
-		d.log.Info("Waiting for for VRG MW to be fully deleted", "cluster", clusterName)
+		d.log.Info("Waiting for VRG MW to be fully deleted", "cluster", clusterName)
 		// As long as the Manifestwork still exist, then we are not done
 		return !done, nil
 	}


### PR DESCRIPTION
This commit resolves an issue where the system mistakenly identified a setup as a `MetroDR` setup instead of a `RegionDR` setup during a `Failover` operation. The problem occurred specifically when the `failoverCluster` was down, resulting in incorrect detection.

To fix this problem, we now ignore running the failover logic again if the `Placement` is already set to the `failoverCluster` and the `ManifestWork` for it exists.

Fixes: Bug [2207559](https://bugzilla.redhat.com/show_bug.cgi?id=2207559)