### PR TITLE
api: make the pvcSelector optional in the DRPlacementControl CRD

### DIFF
--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -112,7 +112,7 @@ type DRPlacementControlSpec struct {
 	// Label selector to identify all the PVCs that need DR protection.
 	// This selector is assumed to be the same for all subscriptions that
 	// need DR protection. It will be passed in to the VRG when it is created
-	PVCSelector metav1.LabelSelector `json:"pvcSelector"`
+	PVCSelector metav1.LabelSelector `json:"pvcSelector,omitempty"`
 
 	// Action is either Failover or Relocate operation
 	Action DRAction `json:"action,omitempty"`

--- a/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
@@ -229,7 +229,6 @@ spec:
             required:
             - drPolicyRef
             - placementRef
-            - pvcSelector
             type: object
           status:
             description: DRPlacementControlStatus defines the observed state of DRPlacementControl


### PR DESCRIPTION
When admission webhooks are enabled, then not having a omitempty tag on the pvcSelector causes the DRPC controller to update the field which is denied by the admission webhook.