### PR TITLE
Optimize image pulls

### DIFF
--- a/test/addons/demo/deployment.yaml
+++ b/test/addons/demo/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: demo
-        image: docker.io/library/nginx:stable
+        image: docker.io/library/nginx:stable-alpine-slim
         ports:
         - containerPort: 80
           name: demo-port

--- a/test/addons/submariner/base/dst/deploy.yaml
+++ b/test/addons/submariner/base/dst/deploy.yaml
@@ -18,7 +18,7 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: nginx
+      - image: docker.io/library/nginx:stable-alpine-slim
         name: nginx
         ports:
         - containerPort: 80

--- a/test/addons/submariner/base/src/pod.yaml
+++ b/test/addons/submariner/base/src/pod.yaml
@@ -10,7 +10,8 @@ metadata:
 spec:
   containers:
     - name: test
-      image: quay.io/submariner/nettest
+      # NOTE: keep in sync with start:VERSION.
+      image: quay.io/submariner/nettest:0.15.2
       command:
         - sh
         - -c

--- a/test/addons/submariner/start
+++ b/test/addons/submariner/start
@@ -11,6 +11,8 @@ from drenv import cluster as drenv_cluster
 from drenv import kubectl
 from drenv import subctl
 
+VERSION = "0.15.2"
+
 NAMESPACE = "submariner-operator"
 
 BROKER_DEPLOYMENTS = ("submariner-operator",)
@@ -33,7 +35,12 @@ def deploy_broker(broker):
     os.makedirs(broker_dir, exist_ok=True)
 
     print(f"Deploying submariner broker in cluster '{broker}'")
-    subctl.deploy_broker(broker, globalnet=True, broker_info=broker_info)
+    subctl.deploy_broker(
+        broker,
+        globalnet=True,
+        broker_info=broker_info,
+        version=VERSION,
+    )
     print(f"Broker info stored in '{broker_info}'")
 
     print(f"Waiting for submariner broker deployments in cluster '{broker}'")
@@ -47,7 +54,13 @@ def join_cluster(cluster, broker_info):
     drenv_cluster.wait_until_ready(cluster)
 
     print(f"Joining cluster '{cluster}' to broker")
-    subctl.join(broker_info, context=cluster, clusterid=cluster, cable_driver="vxlan")
+    subctl.join(
+        broker_info,
+        context=cluster,
+        clusterid=cluster,
+        cable_driver="vxlan",
+        version=VERSION,
+    )
 
 
 def wait_for_cluster(cluster):

--- a/test/addons/velero/nginx.yaml
+++ b/test/addons/velero/nginx.yaml
@@ -32,7 +32,7 @@ spec:
         app: nginx
     spec:
       containers:
-      - image: nginx:1.17.6
+      - image: docker.io/library/nginx:stable-alpine-slim
         name: nginx
         ports:
         - containerPort: 80

--- a/test/addons/volsync/source/deploy.yaml
+++ b/test/addons/volsync/source/deploy.yaml
@@ -20,7 +20,7 @@ spec:
         appname: busybox
     spec:
       containers:
-      - image: docker.io/library/busybox:latest
+      - image: docker.io/library/busybox:stable
         imagePullPolicy: IfNotPresent
         name: busybox
         command:

--- a/test/drenv/minikube.py
+++ b/test/drenv/minikube.py
@@ -5,6 +5,16 @@ import logging
 
 from . import commands
 
+EXTRA_CONFIG = [
+    # When enabled, tells the Kubelet to pull images one at a time. This slows
+    # down concurrent image pulls and cause timeouts when using slow network.
+    # Defaults to true becasue it is not safe with docker daemon with version
+    # < 1.9 or an Aufs storage backend.
+    # https://github.com/kubernetes/kubernetes/issues/10959
+    # Speeds up regional-dr start by 20%.
+    "kubelet.serialize-image-pulls=false"
+]
+
 
 def profile(command, output=None):
     return _run("profile", command, output=output)
@@ -54,9 +64,14 @@ def start(
         args.extend(("--addons", ",".join(addons)))
     if service_cluster_ip_range:
         args.extend(("--service-cluster-ip-range", service_cluster_ip_range))
+
+    for pair in EXTRA_CONFIG:
+        args.extend(("--extra-config", pair))
+
     if extra_config:
         for pair in extra_config:
             args.extend(("--extra-config", pair))
+
     if alsologtostderr:
         args.append("--alsologtostderr")
 

--- a/test/drenv/subctl.py
+++ b/test/drenv/subctl.py
@@ -8,7 +8,7 @@ from . import commands
 BROKER_INFO = "broker-info.subm"
 
 
-def deploy_broker(context, globalnet=False, broker_info=None, log=print):
+def deploy_broker(context, globalnet=False, broker_info=None, version=None, log=print):
     """
     Run subctl deploy-broker ... logging progress messages.
 
@@ -18,6 +18,8 @@ def deploy_broker(context, globalnet=False, broker_info=None, log=print):
     args = ["deploy-broker", "--context", context]
     if globalnet:
         args.append("--globalnet")
+    if version:
+        args.append(f"--version={version}")
 
     _watch(*args, log=log)
 
@@ -25,13 +27,15 @@ def deploy_broker(context, globalnet=False, broker_info=None, log=print):
         shutil.move(BROKER_INFO, broker_info)
 
 
-def join(broker_info, context, clusterid, cable_driver=None, log=print):
+def join(broker_info, context, clusterid, cable_driver=None, version=None, log=print):
     """
     Run subctl join ... logging progress messages.
     """
     args = ["join", broker_info, "--context", context, "--clusterid", clusterid]
     if cable_driver:
         args.extend(("--cable-driver", cable_driver))
+    if version:
+        args.append(f"--version={version}")
     _watch(*args, log=log)
 
 


### PR DESCRIPTION
Optimize images pulls, hopefully eliminating the deploy timeouts we see recently.

- Enable parallel image pulls, speeding up `drenv start envs/regional-dr.yaml` by 20%
- Use same nginx image everywhere, switching to stable-alipne-slim version which is 13 times smaller (5 MiB vs 67 MiB)
- Use same busybox image
- Pin submariner version and use same nettest image

With all changes I see up to 30% speed up in `drenv start envs/regional-dr.yaml` - 490 seconds vs 640 seconds.