### PR TITLE
Enable automatic managed clusters approval

### DIFF
--- a/test/addons/ocm-cluster/start
+++ b/test/addons/ocm-cluster/start
@@ -43,7 +43,6 @@ HUB_DEPLOYMENTS = (
 def deploy(cluster, hub):
     wait_for_hub(hub)
     join_cluster(cluster, hub)
-    accept_cluster(cluster, hub)
     label_cluster(cluster, hub)
     wait_for_managed_cluster(cluster, hub)
     enable_addons(cluster, hub)
@@ -94,11 +93,6 @@ def join_cluster(cluster, hub):
         wait=True,
         context=cluster,
     )
-
-
-def accept_cluster(cluster, hub):
-    print("Accepting cluster")
-    clusteradm.accept([cluster], wait=True, context=hub)
 
 
 def label_cluster(cluster, hub):

--- a/test/addons/ocm-hub/start
+++ b/test/addons/ocm-hub/start
@@ -41,7 +41,12 @@ DEPLOYMENTS = {
 
 def deploy(cluster):
     print("Initializing hub")
-    clusteradm.init(wait=True, context=cluster)
+    clusteradm.init(
+        # With auto approval joined clusters are accepted automatically.
+        feature_gates=["ManagedClusterAutoApproval=true"],
+        wait=True,
+        context=cluster,
+    )
 
     print("Installing hub addons")
     for addon in ADDONS:

--- a/test/drenv/clusteradm.py
+++ b/test/drenv/clusteradm.py
@@ -4,11 +4,13 @@
 from . import commands
 
 
-def init(wait=False, context=None, log=print):
+def init(feature_gates=None, wait=False, context=None, log=print):
     """
     Initialize a Kubernetes cluster into an OCM hub cluster.
     """
     cmd = ["clusteradm", "init"]
+    if feature_gates:
+        cmd.extend(("--feature-gates", ",".join(feature_gates)))
     if wait:
         cmd.append("--wait")
     if context:
@@ -54,18 +56,6 @@ def join(hub_token, hub_apiserver, cluster_name, wait=False, context=None, log=p
         "--cluster-name",
         cluster_name,
     ]
-    if wait:
-        cmd.append("--wait")
-    if context:
-        cmd.extend(("--context", context))
-    _watch(*cmd, log=log)
-
-
-def accept(clusters, wait=False, context=None, log=print):
-    """
-    Accept clusters to the hub.
-    """
-    cmd = ["clusteradm", "accept", "--clusters", ",".join(clusters)]
     if wait:
         cmd.append("--wait")
     if context:


### PR DESCRIPTION
To avoid idempotency issues in `clusteradm accept`[1] enable the ManagedClusterAutoApproval feature gate, so `clusteradm accept` is not needed.

Another way to solve this is to add `--skip-approve-check` option in `clusteradm accept` but the approval step is not needed in context of a testing environment.

[1] https://github.com/open-cluster-management-io/clusteradm/issues/395

Thanks: Mike Ng <ming@redhat.com>