### PR TITLE
CI: make sanity check work and simplify it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,14 @@ jobs:
       - name: Run linters
         run: ./hack/pre-commit.sh
 
+      - name: Check that generated files were not modified
+        run: |
+          make generate
+          make manifests
+          go mod tidy
+          git --no-pager diff
+          git diff-index --quiet HEAD
+
   golangci:
     name: Golangci Lint
     runs-on: ubuntu-20.04
@@ -186,11 +194,6 @@ jobs:
       - name: Go tidy
         run: go mod tidy
 
-      - name: Check auto generated files
-        run: |
-          echo "Failing if any auto generated files are updated, checking 'git status'"
-          git --no-pager diff
-          git status --porcelain 2>&1 | tee /dev/stderr | (! read)
 
   deploy-check:
     name: Check artifacts and operator deployment


### PR DESCRIPTION
This change indicates any sanity issues before starting the build and hence saves us the waiting time of 2m31s

Fixes: #573