### PR TITLE
Simplify updateDRClusterManifestWorkStatus retry loop

### DIFF
--- a/controllers/drcluster_controller_test.go
+++ b/controllers/drcluster_controller_test.go
@@ -244,18 +244,14 @@ func updateDRClusterManifestWorkStatus(clusterNamespace string) {
 	}
 
 	retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		var err error
-
-		err = apiReader.Get(context.TODO(), manifestLookupKey, mw)
+		err := apiReader.Get(context.TODO(), manifestLookupKey, mw)
 		if err != nil {
 			return err
 		}
 
 		mw.Status = DRClusterStatusConditions
 
-		err = k8sClient.Status().Update(context.TODO(), mw)
-
-		return err
+		return k8sClient.Status().Update(context.TODO(), mw)
 	})
 
 	Expect(retryErr).NotTo(HaveOccurred())


### PR DESCRIPTION
Return update result instead of keeping it in temporary error and remove unneeded error definition.