### PR TITLE
Disable unhelpful linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -43,6 +43,7 @@ linters:
     - godot
     - godox
     - paralleltest
+    - nlreturn
     - goerr113  # TODO: Need to introduce error definition and bring this back
     - goheader  # TODO: Introduce back post fixing linter errors
     - gci

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,9 +30,6 @@ linters-settings:
       SPDX-License-Identifier: Apache-2.0
   misspell:
     locale: US
-  wsl:
-    allow-trailing-comment: true
-    enforce-err-cuddling: true
 
 linters:
   enable-all: true
@@ -44,6 +41,7 @@ linters:
     - godox
     - paralleltest
     - nlreturn
+    - wsl
     - goerr113  # TODO: Need to introduce error definition and bring this back
     - goheader  # TODO: Introduce back post fixing linter errors
     - gci

--- a/controllers/drcluster_controller.go
+++ b/controllers/drcluster_controller.go
@@ -84,7 +84,6 @@ func (r *DRClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 
 		ctrl.Log.Info(fmt.Sprintf("DRCluster: Filtering DRPC (%s/%s)", drpc.Name, drpc.Namespace))
-
 		return filterDRPC(drpc)
 	}))
 
@@ -97,7 +96,6 @@ func (r *DRClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 
 		ctrl.Log.Info(fmt.Sprintf("DRCluster: Filtering ManifestWork (%s/%s)", mw.Name, mw.Namespace))
-
 		return filterDRClusterMW(mw)
 	}))
 
@@ -110,7 +108,6 @@ func (r *DRClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 
 		ctrl.Log.Info(fmt.Sprintf("DRCluster: Filtering MCV (%s/%s)", mcv.Name, mcv.Namespace))
-
 		return filterDRClusterMCV(mcv)
 	}))
 
@@ -180,7 +177,6 @@ func DRPCUpdateOfInterest(oldDRPC, newDRPC *ramen.DRPlacementControl) bool {
 		log.Info("Processing DRPC failover cluster change event",
 			"name", newDRPC.GetName(),
 			"namespace", newDRPC.GetNamespace())
-
 		return true
 	}
 
@@ -193,14 +189,12 @@ func DRPCUpdateOfInterest(oldDRPC, newDRPC *ramen.DRPlacementControl) bool {
 			log.Info("Processing DRPC failed over event",
 				"name", newDRPC.GetName(),
 				"namespace", newDRPC.GetNamespace())
-
 			return true
 		}
 
 		log.Info("Ignoring DRPC failed over event",
 			"name", newDRPC.GetName(),
 			"namespace", newDRPC.GetNamespace())
-
 		return false
 	}
 
@@ -509,17 +503,14 @@ func (u *drclusterInstance) statusUpdate() error {
 		if err := u.client.Status().Update(u.ctx, u.object); err != nil {
 			u.log.Info(fmt.Sprintf("Failed to update drCluster status (%s/%s/%v)",
 				u.object.Name, u.object.Namespace, err))
-
 			return fmt.Errorf("failed to update drCluster status (%s/%s)", u.object.Name, u.object.Namespace)
 		}
 
 		u.log.Info(fmt.Sprintf("Updated drCluster Status %+v", u.object.Status))
-
 		return nil
 	}
 
 	u.log.Info(fmt.Sprintf("Nothing to update %+v", u.object.Status))
-
 	return nil
 }
 
@@ -647,7 +638,6 @@ func (u *drclusterInstance) clusterUnfence() (bool, error) {
 
 	if requeue {
 		u.log.Info("requing as cluster unfence operation is not complete")
-
 		return requeue, nil
 	}
 
@@ -710,7 +700,6 @@ func (u *drclusterInstance) fenceClusterOnCluster(peerCluster *ramen.DRCluster) 
 			"fencing operation not successful")
 
 		u.log.Info("Fencing operation not successful", "cluster", u.object.Name)
-
 		return true, fmt.Errorf("fencing operation result not successful")
 	}
 
@@ -776,7 +765,6 @@ func (u *drclusterInstance) unfenceClusterOnCluster(peerCluster *ramen.DRCluster
 			"unfencing operation not successful")
 
 		u.log.Info("Unfencing operation not successful", "cluster", u.object.Name)
-
 		return true, fmt.Errorf("un operation result not successful")
 	}
 
@@ -1241,7 +1229,6 @@ func (u *drclusterInstance) createNFManifestWork(targetCluster *ramen.DRCluster,
 		u.object.Name, u.object.Namespace,
 		peerCluster.Name, nf, annotations); err != nil {
 		log.Error(err, "failed to create or update NetworkFence manifest")
-
 		return fmt.Errorf("failed to create or update NetworkFence manifest in cluster %s to fence off cluster %s (%w)",
 			peerCluster.Name, targetCluster.Name, err)
 	}

--- a/controllers/drcluster_controller_test.go
+++ b/controllers/drcluster_controller_test.go
@@ -217,7 +217,6 @@ func updateDRClusterManifestWorkStatus(clusterNamespace string) {
 
 	Eventually(func() bool {
 		err := apiReader.Get(context.TODO(), manifestLookupKey, mw)
-
 		return err == nil
 	}, timeout, interval).Should(BeTrue(),
 		fmt.Sprintf("failed to get manifest for DRCluster %s", clusterNamespace))

--- a/controllers/drcluster_controller_test.go
+++ b/controllers/drcluster_controller_test.go
@@ -244,18 +244,14 @@ func updateDRClusterManifestWorkStatus(clusterNamespace string) {
 	}
 
 	retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		var err error
-
-		err = apiReader.Get(context.TODO(), manifestLookupKey, mw)
+		err := apiReader.Get(context.TODO(), manifestLookupKey, mw)
 		if err != nil {
 			return err
 		}
 
 		mw.Status = DRClusterStatusConditions
 
-		err = k8sClient.Status().Update(context.TODO(), mw)
-
-		return err
+		return k8sClient.Status().Update(context.TODO(), mw)
 	})
 
 	Expect(retryErr).NotTo(HaveOccurred())


### PR DESCRIPTION
Some linters used by golangci-lint are not helpful and enforce worse
code style. Disabling the linters allows improving the style and remove
unneeded obstacles for developers.

This pr modifies only 2 files to show some examples of possible formatting.
We can deffer the actual changes and modify the code as needed later.