### PR TITLE
Update hub RBAC to include Placement finalizer "update"

### DIFF
--- a/config/hub/rbac/role.yaml
+++ b/config/hub/rbac/role.yaml
@@ -100,6 +100,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - placements/finalizers
+  verbs:
+  - update
+- apiGroups:
   - policy.open-cluster-management.io
   resources:
   - placementbindings

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -103,7 +103,14 @@ rules:
   verbs:
   - get
   - list
+  - update
   - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - placements/finalizers
+  verbs:
+  - update
 - apiGroups:
   - ""
   resources:

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -566,7 +566,8 @@ func (r *DRPlacementControlReconciler) SetupWithManager(mgr ctrl.Manager) error 
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;create;patch;update
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placementdecisions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placementdecisions/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placements,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placements,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=placements/finalizers,verbs=update
 // +kubebuilder:rbac:groups=argoproj.io,resources=applicationsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1734,7 +1734,7 @@ func (r *DRPlacementControlReconciler) createOrUpdatePlacementDecision(ctx conte
 		plDecision.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*owner}
 
 		if err := r.Create(ctx, plDecision); err != nil {
-			return err
+			return fmt.Errorf("failed to create PlacementDecision %w", err)
 		}
 	}
 


### PR DESCRIPTION
As per [1] when setting owner references to a resource and
specifically while setting blockOwnerDeletion to true, an
RBAC to update the finalizer of the resource set as the owner
is required.

This commit adds the required RBAC for the same.

[1] https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement