### PR TITLE
Better errors for missing executable

### DIFF
--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import re
 import subprocess
 from contextlib import contextmanager
 
@@ -183,6 +184,25 @@ print("last", end="", flush=True);
     assert output == ["first second last"]
 
 
+def test_watch_error_missing_executable():
+    cmd = ("no-such-executable-in-path",)
+    output = []
+
+    with pytest.raises(commands.Error) as e:
+        for line in commands.watch(*cmd):
+            output.append(line)
+
+    assert output == []
+
+    assert e.value.command == cmd
+    assert e.value.exitcode is None
+    assert e.value.output is None
+    assert re.match(
+        r"Could not execute: .*'no-such-executable-in-path'.*",
+        e.value.error,
+    )
+
+
 def test_watch_error_empty():
     cmd = ("false",)
     output = []
@@ -246,6 +266,20 @@ def test_run_input():
 def test_run_input_non_ascii():
     output = commands.run("cat", input="\u05d0")
     assert output == "\u05d0"
+
+
+def test_run_error_missing_executable():
+    cmd = ("no-such-executable-in-path",)
+    with pytest.raises(commands.Error) as e:
+        commands.run(*cmd)
+
+    assert e.value.command == cmd
+    assert e.value.exitcode is None
+    assert e.value.output is None
+    assert re.match(
+        r"Could not execute: .*'no-such-executable-in-path'.*",
+        e.value.error,
+    )
 
 
 def test_run_error_empty():


### PR DESCRIPTION
When trying to run a missing executable (e.g. developer forgot to installed a required tool) we logged a generic error that makes it harder to understand and the debug the issue:

    $ addons/velero/start velero
    Deploying velero
    Traceback (most recent call last):
      File "/home/nsoffer/src/ramen/test/addons/velero/start", line 38, in <module>
        deploy(cluster)
      File "/home/nsoffer/src/ramen/test/addons/velero/start", line 16, in deploy
        for line in commands.watch(
      File "/home/nsoffer/src/ramen/test/drenv/commands.py", line 96, in watch
        with subprocess.Popen(
             ^^^^^^^^^^^^^^^^^
      File "/usr/lib64/python3.11/subprocess.py", line 1026, in __init__
        self._execute_child(args, executable, preexec_fn, close_fds,
      File "/usr/lib64/python3.11/subprocess.py", line 1950, in _execute_child
        raise child_exception_type(errno_num, err_msg, err_filename)
    FileNotFoundError: [Errno 2] No such file or directory: 'velero'

There is no information on the code code that failed inside the script, and in particular, the command we tried to run.

This is caused by not handling the error when subprocess.Popen() fail to execute the child process. Now we raise the standard `commands.Error`, preserving the traceback from the underlying error.

Example error with this change:

    $ addons/velero/start velero
    Deploying velero
    Traceback (most recent call last):
      File "/home/nsoffer/src/ramen/test/addons/velero/start", line 38, in <module>
        deploy(cluster)
      File "/home/nsoffer/src/ramen/test/addons/velero/start", line 16, in deploy
        for line in commands.watch(
      File "/home/nsoffer/src/ramen/test/drenv/commands.py", line 119, in watch
        raise Error(args, f"Could not execute: {e}").with_exception(e)
      File "/home/nsoffer/src/ramen/test/drenv/commands.py", line 111, in watch
        p = subprocess.Popen(
            ^^^^^^^^^^^^^^^^^
      File "/usr/lib64/python3.11/subprocess.py", line 1026, in __init__
        self._execute_child(args, executable, preexec_fn, close_fds,
      File "/usr/lib64/python3.11/subprocess.py", line 1950, in _execute_child
        raise child_exception_type(errno_num, err_msg, err_filename)
    drenv.commands.Error: Command failed:
       command: ('velero', 'install', '--provider=aws',
           '--plugins=velero/velero-plugin-for-aws:v1.2.1',
           '--bucket=bucket', '--secret-file=credentials.conf',
           '--use-volume-snapshots=false',
           '--backup-location-config=region=minio,s3ForcePathStyle=true,s3Url=http://192.168.39.8:30000',
           '--kubecontext=velero', '--wait')
       error:
          Could not execute: [Errno 2] No such file or directory: 'velero'