### PR TITLE
Use last good commit for ocm-controller

### DIFF
--- a/test/addons/ocm-controller/kustomization.yaml
+++ b/test/addons/ocm-controller/kustomization.yaml
@@ -25,7 +25,7 @@ resources:
 images:
 - name: quay.io/stolostron/multicloud-manager
   newName: quay.io/stolostron/multicloud-manager
-  newTag: latest
+  newTag: $image_tag
 
 patches:
 # Replace upstream patches.yaml with version that does not need modification
@@ -36,4 +36,4 @@ patches:
   patch: |-
     - op: add
       path: /spec/template/spec/containers/0/args/-
-      value: "--agent-addon-image=quay.io/stolostron/multicloud-manager:latest"
+      value: "--agent-addon-image=quay.io/stolostron/multicloud-manager:$image_tag"

--- a/test/addons/ocm-controller/start
+++ b/test/addons/ocm-controller/start
@@ -9,9 +9,9 @@ import sys
 import drenv
 from drenv import kubectl
 
-# Using main since there are no releases, last tag is more than year old and
-# the image contains 36 vulnerabilities.
-VERSION = "main"
+# Use latest good commit and the matching image tag (found using quay.io).
+VERSION = "7c7eb070997853cc355facf783fcf9be6a5c5d77"
+IMAGE_TAG = f"2.4.0-{VERSION}"
 
 BASE_URL = f"https://raw.githubusercontent.com/stolostron/multicloud-operators-foundation/{VERSION}/deploy/foundation/hub"
 
@@ -21,6 +21,7 @@ def deploy(cluster):
     with drenv.kustomization(
         "kustomization.yaml",
         base_url=BASE_URL,
+        image_tag=IMAGE_TAG,
     ) as kustomization:
         kubectl.apply("--kustomize", kustomization, context=cluster)
 


### PR DESCRIPTION
Recent change[1] in `ocm-controller` broke the `work-manager` addon. The addon is not installed on the managed clusters and we fail with:

    drenv.commands.Error: Command failed:
       command: ('addons/ocm-cluster/start', 'dr1', 'hub')
       exitcode: 1
       error:
          Traceback (most recent call last):
            File "/home/nsoffer/src/ramen/test/addons/ocm-cluster/start", line 135, in <module>
              wait(cluster_name)
            File "/home/nsoffer/src/ramen/test/addons/ocm-cluster/start", line 59, in wait
              drenv.wait_for(deployment, namespace=ADDONS_NAMESPACE, profile=cluster)
            File "/home/nsoffer/src/ramen/test/drenv/__init__.py", line 50, in wait_for
              raise RuntimeError(f"Timeout waiting for {resource}")
          RuntimeError: Timeout waiting for deploy/klusterlet-addon-workmgr

On the hub we see:

    $ kubectl get managedclusteraddon -A --context hub | grep work-manager
    dr1         work-manager                  Unknown
    dr2         work-manager                  Unknown

Using the commit before this change fixes this issue.

To use the right commit, we pin the code using the commit hash and the image tag for this commit hash. I don't know how to find the right image tag, but quay.io can find the tag using the commit hash.

When the issue is fixed we can move back to consume main, or maybe keep updating the version manually until we get a proper release tag.

[1] https://github.com/stolostron/multicloud-operators-foundation/commit/629b9e066e342d7c0ce8141aa2f1f3ca5128c771