### PR TITLE
Include events in kubectl.wait() and kubectl.rollout() errors

### DIFF
--- a/ramenctl/ramenctl/config.py
+++ b/ramenctl/ramenctl/config.py
@@ -106,19 +106,19 @@ def run(args):
 
     command.info("Waiting until DRClusters phase is available")
     kubectl.wait(
-        "drcluster",
-        "--all",
-        "--for=jsonpath={.status.phase}=Available",
-        f"--namespace={args.ramen_namespace}",
+        resource="drcluster",
+        all=True,
+        condition="jsonpath={.status.phase}=Available",
+        namespace=args.ramen_namespace,
         context=env["hub"],
         log=command.debug,
     )
 
     command.info("Waiting until DRPolicy is validated")
     kubectl.wait(
-        "drpolicy/dr-policy",
-        "--for=condition=Validated",
-        f"--namespace={args.ramen_namespace}",
+        resource="drpolicy/dr-policy",
+        condition="condition=Validated",
+        namespace=args.ramen_namespace,
         context=env["hub"],
         log=command.debug,
     )

--- a/ramenctl/ramenctl/config.py
+++ b/ramenctl/ramenctl/config.py
@@ -25,8 +25,8 @@ def run(args):
     kubectl.rollout(
         "status",
         "deploy/ramen-hub-operator",
-        f"--namespace={args.ramen_namespace}",
-        "--timeout=180s",
+        namespace=args.ramen_namespace,
+        timeout=180,
         context=env["hub"],
         log=command.debug,
     )

--- a/test/addons/cert-manager/start
+++ b/test/addons/cert-manager/start
@@ -20,11 +20,10 @@ def deploy(cluster):
 def wait(cluster):
     print("Waiting until all deployments are available")
     kubectl.wait(
-        "deploy",
-        "--all",
-        "--for=condition=Available",
-        "--namespace=cert-manager",
-        "--timeout=300s",
+        resource="deploy",
+        all=True,
+        condition="condition=Available",
+        namespace="cert-manager",
         context=cluster,
     )
 

--- a/test/addons/csi-addons/start
+++ b/test/addons/csi-addons/start
@@ -28,8 +28,7 @@ def wait(cluster):
     kubectl.rollout(
         "status",
         "deploy/csi-addons-controller-manager",
-        "--namespace=csi-addons-system",
-        "--timeout=300s",
+        namespace="csi-addons-system",
         context=cluster,
     )
 

--- a/test/addons/demo/start
+++ b/test/addons/demo/start
@@ -25,19 +25,14 @@ print("Creating the service")
 kubectl.apply("--filename", "service.yaml", context=cluster)
 
 print("Waiting until deployment is rolled out")
-kubectl.rollout(
-    "status",
-    "deployment",
-    "--timeout=120s",
-    context=cluster,
-)
+kubectl.rollout("status", "deploy/deployment", timeout=120, context=cluster)
 
 print("Waiting until ingress controller deployment is rolled out")
 kubectl.rollout(
     "status",
-    "ingress",
-    "--namespace=ingress-nginx",
-    "--timeout=120s",
+    "deploy/ingress",
+    namespace="ingress-nginx",
+    timeout=120,
     context=cluster,
 )
 

--- a/test/addons/example/start
+++ b/test/addons/example/start
@@ -22,7 +22,7 @@ print("Waiting until example deployment is rolled out")
 kubectl.rollout(
     "status",
     "deploy/example-deployment",
-    "--timeout=180s",
+    timeout=180,
     context=cluster,
 )
 

