### PR TITLE
Update the golangci-lint.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: GolangCI Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: v1.55.2
 
   unit-test:
     name: Unit tests

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,6 +33,62 @@ linters-settings:
   wsl:
     allow-trailing-comment: true
     enforce-err-cuddling: true
+  revive:
+    ignore-generated-header: false
+    severity: error
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      # - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+      - name: atomic
+      - name: constant-logical-expr
+      - name: unnecessary-stmt
+      # - name: unused-receiver
+      - name: get-return
+      # - name: flag-parameter
+      # - name: confusing-naming
+      - name: modifies-parameter
+      - name: modifies-value-receiver
+      # - name: import-shadowing
+      - name: range-val-in-closure
+      - name: waitgroup-by-value
+      - name: call-to-gc
+      - name: duplicated-imports
+      # - name: argument-limit
+      - name: unhandled-error
+      # - name: line-length-limit
+      # - name: function-result-limit
+      # - confusing-results
+      # - bool-literal-in-expr
+
+issues:
+  exclude-rules:
+    # Allow dot imports for ginkgo and gomega
+    - source: ginkgo|gomega
+      linters:
+      - revive
+      text: "should not use dot imports"
 
 linters:
   enable:
@@ -41,9 +97,7 @@ linters:
     - bidichk
     - bodyclose
     - cyclop
-    - deadcode
     - decorder
-    - depguard
     - dogsled
     - dupl
     - durationcheck
@@ -56,12 +110,10 @@ linters:
     - forbidigo
     - funlen
     - gocognit
-    - goconst
     - gocritic
     - gocyclo
     - gofmt
     - gofumpt
-    - golint
     - gomnd
     - gomodguard
     - goprintffuncname
@@ -69,7 +121,6 @@ linters:
     - gosimple
     - govet
     - grouper
-    - ifshort
     - importas
     - ineffassign
     - interfacebloat
@@ -77,7 +128,6 @@ linters:
     - logrlint
     - maintidx
     - makezero
-    - maligned
     - misspell
     - nakedret
     - nestif
@@ -91,9 +141,7 @@ linters:
     - reassign
     - revive
     - rowserrcheck
-    - scopelint
     - sqlclosecheck
-    - structcheck
     - stylecheck
     - tenv
     - testpackage
@@ -104,35 +152,31 @@ linters:
     - unparam
     - unused
     - usestdlibvars
-    - varcheck
     - wastedassign
     - whitespace
     - wsl
-  disable:
-    - exhaustivestruct
-    - gochecknoglobals
-    - gochecknoinits
-    - godot
-    - godox
-    - paralleltest
-    - goerr113  # TODO: Need to introduce error definition and bring this back
-    - goheader  # TODO: Introduce back post fixing linter errors
-    - gci
-    - interfacer  # interfacer linter is archived and deprecated (https://github.com/mvdan/interfacer)
-    # TODO: fix folloing linter errors.
-    - exhaustruct
-    - tagliatelle
-    - gomoddirectives
-    - goimports
-    - wrapcheck
-    - varnamelen
-    - staticcheck
-    - nosnakecase
-    - ireturn
-    - nilnil
-    - containedctx
-    - nonamedreturns
-    - forcetypeassert
-    - promlinter
-    - contextcheck
-    - errname
+    # - containedctx
+    # - contextcheck
+    # - errname
+    # - exhaustivestruct
+    # - exhaustruct
+    # - forcetypeassert
+    # - gci
+    # - gochecknoglobals
+    # - gochecknoinits
+    # - godot
+    # - godox
+    # - goerr113
+    # - goheader
+    # - goimports
+    # - gomoddirectives
+    # - interfacer
+    # - ireturn
+    # - nilnil
+    # - nonamedreturns
+    # - paralleltest
+    # - promlinter
+    # - tagliatelle
+    # - varnamelen
+    # - wrapcheck
+    # - goconst # Might be useful but I could not get it to ignore the strings in the log messages

