### PR TITLE
Fix waiting for volsync replication

### DIFF
--- a/test/addons/volsync/test
+++ b/test/addons/volsync/test
@@ -105,6 +105,15 @@ def run_replication(cluster):
     print(f"Creating replication source in cluster '{cluster}'")
     kubectl.apply("--filename", "source/replication-src.yaml", context=cluster)
 
+    print(f"Waiting until replication source reports sync status in '{cluster}'")
+    drenv.wait_for(
+        "replicationsource/busybox-src",
+        output="jsonpath={.status.lastManualSync}",
+        namespace=NAMESPACE,
+        timeout=60,
+        profile=cluster,
+    )
+
     print(f"Waiting until replication is completed in cluster '{cluster}'")
     kubectl.wait(
         "replicationsource/busybox-src",

--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -37,13 +37,15 @@ def wait_for(
     if namespace:
         args.extend(("--namespace", namespace))
 
-    deadline = time.monotonic() + timeout
-    delay = min(1.0, timeout / 60)
+    start = time.monotonic()
+    deadline = start + timeout
+    delay = min(0.1, timeout / 60)
 
     while True:
         out = kubectl.get(*args, context=profile)
         if out:
-            log(f"{resource} exists")
+            elapsed = time.monotonic() - start
+            log(f"{resource} outuput={output} found in {elapsed:.2f} seconds")
             return out
 
         if time.monotonic() > deadline:


### PR DESCRIPTION
We waited on `.status.lastManualSync` right after creating the replication source, but there is a small window where status is not reported, and the wait fails with:

    drenv.commands.Error: Command failed:
       command: ('kubectl', 'wait', '--context', 'dr1', 'replicationsource/busybox-src',
               '--for=jsonpath={.status.lastManualSync}=replication-1', '--namespace=busybox',
               '--timeout=120s')
       exitcode: 1
       error:
          error: status is not found

Now wait until `status` is reported before waiting on `lastManualSync`.

Reported-by: Travis Janssen <tjanssen@redhat.com>