### PR TITLE
e2e-test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# yamllint disable rule:line-length
+name: E2E
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  e2e-rdr:
+    runs-on: [self-hosted, e2e-rdr]
+    if: github.repository == 'RamenDR/ramen' && contains(fromJson('["nirs", "ShyamsundarR", "BenamarMk", "raghavendra-talur", "rakeshgm", "ELENAGER", "netzzer", "kseegerrh"]'), github.actor)
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+
+    - name: Run make target e2e-rdr
+      run: |
+        make e2e-rdr

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the manager binary
-FROM golang:1.19.1 as builder
+FROM docker.io/library/golang:1.19.1 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,9 @@ test-drenv:
 test-ramenctl:
 	$(MAKE) -C ramenctl
 
+e2e-rdr: generate manifests docker-build
+	./e2e/rdr-e2e.sh
+
 ##@ Build
 
 # Build manager binary

--- a/e2e/rdr-e2e.sh
+++ b/e2e/rdr-e2e.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Test ran successfully"
+exit 0


### PR DESCRIPTION
This commit has the following changes:
* Add a new dir, e2e, which will host the scripts for e2e tests.
* A make target for e2e is added
* Github workflow file is added which will run the e2e tests for PRs
  created by approved contributors.