### PR TITLE
Use latest release of csi-addons

### DIFF
--- a/test/addons/csi-addons/kustomization.yaml
+++ b/test/addons/csi-addons/kustomization.yaml
@@ -6,3 +6,7 @@ resources:
   - ${base_url}/crds.yaml
   - ${base_url}/rbac.yaml
   - ${base_url}/setup-controller.yaml
+
+images:
+  - name: quay.io/csiaddons/k8s-controller
+    newTag: ${image_tag}

--- a/test/addons/csi-addons/start
+++ b/test/addons/csi-addons/start
@@ -9,8 +9,7 @@ import sys
 import drenv
 from drenv import kubectl
 
-# Using main till a release is available with lastSyncTime.
-VERSION = "main"
+VERSION = "v0.7.0"
 BASE_URL = f"https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/{VERSION}/deploy/controller"
 
 
@@ -19,6 +18,7 @@ def deploy(cluster):
     with drenv.kustomization(
         "kustomization.yaml",
         base_url=BASE_URL,
+        image_tag=VERSION,
     ) as kustomization:
         kubectl.apply("--kustomize", kustomization, context=cluster)
 


### PR DESCRIPTION
We have a proper release now, so we can use it instead of following main and get more stable builds.