### PR TITLE
Adding troubleshooting information for drenv

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -87,6 +87,14 @@ environment.
    docker is used only for running drenv tests locally. You can use
    podman for building and running containers locally.
 
+1. Install `podman`
+
+   ```
+   sudo dnf install podman
+   ```
+
+   See [Installing podman](https://podman.io/docs/installation) for other options.
+
 ### Testing that drenv is healthy
 
 Run this script to make sure `drenv` works:
@@ -784,4 +792,27 @@ To log debug messages use:
 
 ```python
 test.debug("Got reply: %s", reply)
+```
+
+## Troubleshooting drenv issues
+
+### podman commands are failing for rootless access
+
+Reported with Podman version 4.6.2 on Fedora 37.
+
+```
+$ podman version
+ERRO[0000] running /usr/bin/newuidmap 61879 0 1000 1 1 100000 65536: newuidmap:
+open of uid_map failed: Permission denied
+Error: cannot set up namespace using "/usr/bin/newuidmap": exit status 1
+```
+
+While running with root access it works fine.
+
+### Solution
+
+reinstall shadow-utils package:
+
+```
+sudo dnf reinstall shadow-utils
 ```


### PR DESCRIPTION
Added a section to list issues found while setting up drenv. 
podman commands execution was failing with rootless access. Provided a solution for it.