### PR TITLE
Add regional dr kubevirt environment

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -490,6 +490,8 @@ $ drenv delete envs/example.yaml
     - `extra_config`: List of extra config key=value. Each item adds
       `--extra-config` minikube option. See `minikube start --help` to
       see the possible keys and values.
+    - `containerd`: Optional containerd configuration object. See
+      `containerd config default` for available options.
     - `workers`: Optional list of workers to run when starting a
       profile. Use multiple workers to run scripts in parallel.
         - `name`: Optional worker name
@@ -568,6 +570,31 @@ relative path for resources in the same directory:
 ```python
 kubectl.apply("--filename=deployment.yaml", context=cluster)
 ```
+
+#### containerd options
+
+To configure containerd you can add a configuration object matching
+containerd toml structure.
+
+For example to enable this option containerd toml:
+
+```toml
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    device_ownership_from_security_context = true
+```
+
+Add this configuration to the profile:
+
+```yaml
+containerd:
+  plugins:
+    io.containerd.grpc.v1.cri:
+      device_ownership_from_security_context: true
+```
+
+When set, contained configuration is merged into the current
+configuration in `/etc/containerd/config.toml` in the node.
 
 ## Environment files
 

--- a/test/README.md
+++ b/test/README.md
@@ -622,6 +622,7 @@ simpler and faster to work with a minimal environment.
 - `demo.yaml` - interactive demo for exploring the `drenv` tool
 - `e2e.yaml` - example for testing integration with the e2e framework
 - `external.yaml` - example for using external clusters
+- `kubevirt.yaml` - for testing kubevirt and cdi addons
 - `minio.yaml` - for testing `minio` deployment
 - `ocm.yaml` - for testing `ocm` deployment
 - `rook.yaml` - for testing `rook` deployment

--- a/test/README.md
+++ b/test/README.md
@@ -608,6 +608,9 @@ The environments files are located in the `envs` directory.
 - `regional-dr-hubless.yaml` - for testing regional DR using a setup
   without a hub.
 
+- `regional-dr-kubevirt.yaml` - for testing regional DR for kubevirt
+  workloads.
+
 - `regional-dr-external.yaml.example` - A starting point for creating
    environment for testing regional DR using with external storage.
 

