### PR TITLE
Create minified kubeconfigs

### DIFF
--- a/test/drenv/ramen.py
+++ b/test/drenv/ramen.py
@@ -48,7 +48,8 @@ def dump_e2e_config(env):
         if cluster_name is None:
             continue
 
-        data = kubectl.config("view", "--flatten", context=cluster_name)
+        # Create standlone config file for this cluster.
+        data = kubectl.config("view", "--flatten", "--minify", context=cluster_name)
         path = os.path.join(kubeconfigs_dir, cluster_name)
         with open(path, "w") as f:
             f.write(data)


### PR DESCRIPTION
The drenv created kubeconfigs were including information about all clusters, which make them useless for accessing single cluster.

Before:

    $ KUBECONFIG=./hub kubectl get nodes
    NAME   STATUS   ROLES           AGE     VERSION
    hub    Ready    control-plane   4h34m   v1.26.3
    $ KUBECONFIG=./dr1 kubectl get nodes
    NAME   STATUS   ROLES           AGE     VERSION
    hub    Ready    control-plane   4h34m   v1.26.3

After:

    $ KUBECONFIG=./hub kubectl get nodes
    NAME   STATUS   ROLES           AGE     VERSION
    hub    Ready    control-plane   4h27m   v1.26.3

    $ KUBECONFIG=./dr1 kubectl get nodes
    NAME   STATUS   ROLES           AGE     VERSION
    dr1    Ready    control-plane   4h28m   v1.26.3

The e2e connectivity test "works" since it did not validate that we are connecting to the right cluster.

Fixes: eaf35dd40bd5