### PR TITLE
Fetch vrg from s3 stores for MMode

### DIFF
--- a/controllers/drcluster_mmode.go
+++ b/controllers/drcluster_mmode.go
@@ -70,7 +70,16 @@ func (u *drclusterInstance) mModeActivationsRequired() (map[string]ramen.Storage
 			continue
 		}
 
-		required, activationsRequired := requiresRegionalFailoverPrerequisites(vrgs, u.object.GetName(), u.log)
+		required, activationsRequired := requiresRegionalFailoverPrerequisites(
+			u.ctx,
+			u.reconciler.APIReader,
+			[]string{u.object.Spec.S3ProfileName},
+			drpcCollection.drpc.GetName(),
+			drpcCollection.drpc.GetNamespace(),
+			vrgs,
+			u.object.GetName(),
+			u.reconciler.ObjectStoreGetter,
+			u.log)
 		if !required {
 			continue
 		}

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -74,6 +74,7 @@ type DRPlacementControlReconciler struct {
 	Callback            ProgressCallback
 	eventRecorder       *rmnutil.EventReporter
 	savedInstanceStatus rmn.DRPlacementControlStatus
+	ObjStoreGetter      ObjectStoreGetter
 }
 
 func ManifestWorkPredicateFunc() predicate.Funcs {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -65,6 +65,8 @@ var (
 	ramenConfig *ramendrv1alpha1.RamenConfig
 	testLogger  logr.Logger
 
+	drpcReconciler *ramencontrollers.DRPlacementControlReconciler
+
 	namespaceDeletionSupported bool
 
 	timeout  = time.Second * 10
@@ -341,7 +343,7 @@ var _ = BeforeSuite(func() {
 		ObjStoreGetter: fakeObjectStoreGetter{},
 	}).SetupWithManager(k8sManager)).To(Succeed())
 
-	drpcReconciler := (&ramencontrollers.DRPlacementControlReconciler{
+	drpcReconciler = (&ramencontrollers.DRPlacementControlReconciler{
 		Client:    k8sManager.GetClient(),
 		APIReader: k8sManager.GetAPIReader(),
 		Log:       ctrl.Log.WithName("controllers").WithName("DRPlacementControl"),
@@ -349,8 +351,9 @@ var _ = BeforeSuite(func() {
 			Client:    k8sClient,
 			apiReader: k8sManager.GetAPIReader(),
 		},
-		Scheme:   k8sManager.GetScheme(),
-		Callback: FakeProgressCallback,
+		Scheme:         k8sManager.GetScheme(),
+		Callback:       FakeProgressCallback,
+		ObjStoreGetter: fakeObjectStoreGetter{},
 	})
 	err = drpcReconciler.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/main.go
+++ b/main.go
@@ -180,8 +180,9 @@ func setupReconcilersHub(mgr ctrl.Manager) {
 			Client:    mgr.GetClient(),
 			APIReader: mgr.GetAPIReader(),
 		},
-		Scheme:   mgr.GetScheme(),
-		Callback: func(string, string) {},
+		Scheme:         mgr.GetScheme(),
+		Callback:       func(string, string) {},
+		ObjStoreGetter: controllers.S3ObjectStoreGetter(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DRPlacementControl")
 		os.Exit(1)


### PR DESCRIPTION
For MMode, the VRG is fetched from the s3 stores when not found in the stale ManagedClusterView resources.

Fixes the first bullet in issue [835](https://github.com/RamenDR/ramen/issues/835)