### PR TITLE
Fix disable DR for regional-dr and RBD storage

### DIFF
--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -803,13 +803,6 @@ func (v *VRGInstance) undoPVCFinalizersAndPVRetention(pvc *corev1.PersistentVolu
 
 	pvcNamespacedName := types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}
 
-	if pvc.GetAnnotations() != nil && pvc.GetAnnotations()[RestoreAnnotation] == RestoredByRamen {
-		// We created the PVC, delete it
-		if deleted := v.deletePVCIfNotInUse(pvc, log); !deleted {
-			return requeue
-		}
-	}
-
 	if err := v.deleteVR(pvcNamespacedName, log); err != nil {
 		log.Info("Requeuing due to failure in finalizing VolumeReplication resource for PersistentVolumeClaim",
 			"errorValue", err)


### PR DESCRIPTION
Testing disabling dr flow shows that when we delete a VRG, we abort
undoPVCFinalizersAndPVRetention() because the PVC has the ramen-restore
annotation:

    volumereplicationgroups.ramendr.openshift.io/ramen-restore: "True"

and the PVC is used by the pod. Since the VR is not deleted, the VRG
deletion never completes.

Deleting the PVC is never needed since the PVC has the annotation:

    apps.open-cluster-management.io/hosting-subscription: busybox-sample/busybox-sub

The annotation means that the resource is owned by the subscription and
will be deleted when the subscription will be deleted.

I could not find any OCM documentation for this, but the option is
mentioned in ACM docs indirectly[1]. According to Benamar, this works in
ACM 2.8.

This change removes the delete PVC step, fixing disable DR flow for RBD
storage for both subscriptions and application sets.

Notes:
- Metro-DR should not be affected by this issue since there is not VR.
- VolSync is not affected by this change (it also does use the
  ramen-restore annotation).

Status:
- [x] Test with RBD mirroring on minikube
- [x] Test with RBD morroring on openshift
- [x] Test with applicationsets on openshift

[1] https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html/applications/managing-applications#mergeandown-option

Related changes:
- #1012 adds a system test testing enabling and disabling dr
  - depends on https://github.com/RamenDR/ocm-ramen-samples/pull/35

Fixes: #833
Updates: 165fec276514
Related-to: #152