### PR TITLE
Fix VRG upload tests

### DIFF
--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -1443,10 +1443,6 @@ func (v *vrgTest) kubeObjectProtectionValidate() *ramendrv1alpha1.VolumeReplicat
 }
 
 func kubeObjectProtectionValidate(tests []*vrgTest) {
-	if true {
-		return // TODO re-enable
-	}
-
 	protectedVrgList := protectedVrgListCreateAndStatusWait("protectedvrglist-vrg-"+tests[0].uniqueID, vrgS3ProfileNumber)
 	vrgs := make([]ramendrv1alpha1.VolumeReplicationGroup, len(tests))
 


### PR DESCRIPTION
# Problem
PR #1050 fixes VRG S3 upload throttle logic, but breaks VRG upload validation tests

# Proposed solution
- Reenable VRG S3 upload validation tests to fix #1052 
- Change condition to upload VRG to S3 from time-based to when VRG resource version changes

This PR includes the following PRs:
- #1050 because it disables VRG S3 upload validation tests that this PR reenables

This PR requires the following PRs be merged first:
- #1053 because it uses the VRG backup scheduler to throttle S3 updates and bypasses the S3 upload condition that this patch uses; otherwise its uploads to S3 may fail as the resource version is not necessarily updated until the VRG's status is updated later in the reconcile routine