### PR TITLE
Cleanup unneeded and suspicious overrides in rook operator

### DIFF
--- a/test/addons/rook-operator/kustomization.yaml
+++ b/test/addons/rook-operator/kustomization.yaml
@@ -16,9 +16,6 @@ patchesJson6902:
         path: /data/CSI_ENABLE_CSIADDONS
         value: 'true'
       - op: add
-        path: /data/ROOK_CSIADDONS_IMAGE
-        value: quay.io/csiaddons/k8s-sidecar:latest
-      - op: add
         path: /data/CSI_ENABLE_OMAP_GENERATOR
         value: 'true'
 

--- a/test/addons/rook-operator/kustomization.yaml
+++ b/test/addons/rook-operator/kustomization.yaml
@@ -21,12 +21,6 @@ patchesJson6902:
       - op: add
         path: /data/CSI_ENABLE_OMAP_GENERATOR
         value: 'true'
-      - op: add
-        path: /data/ROOK_CSI_ALLOW_UNSUPPORTED_VERSION
-        value: 'true'
-      - op: add
-        path: /data/ROOK_CSI_CEPH_IMAGE
-        value: quay.io/cephcsi/cephcsi:canary
 
 patches:
   # Disable to avoid random failures when restaring the enviroment.


### PR DESCRIPTION
Remove overrides for:
- cephcsi image
- csiaddon sidecar image

Both changes were copied from
https://github.com/RamenDR/ramen/blob/5b80317c82cb484f6a639e24967967adb38d708d/hack/minikube-rook-setup.sh#L154

Relevant historic changes:
- https://github.com/RamenDR/ramen/commit/63728c20
- https://github.com/RamenDR/ramen/commit/3d6e9a47