### PR TITLE
Support disable DR when cluster is unavailable

### DIFF
--- a/controllers/drcluster_controller.go
+++ b/controllers/drcluster_controller.go
@@ -294,7 +294,7 @@ func (r *DRClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	u.initializeStatus()
 
-	if !u.object.ObjectMeta.DeletionTimestamp.IsZero() {
+	if drClusterIsDeleted(drcluster) {
 		return r.processDeletion(u)
 	}
 
@@ -358,6 +358,11 @@ func (r DRClusterReconciler) processCreateOrUpdate(u *drclusterInstance) (ctrl.R
 	}
 
 	return ctrl.Result{Requeue: requeue || u.requeue}, reconcileError
+}
+
+// Return true if dr cluster was marked for deletion.
+func drClusterIsDeleted(c *ramen.DRCluster) bool {
+	return !c.GetDeletionTimestamp().IsZero()
 }
 
 func (u *drclusterInstance) initializeStatus() {

--- a/controllers/drcluster_mmode.go
+++ b/controllers/drcluster_mmode.go
@@ -100,6 +100,11 @@ func (u *drclusterInstance) mModeActivationsRequired() (map[string]ramen.Storage
 
 // getVRGs is a helper function to get the VRGs for the passed in DRPC and DRPolicy association
 func (u *drclusterInstance) getVRGs(drpcCollection DRPCAndPolicy) (map[string]*ramen.VolumeReplicationGroup, error) {
+	drClusters, err := getDRClusters(u.ctx, u.client, drpcCollection.drPolicy)
+	if err != nil {
+		return nil, err
+	}
+
 	placementObj, err := getPlacementOrPlacementRule(u.ctx, u.client, drpcCollection.drpc, u.log)
 	if err != nil {
 		return nil, err
@@ -113,7 +118,7 @@ func (u *drclusterInstance) getVRGs(drpcCollection DRPCAndPolicy) (map[string]*r
 	vrgs, failedToQueryCluster, err := getVRGsFromManagedClusters(
 		u.reconciler.MCVGetter,
 		drpcCollection.drpc,
-		drpcCollection.drPolicy,
+		drClusters,
 		vrgNamespace,
 		u.log)
 	if err != nil {

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
 
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
@@ -1501,7 +1502,7 @@ func (d *DRPCInstance) generateVRG(repState rmn.ReplicationState) rmn.VolumeRepl
 		Spec: rmn.VolumeReplicationGroupSpec{
 			PVCSelector:          d.instance.Spec.PVCSelector,
 			ReplicationState:     repState,
-			S3Profiles:           rmnutil.DRPolicyS3Profiles(d.drPolicy, d.drClusters).List(),
+			S3Profiles:           d.availableS3Profiles(),
 			KubeObjectProtection: d.instance.Spec.KubeObjectProtection,
 		},
 	}
@@ -1511,6 +1512,21 @@ func (d *DRPCInstance) generateVRG(repState rmn.ReplicationState) rmn.VolumeRepl
 	vrg.Spec.Sync = d.generateVRGSpecSync()
 
 	return vrg
+}
+
+func (d *DRPCInstance) availableS3Profiles() []string {
+	profiles := sets.New[string]()
+
+	for i := range d.drClusters {
+		drCluster := &d.drClusters[i]
+		if drClusterIsDeleted(drCluster) {
+			continue
+		}
+
+		profiles.Insert(drCluster.Spec.S3ProfileName)
+	}
+
+	return sets.List(profiles)
 }
 
 func (d *DRPCInstance) generateVRGSpecAsync() *rmn.VRGAsyncSpec {

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -1454,16 +1454,9 @@ func (d *DRPCInstance) createVRGManifestWork(homeCluster string, repState rmn.Re
 	return nil
 }
 
+// ensureVRGManifestWork ensures that the VRG ManifestWork exists and matches the current VRG state.
+// TODO: This may be safe only when the VRG is primary - check if callers use this correctly.
 func (d *DRPCInstance) ensureVRGManifestWork(homeCluster string) error {
-	mw, mwErr := d.mwu.FindManifestWorkByType(rmnutil.MWTypeVRG, homeCluster)
-	if mwErr != nil {
-		d.log.Info("Ensure VRG ManifestWork", "Error", mwErr)
-	}
-
-	if mw != nil {
-		return nil
-	}
-
 	d.log.Info("Ensure VRG ManifestWork",
 		"Last State:", d.getLastDRState(), "cluster", homeCluster)
 

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1460,7 +1460,9 @@ func getVRGsFromManagedClusters(mcvGetter rmnutil.ManagedClusterViewGetter, drpc
 
 	var clustersQueriedSuccessfully int
 
-	for _, drCluster := range drClusters {
+	for i := range drClusters {
+		drCluster := &drClusters[i]
+
 		vrg, err := mcvGetter.GetVRGFromManagedCluster(drpc.Name, vrgNamespace, drCluster.Name, annotations)
 		if err != nil {
 			// Only NotFound error is accepted
@@ -1479,6 +1481,12 @@ func getVRGsFromManagedClusters(mcvGetter rmnutil.ManagedClusterViewGetter, drpc
 		}
 
 		clustersQueriedSuccessfully++
+
+		if drClusterIsDeleted(drCluster) {
+			log.Info("Skipping VRG on deleted drcluster", "drcluster", drCluster.Name, "vrg", vrg.Name)
+
+			continue
+		}
 
 		vrgs[drCluster.Name] = vrg
 

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -775,7 +775,7 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 		return nil, err
 	}
 
-	vrgs, err := updateVRGsFromManagedClusters(r.MCVGetter, drpc, drPolicy, vrgNamespace, log)
+	vrgs, err := updateVRGsFromManagedClusters(r.MCVGetter, drpc, drClusters, vrgNamespace, log)
 	if err != nil {
 		return nil, err
 	}
@@ -1064,8 +1064,13 @@ func (r *DRPlacementControlReconciler) finalizeDRPC(ctx context.Context, drpc *r
 		}
 	}
 
+	drClusters, err := getDRClusters(ctx, r.Client, drPolicy)
+	if err != nil {
+		return fmt.Errorf("failed to get drclusters. Error (%w)", err)
+	}
+
 	// Verify VRGs have been deleted
-	vrgs, _, err := getVRGsFromManagedClusters(r.MCVGetter, drpc, drPolicy, vrgNamespace, log)
+	vrgs, _, err := getVRGsFromManagedClusters(r.MCVGetter, drpc, drClusters, vrgNamespace, log)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve VRGs. We'll retry later. Error (%w)", err)
 	}
@@ -1421,9 +1426,9 @@ func (r *DRPlacementControlReconciler) clonePlacementRule(ctx context.Context,
 }
 
 func updateVRGsFromManagedClusters(mcvGetter rmnutil.ManagedClusterViewGetter, drpc *rmn.DRPlacementControl,
-	drPolicy *rmn.DRPolicy, vrgNamespace string, log logr.Logger,
+	drClusters []rmn.DRCluster, vrgNamespace string, log logr.Logger,
 ) (map[string]*rmn.VolumeReplicationGroup, error) {
-	vrgs, failedClusterToQuery, err := getVRGsFromManagedClusters(mcvGetter, drpc, drPolicy, vrgNamespace, log)
+	vrgs, failedClusterToQuery, err := getVRGsFromManagedClusters(mcvGetter, drpc, drClusters, vrgNamespace, log)
 	if err != nil {
 		return nil, err
 	}
@@ -1442,7 +1447,7 @@ func updateVRGsFromManagedClusters(mcvGetter rmnutil.ManagedClusterViewGetter, d
 }
 
 func getVRGsFromManagedClusters(mcvGetter rmnutil.ManagedClusterViewGetter, drpc *rmn.DRPlacementControl,
-	drPolicy *rmn.DRPolicy, vrgNamespace string, log logr.Logger,
+	drClusters []rmn.DRCluster, vrgNamespace string, log logr.Logger,
 ) (map[string]*rmn.VolumeReplicationGroup, string, error) {
 	vrgs := map[string]*rmn.VolumeReplicationGroup{}
 
@@ -1455,33 +1460,33 @@ func getVRGsFromManagedClusters(mcvGetter rmnutil.ManagedClusterViewGetter, drpc
 
 	var clustersQueriedSuccessfully int
 
-	for _, drCluster := range rmnutil.DrpolicyClusterNames(drPolicy) {
-		vrg, err := mcvGetter.GetVRGFromManagedCluster(drpc.Name, vrgNamespace, drCluster, annotations)
+	for _, drCluster := range drClusters {
+		vrg, err := mcvGetter.GetVRGFromManagedCluster(drpc.Name, vrgNamespace, drCluster.Name, annotations)
 		if err != nil {
 			// Only NotFound error is accepted
 			if errors.IsNotFound(err) {
-				log.Info(fmt.Sprintf("VRG not found on %q", drCluster))
+				log.Info(fmt.Sprintf("VRG not found on %q", drCluster.Name))
 				clustersQueriedSuccessfully++
 
 				continue
 			}
 
-			failedClusterToQuery = drCluster
+			failedClusterToQuery = drCluster.Name
 
-			log.Info(fmt.Sprintf("failed to retrieve VRG from %s. err (%v)", drCluster, err))
+			log.Info(fmt.Sprintf("failed to retrieve VRG from %s. err (%v)", drCluster.Name, err))
 
 			continue
 		}
 
 		clustersQueriedSuccessfully++
 
-		vrgs[drCluster] = vrg
+		vrgs[drCluster.Name] = vrg
 
-		log.Info("VRG location", "VRG on", drCluster)
+		log.Info("VRG location", "VRG on", drCluster.Name)
 	}
 
 	// We are done if we successfully queried all drClusters
-	if clustersQueriedSuccessfully == len(rmnutil.DrpolicyClusterNames(drPolicy)) {
+	if clustersQueriedSuccessfully == len(drClusters) {
 		return vrgs, "", nil
 	}
 


### PR DESCRIPTION
When cluster is not available, disabling DR get suck waiting for the vrgs.

On the remaining cluster, the vrg is stuck trying to delete data from the s3 store on the unavailable cluster.

On the hub, the drpc is stuck waiting for the stuck vrg, and for the stale vrg reported bu the managedclusterview of the unavailable cluster.

To fix the issue we require the admin to delete the failed drcluter after failing over to another cluster. The system will avoid accessing s3 profiles on deleted drcluster and do not wait for VRG on deleted clusters.

## Disable DR flow when a cluster is not available

1. For each application on the failed cluster, fail over to the secondary cluster

1. Mark the failed drcluster for deletion on the hub
   
   ```
   kubectl delete drcluster clustername --wait=false --context hub
   ```

   Using --wait=false since the drcluster will not be deleted until the drpolicy referencing it will be deleted, and the drpolicy will not be deleted before the drpc referencing it will be deleted.

1. For each application disable DR:
   1. Ensure Placement is pointing to failover cluster

   1. Wait until the vrg for the application has only one s3 profile:

      ```
      kubectl get vrg -n appnamespace --context cluster2 \
          -o jsonpath='{.items[0].spec.s3Profiles}' | jq
      ```

      This can take few minutes after the drcluster was deleted.

   1. Delete the drpc resource for the OCM application on the hub

      ```
      kubectl delete drpc drpcname -n drpcnamespace --context hub
      ```

      If the drpc delete does not finish, check that the vrg does not have s3 profile for the failed cluster. If it does, you need to edit the vrg and remove it manually.

   1. Change the Placement to be reconciled by OCM

       ```
       kubectl annotate placement placementname -n drpcnamespace \
          cluster.open-cluster-management.io/experimental-scheduling-disable-
       ```

## Known issues

- Docs on disabling DR needed

- It can take few minutes after deleting the drcluster until the vrg on failover cluster updates to exclude the s3 profile. If the drpc is deleted after the vrg is updated, the delete will complete quickly.

- If disable DR is started *before* the vrg is updated on the failover cluster, disabling DR will not complete, since deleting a drpc deletes the manifestwork for the vrg, and after that no change in the manifest work is propagated to the managed cluster.
  - You need to edit the vrg on the managed cluster and delete the s3 profile for the deleted drcluster

- With volsync (cephfs) disabling dr also delete the PVC: #1150

## Testing

1. Update the the ramen-operator image in csv on the hub and drcluster:

   ```
   image: quay.io/nirsof/ramen-operator:drcluster-unavailable-v6
   ```

1. If upgrading an older version (e.g. 4.14), apply the CRDs from main:

   ```
   for cluster in hub cluster1 cluster2; do
       oc apply -k 'https://github.com/RamenDR/ramen.git/config/crd' --context $cluster
   done
   ```

## Status

Tested using https://github.com/RamenDR/ocm-ramen-samples/pull/41 on top of #1153 

### basic-test

drenv:
- [x] busybox-regional-rbd-deploy
- [x] busybox-regional-rbd-sts
- [x] busybox-regional-rbd-ds

ocp:
- [x] busybox-regional-rbd-deploy
- [x] busybox-regional-cephfs-deploy

### Disable DR flow

Tested without the commit updating the vrg.

drenv:
- [x] busybox-regional-rbd-deploy

ocp:
- [x] rbd sub
- [x] rbd appset
- [x] cephfs sub
- [x] cephfs appset

Todo:
- [x] Test that VRG is regenerated when drclsuter is deleted
  - took 8 minutes because we don't watch drcluster delete events
- [x] Test watching delete events - need more work on filtering drclusters events

Fixes #1139 