### PR TITLE
Ordered initialization for the DRPC condition array

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -107,7 +107,7 @@ func (d *DRPCInstance) RunInitialDeployment() (bool, error) {
 
 	if homeCluster == "" {
 		err := fmt.Errorf("PreferredCluster not set. Placement (%v)", d.userPlacement)
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), err.Error())
 		// needStatusUpdate is not set. Still better to capture the event to report later
 		rmnutil.ReportIfNotPresent(d.reconciler.eventRecorder, d.instance, corev1.EventTypeWarning,
@@ -137,7 +137,7 @@ func (d *DRPCInstance) RunInitialDeployment() (bool, error) {
 
 		_, err := d.startDeploying(homeCluster, homeClusterNamespace)
 		if err != nil {
-			d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+			addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 				d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), err.Error())
 
 			return !done, err
@@ -324,7 +324,7 @@ func (d *DRPCInstance) RunFailover() (bool, error) {
 	// We are done if empty
 	if d.instance.Spec.FailoverCluster == "" {
 		msg := "failover cluster not set. FailoverCluster is a mandatory field"
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), msg)
 
 		return done, fmt.Errorf(msg)
@@ -335,7 +335,7 @@ func (d *DRPCInstance) RunFailover() (bool, error) {
 	// IFF VRG exists and it is primary in the failoverCluster, the clean up and setup VolSync if needed.
 	if d.vrgExistsAndPrimary(failoverCluster) {
 		d.setDRState(rmn.FailedOver)
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			metav1.ConditionTrue, string(d.instance.Status.Phase), "Completed")
 
 		// Make sure VolRep 'Data' and VolSync 'setup' conditions are ready
@@ -389,9 +389,9 @@ func (d *DRPCInstance) switchToFailoverCluster() (bool, error) {
 	const done = true
 	// Make sure we record the state that we are failing over
 	d.setDRState(rmn.FailingOver)
-	d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 		d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), "Starting failover")
-	d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
+	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
 		metav1.ConditionFalse, rmn.ReasonNotStarted,
 		fmt.Sprintf("Started failover to cluster %q", d.instance.Spec.FailoverCluster))
 	d.setProgression(rmn.ProgressionCheckingFailoverPrequisites)
@@ -401,7 +401,7 @@ func (d *DRPCInstance) switchToFailoverCluster() (bool, error) {
 	if curHomeCluster == "" {
 		msg := "Invalid Failover request. Current home cluster does not exists"
 		d.log.Info(msg)
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), msg)
 
 		err := fmt.Errorf("failover requested on invalid state %v", d.instance.Status)
@@ -421,7 +421,7 @@ func (d *DRPCInstance) switchToFailoverCluster() (bool, error) {
 
 	err := d.switchToCluster(newHomeCluster, "")
 	if err != nil {
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), err.Error())
 		rmnutil.ReportIfNotPresent(d.reconciler.eventRecorder, d.instance, corev1.EventTypeWarning,
 			rmnutil.EventReasonSwitchFailed, err.Error())
@@ -430,7 +430,7 @@ func (d *DRPCInstance) switchToFailoverCluster() (bool, error) {
 	}
 
 	d.setDRState(rmn.FailedOver)
-	d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 		d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), "Completed")
 	d.log.Info("Failover completed", "state", d.getLastDRState())
 
@@ -490,7 +490,7 @@ func (d *DRPCInstance) checkFailoverPrerequisites(curHomeCluster string) (bool, 
 			rmnutil.EventReasonSwitchFailed, err.Error())
 	}
 
-	d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 		d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), msg)
 
 	return met, err
@@ -711,7 +711,7 @@ func (d *DRPCInstance) RunRelocate() (bool, error) {
 	// Before relocating to the preferredCluster, do a quick validation and select the current preferred cluster.
 	curHomeCluster, err := d.validateAndSelectCurrentPrimary(preferredCluster)
 	if err != nil {
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), err.Error())
 
 		return !done, err
@@ -720,7 +720,7 @@ func (d *DRPCInstance) RunRelocate() (bool, error) {
 	// We are done if already relocated; if there were secondaries they are cleaned up above
 	if curHomeCluster != "" && d.vrgExistsAndPrimary(preferredCluster) {
 		d.setDRState(rmn.Relocated)
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			metav1.ConditionTrue, string(d.instance.Status.Phase), "Completed")
 
 		return d.ensureActionCompleted(preferredCluster)
@@ -732,7 +732,7 @@ func (d *DRPCInstance) RunRelocate() (bool, error) {
 	if curHomeCluster != "" && curHomeCluster != preferredCluster &&
 		!d.readyToSwitchOver(curHomeCluster, preferredCluster) {
 		errMsg := fmt.Sprintf("current cluster (%s) has not completed protection actions", curHomeCluster)
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), errMsg)
 
 		return !done, fmt.Errorf(errMsg)
@@ -829,7 +829,7 @@ func (d *DRPCInstance) quiesceAndRunFinalSync(homeCluster string) (bool, error) 
 	clusterDecision := d.reconciler.getClusterDecision(d.userPlacement)
 	if clusterDecision.ClusterName != "" {
 		d.setDRState(rmn.Relocating)
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), "Starting quiescing for relocation")
 
 		// clear current user PlacementRule's decision
