### PR TITLE
test: fix the drenv-selftest script

### DIFF
--- a/test/scripts/drenv-selftest
+++ b/test/scripts/drenv-selftest
@@ -9,7 +9,7 @@ echo
 echo "1. Activating the ramen virtual enviroment ..."
 echo
 
-source venv
+source ../venv
 
 echo
 echo "2. Creating a test cluster ..."

--- a/test/scripts/drenv-selftest
+++ b/test/scripts/drenv-selftest
@@ -6,7 +6,7 @@ cd $(dirname $(dirname $0))
 prefix="test-$(uuidgen)"
 
 echo
-echo "1. Activating the ramen virtual enviroment ..."
+echo "1. Activating the ramen virtual environment ..."
 echo
 
 source ../venv


### PR DESCRIPTION
With the recent change in the Makefile and other places, we have the venv in the root of the repository. Update the script to match the changes.