### PR TITLE
Deploy recipe CRD in all DR environments

### DIFF
--- a/test/addons/recipe/start
+++ b/test/addons/recipe/start
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from drenv import kubectl
+
+if len(sys.argv) != 2:
+    sys.exit(f"Usage: {sys.argv[0]} cluster")
+
+os.chdir(os.path.dirname(__file__))
+cluster = sys.argv[1]
+
+print("Deploying recipe crd")
+kubectl.apply(
+    "--kustomize",
+    "https://github.com/RamenDR/recipe.git/config/crd?ref=main&timeout=120s",
+    context=cluster,
+)

--- a/test/envs/regional-dr-external.yaml.example
+++ b/test/envs/regional-dr-external.yaml.example
@@ -20,6 +20,7 @@ templates:
       - addons:
           - name: ocm-cluster
             args: ["$name", "hub"]
+          - name: recipe
       - addons:
           - name: cert-manager
           - name: csi-addons

--- a/test/envs/regional-dr-hubless.yaml
+++ b/test/envs/regional-dr-hubless.yaml
@@ -33,6 +33,7 @@ templates:
           - name: olm
           - name: minio
           - name: velero
+          - name: recipe
 
 profiles:
   - name: "dr1"

--- a/test/envs/regional-dr-kubevirt.yaml
+++ b/test/envs/regional-dr-kubevirt.yaml
@@ -38,6 +38,7 @@ templates:
           - name: ocm-cluster
             args: ["$name", "hub"]
           - name: cdi
+          - name: recipe
       - addons:
           - name: csi-addons
           - name: olm

--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -31,6 +31,7 @@ templates:
       - addons:
           - name: ocm-cluster
             args: ["$name", "hub"]
+          - name: recipe
       - addons:
           - name: csi-addons
           - name: olm


### PR DESCRIPTION
Recently the recipe CRD[1] became required if kube object protection is enabled, so we must have it in the test environment unless we disable the feature. Disabling the feature is not a good idea since we will want to be able to test imperative apps or declerative apps that need recipes (e.g. kubvirt with DataVolumeTemplate).

[1] https://github.com/RamenDR/recipe/blob/main/config/crd/bases/ramendr.openshift.io_recipes.yaml