### PR TITLE
Document tested versions of the tools

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -28,22 +28,26 @@ environment.
    ```
 
    You need `minikube` version supporting the `--extra-disks` option.
-   The tool was tested with `minikube` v1.26.1.
+   Tested with version  v1.30.1.
 
-1. Install the kubectl tool. See
+1. Install the `kubectl` tool. See
    [Install and Set Up kubectl on Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
+   Tested with version v1.27.3.
 
 1. Install `clusteradm` tool. See
    [Install clusteradm CLI tool](https://open-cluster-management.io/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool)
-   for the details. Version 0.5.0 or later is required.
+   for the details.
+   Version v0.5.0 or later is required, tested with v0.6.0.
 
 1. Install `subctl` tool, See
    [Submariner subctl installation](https://submariner.io/operations/deployment/subctl/)
-   for the details. Version v0.15.1 was tested with drenv.
+   for the details.
+   Tested with version v0.15.2.
 
 1. Install the `velero` tool. See
    [Velero Basic Install](https://velero.io/docs/v1.11/basic-install/)
-   for the details. Version 1.9.3 or later is required.
+   for the details.
+   Version v1.9.3 or later is required, tested with version v1.11.0.
 
 1. Install `helm` tool - on Fedora you can use:
 
@@ -52,6 +56,7 @@ environment.
    ```
 
    See [Installing Helm](https://helm.sh/docs/intro/install/) for other options.
+   Tested with version v3.11.
 
 1. Install `docker`
 


### PR DESCRIPTION
Knowing which version was tested makes it easier to build a working test environment. Unfortunately we need to update the version each time tools are updated.