### PR TITLE
CI: Fix Publish Built Image warning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -310,7 +310,7 @@ jobs:
           ${{env.DOCKERCMD}} load -i /tmp/ramen-operator.tar
 
       - name: Login to Quay
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
We are seeing the warning:

- The following actions uses node12 which is deprecated and will be forced to run on node16: docker/login-action@v1

Updated docker/login-action to v2 as an update with v2.0.0 uses node 16 as default instead of node 12:
https://github.com/docker/login-action/releases

Updates: #998