### PR TITLE
Ensure VRG Manifest Work on Hub recovery

### DIFF
--- a/controllers/drcluster_controller.go
+++ b/controllers/drcluster_controller.go
@@ -788,9 +788,7 @@ func (u *drclusterInstance) unfenceClusterOnCluster(peerCluster *ramen.DRCluster
 }
 
 func (u *drclusterInstance) requeueIfNFMWExists(peerCluster *ramen.DRCluster) (bool, error) {
-	nfMWName := u.mwUtil.BuildManifestWorkName(util.MWTypeNF)
-
-	_, mwErr := u.mwUtil.FindManifestWork(nfMWName, peerCluster.Name)
+	_, mwErr := u.mwUtil.FindManifestWorkByType(util.MWTypeNF, peerCluster.Name)
 	if mwErr != nil {
 		if errors.IsNotFound(mwErr) {
 			u.log.Info("NetworkFence and MW for it not found. Cleaned")

--- a/controllers/drplacementcontrolvolsync.go
+++ b/controllers/drplacementcontrolvolsync.go
@@ -234,10 +234,7 @@ func (d *DRPCInstance) getVolSyncPVCCount(homeCluster string) int {
 }
 
 func (d *DRPCInstance) updateVRGSpec(clusterName string, tgtVRG *rmn.VolumeReplicationGroup) error {
-	vrgMWName := d.mwu.BuildManifestWorkName(rmnutil.MWTypeVRG)
-	d.log.Info(fmt.Sprintf("Updating VRG ownedby MW %s for cluster %s", vrgMWName, clusterName))
-
-	mw, err := d.mwu.FindManifestWork(vrgMWName, clusterName)
+	mw, err := d.mwu.FindManifestWorkByType(rmnutil.MWTypeVRG, clusterName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil
@@ -245,9 +242,11 @@ func (d *DRPCInstance) updateVRGSpec(clusterName string, tgtVRG *rmn.VolumeRepli
 
 		d.log.Error(err, "failed to update VRG")
 
-		return fmt.Errorf("failed to update VRG %s, in namespace %s (%w)",
-			vrgMWName, clusterName, err)
+		return fmt.Errorf("failed to update VRG MW, in namespace %s (%w)",
+			clusterName, err)
 	}
+
+	d.log.Info(fmt.Sprintf("Updating VRG ownedby MW %s for cluster %s", mw.Name, clusterName))
 
 	vrg, err := d.extractVRGFromManifestWork(mw)
 	if err != nil {
@@ -330,10 +329,7 @@ func (d *DRPCInstance) ResetVolSyncRDOnPrimary(clusterName string) error {
 		return nil
 	}
 
-	vrgMWName := d.mwu.BuildManifestWorkName(rmnutil.MWTypeVRG)
-	d.log.Info(fmt.Sprintf("Resetting RD VRG ownedby MW %s for cluster %s", vrgMWName, clusterName))
-
-	mw, err := d.mwu.FindManifestWork(vrgMWName, clusterName)
+	mw, err := d.mwu.FindManifestWork(rmnutil.MWTypeVRG, clusterName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil
@@ -341,9 +337,11 @@ func (d *DRPCInstance) ResetVolSyncRDOnPrimary(clusterName string) error {
 
 		d.log.Error(err, "failed to update VRG state")
 
-		return fmt.Errorf("failed to update VRG state for %s, in namespace %s (%w)",
-			vrgMWName, clusterName, err)
+		return fmt.Errorf("failed to update VRG state for MW, in namespace %s (%w)",
+			clusterName, err)
 	}
+
+	d.log.Info(fmt.Sprintf("Resetting RD VRG ownedby MW %s for cluster %s", mw.Name, clusterName))
 
 	vrg, err := d.extractVRGFromManifestWork(mw)
 	if err != nil {

--- a/controllers/util/mw_util.go
+++ b/controllers/util/mw_util.go
@@ -64,6 +64,12 @@ func (mwu *MWUtil) BuildManifestWorkName(mwType string) string {
 	return ManifestWorkName(mwu.InstName, mwu.TargetNamespace, mwType)
 }
 
+func (mwu *MWUtil) FindManifestWorkByType(mwType, managedCluster string) (*ocmworkv1.ManifestWork, error) {
+	mwName := mwu.BuildManifestWorkName(mwType)
+
+	return mwu.FindManifestWork(mwName, managedCluster)
+}
+
 func (mwu *MWUtil) FindManifestWork(mwName, managedCluster string) (*ocmworkv1.ManifestWork, error) {
 	if managedCluster == "" {
 		return nil, fmt.Errorf("invalid cluster for MW %s", mwName)
@@ -137,9 +143,7 @@ func (mwu *MWUtil) generateVRGManifestWork(name, namespace, homeCluster string,
 	return mwu.newManifestWork(
 		fmt.Sprintf(ManifestWorkNameFormat, name, namespace, MWTypeVRG),
 		homeCluster,
-		map[string]string{
-			"cluster.open-cluster-management.io/backup": "",
-		}, // backup this VRG MW as part of Hub Recovery
+		map[string]string{},
 		manifests, annotations), nil
 }
 


### PR DESCRIPTION
We are handling here VRG manifest work recreation during Hub recovery in all main flows - Initial Deploy, Failover and Relocate.
We are assuming, that hub recovery does not delete the VRG on the managed cluster, but it's corresponding VRG manifest Work does not exist on the Hub.

We will recreate MW for VRG, cached by drplacement controller from the managed cluster (using MCV). Replication state of MW for VRG recreation is also based on Spec read from the managed cluster.