### PR TITLE
Add ramen cloud credentials secret in managed clusters

### DIFF
--- a/ramenctl/ramenctl/config.py
+++ b/ramenctl/ramenctl/config.py
@@ -32,9 +32,10 @@ def run(args):
     )
 
     command.info("Creating s3 secret in ramen hub namespace")
+    template = drenv.template(command.resource("ramen-s3-secret.yaml"))
     kubectl.apply(
-        "--filename",
-        command.resource("ramen-s3-secret.yaml"),
+        "--filename=-",
+        input=template.substitute(namespace=args.ramen_namespace),
         context=env["hub"],
         log=command.debug,
     )
@@ -47,6 +48,7 @@ def run(args):
         cluster2=env["clusters"][1],
         minio_url_cluster1=minio.service_url(env["clusters"][0]),
         minio_url_cluster2=minio.service_url(env["clusters"][1]),
+        namespace=args.ramen_namespace,
     )
     kubectl.apply(
         "--filename=-",

--- a/ramenctl/ramenctl/resources/cloud-credentials-secret.yaml
+++ b/ramenctl/ramenctl/resources/cloud-credentials-secret.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: cloud-credentials
+  namespace: $namespace
+data:
+  cloud: $cloud

--- a/ramenctl/ramenctl/resources/configmap.yaml
+++ b/ramenctl/ramenctl/resources/configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     cluster.open-cluster-management.io/backup: resource
   name: ramen-hub-operator-config
-  namespace: ramen-system
+  namespace: $namespace
 data:
   ramen_manager_config.yaml: |
     apiVersion: ramendr.openshift.io/v1alpha1

--- a/ramenctl/ramenctl/resources/ramen-s3-secret.yaml
+++ b/ramenctl/ramenctl/resources/ramen-s3-secret.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ramen-s3-secret
-  namespace: ramen-system
+  namespace: $namespace
 stringData:
   AWS_ACCESS_KEY_ID: minio
   AWS_SECRET_ACCESS_KEY: minio123

--- a/ramenctl/ramenctl/unconfig.py
+++ b/ramenctl/ramenctl/unconfig.py
@@ -47,3 +47,16 @@ def run(args):
         context=env["hub"],
         log=command.debug,
     )
+
+    template = drenv.template(command.resource("cloud-credentials-secret.yaml"))
+    yaml = template.substitute(cloud="", namespace=args.ramen_namespace)
+
+    for cluster in env["clusters"]:
+        command.info("Deleting cloud credentials secret in cluster '%s'", cluster)
+        kubectl.delete(
+            "--filename=-",
+            "--ignore-not-found",
+            input=yaml,
+            context=cluster,
+            log=command.debug,
+        )

--- a/ramenctl/ramenctl/unconfig.py
+++ b/ramenctl/ramenctl/unconfig.py
@@ -39,10 +39,11 @@ def run(args):
     # We keep the ramen config map since we do not own it.
 
     command.info("Deleting s3 secret in ramen hub namespace")
+    template = drenv.template(command.resource("ramen-s3-secret.yaml"))
     kubectl.delete(
-        "--filename",
-        command.resource("ramen-s3-secret.yaml"),
+        "--filename=-",
         "--ignore-not-found",
+        input=template.substitute(namespace=args.ramen_namespace),
         context=env["hub"],
         log=command.debug,
     )


### PR DESCRIPTION
We configured ramen to access velero cloud-credentials secret:

    veleroNamespaceSecretKeyRef:
      key: cloud
      name: cloud-credentials

Using the secret created by `velero install`. However this secret is installed in `velero` namespace and we need it in `ramen-system` namespace.