### PR TITLE
VRG: Handle Kube objects recovery point pointer update errors

### DIFF
--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -981,7 +981,6 @@ func (v *VRGInstance) relocate(result *ctrl.Result, s3StoreAccessors []s3StoreAc
 	); clusterDataProtected != nil && (clusterDataProtected.Status != metav1.ConditionTrue ||
 		clusterDataProtected.ObservedGeneration != vrg.Generation) {
 		v.kubeObjectsProtectSecondary(result, s3StoreAccessors)
-		v.vrgObjectProtect(result, s3StoreAccessors)
 	}
 }
 


### PR DESCRIPTION
# Problem

Critical update of pointer to latest velero backup, 0 or 1, in S3 store fails without notifying caller.  The _other_ backup is either missing, partial, or old resulting in recovery failure or data loss.

# Proposed solution

- If updating pointer to latest velero backup in an S3 store fails, then
   - do not update it in API server
   - requeue VRG for reconcile
- Use existing velero backup scheduler to throttle its VRG uploads
- Throttle VRG upload to S3 stores for `ProtectedVolumeReplicationGroupList` queries to one per minute

This patch partially addresses #844.  It does not address the case where a VRG upload to one S3 store succeeds but the another fails.

## End-to-end test results

Last resource group captured
```sh
2023-09-01T09:34:11.774Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:257      Kube objects group captured     {"VolumeReplicationGroup": "asdf/bb", "rid": "83ea0a93-78ae-48f6-80a4-ad7ed4faa4e8", "State": "primary", "number": 1, "profile": "minio-on-cluster1", "start": "2023-09-01 09:34:08 +0000 UTC", "end": "2023-09-01 09:34:11 +0000 UTC"}
```
VRG uploaded to both S3 stores successfully:
```sh
2023-09-01T09:34:11.858Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_vrgobject.go:62 VRG Kube object protected       {"VolumeReplicationGroup": "asdf/bb", "rid": "83ea0a93-78ae-48f6-80a4-ad7ed4faa4e8", "State": "primary", "profile": "minio-on-cluster2"}
2023-09-01T09:34:11.917Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_vrgobject.go:62 VRG Kube object protected       {"VolumeReplicationGroup": "asdf/bb", "rid": "83ea0a93-78ae-48f6-80a4-ad7ed4faa4e8", "State": "primary", "profile": "minio-on-cluster1"}
```
Capture completed, schedule next one:
```sh
2023-09-01T09:34:11.974Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:355      Kube objects captured   {"VolumeReplicationGroup": "asdf/bb", "rid": "83ea0a93-78ae-48f6-80a4-ad7ed4faa4e8", "State": "primary", "recovery point": {"number":1,"startTime":"2023-09-01T09:34:04Z","startGeneration":2}, "duration": "7.974931578s"}
2023-09-01T09:34:11.975Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:189      Kube objects capture start delay        {"VolumeReplicationGroup": "asdf/bb", "rid": "83ea0a93-78ae-48f6-80a4-ad7ed4faa4e8", "State": "primary", "delay": "52.025068422s", "interval": "1m0s"}
```

Modify code to inject error
```diff
diff --git a/controllers/vrg_vrgobject.go b/controllers/vrg_vrgobject.go
index 85ef60b..b68408a 100644
--- a/controllers/vrg_vrgobject.go
+++ b/controllers/vrg_vrgobject.go
@@ -42,7 +42,7 @@ func (v *VRGInstance) vrgObjectProtectThrottled(result *ctrl.Result, s3StoreAcce
        for _, s3StoreAccessor := range s3StoreAccessors {
                log1 := log.WithValues("profile", s3StoreAccessor.S3ProfileName)

-               if err := VrgObjectProtect(s3StoreAccessor.ObjectStorer, *vrg); err != nil {
+               if err := VrgObjectProtect(s3StoreAccessor.ObjectStorer, *vrg, s3StoreAccessor.S3ProfileName); err != nil {
                        util.ReportIfNotPresent(
                                eventReporter, vrg, corev1.EventTypeWarning, util.EventReasonVrgUploadFailed, err.Error(),
                        )
@@ -76,7 +76,10 @@ func shouldThrottleVRGProtection(lastUploadTime metav1.Time, maxVRGProtectionTim

 const vrgS3ObjectNameSuffix = "a"

-func VrgObjectProtect(objectStorer ObjectStorer, vrg ramen.VolumeReplicationGroup) error {
+type asdf struct{}; func (a asdf) Error() string{ return "asdf"}
+func VrgObjectProtect(objectStorer ObjectStorer, vrg ramen.VolumeReplicationGroup, s string) error {
+       if s == "minio-on-cluster1" { return asdf{} }
+
        return uploadTypedObject(objectStorer, s3PathNamePrefix(vrg.Namespace, vrg.Name), vrgS3ObjectNameSuffix, vrg)
 }
```

