### PR TITLE
Fencing takes a very long time

### DIFF
--- a/controllers/drcluster_controller.go
+++ b/controllers/drcluster_controller.go
@@ -724,7 +724,7 @@ func (u *drclusterInstance) fenceClusterOnCluster(peerCluster *ramen.DRCluster) 
 	}
 
 	annotations := make(map[string]string)
-	annotations[DRPCNameAnnotation] = u.object.Name // ?
+	annotations[DRClusterNameAnnotation] = u.object.Name
 
 	nf, err := u.reconciler.MCVGetter.GetNFFromManagedCluster(u.object.Name,
 		u.object.Namespace, peerCluster.Name, annotations)


### PR DESCRIPTION
Second time when we Fence the cluster, it takes more time(approx ~10-15 min) to reach Fenced state then the expected time.
Once we edit/update drcluster to Fenced state, corresponding IPs and networkfence CR, managedclusterview updates to Fenced state, but the drcluster states show "Fencing" or fails to update in drcluster status

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2249462