--- a/test/addons/example/start
+++ b/test/addons/example/start
@@ -28,9 +28,9 @@ kubectl.rollout(
 
 print("waiting until pod is ready")
 kubectl.wait(
-    "pod",
-    "--selector=app=example",
-    "--for=condition=Ready",
-    "--timeout=180s",
+    resource="pod",
+    selector="app=example",
+    condition="condition=Ready",
+    timeout=180,
     context=cluster,
 )

--- a/test/addons/minio/start
+++ b/test/addons/minio/start
@@ -16,13 +16,7 @@ def deploy(cluster):
 
 def wait(cluster):
     print("Waiting until minio is rolled out")
-    kubectl.rollout(
-        "status",
-        "deployment/minio",
-        "--namespace=minio",
-        "--timeout=300s",
-        context=cluster,
-    )
+    kubectl.rollout("status", "deploy/minio", namespace="minio", context=cluster)
 
 
 if len(sys.argv) != 2:

--- a/test/addons/ocm-cluster/start
+++ b/test/addons/ocm-cluster/start
@@ -51,15 +51,9 @@ def deploy(cluster, hub):
 def wait(cluster):
     print("Waiting until deployments are rolled out")
     for addon in ADDONS:
-        deployment = f"deploy/{addon['deployment']}"
-        drenv.wait_for(deployment, namespace=ADDONS_NAMESPACE, profile=cluster)
-        kubectl.rollout(
-            "status",
-            deployment,
-            f"--namespace={ADDONS_NAMESPACE}",
-            "--timeout=300s",
-            context=cluster,
-        )
+        deploy = f"deploy/{addon['deployment']}"
+        drenv.wait_for(deploy, namespace=ADDONS_NAMESPACE, profile=cluster)
+        kubectl.rollout("status", deploy, namespace=ADDONS_NAMESPACE, context=cluster)
 
 
 def wait_for_hub(hub):
@@ -69,15 +63,9 @@ def wait_for_hub(hub):
     drenv.wait_for(f"namespace/{HUB_NAMESPACE}", profile=hub)
 
     for name in HUB_DEPLOYMENTS:
-        deployment = f"deploy/{name}"
-        drenv.wait_for(deployment, namespace=HUB_NAMESPACE, profile=hub)
-        kubectl.rollout(
-            "status",
-            deployment,
-            f"--namespace={HUB_NAMESPACE}",
-            "--timeout=300s",
-            context=hub,
-        )
+        deploy = f"deploy/{name}"
+        drenv.wait_for(deploy, namespace=HUB_NAMESPACE, profile=hub)
+        kubectl.rollout("status", deploy, namespace=HUB_NAMESPACE, context=hub)
 
 
 def join_cluster(cluster, hub):

--- a/test/addons/ocm-cluster/test
+++ b/test/addons/ocm-cluster/test
@@ -18,10 +18,10 @@ def deploy_work(cluster, hub, work):
 def wait_for_work(cluster, hub):
     print(f"Waiting until manifestwork is applied in namespace '{cluster}'")
     kubectl.wait(
-        "manifestwork/example-manifestwork",
-        "--for=condition=applied",
-        f"--namespace={cluster}",
-        "--timeout=120s",
+        resource="manifestwork/example-manifestwork",
+        condition="condition=applied",
+        namespace=cluster,
+        timeout=120,
         context=hub,
     )
 
@@ -29,18 +29,18 @@ def wait_for_work(cluster, hub):
 def wait_for_deployment(cluster, hub):
     print(f"Waiting until manifestwork is available in namespace '{cluster}'")
     kubectl.wait(
-        "manifestwork/example-manifestwork",
-        "--for=condition=available",
-        f"--namespace={cluster}",
-        "--timeout=120s",
+        resource="manifestwork/example-manifestwork",
+        condition="condition=available",
+        namespace=cluster,
+        timeout=120,
         context=hub,
     )
 
     print(f"Waiting until deployment is available in cluster '{cluster}'")
     kubectl.wait(
-        "deploy/example-deployment",
-        "--for=condition=available",
-        "--timeout=120s",
+        resource="deploy/example-deployment",
+        condition="condition=available",
+        timeout=120,
         context=cluster,
     )
 
@@ -53,10 +53,10 @@ def delete_work(cluster, hub, work):
 def wait_for_delete_work(cluster, hub):
     print(f"Waiting until manifestwork is deleted from namspace '{cluster}'")
     kubectl.wait(
-        "manifestwork/example-manifestwork",
-        "--for=delete",
-        f"--namespace={cluster}",
-        "--timeout=120s",
+        resource="manifestwork/example-manifestwork",
+        condition="delete",
+        namespace=cluster,
+        timeout=120,
         context=hub,
     )
 
@@ -64,9 +64,9 @@ def wait_for_delete_work(cluster, hub):
 def wait_for_delete_deployment(cluster):
     print(f"Waiting until deployment is deleted from cluster '{cluster}'")
     kubectl.wait(
-        "deploy/example-deployment",
-        "--for=delete",
-        "--timeout=120s",
+        resource="deploy/example-deployment",
+        condition="delete",
+        timeout=120,
         context=cluster,
     )
 

--- a/test/addons/ocm-controller/start
+++ b/test/addons/ocm-controller/start
@@ -32,8 +32,7 @@ def wait(cluster):
     kubectl.rollout(
         "status",
         "deploy/ocm-controller",
-        "--namespace=open-cluster-management",
-        "--timeout=300s",
+        namespace="open-cluster-management",
         context=cluster,
     )
 

--- a/test/addons/ocm-hub/start
+++ b/test/addons/ocm-hub/start
@@ -59,13 +59,7 @@ def wait(cluster):
         for name in names:
             deployment = f"deploy/{name}"
             drenv.wait_for(deployment, namespace=ns, profile=cluster)
-            kubectl.rollout(
-                "status",
-                deployment,
-                f"--namespace={ns}",
-                "--timeout=300s",
-                context=cluster,
-            )
+            kubectl.rollout("status", deployment, namespace=ns, context=cluster)
 
 
 if len(sys.argv) != 2:

--- a/test/addons/olm/start
+++ b/test/addons/olm/start
@@ -43,9 +43,8 @@ def wait(cluster):
         print(f"Waiting until {operator} is rolled out")
         kubectl.rollout(
             "status",
-            "deploy",
-            operator,
-            f"--namespace={NAMESPACE}",
+            f"deploy/{operator}",
+            namespace=NAMESPACE,
             context=cluster,
         )
 
@@ -67,7 +66,7 @@ def wait(cluster):
     kubectl.rollout(
         "status",
         "deploy/packageserver",
-        f"--namespace={NAMESPACE}",
+        namespace=NAMESPACE,
         context=cluster,
     )
 

--- a/test/addons/olm/start
+++ b/test/addons/olm/start
@@ -29,8 +29,8 @@ def deploy(cluster):
 
     print("Waiting until cdrs are established")
     kubectl.wait(
-        "--for=condition=established",
-        f"--filename={BASE_URL}/crds.yaml",
+        filename=f"{BASE_URL}/crds.yaml",
+        condition="condition=established",
         context=cluster,
     )
 
@@ -57,10 +57,9 @@ def wait(cluster):
         profile=cluster,
     )
     kubectl.wait(
-        "csv/packageserver",
-        f"--namespace={NAMESPACE}",
-        "--for=jsonpath={.status.phase}=Succeeded",
-        "--timeout=300s",
+        resource="csv/packageserver",
+        condition="jsonpath={.status.phase}=Succeeded",
+        namespace=NAMESPACE,
         context=cluster,
     )
 

