### PR TITLE
drenv: make accept_cluster idempotent

### DIFF
--- a/test/addons/ocm-cluster/start
+++ b/test/addons/ocm-cluster/start
@@ -6,6 +6,7 @@
 import json
 import os
 import sys
+import yaml
 
 import drenv
 from drenv import cluster
@@ -97,6 +98,19 @@ def join_cluster(cluster, hub):
 
 def accept_cluster(cluster, hub):
     print("Accepting cluster")
+
+    managed_clusters = clusteradm.get("clusters", output="yaml", context=hub)
+
+    managed_clusters = managed_clusters.split("---")
+    for mc in managed_clusters:
+        managed_cluster = yaml.safe_load(mc)
+        metadata_name = managed_cluster["metadata"]["name"]
+        hub_accepts_client = managed_cluster["spec"]["hubAcceptsClient"]
+
+        if metadata_name == cluster and hub_accepts_client:
+            print(f"Cluster '{cluster}' already accepted")
+            return
+
     clusteradm.accept([cluster], wait=True, context=hub)
 
 


### PR DESCRIPTION
There is a bug in the clusteradm accept command where it doesn't work for managed clusters that are already approved. It errors out like shown below

Error: no CSR to approve for cluster c2
See https://github.com/open-cluster-management-io/clusteradm/issues/56

In this PR, we check if the managed cluster is already approved by the hub and if so, we don't run the accept command.