### PR TITLE
Dockerfile: Up go version from 1.19 to 1.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM golang:1.19.1 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
# Problem
`make docker-build` from commit 7bbfe3c on Ubuntu 18.04 fails consistently on `step 5: RUN go mod download`

```sh
$ hack/minikube-ramen.sh manager_image_build
+ make -C hack/.. docker-build IMG=localhost/ramendr/ramen-operator:canary
make: Entering directory '/home/bhatfiel/ramen'
podman build -t localhost/ramendr/ramen-operator:canary .
STEP 1: FROM golang:1.19 AS builder
STEP 2: WORKDIR /workspace
--> Using cache 715fa79c38f19e372f9efa1e20579e64910b08e9a377fd86faaa8a1352095658
--> 715fa79c38f
STEP 3: COPY go.mod go.mod
--> 4ad47a5788f
STEP 4: COPY go.sum go.sum
--> aabc9ceb910
STEP 5: RUN go mod download
runtime/cgo: pthread_create failed: Operation not permitted
SIGABRT: abort
PC=0x7fd2f5f98d3c m=0 sigcode=18446744073709551610

goroutine 0 [idle]:
runtime: g 0: unknown pc 0x7fd2f5f98d3c
stack: frame={sp:0x7ffd9d4a9ab0, fp:0x0} stack=[0x7ffd9ccaaf30,0x7ffd9d4a9f40)
0x00007ffd9d4a99b0:  0x0000000000e6f26c  0x0000000000000000
0x00007ffd9d4a99c0:  0x0000000000a28859  0x0000000000000005
0x00007ffd9d4a99d0:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a99e0:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a99f0:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a00:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a10:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a20:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a30:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a40:  0x0000000000000002  0x0000000000000000
0x00007ffd9d4a9a50:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a60:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a70:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a80:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a90:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9aa0:  0x0000000000000000  0x00007fd2f5f98d2e
0x00007ffd9d4a9ab0: <0x0000000000000000  0xc68cf45338feac00
0x00007ffd9d4a9ac0:  0x0000000000000006  0x00007fd2f5f0b740
0x00007ffd9d4a9ad0:  0x0000000001d682e0  0x0000000000000178
0x00007ffd9d4a9ae0:  0x0000000000e3dda0  0x00007fd2f5f49f32
0x00007ffd9d4a9af0:  0x00007fd2f60e1e70  0x00007fd2f5f34472
0x00007ffd9d4a9b00:  0x0000000000000020  0x0000000000000000
0x00007ffd9d4a9b10:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9b20:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9b30:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9b40:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9b50:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9b60:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9b70:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9b80:  0x00007fd2f5f0b740  0x00007fd2f5f8b87a
0x00007ffd9d4a9b90:  0x00007fd2f60e1840  0xc68cf45338feac00
0x00007ffd9d4a9ba0:  0x00007fd2f60e1840  0x00007fd2f60e1840
runtime: g 0: unknown pc 0x7fd2f5f98d3c
stack: frame={sp:0x7ffd9d4a9ab0, fp:0x0} stack=[0x7ffd9ccaaf30,0x7ffd9d4a9f40)
0x00007ffd9d4a99b0:  0x0000000000e6f26c  0x0000000000000000
0x00007ffd9d4a99c0:  0x0000000000a28859  0x0000000000000005
0x00007ffd9d4a99d0:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a99e0:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a99f0:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a00:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a10:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a20:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a30:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a40:  0x0000000000000002  0x0000000000000000
0x00007ffd9d4a9a50:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a60:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a70:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a80:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9a90:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9aa0:  0x0000000000000000  0x00007fd2f5f98d2e
0x00007ffd9d4a9ab0: <0x0000000000000000  0xc68cf45338feac00
0x00007ffd9d4a9ac0:  0x0000000000000006  0x00007fd2f5f0b740
0x00007ffd9d4a9ad0:  0x0000000001d682e0  0x0000000000000178
0x00007ffd9d4a9ae0:  0x0000000000e3dda0  0x00007fd2f5f49f32
0x00007ffd9d4a9af0:  0x00007fd2f60e1e70  0x00007fd2f5f34472
0x00007ffd9d4a9b00:  0x0000000000000020  0x0000000000000000
0x00007ffd9d4a9b10:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9b20:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9b30:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9b40:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9b50:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9b60:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9b70:  0x0000000000000000  0x0000000000000000
0x00007ffd9d4a9b80:  0x00007fd2f5f0b740  0x00007fd2f5f8b87a
0x00007ffd9d4a9b90:  0x00007fd2f60e1840  0xc68cf45338feac00
0x00007ffd9d4a9ba0:  0x00007fd2f60e1840  0x00007fd2f60e1840

goroutine 1 [running]:
runtime.systemstack_switch()
        /usr/local/go/src/runtime/asm_amd64.s:459 fp=0xc00004e780 sp=0xc00004e778 pc=0x4662e0
runtime.main()
        /usr/local/go/src/runtime/proc.go:170 +0x6d fp=0xc00004e7e0 sp=0xc00004e780 pc=0x439ded
runtime.goexit()
        /usr/local/go/src/runtime/asm_amd64.s:1594 +0x1 fp=0xc00004e7e8 sp=0xc00004e7e0 pc=0x468501

rax    0x0
rbx    0x2
rcx    0x7fd2f5f98d3c
rdx    0x6
rdi    0x2
rsi    0x2
rbp    0x7fd2f5f0b740
rsp    0x7ffd9d4a9ab0
r8     0x0
r9     0x73
r10    0x8
r11    0x246
r12    0x6
r13    0x178
r14    0xe3dda0
r15    0x7fd2ceb9a35b
rip    0x7fd2f5f98d3c
rflags 0x246
cs     0x33
fs     0x0
gs     0x0
STEP 6: FROM registry.access.redhat.com/ubi8/ubi
^CMakefile:202: recipe for target 'docker-build' failed
make: *** [docker-build] Error 1
```

