### PR TITLE
Pin ocm-controller to last good version

### DIFF
--- a/test/addons/ocm-controller/start
+++ b/test/addons/ocm-controller/start
@@ -9,9 +9,10 @@ import sys
 import drenv
 from drenv import kubectl
 
-# Use main since last release is too old (more than 1 year old).
-VERSION = "main"
-IMAGE_TAG = "latest"
+# Use latest good commit and the matching image tag (found using quay.io).
+VERSION = "629b9e066e342d7c0ce8141aa2f1f3ca5128c771"
+IMAGE_TAG = f"2.4.0-{VERSION}"
+
 
 BASE_URL = f"https://raw.githubusercontent.com/stolostron/multicloud-operators-foundation/{VERSION}/deploy/foundation/hub"
 


### PR DESCRIPTION
ocm-controller changed the deployment to make it easier to deploy ocm-controller without the components that work only on OCP. The change broke our current deployment. Pin ocm-controller version to the last good version to unbreak the deployment until we find how to consume the new deployment.

[1] https://github.com/stolostron/multicloud-operators-foundation/commit/18e935495672315848776076b4ebbd971de831e3