### PR TITLE
Fix flakey drpolicy secrets plrule test

### DIFF
--- a/controllers/drpolicy_controller_test.go
+++ b/controllers/drpolicy_controller_test.go
@@ -134,7 +134,7 @@ var _ = Describe("DrpolicyController", func() {
 				}
 
 				return
-			}(), timeout, interval).Should(ConsistOf(clusterList))
+			}, timeout, interval).Should(ConsistOf(clusterList))
 		}
 	}
 


### PR DESCRIPTION
# Problem

A DRPolicy test fails sometimes.  Here's a recent example in a main CI run:
https://github.com/RamenDR/ramen/actions/runs/6594082563/job/17917524899

```
• [FAILED] [10.042 seconds]
DrpolicyController when a 1st drpolicy is created [It] should create a secret placement rule for each cluster specified in a 1st drpolicy
/home/runner/work/ramen/ramen/controllers/drpolicy_controller_test.go:2[41](https://github.com/RamenDR/ramen/actions/runs/6594082563/job/17917524899#step:4:42)

  Timeline >>
  2023-10-21T00:[45](https://github.com/RamenDR/ramen/actions/runs/6594082563/job/17917524899#step:4:46):00.787Z	INFO	controllers.DRPolicy	reconcile enter	{"DRPolicy": "drpolicy0", "rid": "5958fdaf-e4ee-[47](https://github.com/RamenDR/ramen/actions/runs/6594082563/job/17917524899#step:4:48)7f-9613-e33936774545"}
  2023-10-21T00:45:00.796Z	INFO	controllers.DRPolicy	create/update	{"DRPolicy": "drpolicy0", "rid": "5958fdaf-e4ee-477f-9613-e33936774545"}
  2023-10-21T00:45:00.797Z	INFO	controllers.DRPolicy	finalizer or label add	{"DRPolicy": "drpolicy0", "rid": "5958fdaf-e4ee-477f-9613-e33936774545"}
  2023-10-21T00:45:00.800Z	INFO	controllers.DRPolicy	condition append	{"DRPolicy": "drpolicy0", "rid": "5958fdaf-e4ee-477f-9613-e33936774545", "type": "Validated", "status": "True", "reason": "Succeeded", "message": "drpolicy validated", "generation": 1}
  2023-10-21T00:45:00.804Z	INFO	controllers.DRPolicy	Add Secret	{"DRPolicy": "drpolicy0", "rid": "5958fdaf-e4ee-477f-9613-e33936774545", "cluster": "drp-cluster0", "secret": "s3secret0"}
  2023-10-21T00:45:00.805Z	INFO	controllers.DRPolicy	Creating secret policy	{"DRPolicy": "drpolicy0", "rid": "5958fdaf-e4ee-477f-9613-e33936774545", "secret": "s3secret0", "cluster": "drp-cluster0", "namespace": "ns-envtest"}
  2023-10-21T00:45:00.814Z	INFO	controllers.DRPolicy	Initializing secret policy trigger	{"DRPolicy": "drpolicy0", "rid": "5958fdaf-e4ee-477f-9613-e33936774545", "secret": "s3secret0", "trigger": "1073"}
  2023-10-21T00:45:00.821Z	INFO	controllers.DRPolicy	Add Secret	{"DRPolicy": "drpolicy0", "rid": "5958fdaf-e4ee-477f-9613-e33936774545", "cluster": "drp-cluster1", "secret": "s3secret0"}
  2023-10-21T00:45:00.823Z	INFO	controllers.DRPolicy	Updating placement rule for secret policy	{"DRPolicy": "drpolicy0", "rid": "5958fdaf-e4ee-477f-9613-e33936774545", "secret": "s3secret0", "clusters": [{"name":"drp-cluster0"},{"name":"drp-cluster1"}]}
  2023-10-21T00:45:00.827Z	INFO	controllers.DRPolicy	Setting metric: (policy_schedule_interval_seconds)
  2023-10-21T00:45:00.827Z	INFO	controllers.DRPolicy	reconcile exit	{"DRPolicy": "drpolicy0", "rid": "5958fdaf-e4ee-477f-9613-e33936774545"}
  2023-10-21T00:45:00.827Z	INFO	controllers.DRPolicy	reconcile enter	{"DRPolicy": "drpolicy0", "rid": "e7d9c21d-0ae3-4a07-b61b-c7d[50](https://github.com/RamenDR/ramen/actions/runs/6594082563/job/17917524899#step:4:51)b67d121"}
  2023-10-21T00:45:00.829Z	INFO	controllers.DRPolicy	create/update	{"DRPolicy": "drpolicy0", "rid": "e7d9c21d-0ae3-4a07-b[61](https://github.com/RamenDR/ramen/actions/runs/6594082563/job/17917524899#step:4:62)b-c7d50b67d121"}
  2023-10-21T00:45:00.831Z	INFO	controllers.DRPolicy	condition unchanged	{"DRPolicy": "drpolicy0", "rid": "e7d9c21d-0ae3-4a07-b61b-c7d50b67d121", "type": "Validated", "status": "True", "reason": "Succeeded", "message": "drpolicy validated", "generation": 1}
  2023-10-21T00:45:00.831Z	INFO	controllers.DRPolicy	Add Secret	{"DRPolicy": "drpolicy0", "rid": "e7d9c21d-0ae3-4a07-b61b-c7d50b67d121", "cluster": "drp-cluster0", "secret": "s3secret0"}
  2023-10-21T00:45:00.833Z	INFO	controllers.DRPolicy	Add Secret	{"DRPolicy": "drpolicy0", "rid": "e7d9c21d-0ae3-4a07-b61b-c7d50b67d121", "cluster": "drp-cluster1", "secret": "s3secret0"}
  2023-10-21T00:45:00.834Z	INFO	controllers.DRPolicy	Setting metric: (policy_schedule_interval_seconds)
  2023-10-21T00:45:00.834Z	INFO	controllers.DRPolicy	reconcile exit	{"DRPolicy": "drpolicy0", "rid": "e7d9c21d-0ae3-4a07-b61b-c7d50b67d121"}
  [FAILED] in [It] - /home/runner/work/ramen/ramen/controllers/drpolicy_controller_test.go:137 @ 10/21/23 00:45:10.827
  << Timeline

  [FAILED] Timed out after 10.000s.
  Expected
      <[]string | len:1, cap:1>: ["drp-cluster0"]
  to consist of
      <[]string | len:2, cap:2>: ["drp-cluster0", "drp-cluster1"]
  the missing elements were
      <[]string | len:1, cap:1>: ["drp-cluster1"]
  In [It] at: /home/runner/work/ramen/ramen/controllers/drpolicy_controller_test.go:137 @ 10/21/23 00:45:10.827
  ```

# Proposed fix
Pass function as first argument to Eventually instead of its return value
- Fixes #1095 