--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -84,31 +84,25 @@ def configure_rbd_mirroring(cluster, peer_info):
 def wait_until_pool_mirroring_is_healthy(cluster):
     print(f"Waiting until ceph mirror daemon is healthy in cluster '{cluster}'")
     kubectl.wait(
-        "cephblockpools.ceph.rook.io",
-        POOL_NAME,
-        "--for=jsonpath={.status.mirroringStatus.summary.daemon_health}=OK",
-        "--namespace=rook-ceph",
-        "--timeout=300s",
+        resource=f"cephblockpools.ceph.rook.io/{POOL_NAME}",
+        condition="jsonpath={.status.mirroringStatus.summary.daemon_health}=OK",
+        namespace="rook-ceph",
         context=cluster,
     )
 
     print(f"Waiting until ceph mirror is healthy in cluster '{cluster}'")
     kubectl.wait(
-        "cephblockpools.ceph.rook.io",
-        POOL_NAME,
-        "--for=jsonpath={.status.mirroringStatus.summary.health}=OK",
-        "--namespace=rook-ceph",
-        "--timeout=300s",
+        resource=f"cephblockpools.ceph.rook.io/{POOL_NAME}",
+        condition="jsonpath={.status.mirroringStatus.summary.health}=OK",
+        namespace="rook-ceph",
         context=cluster,
     )
 
     print(f"Waiting until ceph mirror image is healthy in cluster '{cluster}'")
     kubectl.wait(
-        "cephblockpools.ceph.rook.io",
-        POOL_NAME,
-        "--for=jsonpath={.status.mirroringStatus.summary.image_health}=OK",
-        "--namespace=rook-ceph",
-        "--timeout=300s",
+        resource=f"cephblockpools.ceph.rook.io/{POOL_NAME}",
+        condition="jsonpath={.status.mirroringStatus.summary.image_health}=OK",
+        namespace="rook-ceph",
         context=cluster,
     )
 

