### PR TITLE
Use default vm and network values

### DIFF
--- a/test/envs/minio.yaml
+++ b/test/envs/minio.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-# Enviroment for testing minio deployment with both podman and kvm2 drivers.
+# Enviroment for testing minio deployment with both container and vm drivers.
 ---
 name: "minio"
 

--- a/test/envs/regional-dr-hubless.yaml
+++ b/test/envs/regional-dr-hubless.yaml
@@ -12,9 +12,9 @@ ramen:
 
 templates:
   - name: "dr-cluster"
-    driver: kvm2
+    driver: "$vm"
     container_runtime: containerd
-    network: default
+    network: "$network"
     memory: "6g"
     extra_disks: 1
     disk_size: "50g"


### PR DESCRIPTION
- Use the new $vm and $network options in regional-dr-hubless.yaml
- Refer to vm and network driver in comments instead of `kvm2` and `podman`

Updates: #717