### PR TITLE
Exclude VolSync secret Policy from hub backup

### DIFF
--- a/controllers/volsync/secret_propagator.go
+++ b/controllers/volsync/secret_propagator.go
@@ -174,6 +174,8 @@ func (sp *secretPropagator) reconcileSecretPropagationPolicy() error {
 			return fmt.Errorf("%w", err)
 		}
 
+		util.AddLabel(policy, "velero.io/exclude-from-backup", "true")
+
 		policy.Spec = policyv1.PolicySpec{
 			Disabled: false,
 			PolicyTemplates: []*policyv1.PolicyTemplate{

--- a/controllers/volsync/secret_propagator_test.go
+++ b/controllers/volsync/secret_propagator_test.go
@@ -214,6 +214,7 @@ var _ = Describe("Secret_propagator", func() {
 					Expect(plBindingSubject.APIGroup).To(Equal("policy.open-cluster-management.io"))
 					Expect(plBindingSubject.Kind).To(Equal("Policy"))
 					Expect(plBindingSubject.Name).To(Equal(createdPolicy.GetName()))
+					Expect(createdPolicy.GetLabels()["velero.io/exclude-from-backup"]).Should(Equal("true"))
 				})
 
 				Context("When Policy name combined with namespace is longer than 62 characters", func() {


### PR DESCRIPTION
Exclude the Policy that is used to propagate the secret used by VolSync.
This will fix the second part in [this bz](https://github.com/RamenDR/ramen/pull/1157). We are basically working around [this](https://issues.redhat.com/browse/ACM-8744) and [this](https://issues.redhat.com/browse/ACM-8857) ACM issues

- [ ] Add unit test