### PR TITLE
Remove unneeded newName

### DIFF
--- a/test/addons/ocm-controller/kustomization.yaml
+++ b/test/addons/ocm-controller/kustomization.yaml
@@ -25,7 +25,6 @@ resources:
 
 images:
 - name: quay.io/stolostron/multicloud-manager
-  newName: quay.io/stolostron/multicloud-manager
   newTag: $image_tag
 
 patches:


### PR DESCRIPTION
When kustomizing images newName instead required only if we want to change the image. In ocm-controller we only want to set the tag.