--- a/test/addons/rbd-mirror/test
+++ b/test/addons/rbd-mirror/test
@@ -64,10 +64,9 @@ def test_volume_replication(primary, secondary):
 
     print(f"Waiting until pvc {PVC_NAME} is bound in cluster '{primary}'")
     kubectl.wait(
-        f"pvc/{PVC_NAME}",
-        "--for=jsonpath={.status.phase}=Bound",
-        "--namespace=rook-ceph",
-        "--timeout=300s",
+        resource=f"pvc/{PVC_NAME}",
+        condition="jsonpath={.status.phase}=Bound",
+        namespace="rook-ceph",
         context=primary,
     )
 
@@ -80,19 +79,17 @@ def test_volume_replication(primary, secondary):
 
     print(f"Waiting until vr vr-sample is completed in cluster '{primary}'")
     kubectl.wait(
-        "volumereplication/vr-sample",
-        "--for=condition=Completed",
-        "--namespace=rook-ceph",
-        "--timeout=300s",
+        resource="volumereplication/vr-sample",
+        condition="condition=Completed",
+        namespace="rook-ceph",
         context=primary,
     )
 
     print(f"Waiting until vr vr-sample state is primary in cluster '{primary}'")
     kubectl.wait(
-        "volumereplication/vr-sample",
-        "--for=jsonpath={.status.state}=Primary",
-        "--namespace=rook-ceph",
-        "--timeout=300s",
+        resource="volumereplication/vr-sample",
+        condition="jsonpath={.status.state}=Primary",
+        namespace="rook-ceph",
         context=primary,
     )
 

--- a/test/addons/rook-cluster/start
+++ b/test/addons/rook-cluster/start
@@ -32,10 +32,9 @@ def wait(cluster):
         profile=cluster,
     )
     kubectl.wait(
-        "cephcluster/my-cluster",
-        "--for=jsonpath={.status.phase}=Ready",
-        "--namespace=rook-ceph",
-        "--timeout=300s",
+        resource="cephcluster/my-cluster",
+        condition="jsonpath={.status.phase}=Ready",
+        namespace="rook-ceph",
         context=cluster,
     )
 

--- a/test/addons/rook-operator/start
+++ b/test/addons/rook-operator/start
@@ -28,8 +28,7 @@ def wait(cluster):
     kubectl.rollout(
         "status",
         "deploy/rook-ceph-operator",
-        "--namespace=rook-ceph",
-        "--timeout=300s",
+        namespace="rook-ceph",
         context=cluster,
     )
 

--- a/test/addons/rook-operator/start
+++ b/test/addons/rook-operator/start
@@ -35,11 +35,10 @@ def wait(cluster):
 
     print("Waiting until rook ceph operator is ready")
     kubectl.wait(
-        "pod",
-        "--for=jsonpath={.status.phase}=Running",
-        "--namespace=rook-ceph",
-        "--selector=app=rook-ceph-operator",
-        "--timeout=300s",
+        resource="pod",
+        selector="app=rook-ceph-operator",
+        condition="jsonpath={.status.phase}=Running",
+        namespace="rook-ceph",
         context=cluster,
     )
 

--- a/test/addons/rook-pool/start
+++ b/test/addons/rook-pool/start
@@ -29,19 +29,17 @@ def wait(cluster):
         profile=cluster,
     )
     kubectl.wait(
-        "cephblockpool/replicapool",
-        "--for=jsonpath={.status.phase}=Ready",
-        "--namespace=rook-ceph",
-        "--timeout=300s",
+        resource="cephblockpool/replicapool",
+        condition="jsonpath={.status.phase}=Ready",
+        namespace="rook-ceph",
         context=cluster,
     )
 
     print("Waiting for replica pool peer token")
     kubectl.wait(
-        "cephblockpool/replicapool",
-        "--for=jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}=pool-peer-token-replicapool",
-        "--namespace=rook-ceph",
-        "--timeout=300s",
+        resource="cephblockpool/replicapool",
+        condition="jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}=pool-peer-token-replicapool",
+        namespace="rook-ceph",
         context=cluster,
     )
 

