### PR TITLE
golangci-lint: enable dot-imports rule of revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -40,7 +40,7 @@ linters-settings:
       - name: blank-imports
       - name: context-as-argument
       - name: context-keys-type
-      # - name: dot-imports
+      - name: dot-imports
       - name: error-return
       - name: error-strings
       - name: error-naming
@@ -78,6 +78,15 @@ linters-settings:
       # - name: import-shadowing
       # - name: confusing-results
       # - name: bool-literal-in-expr
+
+issues:
+  exclude-rules:
+    # Allow dot imports for ginkgo and gomega
+    - source: ginkgo|gomega
+      linters:
+        - revive
+      text: "should not use dot imports"
+
 
 linters:
   disable-all: true


### PR DESCRIPTION
Discouraging dot-imports is a good rule. We can enable it again now with an exception for the Ginkgo and Gomega packages. Importing those two packages with dot-import makes test files more readable.