### PR TITLE
Test enable and disable dr

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -12,6 +12,8 @@ sources := $(wildcard \
 	*/undeploy \
 	*/failover \
 	*/relocate \
+	*/protect \
+	*/unprotect \
 )
 
 all: flake8 pylint black test coverage

--- a/test/README.md
+++ b/test/README.md
@@ -28,11 +28,11 @@ environment.
    ```
 
    You need `minikube` version supporting the `--extra-disks` option.
-   Tested with version  v1.30.1.
+   Tested with version v1.31.2.
 
 1. Install the `kubectl` tool. See
    [Install and Set Up kubectl on Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
-   Tested with version v1.27.3.
+   Tested with version v1.27.4.
 
 1. Install `clusteradm` tool. See
    [Install clusteradm CLI tool](https://open-cluster-management.io/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool)

--- a/test/addons/rook-cluster/start
+++ b/test/addons/rook-cluster/start
@@ -10,7 +10,7 @@ import drenv
 from drenv import kubectl
 
 # Update this when upgrading rook.
-VERSION = "release-1.10"
+VERSION = "release-1.12"
 BASE_URL = f"https://raw.githubusercontent.com/rook/rook/{VERSION}/deploy/examples"
 
 

--- a/test/addons/rook-operator/start
+++ b/test/addons/rook-operator/start
@@ -10,7 +10,7 @@ import drenv
 from drenv import kubectl
 
 # Update this when upgrading rook.
-VERSION = "release-1.10"
+VERSION = "release-1.12"
 BASE_URL = f"https://raw.githubusercontent.com/rook/rook/{VERSION}/deploy/examples"
 
 

--- a/test/addons/rook-toolbox/start
+++ b/test/addons/rook-toolbox/start
@@ -9,7 +9,7 @@ import sys
 from drenv import kubectl
 
 # Update this when upgrading rook.
-VERSION = "release-1.10"
+VERSION = "release-1.12"
 BASE_URL = f"https://raw.githubusercontent.com/rook/rook/{VERSION}/deploy/examples"
 
 

--- a/test/basic-test/config.yaml
+++ b/test/basic-test/config.yaml
@@ -2,14 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-# We use well known path since we need the same directory for multiple scripts.
-# To use a tempoary directory we need to keep the path of the tempoary
-# directory somewhere.
-tmp_dir: /tmp/ramen-test/basic-test
-
-samples_repo: https://github.com/ramendr/ocm-ramen-samples.git
-samples_branch: main
-samples_dir: /tmp/ramen-test/basic-test/ocm-ramen-samples
-
+repo: https://github.com/nirs/ocm-ramen-samples.git
+branch: test
 namespace: busybox-sample
-name: busybox-drpc
+drpc: busybox-drpc
+subscription: busybox-sub
+placement: busybox-placement
+deploy: busybox
+pvc: busybox-pvc

--- a/test/basic-test/deploy
+++ b/test/basic-test/deploy
@@ -3,55 +3,31 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-
 import drenv
-from drenv import commands
 from drenv import kubectl
 from drenv import test
 
 test.start("deploy", __file__)
-test.add_argument(
-    "--cluster",
-    help="Cluster name to deploy on (default first cluster)",
-)
 args = test.parse_args()
 config = test.config
 
-cluster = args.cluster or test.env["clusters"][0]
-test.info("Deploying on cluster '%s'", cluster)
-
-test.info("Creating temporary directory %s", config["tmp_dir"])
-os.makedirs(config["tmp_dir"], exist_ok=True)
-
-test.info("Cloning ocm-ramen-samples")
-if not os.path.exists(config["samples_dir"]):
-    cmd = [
-        "git",
-        "clone",
-        "--depth=1",
-        "--branch",
-        config["samples_branch"],
-        config["samples_repo"],
-        config["samples_dir"],
-    ]
-    for line in commands.watch(*cmd):
-        test.debug(line)
-
-test.info("Creating kustomization for using cluster '%s'", cluster)
-template = drenv.template("kustomization.yaml")
-yaml = template.substitute(cluster_name=cluster)
-with open(os.path.join(config["tmp_dir"], "kustomization.yaml"), "w") as f:
-    f.write(yaml)
-
-test.info("Deploying busybox example application")
+test.info("Deploying sample channel")
 kubectl.apply(
-    f"--kustomize={config['tmp_dir']}",
+    f"--kustomize={config['repo']}/channel?ref={config['branch']}",
     context=test.env["hub"],
     log=test.debug,
 )
 
-test.info("waiting for namespace %s", config["namespace"])
+test.info("Deploying '%s' subscription", config["namespace"])
+with drenv.kustomization(
+    "subscription/kustomization.yaml",
+    namespace=config["namespace"],
+    repo=config["repo"],
+    branch=config["branch"],
+) as sub:
+    kubectl.apply(f"--kustomize={sub}", context=test.env["hub"], log=test.debug)
+
+test.info("waiting for namespace '%s'", config["namespace"])
 drenv.wait_for(
     f"namespace/{config['namespace']}",
     timeout=60,
@@ -59,9 +35,26 @@ drenv.wait_for(
     log=test.debug,
 )
 
-test.info("Waiting until busybox drpc reports phase")
+test.info("Waiting for '%s' placement decision", config["namespace"])
 drenv.wait_for(
-    f"drpc/{config['name']}",
+    f"placementrule/{config['placement']}",
+    output="jsonpath={.status.decisions}",
+    namespace=config["namespace"],
+    timeout=60,
+    profile=test.env["hub"],
+    log=test.debug,
+)
+
+cluster = kubectl.get(
+    f"placementrule/{config['placement']}",
+    f"--namespace={config['namespace']}",
+    "--output=jsonpath={.status.decisions[0].clusterName}",
+    context=test.env["hub"],
+)
+
+test.info("Waiting until '%s' subscription reports phase", config["namespace"])
+drenv.wait_for(
+    f"subscription/{config['subscription']}",
     output="jsonpath={.status.phase}",
     namespace=config["namespace"],
     timeout=60,
@@ -69,24 +62,48 @@ drenv.wait_for(
     log=test.debug,
 )
 
-test.info("Waiting until busybox drpc is deployed")
+test.info("Waiting until '%s' subscription is propagated", config["namespace"])
 kubectl.wait(
-    f"drpc/{config['name']}",
-    "--for=jsonpath={.status.phase}=Deployed",
+    f"subscription/{config['subscription']}",
+    "--for=jsonpath={.status.phase}=Propagated",
     f"--namespace={config['namespace']}",
     "--timeout=60s",
     context=test.env["hub"],
     log=test.debug,
 )
 
-test.info("Waiting until application is replicated")
-drenv.wait_for(
-    f"drpc/{config['name']}",
-    output="jsonpath={.status.lastGroupSyncTime}",
-    namespace=config["namespace"],
-    timeout=300,
-    profile=test.env["hub"],
+test.info("Waiting until '%s' manifestwork is available", config["namespace"])
+kubectl.wait(
+    f"manifestwork/{config['namespace']}-{config['subscription']}",
+    "--for=condition=available",
+    f"--namespace={cluster}",
+    "--timeout=60s",
+    context=test.env["hub"],
     log=test.debug,
 )
 
-test.info("Application was deployed successfully")
+# Manifestwork can report condition=available before the deployment exist.
+test.info("Waiting for '%s' deployment on cluster '%s'", config["namespace"], cluster)
+drenv.wait_for(
+    f"deploy/{config['deploy']}",
+    namespace=config["namespace"],
+    timeout=60,
+    profile=cluster,
+    log=test.debug,
+)
+
+test.info(
+    "Waiting until '%s' deployment is rolled out on cluster '%s'",
+    config["namespace"],
+    cluster,
+)
+kubectl.rollout(
+    "status",
+    f"deploy/{config['deploy']}",
+    f"--namespace={config['namespace']}",
+    "--timeout=60s",
+    context=cluster,
+    log=test.debug,
+)
+
+test.info("Application '%s' was deployed successfully", config["namespace"])

--- a/test/basic-test/dr/kustomization.yaml
+++ b/test/basic-test/dr/kustomization.yaml
@@ -1,14 +1,13 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-# Kustomization template for deploying ramen busybox sample using user
-# configurable cluster name.
+# Kustomization template for deploying sample application drpc.
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: ${namespace}
 resources:
-  - ocm-ramen-samples/subscriptions
-  - ocm-ramen-samples/subscriptions/busybox
+  - ${repo}/dr?ref=${branch}
 patches:
   - target:
       kind: DRPlacementControl
@@ -16,4 +15,4 @@ patches:
     patch: |-
       - op: replace
         path: /spec/preferredCluster
-        value: $cluster_name
+        value: ${cluster}

--- a/test/basic-test/failover
+++ b/test/basic-test/failover
@@ -10,19 +10,30 @@ from drenv import kubectl
 from drenv import test
 
 test.start("failover", __file__)
-test.add_argument(
-    "--cluster",
-    help="Cluster name to failover to (default second cluster).",
-)
 args = test.parse_args()
 config = test.config
 
-cluster = args.cluster or test.env["clusters"][1]
-test.info("Failing over to cluster '%s'", cluster)
+old_cluster = kubectl.get(
+    f"placementrule/{config['placement']}",
+    f"--namespace={config['namespace']}",
+    "--output=jsonpath={.status.decisions[0].clusterName}",
+    context=test.env["hub"],
+)
+if old_cluster == test.env["clusters"][0]:
+    new_cluster = test.env["clusters"][1]
+else:
+    new_cluster = test.env["clusters"][0]
 
-test.info("Waiting until application is replicated")
+test.info(
+    "Failing over application '%s' from cluster '%s' to cluster '%s'",
+    config["namespace"],
+    old_cluster,
+    new_cluster,
+)
+
+test.info("Waiting until '%s' application is replicated", config["namespace"])
 drenv.wait_for(
-    f"drpc/{config['name']}",
+    f"drpc/{config['drpc']}",
     output="jsonpath={.status.lastGroupSyncTime}",
     namespace=config["namespace"],
     timeout=300,
@@ -31,9 +42,9 @@ drenv.wait_for(
 )
 
 test.info("Starting failover")
-patch = {"spec": {"action": "Failover", "failoverCluster": cluster}}
+patch = {"spec": {"action": "Failover", "failoverCluster": new_cluster}}
 kubectl.patch(
-    f"drpc/{config['name']}",
+    f"drpc/{config['drpc']}",
     "--patch",
     json.dumps(patch),
     "--type=merge",
@@ -42,9 +53,9 @@ kubectl.patch(
     log=test.debug,
 )
 
-test.info("Waiting until application is failed over...")
+test.info("Waiting until '%s' application is failed over...", config["namespace"])
 kubectl.wait(
-    f"drpc/{config['name']}",
+    f"drpc/{config['drpc']}",
     "--for=jsonpath={.status.phase}=FailedOver",
     f"--namespace={config['namespace']}",
     "--timeout=300s",
@@ -52,9 +63,9 @@ kubectl.wait(
     log=test.debug,
 )
 
-test.info("Waiting until application is replicated")
+test.info("Waiting until '%s' application is replicated", config["namespace"])
 drenv.wait_for(
-    f"drpc/{config['name']}",
+    f"drpc/{config['drpc']}",
     output="jsonpath={.status.lastGroupSyncTime}",
     namespace=config["namespace"],
     timeout=300,
@@ -62,4 +73,8 @@ drenv.wait_for(
     log=test.debug,
 )
 
-test.info("Application was failed over to cluster %s successfully", cluster)
+test.info(
+    "Application '%s' was failed over to cluster %s successfully",
+    config["namespace"],
+    new_cluster,
+)

--- a/test/basic-test/protect
+++ b/test/basic-test/protect
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import drenv
+from drenv import kubectl
+from drenv import test
+
+test.start("protect", __file__)
+args = test.parse_args()
+config = test.config
+
+test.info("Enabling DR for application '%s'", config["namespace"])
+
+test.info("Setting '%s' placement scheduler to ramen", config["namespace"])
+patch = {"spec": {"schedulerName": "ramen"}}
+kubectl.patch(
+    f"placementrule/{config['placement']}",
+    "--patch",
+    json.dumps(patch),
+    "--type=merge",
+    f"--namespace={config['namespace']}",
+    context=test.env["hub"],
+    log=test.debug,
+)
+
+cluster = kubectl.get(
+    f"placementrule/{config['placement']}",
+    f"--namespace={config['namespace']}",
+    "--output=jsonpath={.status.decisions[0].clusterName}",
+    context=test.env["hub"],
+)
+
+out = kubectl.get(
+    f"pvc/{config['pvc']}",
+    f"--namespace={config['namespace']}",
+    "--output=json",
+    context=cluster,
+)
+pvc_before = json.loads(out)
+
+test.info("Deploying '%s' drpc", config["namespace"])
+with drenv.kustomization(
+    "dr/kustomization.yaml",
+    namespace=config["namespace"],
+    repo=config["repo"],
+    branch=config["branch"],
+    cluster=cluster,
+) as sub:
+    kubectl.apply(f"--kustomize={sub}", context=test.env["hub"], log=test.debug)
+
+test.info("Waiting until '%s' drpc reports phase", config["namespace"])
+drenv.wait_for(
+    f"drpc/{config['drpc']}",
+    output="jsonpath={.status.phase}",
+    namespace=config["namespace"],
+    timeout=60,
+    profile=test.env["hub"],
+    log=test.debug,
+)
+
+test.info("Waiting until '%s' drpc is deployed", config["namespace"])
+kubectl.wait(
+    f"drpc/{config['drpc']}",
+    "--for=jsonpath={.status.phase}=Deployed",
+    f"--namespace={config['namespace']}",
+    "--timeout=60s",
+    context=test.env["hub"],
+    log=test.debug,
+)
+
+out = kubectl.get(
+    f"pvc/{config['pvc']}",
+    f"--namespace={config['namespace']}",
+    "--output=json",
+    context=cluster,
+)
+pvc_after = json.loads(out)
+
+# Verify that the PVC and PV were not modified by protecting the app.
+# (not sure that this is the best way).
+
+if pvc_after["metadata"]["uid"] != pvc_before["metadata"]["uid"]:
+    raise RuntimeError(f"PVC uid changed: before={pvc_after} after={pvc_before}")
+
+if pvc_after["spec"]["volumeName"] != pvc_before["spec"]["volumeName"]:
+    raise RuntimeError(f"PVC volume changed: before={pvc_after} after={pvc_before}")
+
+# But the PV reclaim policy must change to "Retain".
+
+out = kubectl.get(
+    "pv",
+    pvc_after["spec"]["volumeName"],
+    "--output=json",
+    context=cluster,
+)
+pv = json.loads(out)
+if pv["spec"]["persistentVolumeReclaimPolicy"] != "Retain":
+    raise RuntimeError(f"Unexpected PV reclaim policy: {pv}")
+
+test.info("Waiting until '%s' application is replicated", config["namespace"])
+drenv.wait_for(
+    f"drpc/{config['drpc']}",
+    output="jsonpath={.status.lastGroupSyncTime}",
+    namespace=config["namespace"],
+    timeout=300,
+    profile=test.env["hub"],
+    log=test.debug,
+)
+
+test.info("Application '%s' was protected successfully", config["namespace"])

--- a/test/basic-test/relocate
+++ b/test/basic-test/relocate
@@ -10,19 +10,30 @@ from drenv import kubectl
 from drenv import test
 
 test.start("relocate", __file__)
-test.add_argument(
-    "--cluster",
-    help="Cluster name to relocate to (default first cluster).",
-)
 args = test.parse_args()
 config = test.config
 
-cluster = args.cluster or test.env["clusters"][0]
-test.info("Relocate to cluster '%s'", cluster)
+old_cluster = kubectl.get(
+    f"placementrule/{config['placement']}",
+    f"--namespace={config['namespace']}",
+    "--output=jsonpath={.status.decisions[0].clusterName}",
+    context=test.env["hub"],
+)
+if old_cluster == test.env["clusters"][0]:
+    new_cluster = test.env["clusters"][1]
+else:
+    new_cluster = test.env["clusters"][0]
 
-test.info("Waiting until peer is ready")
+test.info(
+    "Relocating application '%s' from cluster '%s' to cluster '%s'",
+    config["namespace"],
+    old_cluster,
+    new_cluster,
+)
+
+test.info("Waiting until '%s' peer is ready", config["namespace"])
 kubectl.wait(
-    f"drpc/{config['name']}",
+    f"drpc/{config['drpc']}",
     "--for=condition=PeerReady",
     f"--namespace={config['namespace']}",
     "--timeout=300s",
@@ -30,9 +41,9 @@ kubectl.wait(
     log=test.debug,
 )
 
-test.info("Waiting until application is replicated")
+test.info("Waiting until '%s' application is replicated", config["namespace"])
 drenv.wait_for(
-    f"drpc/{config['name']}",
+    f"drpc/{config['drpc']}",
     output="jsonpath={.status.lastGroupSyncTime}",
     namespace=config["namespace"],
     timeout=300,
@@ -41,9 +52,9 @@ drenv.wait_for(
 )
 
 test.info("Starting relocate")
-patch = {"spec": {"action": "Relocate", "preferredCluster": cluster}}
+patch = {"spec": {"action": "Relocate", "preferredCluster": new_cluster}}
 kubectl.patch(
-    f"drpc/{config['name']}",
+    f"drpc/{config['drpc']}",
     "--patch",
     json.dumps(patch),
     "--type=merge",
@@ -52,9 +63,9 @@ kubectl.patch(
     log=test.debug,
 )
 
-test.info("Waiting until application is relocated...")
+test.info("Waiting until '%s' application is relocated...", config["namespace"])
 kubectl.wait(
-    f"drpc/{config['name']}",
+    f"drpc/{config['drpc']}",
     "--for=jsonpath={.status.phase}=Relocated",
     f"--namespace={config['namespace']}",
     "--timeout=300s",
@@ -64,9 +75,9 @@ kubectl.wait(
 
 # NOTE: Deleting the application get stuck if we don't wait until the cleanup
 # after relocate complete before we delete the app.
-test.info("Waiting until relocation completes...")
+test.info("Waiting until '%s' relocation completes...", config["namespace"])
 kubectl.wait(
-    f"drpc/{config['name']}",
+    f"drpc/{config['drpc']}",
     "--for=jsonpath={.status.progression}=Completed",
     f"--namespace={config['namespace']}",
     "--timeout=300s",
@@ -74,4 +85,18 @@ kubectl.wait(
     log=test.debug,
 )
 
-test.info("Application was relocated to cluster %s successfully", cluster)
+test.info("Waiting until '%s' application is replicated", config["namespace"])
+drenv.wait_for(
+    f"drpc/{config['drpc']}",
+    output="jsonpath={.status.lastGroupSyncTime}",
+    namespace=config["namespace"],
+    timeout=300,
+    profile=test.env["hub"],
+    log=test.debug,
+)
+
+test.info(
+    "Application '%s' was relocated to cluster %s successfully",
+    config["namespace"],
+    new_cluster,
+)

--- a/test/basic-test/run
+++ b/test/basic-test/run
@@ -6,6 +6,8 @@
 base="$(dirname $0)"
 
 "$base/deploy" "$@"
+"$base/protect" "$@"
 "$base/failover" "$@"
 "$base/relocate" "$@"
+"$base/unprotect" "$@"
 "$base/undeploy" "$@"

--- a/test/basic-test/subscription/kustomization.yaml
+++ b/test/basic-test/subscription/kustomization.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Kustomization template for deploying sample application OCM resources.
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ${namespace}
+resources:
+  - ${repo}/subscription?ref=${branch}

--- a/test/basic-test/undeploy
+++ b/test/basic-test/undeploy
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import drenv
 from drenv import kubectl
 from drenv import test
 
@@ -10,10 +11,24 @@ test.start("undeploy", __file__)
 args = test.parse_args()
 config = test.config
 
-test.info("Deleting busybox example application")
+test.info("Deleting '%s' subscription", config["namespace"])
+with drenv.kustomization(
+    "subscription/kustomization.yaml",
+    namespace=config["namespace"],
+    repo=config["repo"],
+    branch=config["branch"],
+) as sub:
+    kubectl.delete(
+        f"--kustomize={sub}",
+        "--ignore-not-found",
+        context=test.env["hub"],
+        log=test.debug,
+    )
+
+test.info("Deleting sample channel")
 kubectl.delete(
+    f"--kustomize={config['repo']}/channel?ref={config['branch']}",
     "--ignore-not-found",
-    f"--kustomize={config['tmp_dir']}",
     context=test.env["hub"],
     log=test.debug,
 )

--- a/test/basic-test/unprotect
+++ b/test/basic-test/unprotect
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import drenv
+from drenv import kubectl
+from drenv import test
+
+test.start("unprotect", __file__)
+args = test.parse_args()
+config = test.config
+
+test.info("Disabling DR for application '%s'", config["namespace"])
+
+cluster = kubectl.get(
+    f"placementrule/{config['placement']}",
+    f"--namespace={config['namespace']}",
+    "--output=jsonpath={.status.decisions[0].clusterName}",
+    context=test.env["hub"],
+)
+
+out = kubectl.get(
+    f"pvc/{config['pvc']}",
+    f"--namespace={config['namespace']}",
+    "--output=json",
+    context=cluster,
+)
+pvc_before = json.loads(out)
+
+test.info("Deleting '%s' drpc", config["namespace"])
+with drenv.kustomization(
+    "dr/kustomization.yaml",
+    namespace=config["namespace"],
+    repo=config["repo"],
+    branch=config["branch"],
+    cluster=cluster,
+) as sub:
+    kubectl.delete(
+        f"--kustomize={sub}",
+        "--ignore-not-found",
+        "--timeout=120s",
+        context=test.env["hub"],
+        log=test.debug,
+    )
+
+test.info("Removing '%s' placement scheduler", config["namespace"])
+patch = {"spec": {"schedulerName": None}}
+kubectl.patch(
+    f"placementrule/{config['placement']}",
+    "--patch",
+    json.dumps(patch),
+    "--type=merge",
+    f"--namespace={config['namespace']}",
+    context=test.env["hub"],
+    log=test.debug,
+)
+
+out = kubectl.get(
+    f"pvc/{config['pvc']}",
+    f"--namespace={config['namespace']}",
+    "--output=json",
+    context=cluster,
+)
+pvc_after = json.loads(out)
+
+# Verify that the PVC and PV were not modified by unprotecting the app.
+# (not sure that this is the best way).
+
+if pvc_after["metadata"]["uid"] != pvc_before["metadata"]["uid"]:
+    raise RuntimeError(f"PVC uid changed: before={pvc_after} after={pvc_before}")
+
+if pvc_after["spec"]["volumeName"] != pvc_before["spec"]["volumeName"]:
+    raise RuntimeError(f"PVC volume changed: before={pvc_after} after={pvc_before}")
+
+# But the PV reclaim policy must change to "Delete".
+
+out = kubectl.get(
+    "pv",
+    pvc_after["spec"]["volumeName"],
+    "--output=json",
+    context=cluster,
+)
+pv = json.loads(out)
+if pv["spec"]["persistentVolumeReclaimPolicy"] != "Delete":
+    raise RuntimeError(f"Unexpected PV reclaim policy: {pv}")
+
+test.info("Application '%s' was unprotected successfully", config["namespace"])

--- a/test/drenv/envfile.py
+++ b/test/drenv/envfile.py
@@ -154,6 +154,9 @@ def _prefix_names(env, name_prefix):
 
     env["name"] = name_prefix + env["name"]
 
+    if "ramen" in env:
+        _prefix_ramen(env["ramen"], name_prefix)
+
     for profile in env["profiles"]:
         profile["name"] = name_prefix + profile["name"]
         for worker in profile["workers"]:
@@ -161,6 +164,13 @@ def _prefix_names(env, name_prefix):
 
     for worker in env["workers"]:
         _prefix_worker(worker, profile_names, name_prefix)
+
+
+def _prefix_ramen(info, name_prefix):
+    if info["hub"]:
+        info["hub"] = name_prefix + info["hub"]
+    for i, cluster in enumerate(info["clusters"]):
+        info["clusters"][i] = name_prefix + info["clusters"][i]
 
 
 def _prefix_worker(worker, profile_names, name_prefix):

--- a/test/drenv/envfile_test.py
+++ b/test/drenv/envfile_test.py
@@ -15,6 +15,11 @@ def valid_env(tmpdir):
     yaml = """
 name: test
 
+ramen:
+  hub: hub
+  clusters: [dr1, dr2]
+  topology: regional-dr
+
 templates:
   - name: dr-cluster
     memory: 6g
@@ -181,6 +186,14 @@ def test_name_prefix(valid_env):
     # env
 
     assert env["name"] == "prefix-test"
+
+    # ramen info
+
+    assert env["ramen"] == {
+        "hub": "prefix-hub",
+        "clusters": ["prefix-dr1", "prefix-dr2"],
+        "topology": "regional-dr",
+    }
 
     # profile dr1
 


### PR DESCRIPTION
Change the basic test to test the more generic flow - deploying an application using OCM, and enable DR for the deployed application. Finally test disabling DR after the application was failed over and relocated.

This change depends on ocm-ramen-samples change splitting the channel and drpc from the subscription.

Issues:
- Need to test delete timeout with ramen without #1007 
- Need to split to smaller commits
- Do we want to test enable/disable in all states (Deployed,
  FailedOver, Relocated)?
- some settings ("busybox", "busybox-placement") can move to config.yaml
- With this change we don't test deploy of DR enabled application - is
  this important to test? (looks less useful use case)
