### PR TITLE
Adapt to upstream ocm-controller

### DIFF
--- a/test/addons/ocm-cluster/start
+++ b/test/addons/ocm-cluster/start
@@ -25,10 +25,6 @@ ADDONS = (
         "name": "config-policy-controller",
         "deployment": "config-policy-controller",
     },
-    {
-        "name": "work-manager",
-        "deployment": "klusterlet-addon-workmgr",
-    },
 )
 
 ADDONS_NAMESPACE = "open-cluster-management-agent-addon"

--- a/test/addons/ocm-controller/kustomization.yaml
+++ b/test/addons/ocm-controller/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
 - $base_url/resources/crds/internal.open-cluster-management.io_managedclusterinfos.crd.yaml
 - $base_url/resources/crds/view.open-cluster-management.io_managedclusterviews.crd.yaml
 - $base_url/resources/agent-clusterrole.yaml
+- $base_url/resources/clustermanagementaddon.yaml
 - $base_url/resources/clusterrole.yaml
 - $base_url/resources/controller.yaml
 

--- a/test/addons/ocm-controller/start
+++ b/test/addons/ocm-controller/start
@@ -9,9 +9,9 @@ import sys
 import drenv
 from drenv import kubectl
 
-# Use latest good commit and the matching image tag (found using quay.io).
-VERSION = "7c7eb070997853cc355facf783fcf9be6a5c5d77"
-IMAGE_TAG = f"2.4.0-{VERSION}"
+# Use main since last release is too old (more than 1 year old).
+VERSION = "main"
+IMAGE_TAG = "latest"
 
 BASE_URL = f"https://raw.githubusercontent.com/stolostron/multicloud-operators-foundation/{VERSION}/deploy/foundation/hub"
 


### PR DESCRIPTION
Add the missing managedclusteraddon.ymal for work-manger addon to ocm-controller deployment, and remove the uneeded work-manager addon in ocm-cluster/start.

This is the real fix for the issue seen last week with latest ocm-controller. We fixed this by
pinning ocm-cluster to latest version that worked with our wrong configuration. Now we can continue to follow main.