@@ -1043,13 +1043,13 @@ func (d *DRPCInstance) relocate(preferredCluster, preferredClusterNamespace stri
 
 	// Make sure we record the state that we are failing over
 	d.setDRState(drState)
-	d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 		d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), "Starting relocation")
 
 	// Setting up relocation ensures that all VRGs in all managed cluster are secondaries
 	err := d.setupRelocation(preferredCluster)
 	if err != nil {
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), err.Error())
 
 		return !done, err
@@ -1057,16 +1057,16 @@ func (d *DRPCInstance) relocate(preferredCluster, preferredClusterNamespace stri
 
 	err = d.switchToCluster(preferredCluster, preferredClusterNamespace)
 	if err != nil {
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), err.Error())
 
 		return !done, err
 	}
 
 	d.setDRState(rmn.Relocated)
-	d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 		d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), "Completed")
-	d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
+	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
 		metav1.ConditionFalse, rmn.ReasonNotStarted,
 		fmt.Sprintf("Started relocation to cluster %q", preferredCluster))
 
@@ -1588,7 +1588,7 @@ func (d *DRPCInstance) EnsureCleanup(clusterToSkip string) error {
 	if condition == nil {
 		msg := "Starting cleanup check"
 		d.log.Info(msg)
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
 			metav1.ConditionFalse, rmn.ReasonProgressing, msg)
 
 		condition = findCondition(d.instance.Status.Conditions, rmn.ConditionPeerReady)
@@ -1618,7 +1618,7 @@ func (d *DRPCInstance) EnsureCleanup(clusterToSkip string) error {
 
 	clean, err := d.cleanupSecondaries(clusterToSkip)
 	if err != nil {
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
 			metav1.ConditionFalse, rmn.ReasonCleaning, err.Error())
 
 		return err
@@ -1626,13 +1626,13 @@ func (d *DRPCInstance) EnsureCleanup(clusterToSkip string) error {
 
 	if !clean {
 		msg := "cleaning secondaries"
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
 			metav1.ConditionFalse, rmn.ReasonCleaning, msg)
 
 		return fmt.Errorf("waiting to clean secondaries")
 	}
 
-	d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
+	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
 		metav1.ConditionTrue, rmn.ReasonSuccess, "Cleaned")
 
 	return nil
@@ -1670,7 +1670,7 @@ func (d *DRPCInstance) cleanupForVolSync(clusterToSkip string) error {
 		return fmt.Errorf("still waiting for peer to be ready")
 	}
 
-	d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
+	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
 		metav1.ConditionTrue, rmn.ReasonSuccess, "Ready")
 
 	return nil
@@ -2187,17 +2187,11 @@ func (d *DRPCInstance) getRequeueDuration() time.Duration {
 }
 
 func (d *DRPCInstance) setConditionOnInitialDeploymentCompletion() {
-	d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 		d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), "Initial deployment completed")
 
-	d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
+	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
 		metav1.ConditionTrue, rmn.ReasonSuccess, "Ready")
-}
-
-func (d *DRPCInstance) setDRPCCondition(conditions *[]metav1.Condition, conditionType string,
-	observedGeneration int64, status metav1.ConditionStatus, reason, msg string,
-) {
-	SetDRPCStatusCondition(conditions, conditionType, observedGeneration, status, reason, msg)
 }
 
 func (d *DRPCInstance) isPlacementNeedsFixing() bool {
@@ -2275,10 +2269,10 @@ func (d *DRPCInstance) fixupPlacementForFailover() error {
 			peerReadyMsg = "NotReady"
 		}
 
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
 			peerReadyConditionStatus, rmn.ReasonSuccess, peerReadyMsg)
 
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			metav1.ConditionTrue, string(d.instance.Status.Phase), "Available")
 
 		return nil
@@ -2305,11 +2299,11 @@ func (d *DRPCInstance) fixupPlacementForRelocate() error {
 		}
 
 		// Assume that it is not clean
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
 			metav1.ConditionFalse, rmn.ReasonNotStarted, "NotReady")
 	} else if len(secondaries) > 1 {
 		// Use case 3: After Hub Recovery, the DRPC Action found to be 'Relocate', and ALL VRGs are secondary
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
 			metav1.ConditionTrue, rmn.ReasonSuccess,
 			fmt.Sprintf("Fixed for relocation to %q", d.instance.Spec.PreferredCluster))
 	}

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -601,6 +601,8 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// Save a copy of the instance status to be used for the VRG status update comparison
 	drpc.Status.DeepCopyInto(&r.savedInstanceStatus)
 
