### PR TITLE
Refactoring metrics creation and initialisation 

### DIFF
--- a/config/prometheus/alerts.yaml
+++ b/config/prometheus/alerts.yaml
@@ -11,7 +11,7 @@ spec:
     - name: recording_rules
       rules:
         - record: ramen_sync_duration_seconds
-          expr: (time() - (ramen_last_sync_timestamp_seconds{job='ramen-hub-operator-metrics-service'} > 0))
+          expr: (time() - (ramen_last_sync_timestamp_seconds{job='ramen-hub-operator-metrics-service'}))
         - record: ramen_rpo_difference
           expr: ramen_sync_duration_seconds / on(policyname) group_left() (ramen_policy_schedule_interval_seconds{job="ramen-hub-operator-metrics-service"})
     - name: alerts

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -57,7 +57,6 @@ type DRPCInstance struct {
 	vrgs                 map[string]*rmn.VolumeReplicationGroup
 	vrgNamespace         string
 	mwu                  rmnutil.MWUtil
-	metrics              *DRPCMetrics
 }
 
 func (d *DRPCInstance) startProcessing() bool {
@@ -67,7 +66,7 @@ func (d *DRPCInstance) startProcessing() bool {
 	done, processingErr := d.processPlacement()
 
 	if d.shouldUpdateStatus() || d.statusUpdateTimeElapsed() {
-		if err := d.reconciler.updateDRPCStatus(d.instance, d.userPlacement, d.metrics, d.log); err != nil {
+		if err := d.reconciler.updateDRPCStatus(d.ctx, d.instance, d.userPlacement, d.log); err != nil {
 			errMsg := fmt.Sprintf("error from update DRPC status: %v", err)
 			if processingErr != nil {
 				errMsg += fmt.Sprintf(", error from process placement: %v", processingErr)

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -613,7 +613,7 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	placementObj, err := r.ownPlacementOrPlacementRule(ctx, drpc, logger)
 	if err != nil && !(errors.IsNotFound(err) && !drpc.GetDeletionTimestamp().IsZero()) {
-		r.recordFailure(drpc, placementObj, "Error", err.Error(), nil, logger)
+		r.recordFailure(ctx, drpc, placementObj, "Error", err.Error(), logger)
 
 		return ctrl.Result{}, err
 	}
@@ -634,7 +634,7 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	d, err := r.createDRPCInstance(ctx, drpc, placementObj, logger)
 	if err != nil && !errorswrapper.Is(err, InitialWaitTimeForDRPCPlacementRule) {
-		err2 := r.updateDRPCStatus(drpc, placementObj, nil, logger)
+		err2 := r.updateDRPCStatus(ctx, drpc, placementObj, logger)
 
 		return ctrl.Result{}, fmt.Errorf("failed to create DRPC instance (%w) and (%v)", err, err2)
 	}
@@ -642,8 +642,8 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if errorswrapper.Is(err, InitialWaitTimeForDRPCPlacementRule) {
 		const initialWaitTime = 5
 
-		r.recordFailure(drpc, placementObj, "Waiting",
-			fmt.Sprintf("%v - wait time: %v", InitialWaitTimeForDRPCPlacementRule, initialWaitTime), nil, logger)
+		r.recordFailure(ctx, drpc, placementObj, "Waiting",
+			fmt.Sprintf("%v - wait time: %v", InitialWaitTimeForDRPCPlacementRule, initialWaitTime), logger)
 
 		return ctrl.Result{RequeueAfter: time.Second * initialWaitTime}, nil
 	}
@@ -665,13 +665,13 @@ func (r *DRPlacementControlReconciler) setProgressionAndUpdate(
 	return nil
 }
 
-func (r *DRPlacementControlReconciler) recordFailure(drpc *rmn.DRPlacementControl,
-	placementObj client.Object, reason, msg string, drpcMetrics *DRPCMetrics, log logr.Logger,
+func (r *DRPlacementControlReconciler) recordFailure(ctx context.Context, drpc *rmn.DRPlacementControl,
+	placementObj client.Object, reason, msg string, log logr.Logger,
 ) {
 	needsUpdate := addOrUpdateCondition(&drpc.Status.Conditions, rmn.ConditionAvailable,
 		drpc.Generation, metav1.ConditionFalse, reason, msg)
 	if needsUpdate {
-		err := r.updateDRPCStatus(drpc, placementObj, drpcMetrics, log)
+		err := r.updateDRPCStatus(ctx, drpc, placementObj, log)
 		if err != nil {
 			log.Info(fmt.Sprintf("Failed to update DRPC status (%v)", err))
 		}
@@ -785,8 +785,6 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 		return nil, fmt.Errorf("configmap get: %w", err)
 	}
 
-	drpcMetrics := r.createDRPCMetrics(drPolicy, drpc)
-
 	d := &DRPCInstance{
 		reconciler:      r,
 		ctx:             ctx,
@@ -798,7 +796,6 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 		vrgs:            vrgs,
 		vrgNamespace:    vrgNamespace,
 		volSyncDisabled: ramenConfig.VolSync.Disabled,
-		metrics:         drpcMetrics,
 		mwu: rmnutil.MWUtil{
 			Client:          r.Client,
 			APIReader:       r.APIReader,
@@ -822,7 +819,7 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 	return d, nil
 }
 
-func (r *DRPlacementControlReconciler) createDRPCMetrics(
+func (r *DRPlacementControlReconciler) createDRPCMetricsInstance(
 	drPolicy *rmn.DRPolicy, drpc *rmn.DRPlacementControl,
 ) *DRPCMetrics {
 	syncMetricLabels := SyncMetricLabels(drPolicy, drpc)
@@ -1515,7 +1512,7 @@ func (r *DRPlacementControlReconciler) getStatusCheckDelay(
 }
 
 func (r *DRPlacementControlReconciler) updateDRPCStatus(
-	drpc *rmn.DRPlacementControl, userPlacement client.Object, drpcMetrics *DRPCMetrics, log logr.Logger,
+	ctx context.Context, drpc *rmn.DRPlacementControl, userPlacement client.Object, log logr.Logger,
 ) error {
 	log.Info("Updating DRPC status")
 
@@ -1526,7 +1523,7 @@ func (r *DRPlacementControlReconciler) updateDRPCStatus(
 
 	clusterDecision := r.getClusterDecision(userPlacement)
 	if clusterDecision != nil && clusterDecision.ClusterName != "" && vrgNamespace != "" {
-		r.updateResourceCondition(drpc, clusterDecision.ClusterName, vrgNamespace, drpcMetrics, log)
+		r.updateResourceCondition(ctx, drpc, clusterDecision.ClusterName, vrgNamespace, log)
 	}
 
 	for i, condition := range drpc.Status.Conditions {
@@ -1554,9 +1551,10 @@ func (r *DRPlacementControlReconciler) updateDRPCStatus(
 }
 
 func (r *DRPlacementControlReconciler) updateResourceCondition(
+	ctx context.Context,
 	drpc *rmn.DRPlacementControl,
 	clusterName, vrgNamespace string,
-	drpcMetrics *DRPCMetrics, log logr.Logger,
+	log logr.Logger,
 ) {
 	annotations := make(map[string]string)
 
@@ -1569,15 +1567,6 @@ func (r *DRPlacementControlReconciler) updateResourceCondition(
 		log.Info("Failed to get VRG from managed cluster", "errMsg", err)
 
 		drpc.Status.ResourceConditions = rmn.VRGConditions{}
-		drpc.Status.LastGroupSyncTime = nil
-		drpc.Status.LastGroupSyncDuration = nil
-		drpc.Status.LastGroupSyncBytes = nil
-
-		if drpcMetrics != nil {
-			r.setLastSyncTimeMetric(&drpcMetrics.SyncMetrics, nil, log)
-			r.setLastSyncDurationMetric(&drpcMetrics.SyncDurationMetrics, nil, log)
-			r.setLastSyncBytesMetric(&drpcMetrics.SyncDataBytesMetrics, nil, log)
-		}
 	} else {
 		drpc.Status.ResourceConditions.ResourceMeta.Kind = vrg.Kind
 		drpc.Status.ResourceConditions.ResourceMeta.Name = vrg.Name
@@ -1591,16 +1580,50 @@ func (r *DRPlacementControlReconciler) updateResourceCondition(
 		}
 
 		drpc.Status.ResourceConditions.ResourceMeta.ProtectedPVCs = protectedPVCs
-		drpc.Status.LastGroupSyncTime = vrg.Status.LastGroupSyncTime
-		drpc.Status.LastGroupSyncDuration = vrg.Status.LastGroupSyncDuration
-		drpc.Status.LastGroupSyncBytes = vrg.Status.LastGroupSyncBytes
 
-		if drpcMetrics != nil {
-			r.setLastSyncTimeMetric(&drpcMetrics.SyncMetrics, vrg.Status.LastGroupSyncTime, log)
-			r.setLastSyncDurationMetric(&drpcMetrics.SyncDurationMetrics, vrg.Status.LastGroupSyncDuration, log)
-			r.setLastSyncBytesMetric(&drpcMetrics.SyncDataBytesMetrics, vrg.Status.LastGroupSyncBytes, log)
+		if vrg.Status.LastGroupSyncTime != nil || drpc.Spec.Action != rmn.ActionRelocate {
+			drpc.Status.LastGroupSyncTime = vrg.Status.LastGroupSyncTime
+			drpc.Status.LastGroupSyncDuration = vrg.Status.LastGroupSyncDuration
+			drpc.Status.LastGroupSyncBytes = vrg.Status.LastGroupSyncBytes
 		}
 	}
+
+	if err := r.setDRPCMetrics(ctx, drpc, log); err != nil {
+		// log the error but do not return the error
+		log.Info("failed to set drpc metrics", "errMSg", err)
+	}
+}
+
+func (r *DRPlacementControlReconciler) setDRPCMetrics(ctx context.Context,
+	drpc *rmn.DRPlacementControl, log logr.Logger,
+) error {
+	log.Info("setting drpc metrics")
+
+	drPolicy, err := r.getDRPolicy(ctx, drpc, log)
+	if err != nil {
+		return fmt.Errorf("failed to get DRPolicy %w", err)
+	}
+
+	drClusters, err := getDRClusters(ctx, r.Client, drPolicy)
+	if err != nil {
+		return err
+	}
+
+	// do not set netrics if metro-dr
+	isMetro, _ := dRPolicySupportsMetro(drPolicy, drClusters)
+	if isMetro {
+		return nil
+	}
+
+	drpcMetrics := r.createDRPCMetricsInstance(drPolicy, drpc)
+
+	if drpcMetrics != nil {
+		r.setLastSyncTimeMetric(&drpcMetrics.SyncMetrics, drpc.Status.LastGroupSyncTime, log)
+		r.setLastSyncDurationMetric(&drpcMetrics.SyncDurationMetrics, drpc.Status.LastGroupSyncDuration, log)
+		r.setLastSyncBytesMetric(&drpcMetrics.SyncDataBytesMetrics, drpc.Status.LastGroupSyncBytes, log)
+	}
+
+	return nil
 }
 
 func ConvertToPlacementRule(placementObj interface{}) *plrv1.PlacementRule {


### PR DESCRIPTION
Metrics were previously created regardless of metro-dr or regional-dr. This has now changed, metrics are not created for metro-dr. The metrics instance creation is also moved from DRPC instance creation to updating DRPC condition, this is done so as not to initialize and set the default value as 0. 

The values now refer to DRPC status and not VRG. we update DPRC LastGroup statuses based on the availability of VRG lastGroupSyncTime and the Relocate action.  In case we do not get VRG,  metrics will have the previous or the last known value from DRPC.

Removed 0 value filtering from alerts. So alerts are fired when metrics have zero value which is set based on DRPC lastGroupSynctime.  

[BZ: 2232242](https://bugzilla.redhat.com/show_bug.cgi?id=2232242)
