### PR TITLE
VolSync tests - make sure the secret is created to avoid timing issues

### DIFF
--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -664,6 +664,15 @@ var _ = Describe("VolSync_Handler", func() {
 					Expect(k8sClient.Create(ctx, dummyPSKSecret)).To(Succeed())
 					Expect(dummyPSKSecret.GetName()).NotTo(BeEmpty())
 
+					// Make sure the secret is created to avoid any timing issues
+					Eventually(func() error {
+						return k8sClient.Get(ctx,
+							types.NamespacedName{
+								Name:      dummyPSKSecret.GetName(),
+								Namespace: dummyPSKSecret.GetNamespace(),
+							}, dummyPSKSecret)
+					}, maxWait, interval).Should(Succeed())
+
 					// Run ReconcileRD
 					var err error
 					returnedRD, err = vsHandler.ReconcileRD(rdSpec)


### PR DESCRIPTION
VolSync_Handler tests fail when trying to reconcile ReplicationDestination, The problem is that after creating a secret we didn't verify, that is was created, 

Fixes: https://github.com/RamenDR/ramen/issues/991 