### PR TITLE
Fix random failures in drenv tests on github

### DIFF
--- a/test/addons/example/start
+++ b/test/addons/example/start
@@ -17,3 +17,11 @@ cluster = sys.argv[1]
 
 print("Deploying example")
 kubectl.apply("--filename", "deployment.yaml", context=cluster)
+
+print("Waiting until example deployment is rolled out")
+kubectl.rollout(
+    "status",
+    "deploy/example-deployment",
+    "--timeout=180s",
+    context=cluster,
+)

--- a/test/addons/example/start
+++ b/test/addons/example/start
@@ -25,3 +25,12 @@ kubectl.rollout(
     "--timeout=180s",
     context=cluster,
 )
+
+print("waiting until pod is ready")
+kubectl.wait(
+    "pod",
+    "--selector=app=example",
+    "--for=condition=Ready",
+    "--timeout=180s",
+    context=cluster,
+)

--- a/test/addons/example/test
+++ b/test/addons/example/test
@@ -16,9 +16,8 @@ os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 print("Testing example deployment")
-kubectl.rollout(
-    "status",
-    "deploy/example-deployment",
-    "--timeout=180s",
-    context=cluster,
-)
+hostname = kubectl.exec(
+    "deploy/example-deployment", "--", "hostname", context=cluster
+).rstrip()
+if not hostname.startswith("example-deployment-"):
+    raise RuntimeError(f"Unexpected hostname: '{hostname}'")

--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -9,6 +9,9 @@ from drenv import kubectl
 
 EXAMPLE_DEPLOYMENT = os.path.join("addons", "example", "deployment.yaml")
 
+# Avoid random timeouts in github.
+TIMEOUT = 30
+
 
 def test_version(tmpenv):
     out = kubectl.version(output="json", context=tmpenv.profile)
@@ -48,7 +51,7 @@ def test_rollout(tmpenv, capsys):
     kubectl.rollout(
         "status",
         "deploy/example-deployment",
-        "--timeout=10s",
+        f"--timeout={TIMEOUT}s",
         context=tmpenv.profile,
     )
     out, err = capsys.readouterr()
@@ -59,7 +62,7 @@ def test_wait(tmpenv, capsys):
     kubectl.wait(
         "deploy/example-deployment",
         "--for=condition=available",
-        "--timeout=10s",
+        f"--timeout={TIMEOUT}s",
         context=tmpenv.profile,
     )
     out, err = capsys.readouterr()


### PR DESCRIPTION
- Change the example addon to wait for deployment like other addons
- Wait  until the pod is ready in start hook
- Increase short timeouts in kubectl tests

The last change may not be required - the timeouts are caused by not waiting
for the pod, but 10 seconds seem to be too short for CI environment that may be
overloaded.

Fixes: #997 