### PR TITLE
makefile: move the installation of golangci-lint to a script 

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -35,7 +35,79 @@ linters-settings:
     enforce-err-cuddling: true
 
 linters:
-  enable-all: true
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - cyclop
+    - deadcode
+    - decorder
+    - depguard
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errorlint
+    - execinquery
+    - exhaustive
+    - exportloopref
+    - forbidigo
+    - funlen
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - gofumpt
+    - golint
+    - gomnd
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - grouper
+    - ifshort
+    - importas
+    - ineffassign
+    - interfacebloat
+    - lll
+    - logrlint
+    - maintidx
+    - makezero
+    - maligned
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - nlreturn
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - prealloc
+    - predeclared
+    - reassign
+    - revive
+    - rowserrcheck
+    - scopelint
+    - sqlclosecheck
+    - structcheck
+    - stylecheck
+    - tenv
+    - testpackage
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - varcheck
+    - wastedassign
+    - whitespace
+    - wsl
   disable:
     - exhaustivestruct
     - gochecknoglobals

--- a/Makefile
+++ b/Makefile
@@ -415,7 +415,7 @@ catalog-push: ## Push a catalog image.
 .PHONY: docker-buildx
 docker-buildx: # Build and push docker image for the manager for cross-platform support
 ifeq ($(DOCKERCMD),docker)
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} and 
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} and
 	# replace GOARCH value to ${TARGETARCH} into Dockerfile.cross, and preserve the original Dockerfile
 	$(eval PLATFORMS="linux/arm64,linux/amd64,linux/s390x,linux/ppc64le")
 	$(SED_CMD) \
@@ -423,7 +423,7 @@ ifeq ($(DOCKERCMD),docker)
 		-e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' \
 		Dockerfile > Dockerfile.cross
 	$(SED_CMD) -e 's/GOARCH=amd64/GOARCH=$${TARGETARCH}/' -i Dockerfile.cross
-	- $(DOCKERCMD) buildx create --name $(IMAGE_NAME)-builder --bootstrap --use 
+	- $(DOCKERCMD) buildx create --name $(IMAGE_NAME)-builder --bootstrap --use
 	- $(DOCKERCMD) buildx build --push --platform="${PLATFORMS}" --tag ${IMG} -f Dockerfile.cross .
 	- $(DOCKERCMD) buildx rm $(IMAGE_NAME)-builder
 	rm Dockerfile.cross

--- a/Makefile
+++ b/Makefile
@@ -124,17 +124,9 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
-GOLANGCI_URL := https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
-GOLANGCI_VERSION := 1.49.0
-GOLANGCI_INSTALLED_VER := $(shell testbin/golangci-lint version --format=short 2>&1)
 .PHONY: golangci-bin
-golangci-bin: ## Download and install goloanci-lint locally if necessary.
-ifeq (,$(GOLANGCI_INSTALLED_VER))
-	$(info Installing golangci-lint (version: $(GOLANGCI_VERSION)) into testbin)
-	curl -sSfL $(GOLANGCI_URL) | sh -s -- -b testbin v$(GOLANGCI_VERSION)
-else ifneq ($(GOLANGCI_VERSION),$(GOLANGCI_INSTALLED_VER))
-	$(error Incorrect version ($(GOLANGCI_INSTALLED_VER)) for golangci-lint found, expecting $(GOLANGCI_VERSION))
-endif
+golangci-bin:
+	hack/install-golangci-lint.sh
 
 .PHONY: lint
 lint: golangci-bin ## Run configured golangci-lint and pre-commit.sh linters against the code.

--- a/hack/install-golangci-lint.sh
+++ b/hack/install-golangci-lint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+GOLANGCI_URL="https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
+GOLANGCI_VERSION="1.49.0"
+
+# Get the installed version of golangci-lint, if available
+GOLANGCI_INSTALLED_VER=$(testbin/golangci-lint version --format=short 2>/dev/null)
+
+# Check if golangci-lint is not installed or if the version does not match
+if [ -z "$GOLANGCI_INSTALLED_VER" ] || [ "$GOLANGCI_VERSION" != "$GOLANGCI_INSTALLED_VER" ]; then
+  if [ -n "$GOLANGCI_INSTALLED_VER" ]; then
+    echo "Incorrect version ($GOLANGCI_INSTALLED_VER) of golangci-lint found, expecting $GOLANGCI_VERSION"
+    rm -f testbin/golangci-lint
+  fi
+
+  # Install the correct version
+  echo "Installing golangci-lint (version: $GOLANGCI_VERSION) into testbin"
+  curl -sSfL "$GOLANGCI_URL" | sh -s -- -b testbin v"$GOLANGCI_VERSION"
+fi


### PR DESCRIPTION
This PR moves the golangci-lint installation code to a shell script and calls it from the Makefile.

We also explicitly list the enabled linters. This will make it easy to change the version of the binary without taking upon the big task of fixing warnings and errors that the newly enabled linters bring.