### PR TITLE
CI: upgrade to setup-go v4 and disable cache with golangci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,6 @@ defaults:
   run:
     shell: bash
 jobs:
-
   lint:
     name: Linters
     runs-on: ubuntu-20.04
@@ -66,9 +65,16 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
+          # when the files to be extracted are already present,
+          # tar extraction in Golangci Lint fails with the "File exists"
+          # errors. These files appear to be present because of
+          # cache in setup-go, on disabling the cache we are no more seeing
+          # such error. Cache is to be enabled once the fix is available for
+          # this issue.
           go-version: ${{ env.GO_VERSION }}
+          cache: false
 
       - name: GolangCI Lint
         uses: golangci/golangci-lint-action@v3
@@ -83,7 +89,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -189,7 +195,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -232,7 +238,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -346,7 +352,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 


### PR DESCRIPTION
Below errors were seen with setup-go@v4 in golangci Lint: Error: /usr/bin/tar: ../../../go/pkg/mod/sigs.k8s.io/yaml@v1.3.0/yaml_ test.go: Cannot open: File exists
/usr/bin/tar: ../../../go/pkg/mod/sigs.k8s.io/yaml@v1.3.0/LICENSE: Cannot open: File exists

Disabling Cache with golangci solves the problem and makes sure that we are in a recent setup-go as well.

Cache can be enabled once the resultant issue is fixed in golangci lint action repo.
Issue that is to be tracked:
https://github.com/golangci/golangci-lint-action/issues/135

Updates: #1000