### PR TITLE
init DRPolicy metrics before secrets propagation

### DIFF
--- a/controllers/drpolicy.go
+++ b/controllers/drpolicy.go
@@ -15,7 +15,7 @@ import (
 
 var drClustersMutex sync.Mutex
 
-func drPolicyDeploy(
+func propagateS3Secret(
 	drpolicy *rmn.DRPolicy,
 	drclusters *rmn.DRClusterList,
 	secretsUtil *util.SecretsUtil,


### PR DESCRIPTION
do not depend on s3 secrets propagation
for initializing DRPolicy metrics  