--- a/controllers/drclusters.go
+++ b/controllers/drclusters.go
@@ -223,7 +223,7 @@ func drClusterUndeploy(
 	mcv util.ManagedClusterViewGetter,
 	log logr.Logger,
 ) error {
-	clusterNames := sets.String{}
+	clusterNames := sets.Set[string]{}
 	drpolicies := rmn.DRPolicyList{}
 
 	if err := mwu.Client.List(mwu.Ctx, &drpolicies); err != nil {

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -538,7 +538,7 @@ func (d *DRPCInstance) checkRegionalFailoverPrerequisites() bool {
 	if required, activationsRequired := requiresRegionalFailoverPrerequisites(
 		d.ctx,
 		d.reconciler.APIReader,
-		rmnutil.DRPolicyS3Profiles(d.drPolicy, d.drClusters).List(),
+		rmnutil.DRPolicyS3Profiles(d.drPolicy, d.drClusters).UnsortedList(),
 		d.instance.GetName(), d.instance.GetNamespace(),
 		d.vrgs, d.instance.Spec.FailoverCluster,
 		d.reconciler.ObjStoreGetter, d.log); required {
@@ -1498,7 +1498,7 @@ func (d *DRPCInstance) generateVRG(repState rmn.ReplicationState) rmn.VolumeRepl
 		Spec: rmn.VolumeReplicationGroupSpec{
 			PVCSelector:          d.instance.Spec.PVCSelector,
 			ReplicationState:     repState,
-			S3Profiles:           rmnutil.DRPolicyS3Profiles(d.drPolicy, d.drClusters).List(),
+			S3Profiles:           rmnutil.DRPolicyS3Profiles(d.drPolicy, d.drClusters).UnsortedList(),
 			KubeObjectProtection: d.instance.Spec.KubeObjectProtection,
 		},
 	}

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -430,8 +430,6 @@ func DRPCsFailingOverToCluster(k8sclient client.Client, log logr.Logger, drclust
 
 // DRPCsFailingOverToClusterForPolicy filters DRPC resources that reference the DRPolicy and are failing over
 // to the target cluster passed in
-//
-//nolint:gocognit
 func DRPCsFailingOverToClusterForPolicy(
 	k8sclient client.Client,
 	log logr.Logger,
@@ -587,7 +585,7 @@ func (r *DRPlacementControlReconciler) SetupWithManager(mgr ctrl.Manager) error 
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.0/pkg/reconcile
 //
-//nolint:cyclop,funlen,gocognit
+//nolint:cyclop,funlen
 func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("DRPC", req.NamespacedName, "rid", uuid.New())
 
@@ -655,7 +653,7 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if err != nil && !errorswrapper.Is(err, InitialWaitTimeForDRPCPlacementRule) {
 		err2 := r.updateDRPCStatus(ctx, drpc, placementObj, logger)
 
-		return ctrl.Result{}, fmt.Errorf("failed to create DRPC instance (%w) and (%v)", err, err2)
+		return ctrl.Result{}, fmt.Errorf("failed to create DRPC instance (%w) and (%w)", err, err2)
 	}
 
 	if errorswrapper.Is(err, InitialWaitTimeForDRPCPlacementRule) {
@@ -927,7 +925,7 @@ func (r *DRPlacementControlReconciler) getDRPolicy(ctx context.Context,
 func (r DRPlacementControlReconciler) updateObjectMetadata(ctx context.Context,
 	drpc *rmn.DRPlacementControl, placementObj client.Object, log logr.Logger,
 ) error {
-	update := false
+	var update bool
 
 	update = rmnutil.AddLabel(drpc, rmnutil.OCMBackupLabelKey, rmnutil.OCMBackupLabelValue)
 	update = rmnutil.AddFinalizer(drpc, DRPCFinalizer) || update

--- a/controllers/drpolicy.go
+++ b/controllers/drpolicy.go
@@ -59,7 +59,7 @@ func drClusterSecretsDeploy(
 		log.Info("Received partial list", "err", err)
 	}
 
-	for _, secretName := range drPolicySecrets.List() {
+	for _, secretName := range drPolicySecrets.UnsortedList() {
 		if err := secretsUtil.AddSecretToCluster(
 			secretName,
 			clusterName,
@@ -102,7 +102,7 @@ func drClustersUndeploySecrets(
 		return nil
 	}
 
-	mustHaveS3Secrets := map[string]sets.String{}
+	mustHaveS3Secrets := map[string]sets.Set[string]{}
 
 	// Determine S3 secrets that must continue to exist per cluster in the policy being deleted
 	for _, clusterName := range util.DrpolicyClusterNames(drpolicy) {
@@ -119,7 +119,7 @@ func drClustersUndeploySecrets(
 	// For each cluster in the must have S3 secrets list, check and delete
 	// S3Profiles that maybe deleted, iff absent in the must have list
 	for clusterName, mustHaveS3Secrets := range mustHaveS3Secrets {
-		for _, s3SecretToDelete := range mayDeleteS3Secrets.List() {
+		for _, s3SecretToDelete := range mayDeleteS3Secrets.UnsortedList() {
 			if mustHaveS3Secrets.Has(s3SecretToDelete) {
 				continue
 			}
@@ -144,8 +144,8 @@ func drClusterListMustHaveSecrets(
 	clusterName string,
 	ignorePolicy *rmn.DRPolicy,
 	ramenConfig *rmn.RamenConfig,
-) sets.String {
-	mustHaveS3Secrets := sets.String{}
+) sets.Set[string] {
+	mustHaveS3Secrets := sets.Set[string]{}
 
 	mustHaveS3Profiles := drClusterListMustHaveS3Profiles(drpolicies, drclusters, clusterName, ignorePolicy)
 
@@ -164,8 +164,8 @@ func drClusterListMustHaveS3Profiles(drpolicies rmn.DRPolicyList,
 	drclusters *rmn.DRClusterList,
 	clusterName string,
 	ignorePolicy *rmn.DRPolicy,
-) sets.String {
-	mustHaveS3Profiles := sets.String{}
+) sets.Set[string] {
+	mustHaveS3Profiles := sets.Set[string]{}
 
 	for idx := range drpolicies.Items {
 		// Skip the policy being ignored (used for delete)
@@ -192,8 +192,8 @@ func drClusterListMustHaveS3Profiles(drpolicies rmn.DRPolicyList,
 func drPolicySecretNames(drpolicy *rmn.DRPolicy,
 	drclusters *rmn.DRClusterList,
 	rmnCfg *rmn.RamenConfig,
-) (sets.String, error) {
-	secretNames := sets.String{}
+) (sets.Set[string], error) {
+	secretNames := sets.Set[string]{}
 
 	var err error
 

--- a/controllers/ramenconfig.go
+++ b/controllers/ramenconfig.go
@@ -6,7 +6,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 
@@ -90,7 +89,7 @@ func ReadRamenConfigFile(log logr.Logger) (ramenConfig ramendrv1alpha1.RamenConf
 
 	log.Info("loading Ramen config file ", "name", cachedRamenConfigFileName)
 
-	fileContents, err := ioutil.ReadFile(cachedRamenConfigFileName)
+	fileContents, err := os.ReadFile(cachedRamenConfigFileName)
 	if err != nil {
 		err = fmt.Errorf("unable to load the config file %s: %w",
 			cachedRamenConfigFileName, err)

--- a/controllers/util/drpolicy_util.go
+++ b/controllers/util/drpolicy_util.go
@@ -40,8 +40,8 @@ func DrpolicyRegionNames(drpolicy *rmn.DRPolicy, drClusters []rmn.DRCluster) []s
 	return regionNames
 }
 
-func DrpolicyRegionNamesAsASet(drpolicy *rmn.DRPolicy, drClusters []rmn.DRCluster) sets.String {
-	return sets.NewString(DrpolicyRegionNames(drpolicy, drClusters)...)
+func DrpolicyRegionNamesAsASet(drpolicy *rmn.DRPolicy, drClusters []rmn.DRCluster) sets.Set[string] {
+	return sets.New[string](DrpolicyRegionNames(drpolicy, drClusters)...)
 }
 
 func DrpolicyValidated(drpolicy *rmn.DRPolicy) error {
@@ -68,8 +68,8 @@ func GetAllDRPolicies(ctx context.Context, client client.Reader) (rmn.DRPolicyLi
 	return drpolicies, nil
 }
 
-func DRPolicyS3Profiles(drpolicy *rmn.DRPolicy, drclusters []rmn.DRCluster) sets.String {
-	mustHaveS3Profiles := sets.String{}
+func DRPolicyS3Profiles(drpolicy *rmn.DRPolicy, drclusters []rmn.DRCluster) sets.Set[string] {
+	mustHaveS3Profiles := sets.Set[string]{}
 
 	for _, managedCluster := range DrpolicyClusterNames(drpolicy) {
 		s3ProfileName := ""

--- a/controllers/volsync/vshandler.go
+++ b/controllers/volsync/vshandler.go
@@ -735,7 +735,6 @@ func (v *VSHandler) DeleteRD(pvcName string) error {
 	return nil
 }
 
-//nolint:gocognit
 func (v *VSHandler) deleteLocalRDAndRS(rd *volsyncv1alpha1.ReplicationDestination) error {
 	latestRDImage, err := v.getRDLatestImage(rd.GetName())
 	if err != nil {

--- a/controllers/vrg_kubeobjects.go
+++ b/controllers/vrg_kubeobjects.go
@@ -325,7 +325,7 @@ func (v *VRGInstance) kubeObjectsGroupCapture(
 
 			result.Requeue = true
 
-			return
+			return requestsCompletedCount
 		}
 
 		captureInProgressStatusUpdate()

--- a/controllers/vrg_recipe_test.go
+++ b/controllers/vrg_recipe_test.go
@@ -436,8 +436,8 @@ var _ = Describe("VolumeReplicationGroupRecipe", func() {
 						recipeHooksDefine(hook(ns0ParameterRef))
 					})
 					JustBeforeEach(func() {
-						recipeExpanded = &*r
-						Expect(controllers.RecipeParametersExpand(recipeExpanded, vrgRecipeParameters(), testLogger)).To(Succeed())
+						recipeExpanded := *r
+						Expect(controllers.RecipeParametersExpand(&recipeExpanded, vrgRecipeParameters(), testLogger)).To(Succeed())
 					})
 					It("expands a parameter list enclosed in double quotes to a single string with quotes preserved", func() {
 						Skip("feature not supported")

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -1995,10 +1995,10 @@ func restoreClusterDataObjects[
 
 	for i := range objList {
 		object := &objList[i]
-		objectCopy := &*object
-		obj := ClientObject(objectCopy)
+		objectCopy := *object
+		obj := ClientObject(&objectCopy)
 
-		cleanupForRestore(objectCopy)
+		cleanupForRestore(&objectCopy)
 		addRestoreAnnotation(obj)
 
 		if err := v.reconciler.Create(v.ctx, obj); err != nil {
@@ -2328,7 +2328,7 @@ func (v *VRGInstance) aggregateVolRepDataReadyCondition() *metav1.Condition {
 	return newVRGDataErrorCondition(v.instance.Generation, msg)
 }
 
-//nolint:funlen,gocognit,cyclop
+//nolint:funlen,cyclop
 func (v *VRGInstance) aggregateVolRepDataProtectedCondition() *metav1.Condition {
 	if len(v.volRepPVCs) == 0 {
 		return nil

--- a/controllers/vrg_volsync.go
+++ b/controllers/vrg_volsync.go
@@ -76,7 +76,7 @@ func (v *VRGInstance) reconcileVolSyncAsPrimary(finalSyncPrepared *bool) (requeu
 	if len(v.volSyncPVCs) == 0 {
 		finalSyncComplete()
 
-		return
+		return requeue
 	}
 
 	v.log.Info(fmt.Sprintf("Reconciling VolSync as Primary. %d VolSyncPVCs", len(v.volSyncPVCs)))
@@ -89,7 +89,7 @@ func (v *VRGInstance) reconcileVolSyncAsPrimary(finalSyncPrepared *bool) (requeu
 
 		requeue = true
 
-		return
+		return requeue
 	}
 
 	for _, pvc := range v.volSyncPVCs {

--- a/hack/install-golangci-lint.sh
+++ b/hack/install-golangci-lint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 GOLANGCI_URL="https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
-GOLANGCI_VERSION="1.49.0"
+GOLANGCI_VERSION="1.55.2"
 
 # Get the installed version of golangci-lint, if available
 GOLANGCI_INSTALLED_VER=$(testbin/golangci-lint version --format=short 2>/dev/null)


### PR DESCRIPTION
This is in preparation to updating the golangci-lint version. This PR is a no-op.

Just moving the deprecated linters to a new sorted section.