--- a/test/README.md
+++ b/test/README.md
@@ -58,6 +58,11 @@ environment.
    See [Installing Helm](https://helm.sh/docs/intro/install/) for other options.
    Tested with version v3.11.
 
+1. Install the `virtctl` tool. See
+   [virtctl install](https://kubevirt.io/quickstart_minikube/#virtctl)
+   for the details.
+   Tested with version v1.0.1.
+
 1. Install `docker`
 
    ```

--- a/test/addons/cdi/cr/kustomization.yaml
+++ b/test/addons/cdi/cr/kustomization.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# yamllint disable rule:line-length
+---
+resources:
+- https://github.com/kubevirt/containerized-data-importer/releases/download/v1.57.0/cdi-cr.yaml

--- a/test/addons/cdi/disk/kustomization.yaml
+++ b/test/addons/cdi/disk/kustomization.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+resources:
+- source.yaml
+- pvc.yaml

--- a/test/addons/cdi/disk/pvc.yaml
+++ b/test/addons/cdi/disk/pvc.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc
+spec:
+  dataSourceRef:
+    apiGroup: cdi.kubevirt.io
+    kind: VolumeImportSource
+    name: cirros-source
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 128Mi
+  storageClassName: csi-hostpath-sc
+  volumeMode: Block

--- a/test/addons/cdi/disk/source.yaml
+++ b/test/addons/cdi/disk/source.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: VolumeImportSource
+metadata:
+  name: cirros-source
+spec:
+  source:
+    registry:
+      url: "docker://quay.io/alitke/cirros:latest"

--- a/test/addons/cdi/operator/kustomization.yaml
+++ b/test/addons/cdi/operator/kustomization.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# yamllint disable rule:line-length
+---
+resources:
+- https://github.com/kubevirt/containerized-data-importer/releases/download/v1.57.0/cdi-operator.yaml

--- a/test/addons/cdi/start
+++ b/test/addons/cdi/start
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from drenv import kubectl
+
+NAMESPACE = "cdi"
+
+
+def deploy(cluster):
+    print("Deploying cdi operator")
+    kubectl.apply("--kustomize=operator", context=cluster)
+
+    print("Waiting until cdi-operator is rolled out")
+    kubectl.rollout(
+        "status",
+        "deploy/cdi-operator",
+        f"--namespace={NAMESPACE}",
+        "--timeout=300s",
+        context=cluster,
+    )
+
+    print("Deploying cdi cr")
+    kubectl.apply("--kustomize=cr", context=cluster)
+
+
+def wait(cluster):
+    print("Waiting until cdi cr is available")
+    kubectl.wait(
+        "cdi.cdi.kubevirt.io/cdi",
+        "--for=condition=available",
+        f"--namespace={NAMESPACE}",
+        "--timeout=300s",
+        context=cluster,
+    )
+
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} cluster")
+    sys.exit(1)
+
+os.chdir(os.path.dirname(__file__))
+cluster = sys.argv[1]
+
+deploy(cluster)
+wait(cluster)

--- a/test/addons/cdi/test
+++ b/test/addons/cdi/test
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from drenv import kubectl
+
+
+def test(cluster):
+    print("Deploying disk")
+    kubectl.apply("--kustomize=disk", context=cluster)
+
+    print("Waiting until pvc is bound")
+    kubectl.wait(
+        "pvc/test-pvc",
+        "--for=jsonpath={.status.phase}=Bound",
+        "--timeout=180s",
+        context=cluster,
+    )
+
+    print("Deletting disk")
+    kubectl.delete("--kustomize=disk", context=cluster)
+
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} cluster")
+    sys.exit(1)
+
+os.chdir(os.path.dirname(__file__))
+cluster = sys.argv[1]
+
+test(cluster)

--- a/test/addons/kubevirt/cr/kustomization.yaml
+++ b/test/addons/kubevirt/cr/kustomization.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# yamllint disable rule:line-length
+---
+resources:
+- https://github.com/kubevirt/kubevirt/releases/download/v1.0.1/kubevirt-cr.yaml

--- a/test/addons/kubevirt/operator/kustomization.yaml
+++ b/test/addons/kubevirt/operator/kustomization.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# yamllint disable rule:line-length
+---
+resources:
+- https://github.com/kubevirt/kubevirt/releases/download/v1.0.1/kubevirt-operator.yaml

--- a/test/addons/kubevirt/start
+++ b/test/addons/kubevirt/start
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from drenv import kubectl
+
+NAMESPACE = "kubevirt"
+
+
+def deploy(cluster):
+    print("Deploying kubevirt operator")
+    kubectl.apply("--kustomize=operator", context=cluster)
+
+    print("Waiting until virt-operator is rolled out")
+    kubectl.rollout(
+        "status",
+        "deploy/virt-operator",
+        f"--namespace={NAMESPACE}",
+        "--timeout=300s",
+        context=cluster,
+    )
+
+    print("Deploying kubevirt cr")
+    kubectl.apply("--kustomize=cr", context=cluster)
+
+
+def wait(cluster):
+    print("Waiting until kubevirt cr is available")
+    kubectl.wait(
+        "kubevirt.kubevirt.io/kubevirt",
+        "--for=condition=available",
+        f"--namespace={NAMESPACE}",
+        "--timeout=300s",
+        context=cluster,
+    )
+
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} cluster")
+    sys.exit(1)
+
+os.chdir(os.path.dirname(__file__))
+cluster = sys.argv[1]
+
+deploy(cluster)
+wait(cluster)

--- a/test/addons/kubevirt/test
+++ b/test/addons/kubevirt/test
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+import time
+
+from drenv import kubectl
+from drenv import virtctl
+
+NAMESPACE = "kubevirt-test"
+
+
+def test(cluster):
+    create_namespace(cluster)
+    create_secret(cluster)
+    create_vm(cluster)
+    wait_until_vm_is_ready(cluster)
+    verify_ssh(cluster)
+    delete_vm(cluster)
+    delete_namespace(cluster)
+
+
+def create_namespace(clsuter):
+    print(f"Creating namespace '{NAMESPACE}'")
+    ns = kubectl.create(
+        "namespace",
+        NAMESPACE,
+        "--dry-run=client",
+        "--output=yaml",
+    )
+    kubectl.apply("--filename=-", input=ns, context=cluster)
+
+
+def delete_namespace(cluster):
+    print(f"Deletting namespace '{NAMESPACE}'")
+    kubectl.delete(f"ns/{NAMESPACE}", context=cluster)
+
+
+def create_secret(cluster):
+    """
+    Create a secret with current user public key for accessing VM via ssh using
+    access credentials API:
+    https://kubevirt.io/user-guide/virtual_machines/accessing_virtual_machines/#static-ssh-public-key-injection-via-cloud-init
+    """
+    public_key = os.path.expanduser("~/.ssh/id_rsa.pub")
+    print(
+        f"Creating secret my-public-key from '{public_key}' in namespace '{NAMESPACE}'"
+    )
+    secret = kubectl.create(
+        "secret",
+        "generic",
+        "my-public-key",
+        f"--from-file=key1={public_key}",
+        "--dry-run=client",
+        "--output=yaml",
+    )
+    kubectl.apply(
+        "--filename=-",
+        f"--namespace={NAMESPACE}",
+        input=secret,
+        context=cluster,
+    )
+
+
+def create_vm(cluster):
+    print(f"Deploying test vm in namespace '{NAMESPACE}'")
+    kubectl.apply("--filename=vm.yaml", f"--namespace={NAMESPACE}", context=cluster)
+
+
+def wait_until_vm_is_ready(cluster):
+    print("Waiting until test vm is ready")
+    kubectl.wait(
+        "vm/testvm",
+        "--for=condition=ready",
+        f"--namespace={NAMESPACE}",
+        "--timeout=180s",
+        context=cluster,
+    )
+
+
+def delete_vm(cluster):
+    print(f"Deleting test vm in namespace '{NAMESPACE}'")
+    kubectl.delete("--filename=vm.yaml", f"--namespace={NAMESPACE}", context=cluster)
+
+
+def verify_ssh(cluster):
+    """
+    Verify that we can run commands via ssh.
+    """
+    delay = 5
+
+    # When running in a vm in the blr lab we need 16 retires. Locally the
+    # second attempt succeeds.
+    retries = 30
+
+    for i in range(retries):
+        time.sleep(delay)
+        print("Running 'hostname' inside the VM via ssh")
+        try:
+            out = virtctl.ssh(
+                "testvm",
+                "hostname",
+                username="cirros",
+                namespace=NAMESPACE,
+                known_hosts="",  # Skip host key verification.
+                context=cluster,
+            )
+        except Exception as e:
+            print(f"Attempt {i+1}/{retries} failed: {e}")
+            print(f"Retrying in {delay} seconds...")
+        else:
+            print(f"Attempt {i+1}/{retries} succeeded")
+            print(out)
+            break
+    else:
+        raise RuntimeError("Failed to connect to VM via ssh")
+
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} cluster")
+    sys.exit(1)
+
+os.chdir(os.path.dirname(__file__))
+cluster = sys.argv[1]
+
+test(cluster)

--- a/test/addons/kubevirt/vm.yaml
+++ b/test/addons/kubevirt/vm.yaml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: testvm
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/size: small
+        kubevirt.io/domain: testvm
+    spec:
+      domain:
+        devices:
+          disks:
+            - name: containerdisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              bridge: {}
+        resources:
+          requests:
+            # See https://github.com/cirros-dev/cirros/issues/53
+            memory: 256Mi
+      networks:
+        - name: default
+          pod: {}
+      accessCredentials:
+        - sshPublicKey:
+            source:
+              secret:
+                secretName: my-public-key
+            propagationMethod:
+              configDrive: {}
+      volumes:
+        - name: containerdisk
+          containerDisk:
+            # TODO: use ramendr repo.
+            image: quay.io/nirsof/cirros:0.6.2
+        - name: cloudinitdisk
+          cloudInitConfigDrive:
+            userData: |
+              #!/bin/sh
+              echo "Running user-data script"

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -15,6 +15,7 @@ import yaml
 import drenv
 from . import cluster
 from . import commands
+from . import containerd
 from . import envfile
 from . import minikube
 from . import ramen
@@ -140,6 +141,9 @@ def start_cluster(profile, hooks=(), verbose=False, **options):
     else:
         is_restart = minikube_profile_exists(profile["name"])
         start_minikube_cluster(profile, verbose=verbose)
+        if profile["containerd"]:
+            logging.info("[%s] Configuring containerd", profile["name"])
+            containerd.configure(profile)
         if is_restart:
             wait_for_deployments(profile)
 

--- a/test/drenv/containerd.py
+++ b/test/drenv/containerd.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import tempfile
+
+import toml
+
+from . import minikube
+from . import patch
+
+
+def configure(profile):
+    config = f"{profile['name']}:/etc/containerd/config.toml"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = os.path.join(tmpdir, "config.toml")
+
+        minikube.cp(profile["name"], config, tmp)
+        with open(tmp) as f:
+            old_config = toml.load(f)
+
+        new_config = patch.merge(old_config, profile["containerd"])
+
+        with open(tmp, "w") as f:
+            toml.dump(new_config, f)
+        minikube.cp(profile["name"], tmp, config)
+
+    minikube.ssh(profile["name"], "sudo systemctl restart containerd")

--- a/test/drenv/envfile.py
+++ b/test/drenv/envfile.py
@@ -106,6 +106,7 @@ def _validate_profile(profile, addons_root):
     profile.setdefault("ser", [])
     profile.setdefault("service_cluster_ip_range", None)
     profile.setdefault("extra_config", [])
+    profile.setdefault("containerd", None)
     profile.setdefault("workers", [])
 
     _validate_platform_defaults(profile)

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -27,6 +27,13 @@ def config(*args, context=None):
     return _run("config", *args, context=context)
 
 
+def create(*args, context=None):
+    """
+    Run kubectl create ... and return the output.
+    """
+    return _run("create", *args, context=context)
+
+
 def get(*args, context=None):
     """
     Run kubectl get ... and return the output.

--- a/test/drenv/minikube.py
+++ b/test/drenv/minikube.py
@@ -86,6 +86,14 @@ def delete(profile):
     _watch("delete", profile=profile)
 
 
+def cp(profile, src, dst):
+    _watch("cp", src, dst, profile=profile)
+
+
+def ssh(profile, command):
+    _watch("ssh", command, profile=profile)
+
+
 def _run(command, *args, profile=None, output=None):
     cmd = ["minikube", command]
     if profile:

--- a/test/drenv/patch.py
+++ b/test/drenv/patch.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+
+def merge(a, b):
+    """
+    Merge b into a recursively.
+    """
+    if type(a) is dict:
+        assert type(b) is dict
+        res = dict(a)
+        for k, v in b.items():
+            if k in res:
+                res[k] = merge(res[k], v)
+            else:
+                res[k] = v
+        return res
+    else:
+        return a if b is None else b

--- a/test/drenv/patch_test.py
+++ b/test/drenv/patch_test.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+from drenv import patch
+
+
+def test_empty():
+    assert patch.merge({}, {}) == {}
+
+
+def test_add_key():
+    a = {"key1": "old-key"}
+    b = {"key2": "new-key"}
+    assert patch.merge(a, b) == {"key1": "old-key", "key2": "new-key"}
+
+
+def test_replace_key():
+    a = {"key": "old-value"}
+    b = {"key": "new-value"}
+    assert patch.merge(a, b) == {"key": "new-value"}
+
+
+def test_add_dict():
+    a = {"key1": "old-key"}
+    b = {"key2": {"key": "new-key"}}
+    assert patch.merge(a, b) == {"key1": "old-key", "key2": {"key": "new-key"}}
+
+
+def test_merge_dict():
+    a = {"key": {"key1": "old-key"}}
+    b = {"key": {"key2": "new-key"}}
+    assert patch.merge(a, b) == {"key": {"key1": "old-key", "key2": "new-key"}}
+
+
+def test_merge_recursive():
+    a = {
+        "key1": {
+            "key1": "old-value",
+            "key2": {
+                "key1": "old-key",
+            },
+        },
+    }
+    b = {
+        "key1": {
+            "key1": "new-value",
+            "key2": {
+                "key2": "new-key",
+            },
+            "key3": "new-key",
+        },
+        "key2": "new-key",
+    }
+    assert patch.merge(a, b) == {
+        "key1": {
+            "key1": "new-value",
+            "key2": {
+                "key1": "old-key",
+                "key2": "new-key",
+            },
+            "key3": "new-key",
+        },
+        "key2": "new-key",
+    }
+
+
+def test_merge_str():
+    assert patch.merge("a", "b") == "b"
+    assert patch.merge("a", None) == "a"
+
+
+def test_merge_number():
+    assert patch.merge(1, 2) == 2
+    assert patch.merge(3.1, 3.14) == 3.14
+    assert patch.merge(1, None) == 1
+
+
+def test_merge_list():
+    assert patch.merge(["a", "b"], ["b", "c"]) == ["b", "c"]
+    assert patch.merge(["a", "b"], None) == ["a", "b"]
+
+
+def test_merge_bool():
+    assert patch.merge(True, False) is False
+    assert patch.merge(False, True) is True
+    assert patch.merge(False, None) is False

--- a/test/drenv/virtctl.py
+++ b/test/drenv/virtctl.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+from . import commands
+
+
+def ssh(vm, command, username=None, namespace=None, known_hosts=None, context=None):
+    """
+    Run ssh command via virtctl.
+    """
+    cmd = ["virtctl", "ssh"]
+    if context:
+        cmd.extend(("--context", context))
+    if username:
+        cmd.extend(("--username", username))
+    if known_hosts is not None:
+        cmd.extend(("--known-hosts", known_hosts))
+    if namespace:
+        cmd.extend(("--namespace", namespace))
+    cmd.extend((vm, "--command", command))
+    return commands.run(*cmd)

--- a/test/envs/kubevirt.yaml
+++ b/test/envs/kubevirt.yaml
@@ -14,3 +14,5 @@ profiles:
     workers:
       - addons:
           - name: kubevirt
+      - addons:
+          - name: cdi

--- a/test/envs/kubevirt.yaml
+++ b/test/envs/kubevirt.yaml
@@ -8,9 +8,15 @@ profiles:
   - name: kubevirt
     driver: $vm
     container_runtime: containerd
+    containerd:
+      plugins:
+        io.containerd.grpc.v1.cri:
+          device_ownership_from_security_context: true
     network: $network
     cni: flannel
     memory: "8g"
+    addons:
+      - csi-hostpath-driver
     workers:
       - addons:
           - name: kubevirt

--- a/test/envs/kubevirt.yaml
+++ b/test/envs/kubevirt.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Environment for testing kubvirt.
+---
+name: kubevirt
+profiles:
+  - name: kubevirt
+    driver: $vm
+    container_runtime: containerd
+    network: $network
+    cni: flannel
+    memory: "8g"
+    workers:
+      - addons:
+          - name: kubevirt

--- a/test/envs/regional-dr-kubevirt.yaml
+++ b/test/envs/regional-dr-kubevirt.yaml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Enviroment for testing kubevirt flows with Regional-DR
+---
+name: "rdr-kubevirt"
+
+ramen:
+  hub: hub
+  clusters: [dr1, dr2]
+  topology: regional-dr
+
+templates:
+  - name: "dr-cluster"
+    driver: "$vm"
+    container_runtime: containerd
+    containerd:
+      plugins:
+        io.containerd.grpc.v1.cri:
+          device_ownership_from_security_context: true
+    network: "$network"
+    cni: flannel
+    cpus: 3
+    memory: "8g"
+    extra_disks: 1
+    disk_size: "50g"
+    addons:
+      - volumesnapshots
+      - csi-hostpath-driver
+    workers:
+      - addons:
+          - name: cert-manager
+          - name: rook-operator
+          - name: rook-cluster
+          - name: rook-pool
+          - name: rook-toolbox
+      - addons:
+          - name: ocm-cluster
+            args: ["$name", "hub"]
+          - name: cdi
+      - addons:
+          - name: csi-addons
+          - name: olm
+          - name: minio
+          - name: velero
+          - name: kubevirt
+  - name: "hub-cluster"
+    driver: "$vm"
+    container_runtime: containerd
+    network: "$network"
+    cni: flannel
+    memory: "4g"
+    workers:
+      - addons:
+          - name: ocm-hub
+          - name: ocm-controller
+          - name: cert-manager
+          - name: olm
+          - name: submariner
+            args: ["hub", "dr1", "dr2"]
+
+profiles:
+  - name: "dr1"
+    template: "dr-cluster"
+  - name: "dr2"
+    template: "dr-cluster"
+  - name: "hub"
+    template: "hub-cluster"
+
+workers:
+  - addons:
+      - name: rbd-mirror
+        args: ["dr1", "dr2"]
+  - addons:
+      - name: volsync
+        args: ["dr1", "dr2"]

--- a/test/setup.py
+++ b/test/setup.py
@@ -20,6 +20,7 @@ setuptools.setup(
     packages=["drenv"],
     install_requires=[
         "PyYAML",
+        "toml",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
With this environment we can deploy and test kubevirt workloads with rbd mirroring.

Tested using https://github.com/nirs/ocm-kubevirt-samples/tree/test

Tested manually:
- deploy vm subscription
- enable dr
- failover
- relocate
- disable dr
- undeploy