### PR TITLE
Fix kubectl apply timeout with slow network

### DIFF
--- a/test/addons/ocm-controller/kustomization.yaml
+++ b/test/addons/ocm-controller/kustomization.yaml
@@ -7,7 +7,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/stolostron/multicloud-operators-foundation.git/deploy/foundation/hub/overlays/ocm-controller?ref=main
+# The default timeout (27 seconds) is too short when using a slow network.
+- https://github.com/stolostron/multicloud-operators-foundation.git/deploy/foundation/hub/overlays/ocm-controller?ref=main&timeout=300s
 images:
 - name: quay.io/stolostron/multicloud-manager
   newTag: latest


### PR DESCRIPTION
Cloning https://github.com/stolostron/multicloud-operators-foundation.git during `kubectl apply --kustomize` can fail with a timeout when using slow network:

    $ kubectl apply -k test/addons/ocm-controller --context hub error: accumulating resources:
    accumulation err='accumulating resources from
    'https://github.com/stolostron/multicloud-operators-foundation.git/deploy/foundation/hub/overlays/ocm-controller?ref=main':
    URL is a git repository': hit 27s timeout running '/usr/bin/git fetch --depth=1
    https://github.com/stolostron/multicloud-operators-foundation.git main'

Turns out that the way to increase the timeout is to add a `timeout` query parameter[1]. Use 300 seconds to avoid random failures when using poor network.

[1] https://github.com/kubernetes-sigs/kustomize/issues/3742