### PR TITLE
Enhancing Data Consistency and Reliability: Introducing a New Option for Snapshot Sync

### DIFF
--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -1081,7 +1081,7 @@ func ensureDRPolicyIsDeleted(drpolicyName string) {
 				drpolicyName,
 			),
 		),
-		"DRPolicy %s not not found\n%s",
+		"DRPolicy %s not found\n%s",
 		drpolicyName,
 		format.Object(*drpolicy, 0),
 	)

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -85,6 +85,10 @@ func (r *VolumeReplicationGroupReconciler) SetupWithManager(
 			handler.EnqueueRequestsFromMapFunc(r.pvcMapFunc),
 			builder.WithPredicates(pvcPredicateFunc()),
 		).
+		Watches(&source.Kind{Type: &corev1.PersistentVolumeClaim{}},
+			handler.EnqueueRequestsFromMapFunc(r.rdMapFunc),
+			builder.WithPredicates(replicationDestinationPredicateFunc()),
+		).
 		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, handler.EnqueueRequestsFromMapFunc(r.configMapFun)).
 		Owns(&volrep.VolumeReplication{})
 
@@ -299,6 +303,72 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 	}
 
 	return req
+}
+
+func replicationDestinationPredicateFunc() predicate.Funcs {
+	log := ctrl.Log.WithName("RDPredicate").WithName("RD")
+	rdPredicate := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			log.Info("Delete event")
+
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldRD, ok := e.ObjectOld.DeepCopyObject().(*volsyncv1alpha1.ReplicationDestination)
+			if !ok {
+				log.Info("Failed to deep copy older MCV")
+
+				return false
+			}
+			newRD, ok := e.ObjectNew.DeepCopyObject().(*volsyncv1alpha1.ReplicationDestination)
+			if !ok {
+				log.Info("Failed to deep copy newer MCV")
+
+				return false
+			}
+
+			log.Info(fmt.Sprintf("Update event for MCV %s/%s", oldRD.Name, oldRD.Namespace))
+
+			return oldRD.Status.LatestImage.Name != newRD.Status.LatestImage.Name
+		},
+	}
+
+	return rdPredicate
+}
+
+func (r *VolumeReplicationGroupReconciler) rdMapFunc(obj client.Object) []reconcile.Request {
+	log := ctrl.Log.WithName("rdmap").WithName("VolumeReplicationGroup")
+
+	rd, ok := obj.(*volsyncv1alpha1.ReplicationDestination)
+	if !ok {
+		log.Info("ReplicationDestination (RD) map function received non-RD resource")
+
+		return []reconcile.Request{}
+	}
+
+	return filterRD(rd)
+}
+
+func filterRD(rd *volsyncv1alpha1.ReplicationDestination) []ctrl.Request {
+	if rd.Annotations[volsync.OwnerNameAnnotation] == "" ||
+		rd.Annotations[volsync.OwnerNamespaceAnnotation] == "" {
+		return []ctrl.Request{}
+	}
+
+	return []ctrl.Request{
+		reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      rd.Annotations[volsync.OwnerNameAnnotation],
+				Namespace: rd.Annotations[volsync.OwnerNamespaceAnnotation],
+			},
+		},
+	}
 }
 
 func GetPVCLabelSelector(

--- a/controllers/vrg_volsync.go
+++ b/controllers/vrg_volsync.go
@@ -133,7 +133,7 @@ func (v *VRGInstance) reconcilePVCAsVolSyncPrimary(pvc corev1.PersistentVolumeCl
 	}
 
 	err := v.volSyncHandler.PreparePVC(pvc.Name, v.instance.Spec.PrepareForFinalSync,
-		v.volSyncHandler.IsCopyMethodDirect())
+		v.volSyncHandler.IsCopyMethodDirectOrLocalDirect())
 	if err != nil {
 		return true
 	}


### PR DESCRIPTION
Prior to this fix, when using VolSync with the copy method set to `Direct`, the replication process from the source to the destination snapshot directly synchronizes with the application PVC. However, if there is a loss of connectivity between the two clusters during the sync process, it can lead to inconsistent synchronization, leaving the application PVC in an unpredictable state.

To address this issue, this commit introduces an additional option for customers to choose from. This new option involves performing a snapshot sync from the source to the destination cluster, syncing it to a temporary PVC. However, on the destination cluster, a 'Direct' copy to the Application PVC is utilized. This approach improves the speed and reliability of the snapshot sync process at the expense of additional storage usage.

It is important to note that this approach requires three times the storage compared to the current method, which may not be suitable for all customers.

To enable this feature, users must set the destinationCopyMethod to `LocalDirect` in the Ramen configmap under spec.data.ramen_manager_config.yaml section, add:
```
  volsync:
    destinationCopyMethod: LocalDirect
```

Fixes: issue [831](https://github.com/RamenDR/ramen/issues/831)

The following workflow describes the updated process for using VolSync with the copy method set to `LocalDirect`

1. The VRG monitors changes in the ReplicationDestination (RD). It compares the latest image name of the old RD with the new RD's latest image name. If they are different, it forces reconciliation to enable quicker syncing from the local ReplicationSource (RS) to the local RD.

2. When setting up the main RD on the destination cluster, the VRG checks if the `LocalDirect` option is set. If enabled, it creates a **local RD** and **local RS**, both named with the PVC name appended with `-local`.

3. The local RD creates the application PVC, which is the PVC that the local RS will sync to. It configures itself to use the direct copy method to sync with the application PVC instead of syncing to a temporary PVC.

4. The local RS performs the following steps:
    a. It takes ownership of the snapshot found in the main RD.
    b. It creates a read-only PVC using the snapshot image found in the main RD as the data source. The PVC name matches the snapshot name.
    c. It sets the source PVC as the read-only PVC created in the previous step.
    d. It sets up a manual sync using the read-only PVC name.
    e. It configures the copyMethod to direct.
    f. When a new snapshot is detected (as mentioned in step 1), it cleans up the previous snapshot/PVC, and the process repeats.

5. When the RD is no longer required, the snapshot, read-only PVC, local RD, and local RS are all deleted. In this step, the final local sync is allowed to complete before the cleanup process is completed.