### PR TITLE
Refactor DRPolicy controller test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,9 @@ test-drpc: generate manifests envtest
 test-drcluster: generate manifests envtest
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus DRClusterController
 
+test-drpolicy: generate manifests envtest
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus Drpolicy
+
 test-util: generate manifests envtest
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers/util -coverprofile cover.out $(GO_TEST_GINKGO_ARGS)
 

--- a/controllers/namespace_test.go
+++ b/controllers/namespace_test.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func namespaceCreateAndDeferDeleteOrConfirmAlreadyExists(name string) {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	err := k8sClient.Create(context.TODO(), ns)
+
+	if !namespaceDeletionSupported {
+		Expect(err).To(Or(BeNil(), MatchError(
+			errors.NewAlreadyExists(schema.GroupResource{Resource: "namespaces"}, ns.Name),
+		)))
+
+		return
+	}
+
+	Expect(err).To(BeNil())
+	DeferCleanup(func() {
+		Expect(k8sClient.Delete(context.TODO(), ns)).To(Succeed())
+		Eventually(apiReader.Get).WithArguments(context.TODO(), types.NamespacedName{Name: ns.Name}, ns).
+			Should(MatchError(errors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, ns.Name)))
+	})
+}


### PR DESCRIPTION
- Group tests into two contexts:
  - drpolicy creation request
  - drpolicies sharing a drcluster
- Allow tests to be run in parallel by moving setup into `BeforeEach` blocks
  - Decorate tests that require ordering `Ordered`
  - Tolerate existing namespaces named the same as a drcluster since drcluster names are static and namespaces are not garbage collected in envtest

