### PR TITLE
Pin csi-addons to latest working commit

### DIFF
--- a/test/addons/csi-addons/start
+++ b/test/addons/csi-addons/start
@@ -9,8 +9,9 @@ import sys
 import drenv
 from drenv import kubectl
 
-# Using main till a release is available with lastSyncTime.
-VERSION = "main"
+# We don't have a release with lastSyncTime, and main is currently broken (no
+# quay.io image matching latest code).
+VERSION = "ee9403c55c3aee9da7b25785b87e370c4095d881"
 BASE_URL = f"https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/{VERSION}/deploy/controller"
 
 


### PR DESCRIPTION
Latest commits in csi-addons changed the executable name but pushing to quay.io fails we latest deployment yaml fail to start the container with:

    runc create failed: unable to start container process: exec:
    "/csi-addons-manager": stat /csi-addons-manager: no such file or
    directory: unknown

Temporary fix this by pinning to latest working commit, matching the latest image in quay.io.