### PR TITLE
Add missing pvc namespace to the vrg rdspec

### DIFF
--- a/controllers/vrg_volsync.go
+++ b/controllers/vrg_volsync.go
@@ -114,6 +114,7 @@ func (v *VRGInstance) reconcileVolSyncAsPrimary(finalSyncPrepared *bool) (requeu
 func (v *VRGInstance) reconcilePVCAsVolSyncPrimary(pvc corev1.PersistentVolumeClaim) (requeue bool) {
 	newProtectedPVC := &ramendrv1alpha1.ProtectedPVC{
 		Name:               pvc.Name,
+		Namespace:          pvc.Namespace,
 		ProtectedByVolSync: true,
 		StorageClassName:   pvc.Spec.StorageClassName,
 		Annotations:        protectedPVCAnnotations(pvc),


### PR DESCRIPTION
It seems that recent change for supporting multiple namespaces have broken failover with volsync when using multiple volsync apps. Add the pvc namespace to the protected pvc, similar to volrep code.

I did not modify the test to validate this change since I don't fully understand the test. It seems that there is a missing `It` section for testing the vrg.

Tested on ocp 4.14.

Issues:
- During upgrade on a system with stuck workload, the vrg is not updated automatically yet.