--- a/test/addons/rook-toolbox/start
+++ b/test/addons/rook-toolbox/start
@@ -23,8 +23,7 @@ def wait(cluster):
     kubectl.rollout(
         "status",
         "deploy/rook-ceph-tools",
-        "--namespace=rook-ceph",
-        "--timeout=300s",
+        namespace="rook-ceph",
         context=cluster,
     )
 

--- a/test/addons/submariner/start
+++ b/test/addons/submariner/start
@@ -78,8 +78,8 @@ def wait_for_deployments(cluster, names, namespace):
         kubectl.rollout(
             "status",
             deployment,
-            f"--namespace={namespace}",
-            "--timeout=180s",
+            namespace=namespace,
+            timeout=180,
             context=cluster,
         )
 

--- a/test/addons/submariner/test
+++ b/test/addons/submariner/test
@@ -95,10 +95,10 @@ def wait_for_delete(namespace, dst, src):
 def wait_for_service(cluster, namespace):
     print(f"Waiting until '{SERVICE}' is rolled out in cluster '{cluster}'")
     kubectl.wait(
-        f"deploy/{SERVICE}",
-        "--for=condition=Available",
-        f"--namespace={namespace}",
-        "--timeout=120s",
+        resource=f"deploy/{SERVICE}",
+        condition="condition=Available",
+        namespace=namespace,
+        timeout=120,
         context=cluster,
     )
 
@@ -106,10 +106,10 @@ def wait_for_service(cluster, namespace):
 def wait_for_pod(cluster, namespace):
     print(f"Waiting until test pod is ready in cluster '{cluster}'")
     kubectl.wait(
-        "pod/test",
-        "--for=condition=Ready",
-        f"--namespace={namespace}",
-        "--timeout=120s",
+        resource="pod/test",
+        condition="condition=Ready",
+        namespace=namespace,
+        timeout=120,
         context=cluster,
     )
 
@@ -127,10 +127,10 @@ def unexport_service(cluster, namespace):
 def wait_for_service_export(cluster, namespace):
     print(f"Waiting for service in namespace '{namespace}' in cluster '{cluster}'")
     kubectl.wait(
-        f"serviceexports/{SERVICE}",
-        "--for=condition=Synced=True",
-        f"--namespace={namespace}",
-        "--timeout=120s",
+        resource=f"serviceexports/{SERVICE}",
+        condition="condition=Synced=True",
+        namespace=namespace,
+        timeout=120,
         context=cluster,
     )
     exports = kubectl.describe(

--- a/test/addons/velero/test
+++ b/test/addons/velero/test
@@ -23,8 +23,8 @@ def test(cluster):
     kubectl.rollout(
         "status",
         "deploy/nginx-deployment",
-        "--namespace=nginx-example",
-        "--timeout=180s",
+        namespace="nginx-example",
+        timeout=180,
         context=cluster,
     )
 
@@ -46,8 +46,8 @@ def test(cluster):
     kubectl.rollout(
         "status",
         "deploy/nginx-deployment",
-        "--namespace=nginx-example",
-        "--timeout=120s",
+        namespace="nginx-example",
+        timeout=120,
         context=cluster,
     )
 

--- a/test/addons/volsync/start
+++ b/test/addons/volsync/start
@@ -49,8 +49,7 @@ def wait_for_deployment(cluster):
     kubectl.rollout(
         "status",
         f"deploy/{DEPLOYMENT}",
-        f"--namespace={NAMESPACE}",
-        "--timeout=300s",
+        namespace=NAMESPACE,
         context=cluster,
     )
 

--- a/test/addons/volsync/test
+++ b/test/addons/volsync/test
@@ -33,8 +33,8 @@ def wait_for_application(cluster):
     kubectl.rollout(
         "status",
         f"deploy/{DEPLOY}",
-        f"--namespace={NAMESPACE}",
-        "--timeout=120s",
+        namespace=NAMESPACE,
+        timeout=120,
         context=cluster,
     )
 

--- a/test/addons/volsync/test
+++ b/test/addons/volsync/test
@@ -44,10 +44,10 @@ def wait_for_replication_destination(cluster):
         f"Waiting until replication destination is synchronizing in cluster '{cluster}'"
     )
     kubectl.wait(
-        "replicationdestination/busybox-dst",
-        "--for=condition=Synchronizing=True",
-        f"--namespace={NAMESPACE}",
-        "--timeout=120s",
+        resource="replicationdestination/busybox-dst",
+        condition="condition=Synchronizing=True",
+        namespace=NAMESPACE,
+        timeout=120,
         context=cluster,
     )
 
