### PR TITLE
Update clusteradm install instructions

### DIFF
--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -130,15 +130,7 @@ enough resources:
 1. Install `clusteradm` tool. See
    [Install clusteradm CLI tool](https://open-cluster-management.io/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool)
    for the details.
-   Tested with v0.6.0.
-
-   ```
-   wget https://github.com/open-cluster-management-io/clusteradm/releases/download/v0.6.0/clusteradm_linux_amd64.tar.gz
-   ```
-
-   After download completes, extract `clusteradm` and copy to /usr/local/bin.
-
-   clusteradm v0.7.0 does not currently work with drenv
+   Version v0.7.1 or later is required.
 
 1. Install `subctl` tool, See
    [Submariner subctl installation](https://submariner.io/operations/deployment/subctl/)

--- a/test/README.md
+++ b/test/README.md
@@ -37,7 +37,7 @@ environment.
 1. Install `clusteradm` tool. See
    [Install clusteradm CLI tool](https://open-cluster-management.io/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool)
    for the details.
-   Version v0.5.0 or later is required, tested with v0.6.0.
+   Version v0.7.1 or later is required.
 
 1. Install `subctl` tool, See
    [Submariner subctl installation](https://submariner.io/operations/deployment/subctl/)


### PR DESCRIPTION
Version 0.7.0 was broken so we had to include detailed instructions for installing 0.6.0. The issue was fixed in 0.7.1 by [1]. Update the instructions to require the new version and remove the now unneeded instructions.

Tested with ocm.yaml.

[1] https://github.com/open-cluster-management-io/clusteradm/pull/388