### PR TITLE
CI: Add nightly build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,10 +7,14 @@
 name: CI
 
 # This workflow will run when developer push a topic branch to their
-# fork in github, minimizing noise for maintainers.
+# fork in github, minimizing noise for maintainers. This
+# workflow also runs on nightly basis at 12:00 AM (00:00 UTC)
+
 on:  # yamllint disable-line rule:truthy
-  - push
-  - pull_request
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 env:
   # Values can be overriden by repository variables.


### PR DESCRIPTION
Build master every night to detect early issues in tools and packages we depend on.

Without this if some tool or package add incompatible change we detect the issue only when someone post a PR, and it is not clear if the issue is caused by the PR or by the system.

Fixes: #566