### PR TITLE
basic-test/undeploy should be idempotent

### DIFF
--- a/test/basic-test/undeploy
+++ b/test/basic-test/undeploy
@@ -12,6 +12,7 @@ config = test.config
 
 test.info("Deleting busybox example application")
 kubectl.delete(
+    "--ignore-not-found",
     f"--kustomize={config['tmp_dir']}",
     context=config["hub"],
     log=test.debug,


### PR DESCRIPTION
Running undeploy again on an already undeployed
env should not return any "not found" errors

This change igonores such errors as the env
is already undeployed and returns success in
such scenario.

Fixes: #923