### PR TITLE
Enhancing Hub Recovery: Reworking DRPC State Rebuilding Algorithm

### DIFF
--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -69,6 +69,7 @@ const (
 	ReasonCleaning    = "Cleaning"
 	ReasonSuccess     = "Success"
 	ReasonNotStarted  = "NotStarted"
+	ReasonPaused      = "Paused"
 )
 
 type ProgressionStatus string
@@ -93,6 +94,7 @@ const (
 	ProgressionEnsuringVolSyncSetup                = ProgressionStatus("EnsuringVolSyncSetup")
 	ProgressionSettingupVolsyncDest                = ProgressionStatus("SettingUpVolSyncDest")
 	ProgressionDeleting                            = ProgressionStatus("Deleting")
+	ProgressionActionPaused                        = ProgressionStatus("Paused")
 )
 
 // DRPlacementControlSpec defines the desired state of DRPlacementControl

--- a/controllers/drcluster_mmode.go
+++ b/controllers/drcluster_mmode.go
@@ -115,7 +115,7 @@ func (u *drclusterInstance) getVRGs(drpcCollection DRPCAndPolicy) (map[string]*r
 		return nil, err
 	}
 
-	vrgs, failedToQueryCluster, err := getVRGsFromManagedClusters(
+	vrgs, _, failedToQueryCluster, err := getVRGsFromManagedClusters(
 		u.reconciler.MCVGetter,
 		drpcCollection.drpc,
 		drClusters,

--- a/controllers/drcluster_mmode.go
+++ b/controllers/drcluster_mmode.go
@@ -62,7 +62,7 @@ func (u *drclusterInstance) mModeActivationsRequired() (map[string]ramen.Storage
 		vrgs, err := u.getVRGs(drpcCollection)
 		if err != nil {
 			u.log.Info("Failed to get VRGs for DRPC that is failing over",
-				"DRPCCommonName", drpcCollection.drpc.GetName(),
+				"DRPCName", drpcCollection.drpc.GetName(),
 				"DRPCNamespace", drpcCollection.drpc.GetNamespace())
 
 			u.requeue = true

--- a/controllers/drcluster_mmode.go
+++ b/controllers/drcluster_mmode.go
@@ -70,12 +70,22 @@ func (u *drclusterInstance) mModeActivationsRequired() (map[string]ramen.Storage
 			continue
 		}
 
+		placementObj, err := getPlacementOrPlacementRule(u.ctx, u.client, drpcCollection.drpc, u.log)
+		if err != nil {
+			return nil, err
+		}
+
+		vrgNamespace, err := selectVRGNamespace(u.client, u.log, drpcCollection.drpc, placementObj)
+		if err != nil {
+			return nil, err
+		}
+
 		required, activationsRequired := requiresRegionalFailoverPrerequisites(
 			u.ctx,
 			u.reconciler.APIReader,
 			[]string{u.object.Spec.S3ProfileName},
 			drpcCollection.drpc.GetName(),
-			drpcCollection.drpc.GetNamespace(),
+			vrgNamespace,
 			vrgs,
 			u.object.GetName(),
 			u.reconciler.ObjectStoreGetter,

--- a/controllers/drcluster_mmode.go
+++ b/controllers/drcluster_mmode.go
@@ -62,7 +62,7 @@ func (u *drclusterInstance) mModeActivationsRequired() (map[string]ramen.Storage
 		vrgs, err := u.getVRGs(drpcCollection)
 		if err != nil {
 			u.log.Info("Failed to get VRGs for DRPC that is failing over",
-				"DRPCName", drpcCollection.drpc.GetName(),
+				"DRPCCommonName", drpcCollection.drpc.GetName(),
 				"DRPCNamespace", drpcCollection.drpc.GetNamespace())
 
 			u.requeue = true

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
 
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
@@ -322,13 +321,6 @@ func (d *DRPCInstance) startDeploying(homeCluster, homeClusterNamespace string) 
 // 8. Delete VRG MW from preferredCluster once the VRG state has changed to Secondary
 func (d *DRPCInstance) RunFailover() (bool, error) {
 	d.log.Info("Entering RunFailover", "state", d.getLastDRState())
-
-	if d.isPlacementNeedsFixing() {
-		err := d.fixupPlacementForFailover()
-		if err != nil {
-			d.log.Info("Couldn't fix up placement for Failover")
-		}
-	}
 
 	const done = true
 
@@ -662,7 +654,7 @@ func GetLastKnownVRGPrimaryFromS3(
 
 		vrg := &rmn.VolumeReplicationGroup{}
 		if err := vrgObjectDownload(objectStorer, sourcePathNamePrefix, vrg); err != nil {
-			log.Error(err, "Kube objects capture-to-recover-from identifier get error")
+			log.Info(fmt.Sprintf("Failed to get VRG from s3 store - s3ProfileName %s. Err %v", s3ProfileName, err))
 
 			continue
 		}
@@ -773,13 +765,6 @@ func checkActivationForStorageIdentifier(
 func (d *DRPCInstance) RunRelocate() (bool, error) {
 	d.log.Info("Entering RunRelocate", "state", d.getLastDRState(), "progression", d.getProgression())
 
-	if d.isPlacementNeedsFixing() {
-		err := d.fixupPlacementForRelocate()
-		if err != nil {
-			d.log.Info("Couldn't fix up placement for Relocate")
-		}
-	}
-
 	const done = true
 
 	preferredCluster := d.instance.Spec.PreferredCluster
@@ -816,7 +801,7 @@ func (d *DRPCInstance) RunRelocate() (bool, error) {
 	}
 
 	if d.getLastDRState() != rmn.Relocating && !d.validatePeerReady() {
-		return !done, fmt.Errorf("clean up on secondaries pending (%+v)", d.instance)
+		return !done, fmt.Errorf("clean up secondaries is pending (%+v)", d.instance.Status.Conditions)
 	}
 
 	if curHomeCluster != "" && curHomeCluster != preferredCluster {
@@ -837,6 +822,11 @@ func (d *DRPCInstance) ensureActionCompleted(srcCluster string) (bool, error) {
 	const done = true
 
 	err := d.ensureVRGManifestWork(srcCluster)
+	if err != nil {
+		return !done, err
+	}
+
+	err = d.ensurePlacement(srcCluster)
 	if err != nil {
 		return !done, err
 	}
@@ -1009,11 +999,11 @@ func (d *DRPCInstance) areMultipleVRGsPrimary() bool {
 
 func (d *DRPCInstance) validatePeerReady() bool {
 	condition := findCondition(d.instance.Status.Conditions, rmn.ConditionPeerReady)
-	d.log.Info(fmt.Sprintf("validatePeerReady -- Condition %v", condition))
-
 	if condition == nil || condition.Status == metav1.ConditionTrue {
 		return true
 	}
+
+	d.log.Info("validatePeerReady", "Condition", condition)
 
 	return false
 }
@@ -1281,15 +1271,13 @@ func (d *DRPCInstance) vrgExistsAndPrimary(targetCluster string) bool {
 		return false
 	}
 
-	clusterDecision := d.reconciler.getClusterDecision(d.userPlacement)
-	if clusterDecision.ClusterName != "" &&
-		targetCluster == clusterDecision.ClusterName {
-		d.log.Info(fmt.Sprintf("Already %q to cluster %s", d.getLastDRState(), targetCluster))
-
-		return true
+	if !vrg.GetDeletionTimestamp().IsZero() {
+		return false
 	}
 
-	return false
+	d.log.Info(fmt.Sprintf("Already %q to cluster %s", d.getLastDRState(), targetCluster))
+
+	return true
 }
 
 func (d *DRPCInstance) mwExistsAndPlacementUpdated(targetCluster string) (bool, error) {
@@ -1435,7 +1423,7 @@ func (d *DRPCInstance) createVRGManifestWork(homeCluster string, repState rmn.Re
 	d.log.Info("Creating VRG ManifestWork",
 		"Last State:", d.getLastDRState(), "cluster", homeCluster)
 
-	vrg := d.generateVRG(repState)
+	vrg := d.generateVRG(homeCluster, repState)
 	vrg.Spec.VolSync.Disabled = d.volSyncDisabled
 
 	annotations := make(map[string]string)
@@ -1468,6 +1456,18 @@ func (d *DRPCInstance) ensureVRGManifestWork(homeCluster string) error {
 	return d.createVRGManifestWork(homeCluster, cachedVrg.Spec.ReplicationState)
 }
 
+func (d *DRPCInstance) ensurePlacement(homeCluster string) error {
+	clusterDecision := d.reconciler.getClusterDecision(d.userPlacement)
+	if clusterDecision.ClusterName == "" ||
+		homeCluster != clusterDecision.ClusterName {
+		d.updatePreferredDecision()
+
+		return d.updateUserPlacementRule(homeCluster, homeCluster)
+	}
+
+	return nil
+}
+
 func vrgAction(drpcAction rmn.DRAction) rmn.VRGAction {
 	switch drpcAction {
 	case rmn.ActionFailover:
@@ -1488,14 +1488,20 @@ func (d *DRPCInstance) setVRGAction(vrg *rmn.VolumeReplicationGroup) {
 	vrg.Spec.Action = action
 }
 
-func (d *DRPCInstance) generateVRG(repState rmn.ReplicationState) rmn.VolumeReplicationGroup {
+func (d *DRPCInstance) generateVRG(dstCluster string, repState rmn.ReplicationState) rmn.VolumeReplicationGroup {
 	vrg := rmn.VolumeReplicationGroup{
-		TypeMeta:   metav1.TypeMeta{Kind: "VolumeReplicationGroup", APIVersion: "ramendr.openshift.io/v1alpha1"},
-		ObjectMeta: metav1.ObjectMeta{Name: d.instance.Name, Namespace: d.vrgNamespace},
+		TypeMeta: metav1.TypeMeta{Kind: "VolumeReplicationGroup", APIVersion: "ramendr.openshift.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      d.instance.Name,
+			Namespace: d.vrgNamespace,
+			Annotations: map[string]string{
+				DestinationClusterAnnotationKey: dstCluster,
+			},
+		},
 		Spec: rmn.VolumeReplicationGroupSpec{
 			PVCSelector:          d.instance.Spec.PVCSelector,
 			ReplicationState:     repState,
-			S3Profiles:           d.availableS3Profiles(),
+			S3Profiles:           AvailableS3Profiles(d.drClusters),
 			KubeObjectProtection: d.instance.Spec.KubeObjectProtection,
 		},
 	}
@@ -1505,21 +1511,6 @@ func (d *DRPCInstance) generateVRG(repState rmn.ReplicationState) rmn.VolumeRepl
 	vrg.Spec.Sync = d.generateVRGSpecSync()
 
 	return vrg
-}
-
-func (d *DRPCInstance) availableS3Profiles() []string {
-	profiles := sets.New[string]()
-
-	for i := range d.drClusters {
-		drCluster := &d.drClusters[i]
-		if drClusterIsDeleted(drCluster) {
-			continue
-		}
-
-		profiles.Insert(drCluster.Spec.S3ProfileName)
-	}
-
-	return sets.List(profiles)
 }
 
 func (d *DRPCInstance) generateVRGSpecAsync() *rmn.VRGAsyncSpec {
@@ -1651,10 +1642,9 @@ func (d *DRPCInstance) ensureClusterDataRestored(homeCluster string) (*rmn.Volum
 	annotations[DRPCNameAnnotation] = d.instance.Name
 	annotations[DRPCNamespaceAnnotation] = d.instance.Namespace
 
-	vrg, err := d.reconciler.MCVGetter.GetVRGFromManagedCluster(d.instance.Name,
-		d.vrgNamespace, homeCluster, annotations)
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to get VRG %s from cluster %s (err: %w)", d.instance.Name, homeCluster, err)
+	vrg := d.vrgs[homeCluster]
+	if vrg == nil {
+		return nil, false, fmt.Errorf("failed to get VRG %s from cluster %s", d.instance.Name, homeCluster)
 	}
 
 	// ClusterDataReady condition tells us whether the PVs have been applied on the
@@ -2313,126 +2303,6 @@ func (d *DRPCInstance) setConditionOnInitialDeploymentCompletion() {
 
 	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
 		metav1.ConditionTrue, rmn.ReasonSuccess, "Ready")
-}
-
-func (d *DRPCInstance) isPlacementNeedsFixing() bool {
-	// Needs fixing if and only if the DRPC Status is empty, the Placement decision is empty, and
-	// the we have VRG(s) in the managed clusters
-	clusterDecision := d.reconciler.getClusterDecision(d.userPlacement)
-	d.log.Info(fmt.Sprintf("Check placement if needs fixing: PrD %v, PlD %v, VRGs %d",
-		d.instance.Status.PreferredDecision, clusterDecision, len(d.vrgs)))
-
-	if reflect.DeepEqual(d.instance.Status.PreferredDecision, plrv1.PlacementDecision{}) &&
-		(clusterDecision == nil || clusterDecision.ClusterName == "") && len(d.vrgs) > 0 {
-		return true
-	}
-
-	return false
-}
-
-func (d *DRPCInstance) selectCurrentPrimaries() []string {
-	var primaries []string
-
-	for clusterName, vrg := range d.vrgs {
-		if isVRGPrimary(vrg) {
-			primaries = append(primaries, clusterName)
-		}
-	}
-
-	return primaries
-}
-
-func (d *DRPCInstance) selectPrimaryForFailover(primaries []string) string {
-	for _, clusterName := range primaries {
-		if clusterName == d.instance.Spec.FailoverCluster {
-			return clusterName
-		}
-	}
-
-	return ""
-}
-
-func (d *DRPCInstance) fixupPlacementForFailover() error {
-	d.log.Info("Fixing PlacementRule for failover...")
-
-	var primary string
-
-	var primaries []string
-
-	var secondaries []string
-
-	if d.areMultipleVRGsPrimary() {
-		primaries := d.selectCurrentPrimaries()
-		primary = d.selectPrimaryForFailover(primaries)
-	} else {
-		primary, secondaries = d.selectCurrentPrimaryAndSecondaries()
-	}
-
-	// IFF we have a primary cluster, and it points to the failoverCluster, then rebuild the
-	// drpc status with it.
-	if primary != "" && primary == d.instance.Spec.FailoverCluster {
-		err := d.updateUserPlacementRule(primary, "")
-		if err != nil {
-			return err
-		}
-
-		// Update our 'well known' preferred placement
-		d.updatePreferredDecision()
-
-		peerReadyConditionStatus := metav1.ConditionTrue
-		peerReadyMsg := "Ready"
-		// IFF more than one primary then the failover hasn't entered the cleanup phase.
-		// IFF we have a secondary, then the failover hasn't completed the cleanup phase.
-		// We need to start where it was left off (best guess).
-		if len(primaries) > 1 || len(secondaries) > 0 {
-			d.instance.Status.Phase = rmn.FailingOver
-			peerReadyConditionStatus = metav1.ConditionFalse
-			peerReadyMsg = "NotReady"
-		}
-
-		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
-			peerReadyConditionStatus, rmn.ReasonSuccess, peerReadyMsg)
-
-		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
-			metav1.ConditionTrue, string(d.instance.Status.Phase), "Available")
-
-		return nil
-	}
-
-	return fmt.Errorf("detected a failover, but it can't rebuild the state")
-}
-
-func (d *DRPCInstance) fixupPlacementForRelocate() error {
-	if d.areMultipleVRGsPrimary() {
-		return fmt.Errorf("unconstructable state. Can't have multiple primaries on 'Relocate'")
-	}
-
-	primary, secondaries := d.selectCurrentPrimaryAndSecondaries()
-	d.log.Info(fmt.Sprintf("Fixing PlacementRule for relocation. Primary (%s), Secondaries (%v)",
-		primary, secondaries))
-
-	// IFF we have a primary cluster, then update the PlacementRule and reset PeerReady to false
-	// Setting the PeerReady condition status to false allows peer cleanup if necessary
-	if primary != "" {
-		err := d.updateUserPlacementRule(primary, "")
-		if err != nil {
-			return err
-		}
-
-		// Assume that it is not clean
-		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
-			metav1.ConditionFalse, rmn.ReasonNotStarted, "NotReady")
-	} else if len(secondaries) > 1 {
-		// Use case 3: After Hub Recovery, the DRPC Action found to be 'Relocate', and ALL VRGs are secondary
-		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
-			metav1.ConditionTrue, rmn.ReasonSuccess,
-			fmt.Sprintf("Fixed for relocation to %q", d.instance.Spec.PreferredCluster))
-	}
-
-	// Update our 'well known' preferred placement
-	d.updatePreferredDecision()
-
-	return nil
 }
 
 func (d *DRPCInstance) setStatusInitiating() {

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -538,7 +538,7 @@ func (d *DRPCInstance) checkRegionalFailoverPrerequisites() bool {
 			d.ctx,
 			d.reconciler.APIReader,
 			[]string{drCluster.Spec.S3ProfileName},
-			d.instance.GetName(), d.instance.GetNamespace(),
+			d.instance.GetName(), d.vrgNamespace,
 			d.vrgs, d.instance.Spec.FailoverCluster,
 			d.reconciler.ObjStoreGetter, d.log); required {
 			return checkFailoverMaintenanceActivations(drCluster, activationsRequired, d.log)
@@ -558,7 +558,7 @@ func requiresRegionalFailoverPrerequisites(
 	apiReader client.Reader,
 	s3ProfileNames []string,
 	drpcName string,
-	drpcNamespace string,
+	vrgNamespace string,
 	vrgs map[string]*rmn.VolumeReplicationGroup,
 	failoverCluster string,
 	objectStoreGetter ObjectStoreGetter,
@@ -571,7 +571,7 @@ func requiresRegionalFailoverPrerequisites(
 
 	vrg := getLastKnownPrimaryVRG(vrgs, failoverCluster)
 	if vrg == nil {
-		vrg = GetLastKnownVRGPrimaryFromS3(ctx, apiReader, s3ProfileNames, drpcName, drpcNamespace, objectStoreGetter, log)
+		vrg = GetLastKnownVRGPrimaryFromS3(ctx, apiReader, s3ProfileNames, drpcName, vrgNamespace, objectStoreGetter, log)
 		if vrg == nil {
 			// TODO: Is this an error, should we ensure at least one VRG is found in the edge cases?
 			// Potentially missing VRG and so stop failover? How to recover in that case?

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -337,6 +337,7 @@ func (d *DRPCInstance) RunFailover() (bool, error) {
 
 	// IFF VRG exists and it is primary in the failoverCluster, the clean up and setup VolSync if needed.
 	if d.vrgExistsAndPrimary(failoverCluster) {
+		d.updatePreferredDecision()
 		d.setDRState(rmn.FailedOver)
 		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			metav1.ConditionTrue, string(d.instance.Status.Phase), "Completed")
@@ -432,6 +433,7 @@ func (d *DRPCInstance) switchToFailoverCluster() (bool, error) {
 		return !done, err
 	}
 
+	d.updatePreferredDecision()
 	d.setDRState(rmn.FailedOver)
 	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 		d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), "Completed")
@@ -781,6 +783,7 @@ func (d *DRPCInstance) RunRelocate() (bool, error) {
 
 	// We are done if already relocated; if there were secondaries they are cleaned up above
 	if curHomeCluster != "" && d.vrgExistsAndPrimary(preferredCluster) {
+		d.updatePreferredDecision()
 		d.setDRState(rmn.Relocated)
 		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			metav1.ConditionTrue, string(d.instance.Status.Phase), "Completed")
@@ -1132,6 +1135,7 @@ func (d *DRPCInstance) relocate(preferredCluster, preferredClusterNamespace stri
 		return !done, err
 	}
 
+	d.updatePreferredDecision()
 	d.setDRState(rmn.Relocated)
 	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 		d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), "Completed")

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -559,7 +559,7 @@ func requiresRegionalFailoverPrerequisites(
 	ctx context.Context,
 	apiReader client.Reader,
 	s3ProfileNames []string,
-	drpcName string,
+	DRPCCommonName string,
 	vrgNamespace string,
 	vrgs map[string]*rmn.VolumeReplicationGroup,
 	failoverCluster string,
@@ -573,7 +573,7 @@ func requiresRegionalFailoverPrerequisites(
 
 	vrg := getLastKnownPrimaryVRG(vrgs, failoverCluster)
 	if vrg == nil {
-		vrg = GetLastKnownVRGPrimaryFromS3(ctx, apiReader, s3ProfileNames, drpcName, vrgNamespace, objectStoreGetter, log)
+		vrg = GetLastKnownVRGPrimaryFromS3(ctx, apiReader, s3ProfileNames, DRPCCommonName, vrgNamespace, objectStoreGetter, log)
 		if vrg == nil {
 			// TODO: Is this an error, should we ensure at least one VRG is found in the edge cases?
 			// Potentially missing VRG and so stop failover? How to recover in that case?

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -1479,8 +1479,8 @@ func runFailoverAction(placementObj client.Object, fromCluster, toCluster string
 	//       time this test is made, depending upon whether NetworkFence
 	//       resource is cleaned up or not, number of MW may change.
 	if !isSyncDR {
-		Expect(getManifestWorkCount(toCluster)).Should(Equal(3))   // MW for VRG+DRCluster+NS
-		Expect(getManifestWorkCount(fromCluster)).Should(Equal(2)) // DRCluster + NS MW
+		Expect(getManifestWorkCount(toCluster)).Should(BeElementOf(3, 4)) // MW for VRG+DRCluster+NS
+		Expect(getManifestWorkCount(fromCluster)).Should(Equal(2))        // DRCluster + NS MW
 	} else {
 		Expect(getManifestWorkCount(toCluster)).Should(Equal(4))   // MW for VRG+DRCluster + NS + NF
 		Expect(getManifestWorkCount(fromCluster)).Should(Equal(2)) // NS + DRCluster MW
@@ -1702,7 +1702,7 @@ func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster s
 	updateManifestWorkStatus(preferredCluster, "vrg", ocmworkv1.WorkApplied)
 	verifyUserPlacementRuleDecision(userPlacement.GetName(), userPlacement.GetNamespace(), preferredCluster)
 	verifyDRPCStatusPreferredClusterExpectation(rmn.Deployed)
-	Expect(getManifestWorkCount(preferredCluster)).Should(Equal(3)) // MWs for VRG, 2 namespaces, and DRCluster
+	Expect(getManifestWorkCount(preferredCluster)).Should(BeElementOf(3, 4)) // MWs for VRG, 2 namespaces, and DRCluster
 	waitForCompletion(string(rmn.Deployed))
 
 	latestDRPC := getLatestDRPC()
@@ -1728,7 +1728,7 @@ func verifyFailoverToSecondary(placementObj client.Object, toCluster string,
 	//       resource is cleaned up or not, number of MW may change.
 	if !isSyncDR {
 		// MW for VRG+NS+DRCluster
-		Eventually(getManifestWorkCount, timeout, interval).WithArguments(toCluster).Should(Equal(3))
+		Eventually(getManifestWorkCount, timeout, interval).WithArguments(toCluster).Should(BeElementOf(3, 4))
 	} else {
 		Expect(getManifestWorkCount(toCluster)).Should(Equal(4)) // MW for VRG+NS+DRCluster+NF
 	}
@@ -1892,7 +1892,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				setDRPCSpecExpectationTo(rmn.ActionFailover, East1ManagedCluster, West1ManagedCluster)
 				verifyUserPlacementRuleDecisionUnchanged(userPlacementRule.Name, userPlacementRule.Namespace, West1ManagedCluster)
 				// MWs for VRG, NS, DRCluster, and MMode
-				Eventually(getManifestWorkCount, timeout, interval).WithArguments(West1ManagedCluster).Should(Equal(4))
+				Eventually(getManifestWorkCount, timeout, interval).WithArguments(West1ManagedCluster).Should(BeElementOf(3, 4))
 				setRestorePVsComplete()
 			})
 			It("Should failover to Secondary (West1ManagedCluster)", func() {
@@ -1962,7 +1962,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
 				// ----------------------------- DELETE DRPC from PRIMARY --------------------------------------
 				By("\n\n*** DELETE DRPC ***\n\n")
-				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(3)) // DRCluster + VRG MW
+				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG MW
 				deleteDRPC()
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(2))       // DRCluster + NS MW only
@@ -2004,7 +2004,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				setDRPCSpecExpectationTo(rmn.ActionFailover, East1ManagedCluster, West1ManagedCluster)
 				verifyUserPlacementRuleDecisionUnchanged(placement.Name, placement.Namespace, West1ManagedCluster)
 				// MWs for VRG, NS, VRG DRCluster, and MMode
-				Expect(getManifestWorkCount(West1ManagedCluster)).Should(Equal(4))
+				Expect(getManifestWorkCount(West1ManagedCluster)).Should(BeElementOf(3, 4))
 				Expect(len(getPlacementDecision(placement.GetName(), placement.GetNamespace()).
 					Status.Decisions)).Should(Equal(1))
 				setRestorePVsComplete()
@@ -2036,7 +2036,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		When("Deleting DRPC when using Placement", func() {
 			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
-				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(3)) // DRCluster + VRG + NS MW
+				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG + NS MW
 				deleteDRPC()
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(2))       // DRCluster + NS MW only
@@ -2080,7 +2080,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				setDRPCSpecExpectationTo(rmn.ActionFailover, East1ManagedCluster, West1ManagedCluster)
 				verifyUserPlacementRuleDecisionUnchanged(placement.Name, placement.Namespace, East1ManagedCluster)
 				// MWs for VRG, NS, VRG DRCluster, and MMode
-				Eventually(getManifestWorkCount, timeout, interval).WithArguments(West1ManagedCluster).Should(Equal(4))
+				Eventually(getManifestWorkCount, timeout, interval).WithArguments(West1ManagedCluster).Should(BeElementOf(3, 4))
 				Expect(len(getPlacementDecision(placement.GetName(), placement.GetNamespace()).
 					Status.Decisions)).Should(Equal(1))
 				setRestorePVsComplete()
@@ -2124,7 +2124,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		When("Deleting DRPC when using Placement", func() {
 			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
-				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(3)) // DRCluster + VRG + NS MW
+				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG + NS MW
 				deleteDRPC()
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(2))       // DRCluster + NS MW only
@@ -2164,7 +2164,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				verifyUserPlacementRuleDecisionUnchanged(userPlacementRule.Name, userPlacementRule.Namespace, East2ManagedCluster)
 				// MWs for VRG, VRG DRCluster and the MW for NetworkFence CR to fence off
 				// East1ManagedCluster
-				Expect(getManifestWorkCount(East2ManagedCluster)).Should(Equal(4))
+				Expect(getManifestWorkCount(East2ManagedCluster)).Should(BeElementOf(3, 4))
 				Expect(len(userPlacementRule.Status.Decisions)).Should(Equal(0))
 				setRestorePVsComplete()
 			})
@@ -2240,7 +2240,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				verifyUserPlacementRuleDecisionUnchanged(userPlacementRule.Name, userPlacementRule.Namespace, East2ManagedCluster)
 				// MWs for VRG, VRG DRCluster and the MW for NetworkFence CR to fence off
 				// East1ManagedCluster
-				Expect(getManifestWorkCount(East2ManagedCluster)).Should(Equal(4))
+				Expect(getManifestWorkCount(East2ManagedCluster)).Should(BeElementOf(3, 4))
 				Expect(len(userPlacementRule.Status.Decisions)).Should(Equal(0))
 				setRestorePVsComplete()
 			})
@@ -2280,7 +2280,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting DRPC", func() {
 			It("Should delete VRG from Primary (East1ManagedCluster)", func() {
 				By("\n\n*** DELETE DRPC ***\n\n")
-				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(3)) // DRCluster + NS + VRG MW
+				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + NS + VRG MW
 				deleteDRPC()
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(2)) // DRCluster + NS MW

--- a/controllers/drplacementcontrolvolsync.go
+++ b/controllers/drplacementcontrolvolsync.go
@@ -308,7 +308,7 @@ func (d *DRPCInstance) createVolSyncDestManifestWork(clusterToSkip string) error
 		annotations[DRPCNameAnnotation] = d.instance.Name
 		annotations[DRPCNamespaceAnnotation] = d.instance.Namespace
 
-		vrg := d.generateVRG(rmn.Secondary)
+		vrg := d.generateVRG(dstCluster, rmn.Secondary)
 		if err := d.mwu.CreateOrUpdateVRGManifestWork(
 			d.instance.Name, d.vrgNamespace,
 			dstCluster, vrg, annotations); err != nil {


### PR DESCRIPTION
This PR tackles hub recovery issues by reworking the algorithm responsible for rebuilding the DRPC state. The changes align with the following expectations:

1. **Stop Condition for Both Failed Queries:**
   If attempts to query 2 clusters result in failure for both, the process is halted.

2. **Initial Deployment without VRGs:**
   If 2 clusters are successfully queried, and no VRGs are found, proceed with the initial deployment.

3. **Handling Failures with S3 Store Check:**
   - If 2 clusters are queried, 1 fails, and 0 VRGs are found, perform the following checks:
      - If the VRG is found in the S3 store, ensure that the DRPC action matches the VRG action. If not, stop until the action is corrected, allowing failover if necessary (set PeerReady).
      - If the VRG is not found in the S3 store and the failed cluster is not the destination cluster, continue with the initial deployment.

4. **Verification and Failover for VRGs on Failover Cluster:**
   If 2 clusters are queried, 1 fails, and 1 VRG is found on the failover cluster, check the action:
      - If the actions don't match, stop until corrected by the user.
      - If they match, also stop but allow failover if the VRG in-hand is a secondary. Otherwise, continue.

5. **Handling VRGs on Destination Cluster:**
   If 2 clusters are queried successfully and 1 or more VRGs are found, and one of the VRGs is on the destination cluster, perform the following checks:
      - Continue with the action only if the DRPC and the found VRG action match.
      - Stop until someone investigates if there is a mismatch, but allow failover to take place (set PeerReady).

6. **Otherwise, default to allowing Failover:**
   If none of the above conditions apply, allow failover (set PeerReady) but stop until someone makes the necessary change.

**Testing: DRPC output in various states**
```
oc get drpc -A -o wide
NAMESPACE           NAME           AGE     PREFERREDCLUSTER   FAILOVERCLUSTER   DESIREDSTATE   CURRENTSTATE   PROGRESSION      START TIME             DURATION   PEER READY
busybox-sample      busybox-drpc   6h33m   dr1                dr2               Relocate       Relocated      Cleaning Up                                        False
busybox-samples-1   busybox-drpc   149m    dr1                                                 Deployed       Completed                                          True
busybox-samples-2   busybox-drpc   140m    dr1                dr2               Failover                      Paused                                             True
busybox-samples-3   busybox-drpc   137m    dr2                                                                Paused                                             True
busybox-samples-4   busybox-drpc   137m    dr1                dr1                                             Paused                                             False
busybox-samples-5   busybox-drpc   130m    dr2                                                 Deployed       UpdatingPlRule   2023-12-20T03:52:09Z              True
```
In this test, we have 6 workloads. 3 workloads in `dr1` and another 3 in `dr2`. All 3 were in different actions for each cluster.
- `busybox-sample` recovered, waiting for dr2 to comeback online in order to finish the clean up
- `busybox-samples-1` is completed. It is already deployed on `dr1`
- `busybox-samples-2`  is `Paused` waiting for the user to failover to `dr1`
- `busybox-samples-3` is `Paused` failover is allowed (PeerReady is set) but also, the state is different from what the VRG has, so it needs user intervention.
- `busybox-samples-4` is the same as `busybox-samples-3`. The difference is that `busybox-samples-4` has `PeerReady` set to false.  That's because you can't failover to `dr2`. It is down.
- `busybox-samples-5` was deployed to `dr2`, so it stayed intact with the ability to failover to `dr1` (PeerReady is set) 

Addresses Jira: [[Hub Recovery] Add support for active hub co-situated with the managed cluster](https://issues.redhat.com/browse/RHSTOR-5080)