### PR TITLE
Add DRPC status change when failover/relocate is failed because of deleted policy

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -635,6 +635,8 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	drPolicy, err := r.getAndEnsureValidDRPolicy(ctx, drpc, logger)
 	if err != nil {
+		r.recordFailure(ctx, drpc, placementObj, "Error", err.Error(), logger)
+
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
When drPolicy is deleted, we are failing all new actions (failover/relocate), but user has no indication about it.
I added status change in DRPC when it happens

fixes: https://github.com/RamenDR/ramen/issues/1047
