### PR TITLE
Fix markdown linter error

### DIFF
--- a/docs/design/proposals/VRG-Reconciliation.md
+++ b/docs/design/proposals/VRG-Reconciliation.md
@@ -104,7 +104,7 @@ status:
         - "True" if reconciliation is completed
             - `reason` is "Replicating"
         - "False" if reconciliation is progressing or has errors
-            - `reason`: Progressing|Error
+            - `reason`: Progressing\|Error
 - `status.protectedPVCs`:
     - `pvcName`: Name of the PVC for which conditions are represented
     - `conditions`:
@@ -184,7 +184,7 @@ are taken to ensure the same:
 1. Select all PVCs that match `PVCSelector` for processing
 1. For each PVC
     1. Prepare and protect PVC as [above](#pvc_preparation_and_protection_for_all_states)
-    1. [Find|Create] VR for PVC as `primary`
+    1. [Find\|Create] VR for PVC as `primary`
 1. For each protected PVC
     1. Check if VR status has reached `primary`
         1. If not, update status as progressing


### PR DESCRIPTION
Since mdl 0.13.0 `hack/pre-commit.sh` fails with[1]. Looks like a linter bug[2], treating `A|B` as a table, but escaping seems to be an easy workaround.

[1] MD057: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md057---table-has-missing-or-invalid-header-separation
[2] https://github.com/markdownlint/markdownlint/issues/472