Didn't throttle due to #1050:
```sh
2023-09-01T11:19:26.990Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_kubeobjects.go:257      Kube objects group captured     {"VolumeReplicationGroup": "asdf/bb", "rid": "c0a56d9b-db89-43a7-ac65-76a93d4862fc", "State": "primary", "number": 1, "profile": "minio-on-cluster1", "start": "2023-09-01 09:34:08 +0000 UTC", "end": "2023-09-01 09:34:11 +0000 UTC"}
2023-09-01T11:19:27.115Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_vrgobject.go:62 VRG Kube object protected       {"VolumeReplicationGroup": "asdf/bb", "rid": "c0a56d9b-db89-43a7-ac65-76a93d4862fc", "State": "primary", "profile": "minio-on-cluster2"}
2023-09-01T11:19:27.115Z        ERROR   controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_vrgobject.go:52 VRG Kube object protect error   {"VolumeReplicationGroup": "asdf/bb", "rid": "c0a56d9b-db89-43a7-ac65-76a93d4862fc", "State": "primary", "profile": "minio-on-cluster1", "error": "asdf"}
github.com/ramendr/ramen/controllers.(*VRGInstance).vrgObjectProtectThrottled
        /workspace/controllers/vrg_vrgobject.go:52
github.com/ramendr/ramen/controllers.(*VRGInstance).kubeObjectsCaptureComplete
        /workspace/controllers/vrg_kubeobjects.go:313
github.com/ramendr/ramen/controllers.(*VRGInstance).kubeObjectsCaptureStartOrResume
        /workspace/controllers/vrg_kubeobjects.go:285
github.com/ramendr/ramen/controllers.(*VRGInstance).kubeObjectsCaptureStartOrResumeOrDelay.func1
        /workspace/controllers/vrg_kubeobjects.go:130
github.com/ramendr/ramen/controllers.(*VRGInstance).kubeObjectsCaptureStartOrResumeOrDelay
        /workspace/controllers/vrg_kubeobjects.go:148
github.com/ramendr/ramen/controllers.(*VRGInstance).kubeObjectsProtect
        /workspace/controllers/vrg_kubeobjects.go:108
github.com/ramendr/ramen/controllers.(*VRGInstance).kubeObjectsProtectPrimary
        /workspace/controllers/vrg_kubeobjects.go:61
github.com/ramendr/ramen/controllers.(*VRGInstance).reconcileAsPrimary
        /workspace/controllers/volumereplicationgroup_controller.go:987
github.com/ramendr/ramen/controllers.(*VRGInstance).processAsPrimary
        /workspace/controllers/volumereplicationgroup_controller.go:959
github.com/ramendr/ramen/controllers.(*VRGInstance).processVRGActions
        /workspace/controllers/volumereplicationgroup_controller.go:621
github.com/ramendr/ramen/controllers.(*VRGInstance).processVRG
        /workspace/controllers/volumereplicationgroup_controller.go:594
github.com/ramendr/ramen/controllers.(*VolumeReplicationGroupReconciler).Reconcile
        /workspace/controllers/volumereplicationgroup_controller.go:483
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:122
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:323
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:274
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:235
2023-09-01T11:19:27.117Z        DEBUG   events  recorder/recorder.go:103        asdf    {"type": "Warning", "object": {"kind":"VolumeReplicationGroup","namespace":"asdf","name":"bb","uid":"dc7096df-8fe3-4b2b-8d34-936baaad6c34","apiVersion":"ramendr.openshift.io/v1alpha1","resourceVersion":"20152689"}, "reason": "VrgUploadFailed"}
2023-09-01T11:19:27.156Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_vrgobject.go:62 VRG Kube object protected       {"VolumeReplicationGroup": "asdf/bb", "rid": "c0a56d9b-db89-43a7-ac65-76a93d4862fc", "State": "primary", "profile": "minio-on-cluster2"}
2023-09-01T11:19:27.157Z        ERROR   controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_vrgobject.go:52 VRG Kube object protect error   {"VolumeReplicationGroup": "asdf/bb", "rid": "c0a56d9b-db89-43a7-ac65-76a93d4862fc", "State": "primary", "profile": "minio-on-cluster1", "error": "asdf"}
github.com/ramendr/ramen/controllers.(*VRGInstance).vrgObjectProtectThrottled
        /workspace/controllers/vrg_vrgobject.go:52
github.com/ramendr/ramen/controllers.(*VRGInstance).vrgObjectProtect
        /workspace/controllers/vrg_vrgobject.go:32
github.com/ramendr/ramen/controllers.(*VRGInstance).reconcileAsPrimary
        /workspace/controllers/volumereplicationgroup_controller.go:988
github.com/ramendr/ramen/controllers.(*VRGInstance).processAsPrimary
        /workspace/controllers/volumereplicationgroup_controller.go:959
github.com/ramendr/ramen/controllers.(*VRGInstance).processVRGActions
        /workspace/controllers/volumereplicationgroup_controller.go:621
github.com/ramendr/ramen/controllers.(*VRGInstance).processVRG
        /workspace/controllers/volumereplicationgroup_controller.go:594
github.com/ramendr/ramen/controllers.(*VolumeReplicationGroupReconciler).Reconcile
        /workspace/controllers/volumereplicationgroup_controller.go:483
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:122
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:323
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:274
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:235
2023-09-01T11:19:27.157Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/volumereplicationgroup_controller.go:1056   Updating VRG status     {"VolumeReplicationGroup": "asdf/bb", "rid": "c0a56d9b-db89-43a7-ac65-76a93d4862fc", "State": "primary"}
```

