### PR TITLE
Test disable dr

### DIFF
--- a/test/basic-test/disable-dr
+++ b/test/basic-test/disable-dr
@@ -5,9 +5,9 @@
 
 from drenv import test
 
-test.start("deploy", __file__)
+test.start("disable-dr", __file__)
 args = test.parse_args()
 
-test.info("Deploying application")
-test.deploy()
-test.info("Application running on cluster '%s'", test.lookup_cluster())
+test.info("Disable DR")
+test.disable_dr()
+test.info("DR was disabled")

--- a/test/basic-test/enable-dr
+++ b/test/basic-test/enable-dr
@@ -5,9 +5,11 @@
 
 from drenv import test
 
-test.start("deploy", __file__)
+test.start("enable-dr", __file__)
 args = test.parse_args()
 
-test.info("Deploying application")
-test.deploy()
-test.info("Application running on cluster '%s'", test.lookup_cluster())
+test.info("Enable DR")
+test.enable_dr()
+test.wait_for_drpc_status()
+test.wait_until_drpc_is_stable()
+test.info("DR enabled")

--- a/test/basic-test/failover
+++ b/test/basic-test/failover
@@ -6,17 +6,12 @@
 from drenv import test
 
 test.start("failover", __file__)
-test.add_argument(
-    "--cluster",
-    help="Cluster name to failover to (default second cluster).",
-)
 args = test.parse_args()
 
-cluster = args.cluster or test.env["clusters"][1]
-test.info("Fail over application to cluster '%s'", cluster)
+test.info("Fail over application")
 
 test.wait_until_drpc_is_stable()
-test.failover(cluster)
+test.failover()
 test.wait_until_drpc_is_stable()
 
-test.info("Application was failed over to cluster '%s' successfully", cluster)
+test.info("Application was failed over")

--- a/test/basic-test/relocate
+++ b/test/basic-test/relocate
@@ -6,17 +6,12 @@
 from drenv import test
 
 test.start("relocate", __file__)
-test.add_argument(
-    "--cluster",
-    help="Cluster name to relocate to (default first cluster).",
-)
 args = test.parse_args()
 
-cluster = args.cluster or test.env["clusters"][0]
-test.info("Relocate application to cluster '%s'", cluster)
+test.info("Relocate application")
 
 test.wait_until_drpc_is_stable()
-test.relocate(cluster)
+test.relocate()
 
 # We must wait for the phase since both Available and PeerReady are true at
 # this point. PeerReady becomes false when entering phase: Relocating
@@ -25,4 +20,4 @@ test.wait_for_drpc_phase("Relocated")
 
 test.wait_until_drpc_is_stable()
 
-test.info("Application was relocated to cluster '%s' successfully", cluster)
+test.info("Application was relocated")

--- a/test/basic-test/run
+++ b/test/basic-test/run
@@ -6,6 +6,8 @@
 base="$(dirname $0)"
 
 "$base/deploy" "$@"
+"$base/enable-dr" "$@"
 "$base/failover" "$@"
 "$base/relocate" "$@"
+"$base/disable-dr" "$@"
 "$base/undeploy" "$@"

--- a/test/drenv/test.py
+++ b/test/drenv/test.py
@@ -194,10 +194,11 @@ def _get_cluster_from_placementrule():
     )
 
 
-def failover(cluster):
+def failover():
     """
     Start failover to cluster.
     """
+    cluster = target_cluster()
     drpc = _lookup_app_resource("drpc")
 
     info("Starting failover for '%s' to cluster '%s'", drpc, cluster)
@@ -213,10 +214,11 @@ def failover(cluster):
     )
 
 
-def relocate(cluster):
+def relocate():
     """
     Start relocate to cluster.
     """
+    cluster = target_cluster()
     drpc = _lookup_app_resource("drpc")
 
     info("Starting relocate for '%s' to cluster '%s'", drpc, cluster)

--- a/test/drenv/test.py
+++ b/test/drenv/test.py
@@ -126,7 +126,7 @@ def failover(cluster):
     """
     Start failover to cluster.
     """
-    drpc = _drpc_name()
+    drpc = _lookup_app_resource("drpc")
 
     info("Starting failover for '%s' to cluster '%s'", drpc, cluster)
     patch = {"spec": {"action": "Failover", "failoverCluster": cluster}}
@@ -145,7 +145,7 @@ def relocate(cluster):
     """
     Start relocate to cluster.
     """
-    drpc = _drpc_name()
+    drpc = _lookup_app_resource("drpc")
 
     info("Starting relocate for '%s' to cluster '%s'", drpc, cluster)
     patch = {"spec": {"action": "Relocate", "preferredCluster": cluster}}
@@ -173,7 +173,7 @@ def wait_for_drpc_status():
         log=debug,
     )
 
-    drpc = _drpc_name()
+    drpc = _lookup_app_resource("drpc")
 
     info("Waiting until '%s' reports status", drpc)
     drenv.wait_for(
@@ -187,7 +187,7 @@ def wait_for_drpc_status():
 
 
 def wait_for_drpc_phase(phase):
-    drpc = _drpc_name()
+    drpc = _lookup_app_resource("drpc")
 
     info("Waiting for '%s' phase '%s'", drpc, phase)
     kubectl.wait(
@@ -207,7 +207,7 @@ def wait_until_drpc_is_stable(timeout=300):
     - PeerReady=true
     - lastGroupSyncTime!=''
     """
-    drpc = _drpc_name()
+    drpc = _lookup_app_resource("drpc")
 
     info("Waiting for '%s' Available condition", drpc)
     kubectl.wait(
@@ -240,9 +240,9 @@ def wait_until_drpc_is_stable(timeout=300):
     )
 
 
-def _drpc_name():
+def _lookup_app_resource(kind):
     out = kubectl.get(
-        "drpc",
+        kind,
         f"--selector=app={config['name']}",
         f"--namespace={config['namespace']}",
         "--output=name",


### PR DESCRIPTION
Add more helpers in `drenv.test` for adding enable-dr and disable-dr steps, and modify basic test to test disable and enable dr.

Uses my ocm-ramen-sample fork for testing since the relevant ocm-ramen-samples pr need to be merged together with this pr.

Changes include partial support for placement. We will complete this when switching to placement and removing code for placementrule (in tests).

Should be merged with https://github.com/RamenDR/ocm-ramen-samples/pull/35