### PR TITLE
Use setup-go@v3 to avoid golangci-lint error: "Cannot open: File exists"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -189,7 +189,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -232,7 +232,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -346,7 +346,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
 


### PR DESCRIPTION
Changing the version of setup-go to v3
as the v4 version is leading to errors such as:

Cache Size: ~633 MB (663986965 B)
/usr/bin/tar -xf /home/runner/work/_temp/c621c0af-3135-4a1c-9118-
827d7db5e99b/cache.tzst -P -C /home/runner/work/ramen/ramen
--use-compress-program unzstd

Error: /usr/bin/tar: ../../../go/pkg/mod/sigs.k8s.io/yaml@v1.3.0/
yaml_test.go: Cannot open: File exists

Builds with the error:
- [15198188098](https://github.com/RamenDR/ramen/actions/runs/5609830827/job/15198188098#step:4:28)

Fixes: #993