### PR TITLE
Add OCM backup label to hub config map

### DIFF
--- a/config/hub/manager/kustomization.yaml
+++ b/config/hub/manager/kustomization.yaml
@@ -3,6 +3,8 @@ resources:
 
 generatorOptions:
   disableNameSuffixHash: true
+  labels:
+    cluster.open-cluster-management.io/backup: resource
 
 configMapGenerator:
 - files:

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -382,6 +382,16 @@ func (r *DRPolicyReconciler) configMapMapFunc(configMap client.Object) []reconci
 		return []reconcile.Request{}
 	}
 
+	labelAdded := util.AddLabel(configMap, util.OCMBackupLabelKey, util.OCMBackupLabelValue)
+
+	if labelAdded {
+		if err := r.Update(context.TODO(), configMap); err != nil {
+			r.Log.Error(err, "Failed to add OCM backup label to ramen-hub-operator-config map")
+
+			return []reconcile.Request{}
+		}
+	}
+
 	drpolicies := &ramen.DRPolicyList{}
 	if err := r.Client.List(context.TODO(), drpolicies); err != nil {
 		return []reconcile.Request{}

--- a/controllers/ramenconfig_test.go
+++ b/controllers/ramenconfig_test.go
@@ -9,16 +9,32 @@ import (
 	. "github.com/onsi/gomega"
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/controllers"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/yaml"
 )
 
 func configMapUpdate() {
 	ramenConfigYaml, err := yaml.Marshal(ramenConfig)
-	Expect(err).To(Succeed())
+	Expect(err).NotTo(HaveOccurred())
 
-	configMap.Data[controllers.ConfigMapRamenConfigKeyName] = string(ramenConfigYaml)
+	retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		key := types.NamespacedName{
+			Namespace: ramenNamespace,
+			Name:      controllers.HubOperatorConfigMapName,
+		}
 
-	Expect(k8sClient.Update(context.TODO(), configMap)).To(Succeed())
+		err := k8sClient.Get(context.TODO(), key, configMap)
+		if err != nil {
+			return err
+		}
+
+		configMap.Data[controllers.ConfigMapRamenConfigKeyName] = string(ramenConfigYaml)
+
+		return k8sClient.Update(context.TODO(), configMap)
+	})
+
+	Expect(retryErr).NotTo(HaveOccurred())
 }
 
 func s3ProfilesStore(s3Profiles []ramen.S3StoreProfile) {

--- a/ramenctl/ramenctl/resources/configmap.yaml
+++ b/ramenctl/ramenctl/resources/configmap.yaml
@@ -4,6 +4,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  labels:
+    cluster.open-cluster-management.io/backup: resource
   name: ramen-hub-operator-config
   namespace: ramen-system
 data:


### PR DESCRIPTION
OCM backup label ensures that an OCM backup picks up hub config map to backup and restore for hub recovery situations.

Fixes: #375