### PR TITLE
correct incorrect logging while setting progression

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -2059,7 +2059,7 @@ func (d *DRPCInstance) setDRState(nextState rmn.DRState) {
 func (d *DRPCInstance) setProgression(nextProgression rmn.ProgressionStatus) {
 	if d.instance.Status.Progression != nextProgression {
 		d.log.Info(fmt.Sprintf("Progression: Current '%s'. Next '%s'",
-			d.instance.Status.Phase, nextProgression))
+			d.instance.Status.Progression, nextProgression))
 
 		d.instance.Status.Progression = nextProgression
 	}


### PR DESCRIPTION
correcting the log message which was referenced
to phase instead of progression