+	ensureDRPCConditionsInited(&drpc.Status.Conditions, drpc.Generation, "Initialization")
+
 	placementObj, err := r.ownPlacementOrPlacementRule(ctx, drpc, logger)
 	if err != nil && !(errors.IsNotFound(err) && !drpc.GetDeletionTimestamp().IsZero()) {
 		r.recordFailure(drpc, placementObj, "Error", err.Error(), nil, logger)
@@ -1758,4 +1760,31 @@ func addOrUpdateCondition(conditions *[]metav1.Condition, conditionType string,
 	}
 
 	return false
+}
+
+// Initial creation of the DRPC status condition. This will also preserve the ordering of conditions in the array
+func ensureDRPCConditionsInited(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	const DRPCTotalConditions = 2
+	if len(*conditions) == DRPCTotalConditions {
+		return
+	}
+
+	time := metav1.NewTime(time.Now())
+
+	setStatusConditionIfNotFound(conditions, metav1.Condition{
+		Type:               rmn.ConditionAvailable,
+		Reason:             string(rmn.Initiating),
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		LastTransitionTime: time,
+		Message:            message,
+	})
+	setStatusConditionIfNotFound(conditions, metav1.Condition{
+		Type:               rmn.ConditionPeerReady,
+		Reason:             string(rmn.Initiating),
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		LastTransitionTime: time,
+		Message:            message,
+	})
 }

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -467,32 +467,6 @@ func DRPCsFailingOverToClusterForPolicy(
 	return filteredDRPCs, nil
 }
 
-func SetDRPCStatusCondition(conditions *[]metav1.Condition, conditionType string,
-	observedGeneration int64, status metav1.ConditionStatus, reason, msg string,
-) bool {
-	newCondition := metav1.Condition{
-		Type:               conditionType,
-		Status:             status,
-		ObservedGeneration: observedGeneration,
-		LastTransitionTime: metav1.Now(),
-		Reason:             reason,
-		Message:            msg,
-	}
-
-	existingCondition := findCondition(*conditions, conditionType)
-	if existingCondition == nil ||
-		existingCondition.Status != newCondition.Status ||
-		existingCondition.ObservedGeneration != newCondition.ObservedGeneration ||
-		existingCondition.Reason != newCondition.Reason ||
-		existingCondition.Message != newCondition.Message {
-		setStatusCondition(conditions, newCondition)
-
-		return true
-	}
-
-	return false
-}
-
 // SetupWithManager sets up the controller with the Manager.
 //
 //nolint:funlen
@@ -662,7 +636,7 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 func (r *DRPlacementControlReconciler) recordFailure(drpc *rmn.DRPlacementControl,
 	placementObj client.Object, reason, msg string, syncMetrics *SyncMetrics, log logr.Logger,
 ) {
-	needsUpdate := SetDRPCStatusCondition(&drpc.Status.Conditions, rmn.ConditionAvailable,
+	needsUpdate := addOrUpdateCondition(&drpc.Status.Conditions, rmn.ConditionAvailable,
 		drpc.Generation, metav1.ConditionFalse, reason, msg)
 	if needsUpdate {
 		err := r.updateDRPCStatus(drpc, placementObj, syncMetrics, log)
@@ -1314,10 +1288,10 @@ func updateVRGsFromManagedClusters(mcvGetter rmnutil.ManagedClusterViewGetter, d
 	if len(vrgs) == 0 && failedClusterToQuery != drpc.Spec.FailoverCluster {
 		condition := findCondition(drpc.Status.Conditions, rmn.ConditionPeerReady)
 		if condition == nil {
-			SetDRPCStatusCondition(&drpc.Status.Conditions, rmn.ConditionPeerReady, drpc.Generation,
-				metav1.ConditionTrue, rmn.ReasonSuccess, "Forcing Ready")
-			SetDRPCStatusCondition(&drpc.Status.Conditions, rmn.ConditionAvailable,
+			addOrUpdateCondition(&drpc.Status.Conditions, rmn.ConditionAvailable,
 				drpc.Generation, metav1.ConditionTrue, rmn.ReasonSuccess, "Forcing Available")
+			addOrUpdateCondition(&drpc.Status.Conditions, rmn.ConditionPeerReady, drpc.Generation,
+				metav1.ConditionTrue, rmn.ReasonSuccess, "Forcing Ready")
 		}
 	}
 
@@ -1758,4 +1732,30 @@ func selectVRGNamespace(
 	default:
 		return drpc.Namespace, nil
 	}
+}
+
+func addOrUpdateCondition(conditions *[]metav1.Condition, conditionType string,
+	observedGeneration int64, status metav1.ConditionStatus, reason, msg string,
+) bool {
+	newCondition := metav1.Condition{
+		Type:               conditionType,
+		Status:             status,
+		ObservedGeneration: observedGeneration,
+		LastTransitionTime: metav1.Now(),
+		Reason:             reason,
+		Message:            msg,
+	}
+
+	existingCondition := findCondition(*conditions, conditionType)
+	if existingCondition == nil ||
+		existingCondition.Status != newCondition.Status ||
+		existingCondition.ObservedGeneration != newCondition.ObservedGeneration ||
+		existingCondition.Reason != newCondition.Reason ||
+		existingCondition.Message != newCondition.Message {
+		setStatusCondition(conditions, newCondition)
+
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
Introduce ordered initialization for condition array, ensuring consistent location. Updates preserve condition order.

Fixes this [bug1](https://bugzilla.redhat.com/show_bug.cgi?id=2211883) and this [bug2](https://bugzilla.redhat.com/show_bug.cgi?id=2213118)