### PR TITLE
Don't delete PVC when reconciling VRs as secondary

### DIFF
--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -803,13 +803,6 @@ func (v *VRGInstance) undoPVCFinalizersAndPVRetention(pvc *corev1.PersistentVolu
 
 	pvcNamespacedName := types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}
 
-	if pvc.GetAnnotations() != nil && pvc.GetAnnotations()[RestoreAnnotation] == RestoredByRamen {
-		// We created the PVC, delete it
-		if deleted := v.deletePVCIfNotInUse(pvc, log); !deleted {
-			return requeue
-		}
-	}
-
 	if err := v.deleteVR(pvcNamespacedName, log); err != nil {
 		log.Info("Requeuing due to failure in finalizing VolumeReplication resource for PersistentVolumeClaim",
 			"errorValue", err)

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -140,12 +140,7 @@ func (v *VRGInstance) reconcileVRAsSecondary(pvc *corev1.PersistentVolumeClaim, 
 		skip    bool = true
 	)
 
-	if pvc.GetAnnotations() != nil && pvc.GetAnnotations()[RestoreAnnotation] == RestoredByRamen {
-		// We created the PVC, delete it
-		if deleted := v.deletePVCIfNotInUse(pvc, log); !deleted {
-			return requeue, false, skip
-		}
-	} else if !v.isPVCReadyForSecondary(pvc, log) {
+	if !v.isPVCReadyForSecondary(pvc, log) {
 		return requeue, false, skip
 	}
 
@@ -175,14 +170,6 @@ func (v *VRGInstance) isPVCReadyForSecondary(pvc *corev1.PersistentVolumeClaim, 
 	}
 
 	return !v.isPVCInUse(pvc, log, "Secondary transition")
-}
-
-func (v *VRGInstance) deletePVCIfNotInUse(pvc *corev1.PersistentVolumeClaim, log logr.Logger) bool {
-	if v.isPVCInUse(pvc, log, "PVC deletion") {
-		return false
-	}
-
-	return rmnutil.DeletePVC(v.ctx, v.reconciler.Client, pvc.Name, pvc.Namespace, log) == nil
 }
 
 func (v *VRGInstance) isPVCInUse(pvc *corev1.PersistentVolumeClaim, log logr.Logger, operation string) bool {


### PR DESCRIPTION
The PVC is owned by OCM and will be removed by OCM. The same reason used
in #1007, but we don't know about any issue caused by this attempt.

Status:
- [x] Test with RBD mirroring on minikube
- [x] Test with RBD morroring on openshift
- [x] Test with applicationsets on openshift
    
Fixes: #1022
Updates: 165fec276514
