### PR TITLE
Dockerfile: Use the ubi-minimal image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY main.go main.go
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 FROM registry.access.redhat.com/ubi8/ubi
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY controllers/ controllers/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /
 COPY --from=builder /workspace/manager .
 


### PR DESCRIPTION
This reduces the size of the ramen operator image by half. The new image size is 57% of the old image.

This PR also removes the GO111MODULE=on flag as that has been the
default for quite a few releases in Go.

```
quay.io/ramendr/ramen-operator               latest       551ac1797930  6 seconds ago   284 MB
quay.io/ramendr/ramen-operator               minimal      f1e115aa35ce  3 hours ago     164 MB
```