### PR TITLE
VolRep tests - make sure the PVC is created to avoid timing issues

### DIFF
--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -1259,7 +1259,7 @@ func (v *vrgTest) verifyPVCBindingToPV(shouldBeBound bool) {
 func (v *vrgTest) getPV(pvName string) *corev1.PersistentVolume {
 	pvLookupKey := types.NamespacedName{Name: pvName}
 	pv := &corev1.PersistentVolume{}
-	err := k8sClient.Get(context.TODO(), pvLookupKey, pv)
+	err := apiReader.Get(context.TODO(), pvLookupKey, pv)
 	Expect(err).NotTo(HaveOccurred(),
 		"failed to get PV %s", pvName)
 
@@ -1273,7 +1273,7 @@ func (v *vrgTest) getPVC(pvcName string) *corev1.PersistentVolumeClaim {
 	}
 
 	pvc := &corev1.PersistentVolumeClaim{}
-	err := k8sClient.Get(context.TODO(), key, pvc)
+	err := apiReader.Get(context.TODO(), key, pvc)
 	Expect(err).NotTo(HaveOccurred(),
 		"failed to get PVC %s", pvcName)
 


### PR DESCRIPTION
This PR is fixing the failures in VolumeReplicationGroupVolRepController. The problem is that several PVCs are created, but the latest PVC has not enough time to after creation to update cache and Get failed. The solution is to use non-caching apiReader instead of k8sClient for Get functions.
Fixes: https://github.com/RamenDR/ramen/issues/1010