### PR TITLE
golangci-lint: more config cleanup

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -80,6 +80,7 @@ linters-settings:
       # - name: bool-literal-in-expr
 
 linters:
+  disable-all: true
   enable:
     - asasalint
     - asciicheck
@@ -153,31 +154,29 @@ linters:
     - wastedassign
     - whitespace
     - wsl
-  disable:
-    - exhaustivestruct
-    - gochecknoglobals
-    - gochecknoinits
-    - godot
-    - godox
-    - paralleltest
-    - goerr113  # TODO: Need to introduce error definition and bring this back
-    - goheader  # TODO: Introduce back post fixing linter errors
-    - gci
-    - interfacer  # interfacer linter is archived and deprecated (https://github.com/mvdan/interfacer)
-    # TODO: fix folloing linter errors.
-    - exhaustruct
-    - tagliatelle
-    - gomoddirectives
-    - goimports
-    - wrapcheck
-    - varnamelen
-    - staticcheck
-    - nosnakecase
-    - ireturn
-    - nilnil
-    - containedctx
-    - nonamedreturns
-    - forcetypeassert
-    - promlinter
-    - contextcheck
-    - errname
+    #  - exhaustivestruct
+    #  - gochecknoglobals
+    #  - gochecknoinits
+    #  - godot
+    #  - godox
+    #  - paralleltest
+    #  - goerr113  # TODO: Need to introduce error definition and bring this back
+    #  - goheader  # TODO: Introduce back post fixing linter errors
+    #  - gci
+    #  - interfacer  # interfacer linter is archived and deprecated (https://github.com/mvdan/interfacer)
+    #  - exhaustruct
+    #  - tagliatelle
+    #  - gomoddirectives
+    #  - goimports
+    #  - wrapcheck
+    #  - varnamelen
+    #  - staticcheck
+    #  - nosnakecase
+    #  - ireturn
+    #  - nilnil
+    #  - containedctx
+    #  - nonamedreturns
+    #  - forcetypeassert
+    #  - promlinter
+    #  - contextcheck
+    #  - errname

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,6 +33,51 @@ linters-settings:
   wsl:
     allow-trailing-comment: true
     enforce-err-cuddling: true
+  revive:
+    ignore-generated-header: false
+    severity: error
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unreachable-code
+      - name: redefines-builtin-id
+      - name: atomic
+      - name: constant-logical-expr
+      - name: unnecessary-stmt
+      - name: get-return
+      - name: modifies-parameter
+      - name: modifies-value-receiver
+      - name: range-val-in-closure
+      - name: waitgroup-by-value
+      - name: call-to-gc
+      - name: duplicated-imports
+      - name: unhandled-error
+      # - name: flag-parameter
+      # - name: unused-receiver
+      # - name: unused-parameter
+      # - name: confusing-naming
+      # - name: import-shadowing
+      # - name: confusing-results
+      # - name: bool-literal-in-expr
 
 linters:
   enable:


### PR DESCRIPTION
Just like we did for the list of golangci-lint linters, we explicitly list the rules from revive that we want to run. This will make it easy when we upgrade to the next version of revive.

I also found a way to disable even the default linters for golangci-lint and this enables us to have one list of enabled linters.