# Proposed solution
Increase base image from golang version 1.19 to 1.19.1
https://stackoverflow.com/questions/76667069/when-i-build-go-image-with-circleci-i-get-runtime-cgo-pthread-create-failed-o/76685313#76685313

```sh
$ hack/minikube-ramen.sh manager_image_build
+ make -C hack/.. docker-build IMG=localhost/ramendr/ramen-operator:canary
make: Entering directory '/home/bhatfiel/ramen'
podman build -t localhost/ramendr/ramen-operator:canary .
STEP 1: FROM golang:1.19.1 AS builder
STEP 2: WORKDIR /workspace
--> Using cache 5c9fdf628dd34d91bcdcc0a5663c7e617b345d63215675bb4aef06e3069995b8
--> 5c9fdf628dd
STEP 3: COPY go.mod go.mod
--> 1bd10533277
STEP 4: COPY go.sum go.sum
--> 02d6c8dc774
STEP 5: RUN go mod download
--> 3987e51ec2e
STEP 6: COPY main.go main.go
--> 0285fab328e
STEP 7: COPY api/ api/
--> 7fc5991f5d4
STEP 8: COPY controllers/ controllers/
--> d68349ee942
STEP 9: RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
--> 1765db92a1e
STEP 10: FROM registry.access.redhat.com/ubi8/ubi
STEP 11: WORKDIR /
--> Using cache 8b40dbb445369177b52d4a71d3c4e01de53d6261297be38574d9ef70bc90bf37
--> 8b40dbb4453
STEP 12: COPY --from=builder /workspace/manager .
--> 3fa3bf41634
STEP 13: RUN mkdir -p licenses
--> 4585d31c298
STEP 14: COPY LICENSES/Apache-2.0.txt licenses/Apache-2.0.txt
--> 158a1bbc83b
STEP 15: USER 65532:65532
--> 00c9b67ff10
STEP 16: ENTRYPOINT ["/manager"]
STEP 17: COMMIT localhost/ramendr/ramen-operator:canary
--> 8b728a6d0cd
8b728a6d0cd8ce1616aa1151025a18c7fbff22afce8edd75bda312c0a220b7cb
```