### PR TITLE
Fix VRG reconcile due to `ramen-dr-cluster-operator-config` event in unit test env

### DIFF
--- a/controllers/drclusters.go
+++ b/controllers/drclusters.go
@@ -112,7 +112,7 @@ func objectsToDeploy(hubOperatorRamenConfig *rmn.RamenConfig) ([]interface{}, er
 
 	drClusterOperatorConfigMap, err := ConfigMapNew(
 		drClusterOperatorNamespaceName,
-		drClusterOperatorConfigMapName,
+		DrClusterOperatorConfigMapName,
 		ramenConfig,
 	)
 	if err != nil {

--- a/controllers/drpolicy_controller_test.go
+++ b/controllers/drpolicy_controller_test.go
@@ -86,7 +86,7 @@ var _ = Describe("DrpolicyController", func() {
 
 	getPlRuleForSecrets := func() map[string]plrv1.PlacementRule {
 		plRuleList := &plrv1.PlacementRuleList{}
-		listOptions := &client.ListOptions{Namespace: configMap.Namespace}
+		listOptions := &client.ListOptions{Namespace: ramenNamespace}
 
 		Expect(apiReader.List(context.TODO(), plRuleList, listOptions)).NotTo(HaveOccurred())
 

--- a/controllers/ramenconfig.go
+++ b/controllers/ramenconfig.go
@@ -29,7 +29,7 @@ const (
 	drClusterOperatorNameDefault                      = operatorNamePrefix + drClusterName + operatorNameSuffix
 	configMapNameSuffix                               = "-config"
 	HubOperatorConfigMapName                          = hubOperatorNameDefault + configMapNameSuffix
-	drClusterOperatorConfigMapName                    = drClusterOperatorNameDefault + configMapNameSuffix
+	DrClusterOperatorConfigMapName                    = drClusterOperatorNameDefault + configMapNameSuffix
 	leaderElectionResourceNameSuffix                  = ".ramendr.openshift.io"
 	HubLeaderElectionResourceName                     = hubName + leaderElectionResourceNameSuffix
 	drClusterLeaderElectionResourceName               = drClusterName + leaderElectionResourceNameSuffix
@@ -210,7 +210,7 @@ func ConfigMapGet(
 ) (configMap *corev1.ConfigMap, ramenConfig *ramendrv1alpha1.RamenConfig, err error) {
 	configMapName := HubOperatorConfigMapName
 	if ControllerType != ramendrv1alpha1.DRHubType {
-		configMapName = drClusterOperatorConfigMapName
+		configMapName = DrClusterOperatorConfigMapName
 	}
 
 	configMap = &corev1.ConfigMap{}

--- a/controllers/ramenconfig_test.go
+++ b/controllers/ramenconfig_test.go
@@ -6,22 +6,46 @@ package controllers_test
 import (
 	"context"
 
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/controllers"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/yaml"
 )
 
+var configMapNames = []string{
+	controllers.HubOperatorConfigMapName,
+	controllers.DrClusterOperatorConfigMapName,
+}
+
+func configMapCreate(ramenConfig *ramen.RamenConfig) {
+	for _, configMapName := range configMapNames {
+		configMap, err := controllers.ConfigMapNew(ramenNamespace, configMapName, ramenConfig)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(context.TODO(), configMap)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, context.TODO(), configMap)
+	}
+}
+
 func configMapUpdate() {
 	ramenConfigYaml, err := yaml.Marshal(ramenConfig)
 	Expect(err).NotTo(HaveOccurred())
 
+	for _, configMapName := range configMapNames {
+		configMapUpdate1(configMapName, ramenConfigYaml)
+	}
+}
+
+func configMapUpdate1(configMapName string, ramenConfigYaml []byte) {
+	configMap := &corev1.ConfigMap{}
+
 	retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		key := types.NamespacedName{
 			Namespace: ramenNamespace,
-			Name:      controllers.HubOperatorConfigMapName,
+			Name:      configMapName,
 		}
 
 		err := k8sClient.Get(context.TODO(), key, configMap)

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -123,7 +123,7 @@ func (r *VolumeReplicationGroupReconciler) pvcMapFunc(obj client.Object) []recon
 func (r *VolumeReplicationGroupReconciler) configMapFun(configmap client.Object) []reconcile.Request {
 	log := ctrl.Log.WithName("configmap").WithName("VolumeReplicationGroup")
 
-	if configmap.GetName() != drClusterOperatorConfigMapName || configmap.GetNamespace() != NamespaceName() {
+	if configmap.GetName() != DrClusterOperatorConfigMapName || configmap.GetNamespace() != NamespaceName() {
 		return []reconcile.Request{}
 	}
 


### PR DESCRIPTION
# Problem
In unit test environment, VRGs don't get reconciled despite a config map update.

# Proposed solution
In unit test environment, create and maintain a second Ramen config map, named `ramen-dr-cluster-operator-config`, with the same content as the existing one, `ramen-hub-cluster-operator-config`, so that updates notify watchers of either one.