Applied #1050 and now it throttles as expected:

```sh
2023-09-01T12:51:41.661Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_vrgobject.go:72 VRG Kube object protected       {"VolumeReplicationGroup": "asdf/bb", "rid": "b6440cbf-fb44-4d0e-a256-6386a632b09d", "State": "primary", "profile": "minio-on-cluster2", "key": "asdf/bb", "time": "2023-09-01 12:51:41.661152292 +0000 UTC m=+143.973242311"}
2023-09-01T12:51:41.661Z        ERROR   controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_vrgobject.go:61 VRG Kube object protect error   {"VolumeReplicationGroup": "asdf/bb", "rid": "b6440cbf-fb44-4d0e-a256-6386a632b09d", "State": "primary", "profile": "minio-on-cluster1", "error": "asdf"}
github.com/ramendr/ramen/controllers.(*VRGInstance).vrgObjectProtectThrottled
        /workspace/controllers/vrg_vrgobject.go:61
github.com/ramendr/ramen/controllers.(*VRGInstance).kubeObjectsCaptureComplete
        /workspace/controllers/vrg_kubeobjects.go:313
github.com/ramendr/ramen/controllers.(*VRGInstance).kubeObjectsCaptureStartOrResume
        /workspace/controllers/vrg_kubeobjects.go:285
github.com/ramendr/ramen/controllers.(*VRGInstance).kubeObjectsCaptureStartOrResumeOrDelay.func1
        /workspace/controllers/vrg_kubeobjects.go:130
github.com/ramendr/ramen/controllers.(*VRGInstance).kubeObjectsCaptureStartOrResumeOrDelay
        /workspace/controllers/vrg_kubeobjects.go:148
github.com/ramendr/ramen/controllers.(*VRGInstance).kubeObjectsProtect
        /workspace/controllers/vrg_kubeobjects.go:108
github.com/ramendr/ramen/controllers.(*VRGInstance).kubeObjectsProtectPrimary
        /workspace/controllers/vrg_kubeobjects.go:61
github.com/ramendr/ramen/controllers.(*VRGInstance).reconcileAsPrimary
        /workspace/controllers/volumereplicationgroup_controller.go:987
github.com/ramendr/ramen/controllers.(*VRGInstance).processAsPrimary
        /workspace/controllers/volumereplicationgroup_controller.go:959
github.com/ramendr/ramen/controllers.(*VRGInstance).processVRGActions
        /workspace/controllers/volumereplicationgroup_controller.go:621
github.com/ramendr/ramen/controllers.(*VRGInstance).processVRG
        /workspace/controllers/volumereplicationgroup_controller.go:594
github.com/ramendr/ramen/controllers.(*VolumeReplicationGroupReconciler).Reconcile
        /workspace/controllers/volumereplicationgroup_controller.go:483
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:122
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:323
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:274
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:235
2023-09-01T12:51:41.661Z        INFO    controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_vrgobject.go:27 VRG already protected recently. Throttling...   {"VolumeReplicationGroup": "asdf/bb", "rid": "b6440cbf-fb44-4d0e-a256-6386a632b09d", "State": "primary"}
```