### PR TITLE
Pass in the current primary to createVolSyncDestManifestWork during c…

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -1748,7 +1748,7 @@ func (d *DRPCInstance) cleanupForVolSync(clusterToSkip string) error {
 
 			// Recreate the VRG ManifestWork for the secondary. This typically happens during Hub Recovery.
 			if errors.IsNotFound(err) {
-				err := d.createVolSyncDestManifestWork(clusterName)
+				err := d.createVolSyncDestManifestWork(clusterToSkip)
 				if err != nil {
 					return err
 				}

--- a/controllers/drplacementcontrolvolsync.go
+++ b/controllers/drplacementcontrolvolsync.go
@@ -283,14 +283,16 @@ func (d *DRPCInstance) updateVRGSpec(clusterName string, tgtVRG *rmn.VolumeRepli
 	return nil
 }
 
-func (d *DRPCInstance) createVolSyncDestManifestWork(srcCluster string) error {
+// createVolSyncDestManifestWork creates volsync Secondaries skipping the cluster referenced in clusterToSkip.
+// Typically, clusterToSkip is passed in as the cluster where volsync is the Primary.
+func (d *DRPCInstance) createVolSyncDestManifestWork(clusterToSkip string) error {
 	// create VRG ManifestWork
-	d.log.Info("Creating VRG ManifestWork for source and destination clusters",
-		"Last State:", d.getLastDRState(), "homeCluster", srcCluster)
+	d.log.Info("Creating VRG ManifestWork for destination clusters",
+		"Last State:", d.getLastDRState(), "homeCluster", clusterToSkip)
 
 	// Create or update ManifestWork for all the peers
 	for _, dstCluster := range rmnutil.DrpolicyClusterNames(d.drPolicy) {
-		if dstCluster == srcCluster {
+		if dstCluster == clusterToSkip {
 			// skip source cluster
 			continue
 		}


### PR DESCRIPTION
…leanup

On hub recovery cases when the ManifestWork does not exist on the hub cluster, it is recreated using createVolSyncDestManifestWork.

The function creates VRG for volsync destination on clusters that need to be Secondary, and has to be passed the primary cluster.

This fix addresses the above during cleanup where the cluster passed was not the primary.

This was introduced as part of commit:
ea0c1e41e2a20917d9a84a0d12d73e6f27fc069e