### PR TITLE
Deploy managed clusters s3 secrets using ramen

### DIFF
--- a/ramenctl/ramenctl/resources/configmap.yaml
+++ b/ramenctl/ramenctl/resources/configmap.yaml
@@ -40,7 +40,7 @@ data:
       s3CompatibleEndpoint: $minio_url_cluster1
       s3Region: us-west-1
       s3SecretRef:
-        name: ramen-s3-secret
+        name: ramen-s3-secret-$cluster1
         namespace: ramen-system
       veleroNamespaceSecretKeyRef:
         key: cloud
@@ -50,7 +50,7 @@ data:
       s3CompatibleEndpoint: $minio_url_cluster2
       s3Region: us-east-1
       s3SecretRef:
-        name: ramen-s3-secret
+        name: ramen-s3-secret-$cluster2
         namespace: ramen-system
       veleroNamespaceSecretKeyRef:
         key: cloud

--- a/ramenctl/ramenctl/resources/ramen-s3-secret.yaml
+++ b/ramenctl/ramenctl/resources/ramen-s3-secret.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ramen-s3-secret
+  name: ramen-s3-secret-$cluster
   namespace: $namespace
 stringData:
   AWS_ACCESS_KEY_ID: minio

--- a/test/addons/recipe/start
+++ b/test/addons/recipe/start
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from drenv import kubectl
+
+if len(sys.argv) != 2:
+    sys.exit(f"Usage: {sys.argv[0]} cluster")
+
+os.chdir(os.path.dirname(__file__))
+cluster = sys.argv[1]
+
+print("Deploying recipe crd")
+kubectl.apply(
+    "--kustomize",
+    "https://github.com/RamenDR/recipe.git/config/crd?ref=main&timeout=120s",
+    context=cluster,
+)

--- a/test/envs/regional-dr-external.yaml.example
+++ b/test/envs/regional-dr-external.yaml.example
@@ -20,6 +20,7 @@ templates:
       - addons:
           - name: ocm-cluster
             args: ["$name", "hub"]
+          - name: recipe
       - addons:
           - name: cert-manager
           - name: csi-addons

--- a/test/envs/regional-dr-hubless.yaml
+++ b/test/envs/regional-dr-hubless.yaml
@@ -33,6 +33,7 @@ templates:
           - name: olm
           - name: minio
           - name: velero
+          - name: recipe
 
 profiles:
   - name: "dr1"

--- a/test/envs/regional-dr-kubevirt.yaml
+++ b/test/envs/regional-dr-kubevirt.yaml
@@ -38,6 +38,7 @@ templates:
           - name: ocm-cluster
             args: ["$name", "hub"]
           - name: cdi
+          - name: recipe
       - addons:
           - name: csi-addons
           - name: olm

--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -31,6 +31,7 @@ templates:
       - addons:
           - name: ocm-cluster
             args: ["$name", "hub"]
+          - name: recipe
       - addons:
           - name: csi-addons
           - name: olm


### PR DESCRIPTION
In OpenShift we deploy 2 s3 secrets (one per s3 store) on the hub, and the secrets are propagated to the managed clusters using the policy framework.

In ramenctl we deploy the secrets directly to the managed clusters. This is much simpler and more reliable, but it bypass the ramen code we want to test, hiding issues in the real code path.

Change ramenctl to deploy the secrets in the same way as in OpenShift:
- Use 2 secrets, one per cluster s3 store
- Deploy the secrets only on the hub
- Wait until the secrets are propagated to the managed clusters by ramen.

With this issues in ramen related code or OCM will break ramenctl early. Hopefully this will help to detect regressions before they reach QE or released in OpenShift.