### PR TITLE
go.mod: remove the replace directive for the api module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/client_model v0.4.0
-	github.com/ramendr/ramen/api v0.0.0-00010101000000-000000000000
+	github.com/ramendr/ramen/api v0.0.0-20240117171503-e11c56eac24d
 	github.com/ramendr/recipe v0.0.0-20230817160432-729dc7fd8932
 	github.com/stolostron/multicloud-operators-foundation v0.0.0-20220824091202-e9cd9710d009
 	github.com/stolostron/multicloud-operators-placementrule v1.2.4-1-20220311-8eedb3f.0.20230828200208-cd3c119a7fa0
@@ -96,8 +96,6 @@ require (
 
 // replace directives to accommodate for stolostron
 replace k8s.io/client-go v12.0.0+incompatible => k8s.io/client-go v0.29.0
-
-replace github.com/ramendr/ramen/api => ./api
 
 replace (
 	github.com/open-cluster-management-io/api => open-cluster-management.io/api v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -277,6 +277,8 @@ github.com/prometheus/common v0.44.0 h1:+5BrQJwiBB9xsMygAB3TNvpQKOwlkc25LbISbrdO
 github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO7x0VV9VvuY=
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
+github.com/ramendr/ramen/api v0.0.0-20240117171503-e11c56eac24d h1:cusjxTd7EUt/VP51YA2hBH/+H7svwCAmiFybbssEKx4=
+github.com/ramendr/ramen/api v0.0.0-20240117171503-e11c56eac24d/go.mod h1:KXZjrQDRobLq1FvIpxHVZCG054qQo+2t9uGjb/wc9k4=
 github.com/ramendr/recipe v0.0.0-20230817160432-729dc7fd8932 h1:n89W9K2gDa0XwdIVuWyg53hPgaR97DfGVi9o2V0WcWA=
 github.com/ramendr/recipe v0.0.0-20230817160432-729dc7fd8932/go.mod h1:QHVQXKgNId8EfvNd+Y6JcTrsXwTImtSFkV4IsiOkwCw=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=


### PR DESCRIPTION
Now we can refer to a commit id for the github.com/ramendr/ramen/api module.