### PR TITLE
Wait for managedcluster before enabling addons

### DIFF
--- a/test/addons/ocm-cluster/start
+++ b/test/addons/ocm-cluster/start
@@ -45,6 +45,7 @@ def deploy(cluster, hub):
     join_cluster(cluster, hub)
     accept_cluster(cluster, hub)
     label_cluster(cluster, hub)
+    wait_for_managed_cluster(cluster, hub)
     enable_addons(cluster, hub)
 
 
@@ -109,6 +110,16 @@ def label_cluster(cluster, hub):
         f"managedclusters/{cluster}",
         f"name={cluster}",
         overwrite=True,
+        context=hub,
+    )
+
+
+def wait_for_managed_cluster(cluster, hub):
+    print("Waiting until managed cluster is available")
+    kubectl.wait(
+        f"managedcluster/{cluster}",
+        "--for=condition=ManagedClusterConditionAvailable",
+        "--timeout=60s",
         context=hub,
     )
 


### PR DESCRIPTION
The bigger kubvirt environment reveal new concurrency issues. In this case we try to enable the addons right after we accepted the managed cluster - but the managed cluster namespace was not created yet.

    drenv.commands.Error: Command failed:
       command: ('clusteradm', 'addon', 'enable', '--names',
               'application-manager,governance-policy-framework,config-policy-controller',
               '--clusters', 'dr2', '--context', 'hub')
       exitcode: 1
       error:
          Error: namespaces "dr2" not found

Watching managed cluster status after the cluster is accepted, it takes several iterations until all the conditions are reported. Try to fix this random failure by waiting until the managed cluster is reported as ready. I hope that the controller reconciling the managed cluster updates the condition after the namespace was created.

Testing shows that we wait 0.7 seconds even in the tiny ocm environment:

    2023-11-02 01:50:54,283 DEBUG   [dr2/0] Waiting until managed cluster is available
    2023-11-02 01:50:54,922 DEBUG   [dr2/0] managedcluster.cluster.open-cluster-management.io/dr2 condition met

When running in the bigger regional-dr-kubevirt environment, the wait was 2.26 seconds:

    2023-11-02 01:58:13,990 DEBUG   [dr2/1] Waiting until managed cluster is available
    2023-11-02 01:58:16,254 DEBUG   [dr2/1] managedcluster.cluster.open-cluster-management.io/dr2 condition met