### PR TITLE
Use latest ocm-controller

### DIFF
--- a/test/addons/ocm-controller/kustomization.yaml
+++ b/test/addons/ocm-controller/kustomization.yaml
@@ -3,37 +3,24 @@
 
 # yamllint disable rule:line-length
 
-# Based on https://github.com/stolostron/multicloud-operators-foundation/blob/main/deploy/foundation/hub/kustomization.yaml
-# including only what we need for ocm-controller.
-
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-- $base_url/resources/crds/action.open-cluster-management.io_managedclusteractions.crd.yaml
-- $base_url/resources/crds/hive.openshift.io_clusterclaims.yaml
-- $base_url/resources/crds/hive.openshift.io_clusterdeployments.yaml
-- $base_url/resources/crds/hive.openshift.io_clusterpools.yaml
-- $base_url/resources/crds/imageregistry.open-cluster-management.io_managedclusterimageregistries.crd.yaml
-- $base_url/resources/crds/internal.open-cluster-management.io_managedclusterinfos.crd.yaml
-- $base_url/resources/crds/view.open-cluster-management.io_managedclusterviews.crd.yaml
-- $base_url/resources/agent-clusterrole.yaml
-- $base_url/resources/clustermanagementaddon.yaml
-- $base_url/resources/clusterrole.yaml
-- $base_url/resources/controller.yaml
-
+- https://github.com/stolostron/multicloud-operators-foundation.git/deploy/foundation/hub/overlays/ocm-controller?ref=main
 images:
 - name: quay.io/stolostron/multicloud-manager
-  newTag: $image_tag
-
+  newTag: latest
 patches:
-# Replace upstream patches.yaml with version that does not need modification
-# before applying the patch.
+# Ammend upstream kustomization since it does not add an image tag. We want an
+# image tag to pin to specific version.
 - target:
     kind: Deployment
     name: ocm-controller
   patch: |-
-    - op: add
-      path: /spec/template/spec/containers/0/args/-
-      value: "--agent-addon-image=quay.io/stolostron/multicloud-manager:$image_tag"
+    - op: test
+      path: /spec/template/spec/containers/0/args/2
+      value: "--agent-addon-image=quay.io/stolostron/multicloud-manager"
+    - op: replace
+      path: /spec/template/spec/containers/0/args/2
+      value: "--agent-addon-image=quay.io/stolostron/multicloud-manager:latest"

--- a/test/addons/ocm-controller/start
+++ b/test/addons/ocm-controller/start
@@ -6,25 +6,12 @@
 import os
 import sys
 
-import drenv
 from drenv import kubectl
-
-# Use latest good commit and the matching image tag (found using quay.io).
-VERSION = "629b9e066e342d7c0ce8141aa2f1f3ca5128c771"
-IMAGE_TAG = f"2.4.0-{VERSION}"
-
-
-BASE_URL = f"https://raw.githubusercontent.com/stolostron/multicloud-operators-foundation/{VERSION}/deploy/foundation/hub"
 
 
 def deploy(cluster):
     print("Deploying ocm controller")
-    with drenv.kustomization(
-        "kustomization.yaml",
-        base_url=BASE_URL,
-        image_tag=IMAGE_TAG,
-    ) as kustomization:
-        kubectl.apply("--kustomize", kustomization, context=cluster)
+    kubectl.apply("--kustomize", "./", context=cluster)
 
 
 def wait(cluster):


### PR DESCRIPTION
We are using older version since ocm-controller changed the deployment and broke us. Meantime we see regressions in QE testing the latest downstream build.

Change to consume the new ocm-deployment using latest version from github so we can detect regression earlier.

Fixes: #947