### PR TITLE
Default volsync destinationCopyMethod to use LocalDirect

### DIFF
--- a/config/dr-cluster/manager/ramen_manager_config.yaml
+++ b/config/dr-cluster/manager/ramen_manager_config.yaml
@@ -11,3 +11,5 @@ leaderElection:
   resourceName: dr-cluster.ramendr.openshift.io
 ramenControllerType: dr-cluster
 maxConcurrentReconciles: 50
+volSync:
+  destinationCopyMethod: LocalDirect

--- a/config/hub/manager/ramen_manager_config.yaml
+++ b/config/hub/manager/ramen_manager_config.yaml
@@ -11,3 +11,5 @@ leaderElection:
   resourceName: hub.ramendr.openshift.io
 ramenControllerType: dr-hub
 maxConcurrentReconciles: 50
+volSync:
+  destinationCopyMethod: LocalDirect


### PR DESCRIPTION
LocalDirect method was added for enhanced data consistency when using volsync with CephFS as the backing store for volumes that need DR protection. (ref commit fa43e3a049b80d8e21812f3846f939bcc5136eea)

This commit makes this the default method in the DR operators, to ensure consistency is the base method chosen.

NOTE: For certain storage providers that efficiently clone from a snapshot, the CopyMethodClone would be the prefferred option as this ensures the required consistency. As the default is updated, all providers would now use LocalDirect instead.