### PR TITLE
Preserve old volume after action change

### DIFF
--- a/controllers/volsync/vshandler.go
+++ b/controllers/volsync/vshandler.go
@@ -1875,7 +1875,7 @@ func getRemoteServiceNameForRDFromPVCName(pvcName, rdNamespace string) string {
 // BuildNameForMainDstPVC transforms a given PVC name into a new name following a specific format. Its primary purpose is
 // to create a distinct name for a new PVC. This new PVC is main destinationPVC for the ReplicationDestination.
 func BuildNameForMainDstPVC(pvcName string) string {
-	return fmt.Sprintf("vs-%s-main-dst-for-localdirect", pvcName)
+	return fmt.Sprintf("vs-%s-main-dst-ld", pvcName)
 }
 
 func getKindAndName(scheme *runtime.Scheme, obj client.Object) string {

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -707,7 +707,7 @@ var _ = Describe("VolSync_Handler", func() {
 					}, maxWait, interval).Should(Not(BeNil()))
 				})
 				It("Should create lRD and lRS", func() {
-					_, _, err := vsHandler.ReconcileRD(rdSpec,false)
+					_, _, err := vsHandler.ReconcileRD(rdSpec, false)
 					Expect(err).ToNot(HaveOccurred())
 
 					// Local RD should be created with name=PVCName-local
@@ -832,7 +832,6 @@ var _ = Describe("VolSync_Handler", func() {
 					}, maxWait, interval).Should(Succeed())
 
 					Expect(pvc.GetName()).To(Equal(volsync.BuildNameForMainDstPVC(rdSpec.ProtectedPVC.Name)))
-					Expect(pvc.GetOwnerReferences()[0].Kind).To(Equal("ConfigMap"))
 				})
 			})
 		})

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -1744,10 +1744,10 @@ var _ = Describe("VolSync_Handler", func() {
 
 		It("Should delete an RD when it belongs to the VRG", func() {
 			rdToDelete1 := rdSpecList[3].ProtectedPVC.Name // rd name should == pvc name
-			Expect(vsHandler.DeleteRD(rdToDelete1)).To(Succeed())
+			Expect(vsHandler.DeleteRDWithSpecificOwner(rdToDelete1)).To(Succeed())
 
 			rdToDelete2 := rdSpecList[5].ProtectedPVC.Name // rd name should == pvc name
-			Expect(vsHandler.DeleteRD(rdToDelete2)).To(Succeed())
+			Expect(vsHandler.DeleteRDWithSpecificOwner(rdToDelete2)).To(Succeed())
 
 			remainingRDs := &volsyncv1alpha1.ReplicationDestinationList{}
 			Eventually(func() int {
@@ -1763,8 +1763,8 @@ var _ = Describe("VolSync_Handler", func() {
 		})
 
 		It("Should not delete an RD when it does not belong to the VRG", func() {
-			rdToDelete := rdSpecListOtherOwner[1].ProtectedPVC.Name // rd name should == pvc name
-			Expect(vsHandler.DeleteRD(rdToDelete)).To(Succeed())    // Should not return err
+			rdToDelete := rdSpecListOtherOwner[1].ProtectedPVC.Name               // rd name should == pvc name
+			Expect(vsHandler.DeleteRDWithSpecificOwner(rdToDelete)).To(Succeed()) // Should not return err
 
 			// No RDs should have been deleted
 			remainingRDs := &volsyncv1alpha1.ReplicationDestinationList{}

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -791,7 +791,6 @@ var _ = Describe("VolSync_Handler", func() {
 					}, maxWait, interval).Should(Succeed())
 
 					Expect(pvc.GetName()).To(Equal(volsync.BuildNameForMainDstPVC(rdSpec.ProtectedPVC.Name)))
-					Expect(pvc.GetOwnerReferences()[0].Kind).To(Equal("ConfigMap"))
 				})
 			})
 			Context("With CopyMethod 'LocalDirect', app PVC exists and in deleted state", func() {
@@ -1960,6 +1959,7 @@ var _ = Describe("VolSync_Handler", func() {
 					if err != nil {
 						return false
 					}
+					fmt.Printf("testPVC output %+v", testPVC)
 					// configmap owner is faking out VRG
 					return ownerMatches(testPVC, owner.GetName(), "ConfigMap", false)
 				}, maxWait, interval).Should(BeTrue())

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -266,7 +266,7 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 	// decide if reconcile request needs to be sent to the
 	// corresponding VolumeReplicationGroup CR by:
 	// - whether there is a VolumeReplicationGroup CR in the namespace
-	//   to which the the pvc belongs to.
+	//   to which the pvc belongs to.
 	// - whether the labels on pvc match the label selectors from
 	//    VolumeReplicationGroup CR.
 	err := reader.List(context.TODO(), &vrgs, listOptions...)
@@ -305,6 +305,7 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 	return req
 }
 
+//nolint:gocritic,gocognit,cyclop
 func replicationDestinationPredicateFunc() predicate.Funcs {
 	log := ctrl.Log.WithName("RDPredicate").WithName("RD")
 	rdPredicate := predicate.Funcs{
@@ -623,6 +624,7 @@ func (v *VRGInstance) validateVRGMode() error {
 	return nil
 }
 
+//nolint:gomnd
 func (v *VRGInstance) clusterDataRestore(result *ctrl.Result) error {
 	if v.instance.Spec.PrepareForFinalSync || v.instance.Spec.RunFinalSync {
 		msg := "PV restore skipped, as VRG is orchestrating final sync"
@@ -655,6 +657,7 @@ func (v *VRGInstance) clusterDataRestore(result *ctrl.Result) error {
 	if err != nil {
 		if errorswrapper.Is(err, volsync.WaitingForNotInUsePVC) {
 			v.log.Info("VolSync PV Restore Incomplete")
+
 			result.RequeueAfter = time.Second * 5 // delay by no more than 5 seconds
 
 			return err

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -1687,49 +1687,10 @@ func (v *VRGInstance) addProtectedFinalizerToPVC(pvc *corev1.PersistentVolumeCla
 	return v.addFinalizerToPVC(pvc, pvcVRFinalizerProtected, log)
 }
 
-func (v *VRGInstance) addFinalizerToPVC(pvc *corev1.PersistentVolumeClaim,
-	finalizer string,
-	log logr.Logger,
-) error {
-	if !containsString(pvc.ObjectMeta.Finalizers, finalizer) {
-		pvc.ObjectMeta.Finalizers = append(pvc.ObjectMeta.Finalizers, finalizer)
-		if err := v.reconciler.Update(v.ctx, pvc); err != nil {
-			log.Error(err, "Failed to add finalizer", "finalizer", finalizer)
-
-			return fmt.Errorf("failed to add finalizer (%s) to PersistentVolumeClaim resource"+
-				" (%s/%s) belonging to VolumeReplicationGroup (%s/%s), %w",
-				finalizer, pvc.Namespace, pvc.Name, v.instance.Namespace, v.instance.Name, err)
-		}
-	}
-
-	return nil
-}
-
 func (v *VRGInstance) removeProtectedFinalizerFromPVC(pvc *corev1.PersistentVolumeClaim,
 	log logr.Logger,
 ) error {
-	return v.removeFinalizerFromPVC(pvc, pvcVRFinalizerProtected, log)
-}
-
-// removeFinalizerFromPVC removes the VR finalizer on PVC and also the protected annotation from the PVC
-func (v *VRGInstance) removeFinalizerFromPVC(pvc *corev1.PersistentVolumeClaim,
-	finalizer string,
-	log logr.Logger,
-) error {
-	if containsString(pvc.ObjectMeta.Finalizers, finalizer) {
-		pvc.ObjectMeta.Finalizers = removeString(pvc.ObjectMeta.Finalizers, finalizer)
-		delete(pvc.ObjectMeta.Annotations, pvcVRAnnotationProtectedKey)
-
-		if err := v.reconciler.Update(v.ctx, pvc); err != nil {
-			log.Error(err, "Failed to remove finalizer", "finalizer", finalizer)
-
-			return fmt.Errorf("failed to remove finalizer (%s) from PersistentVolumeClaim resource"+
-				" (%s/%s) detected as part of VolumeReplicationGroup (%s/%s), %w",
-				finalizer, pvc.Namespace, pvc.Name, v.instance.Namespace, v.instance.Name, err)
-		}
-	}
-
-	return nil
+	return v.removeFinalizerAndAnnotationFromPVC(pvc, pvcVRFinalizerProtected, pvcVRAnnotationProtectedKey, log)
 }
 
 func (v *VRGInstance) addArchivedAnnotationForPVC(pvc *corev1.PersistentVolumeClaim, log logr.Logger) error {

--- a/controllers/vrg_volsync.go
+++ b/controllers/vrg_volsync.go
@@ -198,6 +198,7 @@ func (v *VRGInstance) reconcileVolSyncAsSecondary() bool {
 }
 
 func (v *VRGInstance) reconcileVolSyncForDeletion() error {
+	v.log.Info("Reconcile volsync for deletion as Secondary", "volSyncPVCsLen", len(v.volSyncPVCs))
 	for _, pvc := range v.volSyncPVCs {
 		if err := v.removeFinalizerAndAnnotationFromPVC(&pvc, volsync.VolSyncFinalizerName, "", v.log); err != nil {
 			return err

--- a/controllers/vrg_volsync.go
+++ b/controllers/vrg_volsync.go
@@ -24,6 +24,7 @@ func (v *VRGInstance) restorePVsForVolSync() error {
 	}
 
 	numPVsRestored := 0
+
 	var lastErr error
 
 	for _, rdSpec := range v.instance.Spec.VolSync.RDSpec {
@@ -199,8 +200,10 @@ func (v *VRGInstance) reconcileVolSyncAsSecondary() bool {
 
 func (v *VRGInstance) reconcileVolSyncForDeletion() error {
 	v.log.Info("Reconcile volsync for deletion as Secondary", "volSyncPVCsLen", len(v.volSyncPVCs))
-	for _, pvc := range v.volSyncPVCs {
-		if err := v.removeFinalizerAndAnnotationFromPVC(&pvc, volsync.VolSyncFinalizerName, "", v.log); err != nil {
+
+	for idx := range v.volSyncPVCs {
+		err := v.removeFinalizerAndAnnotationFromPVC(&v.volSyncPVCs[idx], volsync.VolSyncFinalizerName, "", v.log)
+		if err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
# Problem
When RDR is enabled and CephFS volumes are in use, `Ramen` uses `VolSync` to synchronize the volumes from the primary cluster to the failover cluster at each scheduled interval. If a switchover is attempted, the copy of the data on the old primary cluster is lost. Consequently, when reconnecting to the old primary cluster, the sync back process starts and the entire dataset must be transferred, rather than preserving the volume and transferring only the incremental changes.

# Solution
To address this issue and optimize the sync process, we created this PR with the following changes:

## What happens at the old Primary when it is back online?
### Preserving Data on the failed Source Cluster

During a failover or relocation event, the volume on the failed source cluster should closely resemble the volume on the new destination cluster (failoverCluster). Since the failed source cluster is typically where the application was actively running, it should ideally contain most of the data present on the new source cluster. In the case of a relocation, the data should be identical. Recognizing this similarity presents an opportunity to optimize the synchronization process when returning data to the old source cluster after a failover or relocation has been successfully completed. Such optimization can significantly expedite the synchronization process, especially in environments with high latency and large volumes of data.

One straightforward approach to achieve this optimization is to leverage the existing volume directly. However, this approach comes with a caveat: it requires the use of the application's PVC, which may not align with our desired strategy. This would effectively revert us to using the `Direct` copy method, which may not be the ideal choice.

### Two Key Changes

The changes in this PR involve two significant steps, the first being the setup of the destination on the failed cluster ([commit1](https://github.com/RamenDR/ramen/commit/4b8d93449731927caa3825dd3ba46d4c2ec60e6f)), and the second pertaining to setting the new source after a failover or relocation event ([commit2](https://github.com/RamenDR/ramen/commit/5f7a3ec8124ae5cb1af951632ae967ec6d838400)).

#### Setting up the VolSync Destination with `copyMethod` as `LocalDirect`

##### 1. On Initial Deployment

During the initial deployment, the destination cluster does not have a reference to the application PVC, and therefore, no optimization is attempted. Instead, we create a new `destinationPVC` to be used by the main `ReplicationDestination`.

##### 2. After a Failover or Relocation

In these scenarios, a `ReplicationSource` is already running when setting up the `ReplicationDestination`. We need to take advantage of the dataset that already exists on the cluster to optimize the synchronization from the new source to this destination.

In this case, the application PVCs must be retained until they are **disassociated from their corresponding PVs**. To achieve this, a finalizer is added to every protected PVC of the application. During the cleanup phase on the new destination cluster, when the application is deleted, the PVCs will transition to a deleted state but remain available due to the finalizer.

During the main `ReplicationDestination` creation, we **detach** the PV from the application PVC (still in deleted state). This operation ensures that the PVC is disassociated from its underlying storage, allowing for the safe removal of the PVC and the reuse of the PV. This function will wait until the `pv.Status.Phase` becomes `Available`.

Following this step, a new PVC is created, named in the following format: `vs-%s-main-dst-for-localdirect` where `%s` represents the main PVC name. Finally, we remove the finalizer from the main application PVC.

Once these steps are completed, we proceed to create the main `ReplicationDestination`, the local `ReplicationDestination`, and the local `ReplicationSource`. 

## What happens at the New Source Cluster?

During the PVC restore process, we implement the following steps to minimize the loss of data:

1. ##### Synchronization of the Last Snapshot Locally
   As part of the PVC restore process, the local sync has to be allowed to complete the sync.

2. ##### Pause of the Main ReplicationDestination
   To prevent any further synchronization attempts during the restore process, we **pause** the main `ReplicationDestination`. This ensures that no additional data changes are propagated from the failing primary cluster to the failover cluster while the restore is in progress.

3. ##### Verification of Application PVC Availability

   Before proceeding with the restore, we verify that the application PVC is not actively in use by any other pod.

The following diagram illustrates the scenario that might occur during a failover:

<img width="731" alt="image" src="https://github.com/RamenDR/ramen/assets/38288784/4e80e0c9-05da-4b4b-bb32-17b27af0dd3c">


In the diagram, we see that `snap: 600` is being synced locally on the failover cluster. Concurrently, `snap: 601` is being synchronized from the primary cluster to the failover cluster, and this process is still in progress. Additionally, the diagram indicates that the primary cluster is experiencing issues, prompting the user to consider a failover to the failover cluster.

A critical consideration in this scenario is that if the sync of `snap: 601` completes before the user decides to initiate the failover while `snap: 600` is still being synced locally, we want to delay the restore process until `snap: 601` is also fully synchronized locally. This may increase the RTO but ensures that the RPO is maintained as desired.

In this scenario, the restore process will wait until `snap: 601` is fully transferred, at which point it pauses the `ReplicationDestination`. This pause action effectively halts any further synchronization attempts from the failing primary cluster to the failover cluster. Simultaneously, the restore process waits for `snap: 600` to complete its local sync. Once both `snap: 601` and `snap: 600` are synchronized locally, the restoration process proceeds to clean up local resources and prepares the application PVC for use. 

# `oc` Output of few resources after initial deployment
## Source (Primary)
```
NAME                           READY   STATUS    RESTARTS   AGE
pod/busybox-5699775f99-jb2ch   1/1     Running   0          16h

NAME                                STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                AGE
persistentvolumeclaim/busybox-pvc   Bound    pvc-90ccf755-ff3a-4a8f-85d0-fca74ca2969b   500Gi      RWX            ocs-storagecluster-cephfs   16h

NAME                                                       DESIREDSTATE   CURRENTSTATE
volumereplicationgroup.ramendr.openshift.io/busybox-drpc   primary        Primary

NAME                                            SOURCE        LAST SYNC              DURATION        NEXT SYNC
replicationsource.volsync.backube/busybox-pvc   busybox-pvc   2023-10-02T12:15:14Z   14.790896382s   2023-10-02T12:20:00Z
```
## Application PVC yaml output
```
oc get persistentvolumeclaim/busybox-pvc -o yaml                                                      
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    apps.open-cluster-management.io/do-not-delete: "true"
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-provisioner: openshift-storage.cephfs.csi.ceph.com
    volume.kubernetes.io/storage-provisioner: openshift-storage.cephfs.csi.ceph.com
  creationTimestamp: "2023-10-01T20:00:24Z"
  finalizers:
  - kubernetes.io/pvc-protection
  - volumereplicationgroups.ramendr.openshift.io/pvc-volsync-protection
  labels:
    app: busybox-samples
    app.kubernetes.io/part-of: busybox-samples
    appname: busybox
    placement: busybox-placement-1
  name: busybox-pvc
  namespace: busybox-samples
  ownerReferences:
  - apiVersion: volsync.backube/v1alpha1
    kind: ReplicationSource
    name: busybox-pvc
    uid: 25c375ef-4f1f-4e3d-8bae-61f28c0c6773
  resourceVersion: "34887995"
  uid: 90ccf755-ff3a-4a8f-85d0-fca74ca2969b
spec:
  accessModes:
  - ReadWriteMany
  resources:
    requests:
      storage: 500Gi
  storageClassName: ocs-storagecluster-cephfs
  volumeMode: Filesystem
  volumeName: pvc-90ccf755-ff3a-4a8f-85d0-fca74ca2969b
status:
  accessModes:
  - ReadWriteMany
  capacity:
    storage: 500Gi
  phase: Bound
```

## Destination (Secondary)
```
NAME                                                READY   STATUS    RESTARTS   AGE
pod/volsync-rsync-tls-dst-busybox-pvc-9vqf4         1/1     Running   0          111s
pod/volsync-rsync-tls-dst-busybox-pvc-local-fn9hp   1/1     Running   0          91s

NAME                                                              STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                AGE
persistentvolumeclaim/busybox-pvc                                 Bound    pvc-d16ceff6-8871-4761-a0a9-1b11c32f9ed3   500Gi      RWX            ocs-storagecluster-cephfs   16h
persistentvolumeclaim/vs-busybox-pvc-main-dst-ld                  Bound    pvc-98baf920-02ca-4503-bd21-54c60032977c   500Gi      RWX            ocs-storagecluster-cephfs   16h
persistentvolumeclaim/vs-busybox-pvc-main-dst-ld-20231002121515   Bound    pvc-bcd0d1a2-4c43-433a-ac29-3a6bce89c865   500Gi      ROX            ocs-storagecluster-cephfs   112s

NAME                                                       DESIREDSTATE   CURRENTSTATE
volumereplicationgroup.ramendr.openshift.io/busybox-drpc   secondary      Secondary

NAME                                                       LAST SYNC              DURATION          NEXT SYNC
replicationdestination.volsync.backube/busybox-pvc         2023-10-02T12:15:15Z   4m55.233362711s   
replicationdestination.volsync.backube/busybox-pvc-local   2023-10-02T12:15:35Z   4m35.230976343s   

NAME                                                  SOURCE                                      LAST SYNC              DURATION        NEXT SYNC
replicationsource.volsync.backube/busybox-pvc-local   vs-busybox-pvc-main-dst-ld-20231002121515   2023-10-02T12:15:35Z   20.220340916s 
```
## PVC yaml output to be used as App PVC on failover/relocate
```
oc get persistentvolumeclaim/busybox-pvc -o yaml                                        
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  annotations:
    pv.kubernetes.io/bind-completed: "yes"
    pv.kubernetes.io/bound-by-controller: "yes"
    volume.beta.kubernetes.io/storage-provisioner: openshift-storage.cephfs.csi.ceph.com
    volume.kubernetes.io/storage-provisioner: openshift-storage.cephfs.csi.ceph.com
  creationTimestamp: "2023-10-01T20:01:41Z"
  finalizers:
  - kubernetes.io/pvc-protection
  labels:
    app: busybox-samples
    app.kubernetes.io/part-of: busybox-samples
    appname: busybox
    placement: busybox-placement-1
  name: busybox-pvc
  namespace: busybox-samples
  ownerReferences:
  - apiVersion: ramendr.openshift.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: VolumeReplicationGroup
    name: busybox-drpc
    uid: aa8f6cef-8f3b-47e8-b3c8-6dd651aab28b
  resourceVersion: "32757703"
  uid: d16ceff6-8871-4761-a0a9-1b11c32f9ed3
spec:
  accessModes:
  - ReadWriteMany
  resources:
    requests:
      storage: 500Gi
  storageClassName: ocs-storagecluster-cephfs
  volumeMode: Filesystem
  volumeName: pvc-d16ceff6-8871-4761-a0a9-1b11c32f9ed3
status:
  accessModes:
  - ReadWriteMany
  capacity:
    storage: 500Gi
  phase: Bound
```

**Destination `oc` Output**

#### PVC Output:

1. **busybox-pvc**: This is the busybox application PVC. Its output is displayed above. During failover/relocation, the busybox application utilizes this PVC.
2.  **vs-busybox-pvc-main-dst-ld**: This serves as the main RD PVC. The remote source synchronizes with this PVC.
3. **vs-busybox-pvc-main-dst-ld-20231002121515**: This PVC represents the local source PVC. It is read-only and a new one is created when new snapshots are taken from the `vs-busybox-pvc-main-dst-ld` PVC. The naming convention matches the current snapshot name.

#### ReplicationDestination Output:

1. **busybox-pvc**: This is the primary RD resource.
2. **busybox-pvc-local**: This is the local RD resource. The local RS's POD synchronizes locally with the POD belonging to this RD.

#### ReplicationSource Output:

1. **busybox-pvc-local**: This serves as the local RS resource. The POD of this local RS syncs locally with the local destination.

### RD/RS resources mapped to PVC:
```
replicationdestination.volsync.backube/busybox-pvc ----------------------> persistentvolumeclaim/vs-busybox-pvc-main-dst-ld
replicationdestination.volsync.backube/busybox-pvc-local ----------------> persistentvolumeclaim/busybox-pvc
replicationsource.volsync.backube/busybox-pvc-local ---------------------> persistentvolumeclaim/vs-busybox-pvc-main-dst-ld-20231002121515
```

### TODOs
- [x] Finish unit test
- [x] fix Linter issue
- [ ] To further enhance relocation optimization, there's no need to wait for the local copy to finish. When the action is detected as `Relocate` we can seamlessly proceed with the same process outlined above to take over the main `ReplicationDestination` PVC.
- [x] Failover has been fully tested, but Relocation is still TODO.

Fixes bz: [2239580](https://bugzilla.redhat.com/show_bug.cgi?id=2239580)