### PR TITLE
Fix kubectl.version() when cluster is not accessible

### DIFF
--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -10,7 +10,14 @@ def version(context=None, output=None):
     APIServer.
     """
     args = ["--output", output] if output else []
-    return _run("version", *args, context=context)
+    try:
+        return _run("version", *args, context=context)
+    except commands.Error as e:
+        # If kubectl provided output this is not really an error and the caller
+        # can use the output.
+        if e.output:
+            return e.output
+        raise
 
 
 def config(*args, context=None):

--- a/test/envs/example.yaml
+++ b/test/envs/example.yaml
@@ -6,8 +6,8 @@
 name: example
 templates:
   - name: "example-cluster"
-    driver: podman
-    container_runtime: cri-o
+    driver: kvm2
+    container_runtime: containerd
     workers:
       - addons:
           - name: example


### PR DESCRIPTION
Looks like `kubect version` change the behavior - if kubectl cannot
access the cluster, it output the expected json, but fails with non zero
error code.

This causes `drenv stop` to fail since it assumes that stopped cluster
is reported by `kubectl.version()` by reporting version info without
server version.

This issue is easy to reproduce:
1. Start example env 
2. Stop one of the vms (using virt-manager or virsh)
3. Run `drenv stop envs/example.yaml`

drenv fails with:

    drenv.commands.Error: Command failed:
       command: ('kubectl', 'version', '--context', 'ex1', '--output', 'json')
       exitcode: 1
       output:
          {
            "clientVersion": {
              "major": "1",
              "minor": "27",
              "gitVersion": "v1.27.2",
              "gitCommit": "7f6f68fdabc4df88cfea2dcf9a19b2b830f1e647",
              "gitTreeState": "clean",
              "buildDate": "2023-05-17T14:20:07Z",
              "goVersion": "go1.20.4",
              "compiler": "gc",
              "platform": "linux/amd64"
            },
            "kustomizeVersion": "v5.0.1"
          }
       error:
          Unable to connect to the server: dial tcp 192.168.39.232:8443:
          connect: no route to host

Fixed by treating the special case of failing with output as success (as
it should be) and returning the output to the caller. The caller can
detect that the cluster is not running since the "serverVersion" is
missing.

Fixes: #817