### PR TITLE
Use environment file in drenv tests

### DIFF
--- a/ramenctl/ramenctl/command.py
+++ b/ramenctl/ramenctl/command.py
@@ -4,9 +4,8 @@
 import logging
 import os
 
-import yaml
-
 from drenv import commands
+from drenv import ramen
 
 RAMEN_NAMESPACE = "ramen-system"
 SOURCE_DIR = "."
@@ -27,16 +26,7 @@ def env_info(args):
     Load ramen environment info from drenv environment file specified in
     command line arguments.
     """
-    with open(args.filename) as f:
-        env = yaml.safe_load(f)
-
-    ramen = env["ramen"]
-
-    if args.name_prefix:
-        ramen["hub"] = args.name_prefix + info["hub"]
-        ramen["clusters"] = [args.name_prefix + cluster for cluster in info["clusters"]]
-
-    return ramen
+    return ramen.env_info(args.filename, name_prefix=args.name_prefix)
 
 
 def add_common_arguments(parser):

--- a/ramenctl/ramenctl/resources/configmap.yaml
+++ b/ramenctl/ramenctl/resources/configmap.yaml
@@ -33,9 +33,9 @@ data:
     kubeObjectProtection:
       veleroNamespaceName: velero
     s3StoreProfiles:
-    - s3ProfileName: minio-on-dr1
+    - s3ProfileName: minio-on-$cluster1
       s3Bucket: bucket
-      s3CompatibleEndpoint: $minio_url_dr1
+      s3CompatibleEndpoint: $minio_url_cluster1
       s3Region: us-west-1
       s3SecretRef:
         name: ramen-s3-secret
@@ -43,9 +43,9 @@ data:
       veleroNamespaceSecretKeyRef:
         key: cloud
         name: cloud-credentials
-    - s3ProfileName: minio-on-dr2
+    - s3ProfileName: minio-on-$cluster2
       s3Bucket: bucket
-      s3CompatibleEndpoint: $minio_url_dr2
+      s3CompatibleEndpoint: $minio_url_cluster2
       s3Region: us-east-1
       s3SecretRef:
         name: ramen-s3-secret

--- a/ramenctl/ramenctl/resources/regional-dr/dr-clusters.yaml
+++ b/ramenctl/ramenctl/resources/regional-dr/dr-clusters.yaml
@@ -4,15 +4,15 @@
 apiVersion: ramendr.openshift.io/v1alpha1
 kind: DRCluster
 metadata:
-  name: dr1
+  name: $cluster1
 spec:
-  s3ProfileName: minio-on-dr1
+  s3ProfileName: minio-on-$cluster1
   region: west
 ---
 apiVersion: ramendr.openshift.io/v1alpha1
 kind: DRCluster
 metadata:
-  name: dr2
+  name: $cluster2
 spec:
-  s3ProfileName: minio-on-dr2
+  s3ProfileName: minio-on-$cluster2
   region: east

--- a/ramenctl/ramenctl/resources/regional-dr/dr-policy.yaml
+++ b/ramenctl/ramenctl/resources/regional-dr/dr-policy.yaml
@@ -7,6 +7,6 @@ metadata:
   name: dr-policy
 spec:
   drClusters:
-  - dr1
-  - dr2
+  - $cluster1
+  - $cluster2
   schedulingInterval: 1m

--- a/ramenctl/ramenctl/resources/regional-dr/kustomization.yaml
+++ b/ramenctl/ramenctl/resources/regional-dr/kustomization.yaml
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: The RamenDR authors
-# SPDX-License-Identifier: Apache-2.0
----
-resources:
-  - dr-clusters.yaml
-  - dr-policy.yaml

--- a/test/basic-test/config.yaml
+++ b/test/basic-test/config.yaml
@@ -11,6 +11,5 @@ samples_repo: https://github.com/ramendr/ocm-ramen-samples.git
 samples_branch: main
 samples_dir: /tmp/ramen-test/basic-test/ocm-ramen-samples
 
-hub: hub
 namespace: busybox-sample
 name: busybox-drpc

--- a/test/basic-test/deploy
+++ b/test/basic-test/deploy
@@ -11,9 +11,15 @@ from drenv import kubectl
 from drenv import test
 
 test.start("deploy", __file__)
-test.add_argument("cluster", help="Cluster name to deploy on.")
+test.add_argument(
+    "--cluster",
+    help="Cluster name to deploy on (default first cluster)",
+)
 args = test.parse_args()
 config = test.config
+
+cluster = args.cluster or test.env["clusters"][0]
+test.info("Deploying on cluster '%s'", cluster)
 
 test.info("Creating temporary directory %s", config["tmp_dir"])
 os.makedirs(config["tmp_dir"], exist_ok=True)
@@ -32,9 +38,9 @@ if not os.path.exists(config["samples_dir"]):
     for line in commands.watch(*cmd):
         test.debug(line)
 
-test.info("Creating kustomization for using cluster '%s'", args.cluster)
+test.info("Creating kustomization for using cluster '%s'", cluster)
 template = drenv.template("kustomization.yaml")
-yaml = template.substitute(cluster_name=args.cluster)
+yaml = template.substitute(cluster_name=cluster)
 with open(os.path.join(config["tmp_dir"], "kustomization.yaml"), "w") as f:
     f.write(yaml)
 

--- a/test/basic-test/deploy
+++ b/test/basic-test/deploy
@@ -47,7 +47,7 @@ with open(os.path.join(config["tmp_dir"], "kustomization.yaml"), "w") as f:
 test.info("Deploying busybox example application")
 kubectl.apply(
     f"--kustomize={config['tmp_dir']}",
-    context=config["hub"],
+    context=test.env["hub"],
     log=test.debug,
 )
 
@@ -55,7 +55,7 @@ test.info("waiting for namespace %s", config["namespace"])
 drenv.wait_for(
     f"namespace/{config['namespace']}",
     timeout=60,
-    profile=config["hub"],
+    profile=test.env["hub"],
     log=test.debug,
 )
 
@@ -65,7 +65,7 @@ drenv.wait_for(
     output="jsonpath={.status.phase}",
     namespace=config["namespace"],
     timeout=60,
-    profile=config["hub"],
+    profile=test.env["hub"],
     log=test.debug,
 )
 
@@ -75,7 +75,7 @@ kubectl.wait(
     "--for=jsonpath={.status.phase}=Deployed",
     f"--namespace={config['namespace']}",
     "--timeout=60s",
-    context=config["hub"],
+    context=test.env["hub"],
     log=test.debug,
 )
 
@@ -85,7 +85,7 @@ drenv.wait_for(
     output="jsonpath={.status.lastGroupSyncTime}",
     namespace=config["namespace"],
     timeout=300,
-    profile=config["hub"],
+    profile=test.env["hub"],
     log=test.debug,
 )
 

--- a/test/basic-test/failover
+++ b/test/basic-test/failover
@@ -10,9 +10,15 @@ from drenv import kubectl
 from drenv import test
 
 test.start("failover", __file__)
-test.add_argument("cluster", help="Cluster name to failover to.")
+test.add_argument(
+    "--cluster",
+    help="Cluster name to failover to (default second cluster).",
+)
 args = test.parse_args()
 config = test.config
+
+cluster = args.cluster or test.env["clusters"][1]
+test.info("Failing over to cluster '%s'", cluster)
 
 test.info("Waiting until application is replicated")
 drenv.wait_for(
@@ -25,7 +31,7 @@ drenv.wait_for(
 )
 
 test.info("Starting failover")
-patch = {"spec": {"action": "Failover", "failoverCluster": args.cluster}}
+patch = {"spec": {"action": "Failover", "failoverCluster": cluster}}
 kubectl.patch(
     f"drpc/{config['name']}",
     "--patch",
@@ -56,4 +62,4 @@ drenv.wait_for(
     log=test.debug,
 )
 
-test.info("Application was failed over to cluster %s successfully", args.cluster)
+test.info("Application was failed over to cluster %s successfully", cluster)

--- a/test/basic-test/failover
+++ b/test/basic-test/failover
@@ -26,7 +26,7 @@ drenv.wait_for(
     output="jsonpath={.status.lastGroupSyncTime}",
     namespace=config["namespace"],
     timeout=300,
-    profile=config["hub"],
+    profile=test.env["hub"],
     log=test.debug,
 )
 
@@ -38,7 +38,7 @@ kubectl.patch(
     json.dumps(patch),
     "--type=merge",
     f"--namespace={config['namespace']}",
-    context=config["hub"],
+    context=test.env["hub"],
     log=test.debug,
 )
 
@@ -48,7 +48,7 @@ kubectl.wait(
     "--for=jsonpath={.status.phase}=FailedOver",
     f"--namespace={config['namespace']}",
     "--timeout=300s",
-    context=config["hub"],
+    context=test.env["hub"],
     log=test.debug,
 )
 
@@ -58,7 +58,7 @@ drenv.wait_for(
     output="jsonpath={.status.lastGroupSyncTime}",
     namespace=config["namespace"],
     timeout=300,
-    profile=config["hub"],
+    profile=test.env["hub"],
     log=test.debug,
 )
 

--- a/test/basic-test/relocate
+++ b/test/basic-test/relocate
@@ -10,9 +10,15 @@ from drenv import kubectl
 from drenv import test
 
 test.start("relocate", __file__)
-test.add_argument("cluster", help="Cluster name to relocate to.")
+test.add_argument(
+    "--cluster",
+    help="Cluster name to relocate to (default first cluster).",
+)
 args = test.parse_args()
 config = test.config
+
+cluster = args.cluster or test.env["clusters"][0]
+test.info("Relocate to cluster '%s'", cluster)
 
 test.info("Waiting until peer is ready")
 kubectl.wait(
@@ -35,7 +41,7 @@ drenv.wait_for(
 )
 
 test.info("Starting relocate")
-patch = {"spec": {"action": "Relocate", "preferredCluster": args.cluster}}
+patch = {"spec": {"action": "Relocate", "preferredCluster": cluster}}
 kubectl.patch(
     f"drpc/{config['name']}",
     "--patch",
@@ -68,4 +74,4 @@ kubectl.wait(
     log=test.debug,
 )
 
-test.info("Application was relocated to cluster %s successfully", args.cluster)
+test.info("Application was relocated to cluster %s successfully", cluster)

--- a/test/basic-test/relocate
+++ b/test/basic-test/relocate
@@ -26,7 +26,7 @@ kubectl.wait(
     "--for=condition=PeerReady",
     f"--namespace={config['namespace']}",
     "--timeout=300s",
-    context=config["hub"],
+    context=test.env["hub"],
     log=test.debug,
 )
 
@@ -36,7 +36,7 @@ drenv.wait_for(
     output="jsonpath={.status.lastGroupSyncTime}",
     namespace=config["namespace"],
     timeout=300,
-    profile=config["hub"],
+    profile=test.env["hub"],
     log=test.debug,
 )
 
@@ -48,7 +48,7 @@ kubectl.patch(
     json.dumps(patch),
     "--type=merge",
     f"--namespace={config['namespace']}",
-    context=config["hub"],
+    context=test.env["hub"],
     log=test.debug,
 )
 
@@ -58,7 +58,7 @@ kubectl.wait(
     "--for=jsonpath={.status.phase}=Relocated",
     f"--namespace={config['namespace']}",
     "--timeout=300s",
-    context=config["hub"],
+    context=test.env["hub"],
     log=test.debug,
 )
 
@@ -70,7 +70,7 @@ kubectl.wait(
     "--for=jsonpath={.status.progression}=Completed",
     f"--namespace={config['namespace']}",
     "--timeout=300s",
-    context=config["hub"],
+    context=test.env["hub"],
     log=test.debug,
 )
 

--- a/test/basic-test/run
+++ b/test/basic-test/run
@@ -3,9 +3,9 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-cd $(dirname $0)
+base="$(dirname $0)"
 
-./deploy dr1 "$@"
-./failover dr2 "$@"
-./relocate dr1 "$@"
-./undeploy "$@"
+"$base/deploy" "$@"
+"$base/failover" "$@"
+"$base/relocate" "$@"
+"$base/undeploy" "$@"

--- a/test/basic-test/undeploy
+++ b/test/basic-test/undeploy
@@ -14,7 +14,7 @@ test.info("Deleting busybox example application")
 kubectl.delete(
     "--ignore-not-found",
     f"--kustomize={config['tmp_dir']}",
-    context=config["hub"],
+    context=test.env["hub"],
     log=test.debug,
 )
 

--- a/test/drenv/ramen.py
+++ b/test/drenv/ramen.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import yaml
+
+
+def env_info(filename, name_prefix=None):
+    """
+    Load ramen environment info from drenv environment file.
+    """
+    with open(filename) as f:
+        env = yaml.safe_load(f)
+
+    info = env["ramen"]
+
+    if name_prefix:
+        info["hub"] = name_prefix + info["hub"]
+        info["clusters"] = [name_prefix + cluster for cluster in info["clusters"]]
+
+    return info

--- a/test/drenv/test.py
+++ b/test/drenv/test.py
@@ -45,6 +45,10 @@ def start(name, file, config_file="config.yaml"):
         help="Be more verbose.",
     )
     parser.add_argument(
+        "--name-prefix",
+        help="Prefix profile names",
+    )
+    parser.add_argument(
         "filename",
         help="Environment filename",
     )

--- a/test/drenv/test.py
+++ b/test/drenv/test.py
@@ -8,7 +8,10 @@ import sys
 
 import yaml
 
+from . import ramen
+
 workdir = None
+env = None
 config = None
 log = None
 parser = None
@@ -41,6 +44,10 @@ def start(name, file, config_file="config.yaml"):
         action="store_true",
         help="Be more verbose.",
     )
+    parser.add_argument(
+        "filename",
+        help="Environment filename",
+    )
 
 
 def add_argument(*args, **kw):
@@ -48,10 +55,15 @@ def add_argument(*args, **kw):
 
 
 def parse_args():
+    global env
+
     args = parser.parse_args()
     if args.verbose:
         log.setLevel(logging.DEBUG)
     debug("Parsed arguments: %s", args)
+
+    env = ramen.env_info(args.filename, name_prefix=args.name_prefix)
+    debug("Using environment: %s", env)
 
     debug("Entering directory '%s'", workdir)
     os.chdir(workdir)

--- a/test/drenv/test.py
+++ b/test/drenv/test.py
@@ -8,6 +8,7 @@ import sys
 
 import yaml
 
+workdir = None
 config = None
 log = None
 parser = None
@@ -15,7 +16,7 @@ log_format = "%(asctime)s %(levelname)-7s [%(name)s] %(message)s"
 
 
 def start(name, file, config_file="config.yaml"):
-    global config, parser, log
+    global workdir, config, parser, log
 
     # Setting up logging and sys.excepthook must be first so any failure will
     # be reported using the logger.
@@ -26,10 +27,11 @@ def start(name, file, config_file="config.yaml"):
     # the level to debug.
     logging.basicConfig(level=logging.INFO, format=log_format)
 
-    # Change directory so the test script can run from any directory.
-    os.chdir(os.path.dirname(file))
+    # Working directory for runing the test.
+    workdir = os.path.abspath(os.path.dirname(file))
 
-    with open(config_file) as f:
+    config_path = os.path.join(workdir, config_file)
+    with open(config_path) as f:
         config = yaml.safe_load(f)
 
     parser = argparse.ArgumentParser(name)
@@ -50,6 +52,10 @@ def parse_args():
     if args.verbose:
         log.setLevel(logging.DEBUG)
     debug("Parsed arguments: %s", args)
+
+    debug("Entering directory '%s'", workdir)
+    os.chdir(workdir)
+
     return args
 
 


### PR DESCRIPTION
Use hub and clusters names from the environment file in basic-test, allowing testing
on any clusters and unifying the way we run tools.

Fixes #959 