### PR TITLE
Use kind,group,version instead of resource

### DIFF
--- a/controllers/util/mcv_util.go
+++ b/controllers/util/mcv_util.go
@@ -71,7 +71,9 @@ func (m ManagedClusterViewGetterImpl) GetVRGFromManagedCluster(resourceName, res
 	}
 
 	mcvViewscope := viewv1beta1.ViewScope{
-		Resource:  "VolumeReplicationGroup",
+		Kind:      "VolumeReplicationGroup",
+		Group:     rmn.GroupVersion.Group,
+		Version:   rmn.GroupVersion.Version,
 		Name:      resourceName,
 		Namespace: resourceNamespace,
 	}
@@ -98,7 +100,9 @@ func (m ManagedClusterViewGetterImpl) GetNFFromManagedCluster(resourceName, reso
 	}
 
 	mcvViewscope := viewv1beta1.ViewScope{
-		Resource:  "NetworkFence",
+		Kind:      "NetworkFence",
+		Group:     csiaddonsv1alpha1.GroupVersion.Group,
+		Version:   csiaddonsv1alpha1.GroupVersion.Version,
 		Name:      "network-fence-" + resourceName,
 		Namespace: resourceNamespace,
 	}
@@ -128,8 +132,10 @@ func (m ManagedClusterViewGetterImpl) GetMModeFromManagedCluster(resourceName, m
 	}
 
 	mcvViewscope := viewv1beta1.ViewScope{
-		Resource: "MaintenanceMode",
-		Name:     resourceName,
+		Kind:    "MaintenanceMode",
+		Group:   rmn.GroupVersion.Group,
+		Version: rmn.GroupVersion.Version,
+		Name:    resourceName,
 	}
 
 	mMode := &rmn.MaintenanceMode{}
@@ -191,8 +197,10 @@ func (m ManagedClusterViewGetterImpl) GetNamespaceFromManagedCluster(
 	}
 
 	mcvViewscope := viewv1beta1.ViewScope{
-		Resource: "Namespace",
-		Name:     namespaceString,
+		Kind:    "Namespace",
+		Group:   corev1.SchemeGroupVersion.Group,
+		Version: corev1.SchemeGroupVersion.Version,
+		Name:    namespaceString,
 	}
 
 	namespace := &corev1.Namespace{}

--- a/controllers/util/mcv_util.go
+++ b/controllers/util/mcv_util.go
@@ -330,7 +330,14 @@ func (m ManagedClusterViewGetterImpl) getOrCreateManagedClusterView(
 	}
 
 	if mcv.Spec.Scope != viewscope {
-		logger.Info("WARNING: existing ManagedClusterView has different ViewScope than desired one")
+		// Expected once when uprading ramen if scope format or details have changed.
+		logger.Info(fmt.Sprintf("Updating ManagedClusterView %s scope %+v to %+v",
+			key, mcv.Spec.Scope, viewscope))
+
+		mcv.Spec.Scope = viewscope
+		if err := m.Update(context.TODO(), mcv); err != nil {
+			return nil, errorswrapper.Wrap(err, "failed to update ManagedClusterView")
+		}
 	}
 
 	return mcv, nil


### PR DESCRIPTION
We create a ManagedClusterView scope with resource:

```
  scope:
    name: busybox-sample-placement-1-drpc
    namespace: busybox-sample
    resource: VolumeReplicationGroup
```

With this the MCV fail with:

  - lastTransitionTime: "2023-09-13T09:44:04Z" message: 'failed to get resource with err: the server doesn''t have a resource type "VolumeReplicationGroup"' reason: ResourceTypeInvalid status: "False" type: Processing

It works if we change the spec to:

```
  scope:
    name: busybox-sample-placement-1-drpc
    namespace: busybox-sample
    resource: VolumeReplicationGroup.ramendr.openshift.io/v1alpha1
```

Not clear yet why this started to fail with ACM 2.9, but it seems more robust to use kind, group, version format:

```
    Kind: VolumeReplicationGroup
    group: ramendr.openshift.io
    version: v1alpha1
```

Change all the MCVs to use the kind, group, version format.

Testing:
- [x] minikube
  - works with ocm-controller used in main (we pinned to old version)
  - works with latest commit in ocm-controller #1067
- [x] OCP 4.14 / ODR 4.13 using https://github.com/nirs/ramen/tree/mcv-scope-4.13
- [x] OCP 4.14 / ODR 4.14 using https://github.com/nirs/ramen/tree/mcv-scope-4.14
  - **does not work, latest ocm-controllers was broken when tested**
- [ ] do we need to test with older ACM?

Bug-Url: https://bugzilla.redhat.com/2238682