### PR TITLE
Change DRPC logs to user configurable level

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -58,7 +58,7 @@ type DRPCInstance struct {
 }
 
 func (d *DRPCInstance) startProcessing() bool {
-	d.log.Info("Starting to process placement")
+	d.log.V(1).Info("Starting to process placement")
 
 	requeue := true
 	done, processingErr := d.processPlacement()
@@ -84,7 +84,7 @@ func (d *DRPCInstance) startProcessing() bool {
 }
 
 func (d *DRPCInstance) processPlacement() (bool, error) {
-	d.log.Info("Process DRPC Placement", "DRAction", d.instance.Spec.Action)
+	d.log.V(1).Info("Process DRPC Placement", "DRAction", d.instance.Spec.Action)
 
 	switch d.instance.Spec.Action {
 	case rmn.ActionFailover:
@@ -1015,7 +1015,7 @@ func (d *DRPCInstance) checkReadinessAfterFailover(homeCluster string) bool {
 func (d *DRPCInstance) isVRGConditionMet(cluster string, conditionType string) bool {
 	const ready = true
 
-	d.log.Info(fmt.Sprintf("Checking if VRG is %s on cluster %s", conditionType, cluster))
+	d.log.V(1).Info(fmt.Sprintf("Checking if VRG is %s on cluster %s", conditionType, cluster))
 
 	vrg := d.vrgs[cluster]
 
@@ -2204,7 +2204,7 @@ func (d *DRPCInstance) isPlacementNeedsFixing() bool {
 	// Needs fixing if and only if the DRPC Status is empty, the Placement decision is empty, and
 	// the we have VRG(s) in the managed clusters
 	clusterDecision := d.reconciler.getClusterDecision(d.userPlacement)
-	d.log.Info(fmt.Sprintf("Check placement if needs fixing: PrD %v, PlD %v, VRGs %d",
+	d.log.V(1).Info(fmt.Sprintf("Check placement if needs fixing: PrD %v, PlD %v, VRGs %d",
 		d.instance.Status.PreferredDecision, clusterDecision, len(d.vrgs)))
 
 	if reflect.DeepEqual(d.instance.Status.PreferredDecision, plrv1.PlacementDecision{}) &&

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -518,7 +518,7 @@ func (r *DRPlacementControlReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			return []reconcile.Request{}
 		}
 
-		ctrl.Log.Info(fmt.Sprintf("DRPC: Filtering MCV (%s/%s)", mcv.Name, mcv.Namespace))
+		ctrl.Log.V(1).Info(fmt.Sprintf("DRPC: Filtering MCV (%s/%s)", mcv.Name, mcv.Namespace))
 
 		return filterMCV(mcv)
 	}))
@@ -1078,7 +1078,7 @@ func getPlacementOrPlacementRule(
 	drpc *rmn.DRPlacementControl,
 	log logr.Logger,
 ) (client.Object, error) {
-	log.Info("Getting user placement object", "placementRef", drpc.Spec.PlacementRef)
+	log.V(1).Info("Getting user placement object", "placementRef", drpc.Spec.PlacementRef)
 
 	var usrPlacement client.Object
 
@@ -1109,7 +1109,7 @@ func getPlacementOrPlacementRule(
 func getPlacementRule(ctx context.Context, k8sclient client.Client,
 	drpc *rmn.DRPlacementControl, log logr.Logger,
 ) (*plrv1.PlacementRule, error) {
-	log.Info("Trying user PlacementRule", "usrPR", drpc.Spec.PlacementRef.Name+"/"+drpc.Spec.PlacementRef.Namespace)
+	log.V(1).Info("Trying user PlacementRule", "usrPR", drpc.Spec.PlacementRef.Name+"/"+drpc.Spec.PlacementRef.Namespace)
 
 	plRuleNamespace := drpc.Spec.PlacementRef.Namespace
 	if plRuleNamespace == "" {
@@ -1127,7 +1127,7 @@ func getPlacementRule(ctx context.Context, k8sclient client.Client,
 	err := k8sclient.Get(ctx,
 		types.NamespacedName{Name: drpc.Spec.PlacementRef.Name, Namespace: plRuleNamespace}, usrPlRule)
 	if err != nil {
-		log.Info(fmt.Sprintf("Get PlacementRule returned: %v", err))
+		log.V(1).Info(fmt.Sprintf("Get PlacementRule returned: %v", err))
 
 		return nil, err
 	}
@@ -1145,7 +1145,7 @@ func getPlacementRule(ctx context.Context, k8sclient client.Client,
 				" schedule it to a single cluster")
 		}
 
-		log.Info(fmt.Sprintf("PlacementRule Status is: (%+v)", usrPlRule.Status))
+		log.V(1).Info(fmt.Sprintf("PlacementRule Status is: (%+v)", usrPlRule.Status))
 	}
 
 	return usrPlRule, nil
@@ -1236,7 +1236,7 @@ func (r *DRPlacementControlReconciler) getOrClonePlacementRule(ctx context.Conte
 	drpc *rmn.DRPlacementControl, drPolicy *rmn.DRPolicy,
 	userPlRule *plrv1.PlacementRule, log logr.Logger,
 ) (*plrv1.PlacementRule, error) {
-	log.Info("Getting PlacementRule or cloning it", "placement", drpc.Spec.PlacementRef)
+	log.V(1).Info("Getting PlacementRule or cloning it", "placement", drpc.Spec.PlacementRef)
 
 	clonedPlRuleName := fmt.Sprintf(ClonedPlacementRuleNameFormat, drpc.Name, drpc.Namespace)
 
@@ -1260,7 +1260,7 @@ func (r *DRPlacementControlReconciler) getOrClonePlacementRule(ctx context.Conte
 func (r *DRPlacementControlReconciler) getClonedPlacementRule(ctx context.Context,
 	clonedPlRuleName, namespace string, log logr.Logger,
 ) (*plrv1.PlacementRule, error) {
-	log.Info("Getting cloned PlacementRule", "name", clonedPlRuleName)
+	log.V(1).Info("Getting cloned PlacementRule", "name", clonedPlRuleName)
 
 	clonedPlRule := &plrv1.PlacementRule{}
 
@@ -1343,7 +1343,7 @@ func getVRGsFromManagedClusters(mcvGetter rmnutil.ManagedClusterViewGetter, drpc
 		if err != nil {
 			// Only NotFound error is accepted
 			if errors.IsNotFound(err) {
-				log.Info(fmt.Sprintf("VRG not found on %q", drCluster))
+				log.V(1).Info(fmt.Sprintf("VRG not found on %q", drCluster))
 				clustersQueriedSuccessfully++
 
 				continue
@@ -1360,7 +1360,7 @@ func getVRGsFromManagedClusters(mcvGetter rmnutil.ManagedClusterViewGetter, drpc
 
 		vrgs[drCluster] = vrg
 
-		log.Info("VRG location", "VRG on", drCluster)
+		log.V(1).Info("VRG location", "VRG on", drCluster)
 	}
 
 	// We are done if we successfully queried all drClusters
@@ -1452,7 +1452,7 @@ func (r *DRPlacementControlReconciler) getStatusCheckDelay(
 func (r *DRPlacementControlReconciler) updateDRPCStatus(
 	drpc *rmn.DRPlacementControl, userPlacement client.Object, syncmetric *SyncMetrics, log logr.Logger,
 ) error {
-	log.Info("Updating DRPC status")
+	log.V(1).Info("Updating DRPC status")
 
 	vrgNamespace, err := selectVRGNamespace(r.Client, r.Log, drpc, userPlacement)
 	if err != nil {
@@ -1483,7 +1483,7 @@ func (r *DRPlacementControlReconciler) updateDRPCStatus(
 		return errorswrapper.Wrap(err, "failed to update DRPC status")
 	}
 
-	log.Info(fmt.Sprintf("Updated DRPC Status %+v", drpc.Status))
+	log.V(1).Info(fmt.Sprintf("Updated DRPC Status %+v", drpc.Status))
 
 	return nil
 }

--- a/controllers/drplacementcontrolvolsync.go
+++ b/controllers/drplacementcontrolvolsync.go
@@ -190,7 +190,7 @@ func (d *DRPCInstance) IsVolSyncReplicationRequired(homeCluster string) (bool, e
 
 	const required = true
 
-	d.log.Info("Checking if there are PVCs for VolSync replication...", "cluster", homeCluster)
+	d.log.V(1).Info("Checking if there are PVCs for VolSync replication...", "cluster", homeCluster)
 
 	vrg := d.vrgs[homeCluster]
 

--- a/controllers/util/mcv_util.go
+++ b/controllers/util/mcv_util.go
@@ -220,7 +220,7 @@ func (m ManagedClusterViewGetterImpl) getManagedClusterResource(
 		return errorswrapper.Wrap(err, "getManagedClusterResource failed")
 	}
 
-	logger.Info(fmt.Sprintf("MCV Conditions: %v", mcv.Status.Conditions))
+	logger.V(1).Info(fmt.Sprintf("MCV Conditions: %v", mcv.Status.Conditions))
 
 	return m.GetResource(mcv, resource)
 }

--- a/controllers/util/mw_util.go
+++ b/controllers/util/mw_util.go
@@ -117,7 +117,7 @@ func (mwu *MWUtil) CreateOrUpdateVRGManifestWork(
 	name, namespace, homeCluster string,
 	vrg rmn.VolumeReplicationGroup, annotations map[string]string,
 ) error {
-	mwu.Log.Info(fmt.Sprintf("Create or Update manifestwork %s:%s:%s:%+v",
+	mwu.Log.V(1).Info(fmt.Sprintf("Create or Update manifestwork %s:%s:%s:%+v",
 		name, namespace, homeCluster, vrg))
 
 	manifestWork, err := mwu.generateVRGManifestWork(name, namespace, homeCluster, vrg, annotations)


### PR DESCRIPTION
Update the DRPC logging from level verbose to user configurable log level for better understanding and easy debugging in case of large amount of PVCs. All messages with level V(1) are printed, if we are not changing the debug level flag to INFO. Then these messages will disappear from logs.
In order to change flag, it is necessary to add arg  --zap-log-level=info in ramen deploy.