### PR TITLE
Flaky unit tests - fails to change DRCluster fencing state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,9 @@ test-vrg-kubeobjects: generate manifests envtest
 test-drpc: generate manifests envtest
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus DRPlacementControl
 
+test-drcluster: generate manifests envtest
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus DRClusterController
+
 test-util-pvc: generate manifests envtest
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers/util -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus PVCS_Util
 


### PR DESCRIPTION
The purpose of this change is to make an update to a drCluster, when we have to worry about conflicts caused by other code making unrelated updates to the resource at the same time.
For the cleaner code I extracted all the updates made to a drCluster during our tests, into a new function - updateDRClusterParameters and protected with RetryOnConflict.
This RetryOnConflict should fetch the resource to be modified, make appropriate changes to it, try to update it, and return (unmodified) the error from the update function. On a successful update, RetryOnConflict will return nil. If the update function returns a "Conflict" error, RetryOnConflict will wait some amount of time as described by backoff, and then try again. On a non-"Conflict" error, or if it retries too many times and gives up, RetryOnConflict will return an error to the caller.
Fixes: https://github.com/RamenDR/ramen/issues/929