@@ -81,10 +81,10 @@ def setup_replication_service(cluster1, cluster2):
 
     print(f"Waiting until service export is synced in cluster '{cluster2}'")
     kubectl.wait(
-        f"serviceexports/{VOLSYNC_SERVICE}",
-        "--for=condition=Synced=True",
-        f"--namespace={NAMESPACE}",
-        "--timeout=120s",
+        resource=f"serviceexports/{VOLSYNC_SERVICE}",
+        condition="condition=Synced=True",
+        namespace=NAMESPACE,
+        timeout=120,
         context=cluster2,
     )
 
@@ -116,10 +116,10 @@ def run_replication(cluster):
 
     print(f"Waiting until replication is completed in cluster '{cluster}'")
     kubectl.wait(
-        "replicationsource/busybox-src",
-        "--for=jsonpath={.status.lastManualSync}=replication-1",
-        f"--namespace={NAMESPACE}",
-        "--timeout=120s",
+        resource="replicationsource/busybox-src",
+        condition="jsonpath={.status.lastManualSync}=replication-1",
+        namespace=NAMESPACE,
+        timeout=120,
         context=cluster,
     )
     out = kubectl.get(

--- a/test/basic-test/deploy
+++ b/test/basic-test/deploy
@@ -84,7 +84,6 @@ drenv.wait_for(
     f"drpc/{config['name']}",
     output="jsonpath={.status.lastGroupSyncTime}",
     namespace=config["namespace"],
-    timeout=300,
     profile=test.env["hub"],
     log=test.debug,
 )

--- a/test/basic-test/deploy
+++ b/test/basic-test/deploy
@@ -71,10 +71,10 @@ drenv.wait_for(
 
 test.info("Waiting until busybox drpc is deployed")
 kubectl.wait(
-    f"drpc/{config['name']}",
-    "--for=jsonpath={.status.phase}=Deployed",
-    f"--namespace={config['namespace']}",
-    "--timeout=60s",
+    resource=f"drpc/{config['name']}",
+    condition="jsonpath={.status.phase}=Deployed",
+    namespace=config["namespace"],
+    timeout=60,
     context=test.env["hub"],
     log=test.debug,
 )

--- a/test/basic-test/failover
+++ b/test/basic-test/failover
@@ -25,7 +25,6 @@ drenv.wait_for(
     f"drpc/{config['name']}",
     output="jsonpath={.status.lastGroupSyncTime}",
     namespace=config["namespace"],
-    timeout=300,
     profile=test.env["hub"],
     log=test.debug,
 )
@@ -57,7 +56,6 @@ drenv.wait_for(
     f"drpc/{config['name']}",
     output="jsonpath={.status.lastGroupSyncTime}",
     namespace=config["namespace"],
-    timeout=300,
     profile=test.env["hub"],
     log=test.debug,
 )

--- a/test/basic-test/failover
+++ b/test/basic-test/failover
@@ -43,10 +43,9 @@ kubectl.patch(
 
 test.info("Waiting until application is failed over...")
 kubectl.wait(
-    f"drpc/{config['name']}",
-    "--for=jsonpath={.status.phase}=FailedOver",
-    f"--namespace={config['namespace']}",
-    "--timeout=300s",
+    resource=f"drpc/{config['name']}",
+    condition="jsonpath={.status.phase}=FailedOver",
+    namespace=config["namespace"],
     context=test.env["hub"],
     log=test.debug,
 )

--- a/test/basic-test/relocate
+++ b/test/basic-test/relocate
@@ -35,7 +35,6 @@ drenv.wait_for(
     f"drpc/{config['name']}",
     output="jsonpath={.status.lastGroupSyncTime}",
     namespace=config["namespace"],
-    timeout=300,
     profile=test.env["hub"],
     log=test.debug,
 )

--- a/test/basic-test/relocate
+++ b/test/basic-test/relocate
@@ -22,10 +22,9 @@ test.info("Relocate to cluster '%s'", cluster)
 
 test.info("Waiting until peer is ready")
 kubectl.wait(
-    f"drpc/{config['name']}",
-    "--for=condition=PeerReady",
-    f"--namespace={config['namespace']}",
-    "--timeout=300s",
+    resource=f"drpc/{config['name']}",
+    condition="condition=PeerReady",
+    namespace=config["namespace"],
     context=test.env["hub"],
     log=test.debug,
 )
@@ -53,10 +52,9 @@ kubectl.patch(
 
 test.info("Waiting until application is relocated...")
 kubectl.wait(
-    f"drpc/{config['name']}",
-    "--for=jsonpath={.status.phase}=Relocated",
-    f"--namespace={config['namespace']}",
-    "--timeout=300s",
+    resource=f"drpc/{config['name']}",
+    condition="jsonpath={.status.phase}=Relocated",
+    namespace=config["namespace"],
     context=test.env["hub"],
     log=test.debug,
 )
@@ -65,10 +63,9 @@ kubectl.wait(
 # after relocate complete before we delete the app.
 test.info("Waiting until relocation completes...")
 kubectl.wait(
-    f"drpc/{config['name']}",
-    "--for=jsonpath={.status.progression}=Completed",
-    f"--namespace={config['namespace']}",
-    "--timeout=300s",
+    resource=f"drpc/{config['name']}",
+    condition="jsonpath={.status.progression}=Completed",
+    namespace=config["namespace"],
     context=test.env["hub"],
     log=test.debug,
 )

--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -20,11 +20,12 @@ _PIPE_BUF = 4096 if platform.system() == "Linux" else 512
 class Error(Exception):
     INDENT = 3 * " "
 
-    def __init__(self, command, error, exitcode=None, output=None):
+    def __init__(self, command, error, exitcode=None, output=None, events=None):
         self.command = command
         self.error = error
         self.exitcode = exitcode
         self.output = output
+        self.events = events
 
     def with_exception(self, exc):
         """
@@ -48,6 +49,10 @@ class Error(Exception):
         if self.output:
             output = self._indent(self.output.rstrip())
             lines.append(self._indent(f"output:\n{output}\n"))
+
+        if self.events:
+            events = self._indent(self.events.rstrip())
+            lines.append(self._indent(f"events:\n{events}\n"))
 
         error = self._indent(self.error.rstrip())
         lines.append(self._indent(f"error:\n{error}\n"))

--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -290,6 +290,7 @@ def test_run_error_empty():
     assert e.value.exitcode == 1
     assert e.value.output == ""
     assert e.value.error == ""
+    assert e.value.events is None
 
 
 def test_run_error():
@@ -302,6 +303,7 @@ def test_run_error():
     assert e.value.exitcode == 1
     assert e.value.error == "error"
     assert e.value.output == "output"
+    assert e.value.events is None
 
 
 def test_run_non_ascii():
@@ -346,6 +348,27 @@ Command failed:
    output:
       out 1
       out 2
+   error:
+      err 1
+      err 2
+"""
+    assert str(e) == expected
+
+
+def test_error_with_events():
+    e = commands.Error(
+        ("arg1", "arg2"),
+        exitcode=3,
+        error="err 1\nerr 2\n",
+        events="event 1\nevent 2\n",
+    )
+    expected = """\
+Command failed:
+   command: ('arg1', 'arg2')
+   exitcode: 3
+   events:
+      event 1
+      event 2
    error:
       err 1
       err 2

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -45,6 +45,16 @@ def exec(*args, context=None):
     return _run("exec", *args, context=context)
 
 
+def events(resource, namespace=None, context=None):
+    """
+    Run kubectl events ... and return the output.
+    """
+    args = [resource]
+    if namespace:
+        args.append(f"--namespace={namespace}")
+    return _run("events", *args, context=context)
+
+
 def apply(*args, input=None, context=None, log=print):
     """
     Run kubectl apply ... logging progress messages.

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -83,10 +83,33 @@ def rollout(*args, context=None, log=print):
     _watch("rollout", *args, context=context, log=log)
 
 
-def wait(*args, context=None, log=print):
+def wait(
+    resource=None,
+    all=False,
+    selector=None,
+    filename=None,
+    condition=None,
+    namespace=None,
+    timeout=300,
+    context=None,
+    log=print,
+):
     """
     Run kubectl wait ... logging progress messages.
     """
+    args = [f"--timeout={timeout}s"]
+    if resource:
+        args.append(resource)
+    if all:
+        args.append("--all")
+    if selector:
+        args.append(f"--selector={selector}")
+    if filename:
+        args.append(f"--filename={filename}")
+    if condition:
+        args.append(f"--for={condition}")
+    if namespace:
+        args.append(f"--namespace={namespace}")
     _watch("wait", *args, context=context, log=log)
 
 

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -76,10 +76,13 @@ def delete(*args, input=None, context=None, log=print):
     _watch("delete", *args, input=input, context=context, log=log)
 
 
-def rollout(*args, context=None, log=print):
+def rollout(action, resource, timeout=300, namespace=None, context=None, log=print):
     """
     Run kubectl rollout ... logging progress messages.
     """
+    args = [action, resource, f"--timeout={timeout}s"]
+    if namespace:
+        args.append(f"--namespace={namespace}")
     _watch("rollout", *args, context=context, log=log)
 
 

--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -60,9 +60,9 @@ def test_rollout(tmpenv, capsys):
 
 def test_wait(tmpenv, capsys):
     kubectl.wait(
-        "deploy/example-deployment",
-        "--for=condition=available",
-        f"--timeout={TIMEOUT}s",
+        resource="deploy/example-deployment",
+        condition="condition=available",
+        timeout=TIMEOUT,
         context=tmpenv.profile,
     )
     out, err = capsys.readouterr()

--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -41,6 +41,11 @@ def test_exec(tmpenv):
     assert out.startswith("example-deployment-")
 
 
+def test_events(tmpenv):
+    out = kubectl.events("deploy/example-deployment", context=tmpenv.profile)
+    assert out != ""
+
+
 def test_apply(tmpenv, capsys):
     kubectl.apply(f"--filename={EXAMPLE_DEPLOYMENT}", context=tmpenv.profile)
     out, err = capsys.readouterr()

--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -51,7 +51,7 @@ def test_rollout(tmpenv, capsys):
     kubectl.rollout(
         "status",
         "deploy/example-deployment",
-        f"--timeout={TIMEOUT}s",
+        timeout=TIMEOUT,
         context=tmpenv.profile,
     )
     out, err = capsys.readouterr()


### PR DESCRIPTION
Most errors are timeouts, and kubectl error is not helpful. Try to include relevant events in the errors to help debugging the issue.

Changes:
- change `kubectl.wait()` and `kubectl.rollout()` signature so we know what is the resource waited for
- add `kubectl.events()` wrapper
- support optional events in `commands.Error`
- try to add events to kubecl.wait() and kubectl.rollout() errors

Example of error with events:

```
drenv.commands.Error: Command failed:
   command: ('kubectl', 'wait', '--context', 'dr1', 'deploy/nginx', '--for=condition=Available',
             '--namespace=ns1', '--timeout=120s')
   exitcode: 1
   error:
      error: timed out waiting for the condition on deployments/nginx
   events:
      LAST SEEN              TYPE      REASON    OBJECT                       MESSAGE
      36m (x27 over 151m)    Warning   Failed    Pod/nginx-7f456874f4-kqljw   Failed to pull
      image "nginx": rpc error: code = Unknown desc = failed to pull and unpack image
          "docker.io/library/nginx:latest": ...: 429 Too Many Requests - Server message:
          toomanyrequests: You have reached your pull rate limit. You may increase the limit by
          authenticating and upgrading: https://www.docker.com/increase-rate-limit
      26m (x29 over 151m)    Normal    Pulling   Pod/nginx-7f456874f4-kqljw   Pulling image "nginx"
      85s (x648 over 151m)   Normal    BackOff   Pod/nginx-7f456874f4-kqljw   Back-off pulling image "nginx"
```