### PR TITLE
setup-envtest: update to the latest k8s version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Run unit tests
-        run: GO_TEST_GINKGO_ARGS="" make test
+        run: make test
 
   drenv-test:
     name: drenv tests

--- a/Makefile
+++ b/Makefile
@@ -118,9 +118,6 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
-.PHONY: golangci-bin
-golangci-bin:
-	@hack/install-golangci-lint.sh
 
 .PHONY: lint
 lint: golangci-bin ## Run configured golangci-lint and pre-commit.sh linters against the code.
@@ -252,20 +249,29 @@ undeploy-dr-cluster: kustomize ## Undeploy dr-cluster controller from the K8s cl
 ##@ Tools
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
-controller-gen: ## Download controller-gen locally if necessary.
+controller-gen: ## Download controller-gen locally.
 	@hack/install-controller-gen.sh
 
 .PHONY: kustomize
 KUSTOMIZE = $(shell pwd)/bin/kustomize
-kustomize: ## Download kustomize locally if necessary.
+kustomize: ## Download kustomize locally.
 	@hack/install-kustomize.sh
 
-##@ Bundle
+.PHONY: opm
+OPM = ./bin/opm
+opm: ## Download opm locally.
+	@./hack/install-opm.sh
 
 .PHONY: operator-sdk
 OSDK = ./bin/operator-sdk
-operator-sdk: ## Download operator-sdk locally if necessary.
+operator-sdk: ## Download operator-sdk locally.
 	@hack/install-operator-sdk.sh
+
+.PHONY: golangci-bin
+golangci-bin: ## Download golangci-lint locally.
+	@hack/install-golangci-lint.sh
+
+##@ Bundle
 
 .PHONY: bundle
 bundle: bundle-hub bundle-dr-cluster ## Generate all bundle manifests and metadata, then validate generated files.
@@ -320,11 +326,6 @@ bundle-dr-cluster-build: bundle-dr-cluster ## Build the dr-cluster bundle image.
 .PHONY: bundle-dr-cluster-push
 bundle-dr-cluster-push: ## Push the dr-cluster bundle image.
 	$(MAKE) docker-push IMG=$(BUNDLE_IMG_DRCLUSTER)
-
-.PHONY: opm
-OPM = ./bin/opm
-opm: ## Download opm locally if necessary.
-	@./hack/install-opm.sh
 
 # A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
 # These images MUST exist in a registry and be pull-able.

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,6 @@ ifeq ($(GOHOSTOS),darwin)
 	endif
 endif
 
-GO_TEST_GINKGO_ARGS ?= -test.v -ginkgo.v -ginkgo.fail-fast
 
 DOCKERCMD ?= podman
 
@@ -129,46 +128,46 @@ envtest:
 	test -s $(ENVTEST_ASSETS_DIR)/setup-envtest || GOBIN=$(ENVTEST_ASSETS_DIR) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 test: generate manifests envtest ## Run tests.
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./... -coverprofile cover.out $(GO_TEST_GINKGO_ARGS)
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./... -coverprofile cover.out
 
 test-pvrgl: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus ProtectedVolumeReplicationGroupList
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus ProtectedVolumeReplicationGroupList
 
 test-obj: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus FakeObjectStorer
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus FakeObjectStorer
 
 test-vs: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers/volsync -coverprofile cover.out $(GO_TEST_GINKGO_ARGS)
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers/volsync -coverprofile cover.out
 
 test-vrg: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus VolumeReplicationGroup
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroup
 
 test-vrg-pvc: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus VolumeReplicationGroupPVC
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupPVC
 
 test-vrg-vr: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus VolumeReplicationGroupVolRep
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupVolRep
 
 test-vrg-vs: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus VolumeReplicationGroupVolSync
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupVolSync
 
 test-vrg-recipe: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus VolumeReplicationGroupRecipe
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupRecipe
 
 test-vrg-kubeobjects: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus VRG_KubeObjectProtection
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus VRG_KubeObjectProtection
 
 test-drpc: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus DRPlacementControl
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus DRPlacementControl
 
 test-drcluster: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus DRClusterController
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus DRClusterController
 
 test-util: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers/util -coverprofile cover.out $(GO_TEST_GINKGO_ARGS)
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers/util -coverprofile cover.out
 
 test-util-pvc: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers/util -coverprofile cover.out $(GO_TEST_GINKGO_ARGS) -ginkgo.focus PVCS_Util
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers/util -coverprofile cover.out  -ginkgo.focus PVCS_Util
 
 coverage:
 	go tool cover -html=cover.out

--- a/Makefile
+++ b/Makefile
@@ -118,47 +118,58 @@ lint: golangci-bin ## Run configured golangci-lint and pre-commit.sh linters aga
 	testbin/golangci-lint run ./... --config=./.golangci.yaml
 	hack/pre-commit.sh
 
-test: generate manifests envtest ## Run tests.
+##@ Tests
+
+test: generate manifests envtest ## Run all the tests.
 	 go test ./... -coverprofile cover.out
 
-test-pvrgl: generate manifests envtest
+test-pvrgl: generate manifests envtest ## Run ProtectedVolumeReplicationGroupList tests.
 	 go test ./controllers -coverprofile cover.out  -ginkgo.focus ProtectedVolumeReplicationGroupList
 
-test-obj: generate manifests envtest
+test-obj: generate manifests envtest ## Run ObjectStorer tests.
 	 go test ./controllers -coverprofile cover.out  -ginkgo.focus FakeObjectStorer
 
-test-vs: generate manifests envtest
+test-vs: generate manifests envtest ## Run VolumeSync tests.
 	 go test ./controllers/volsync -coverprofile cover.out
 
-test-vrg: generate manifests envtest
+test-vrg: generate manifests envtest ## Run VolumeReplicationGroup tests.
 	 go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroup
 
-test-vrg-pvc: generate manifests envtest
+test-vrg-pvc: generate manifests envtest ## Run VolumeReplicationGroupPVC tests.
 	 go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupPVC
 
-test-vrg-vr: generate manifests envtest
+test-vrg-vr: generate manifests envtest ## Run VolumeReplicationGroupVolRep tests.
 	 go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupVolRep
 
-test-vrg-vs: generate manifests envtest
+test-vrg-vs: generate manifests envtest ## Run VolumeReplicationGroupVolSync tests.
 	 go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupVolSync
 
-test-vrg-recipe: generate manifests envtest
+test-vrg-recipe: generate manifests envtest ## Run VolumeReplicationGroupRecipe tests.
 	 go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupRecipe
 
-test-vrg-kubeobjects: generate manifests envtest
+test-vrg-kubeobjects: generate manifests envtest ## Run VolumeReplicationGroupKubeObjects tests.
 	 go test ./controllers -coverprofile cover.out  -ginkgo.focus VRG_KubeObjectProtection
 
-test-drpc: generate manifests envtest
+test-drpc: generate manifests envtest ## Run DRPlacementControl tests.
 	 go test ./controllers -coverprofile cover.out  -ginkgo.focus DRPlacementControl
 
-test-drcluster: generate manifests envtest
+test-drcluster: generate manifests envtest ## Run DRCluster tests.
 	 go test ./controllers -coverprofile cover.out  -ginkgo.focus DRClusterController
 
-test-util: generate manifests envtest
+test-util: generate manifests envtest ## Run util tests.
 	 go test ./controllers/util -coverprofile cover.out
 
-test-util-pvc: generate manifests envtest
+test-util-pvc: generate manifests envtest ## Run util-pvc tests.
 	 go test ./controllers/util -coverprofile cover.out  -ginkgo.focus PVCS_Util
+
+test-drenv: ## Run drenv tests.
+	$(MAKE) -C test
+
+test-ramenctl: ## Run ramenctl tests.
+	$(MAKE) -C ramenctl
+
+e2e-rdr: generate manifests docker-build ## Run rdr-e2e tests.
+	./e2e/rdr-e2e.sh
 
 coverage:
 	go tool cover -html=cover.out
@@ -166,15 +177,6 @@ coverage:
 .PHONY: venv
 venv:
 	hack/make-venv
-
-test-drenv:
-	$(MAKE) -C test
-
-test-ramenctl:
-	$(MAKE) -C ramenctl
-
-e2e-rdr: generate manifests docker-build
-	./e2e/rdr-e2e.sh
 
 ##@ Build
 

--- a/Makefile
+++ b/Makefile
@@ -75,12 +75,6 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-# Setting SHELL to bash allows bash commands to be executed by recipes.
-# This is a requirement for 'setup-envtest.sh' in the test target.
-# Options are set to exit when a recipe line exits non-zero or a piped command fails.
-SHELL = /usr/bin/env bash -o pipefail
-.SHELLFLAGS = -ec
-
 # Set sed command appropriately
 SED_CMD:=sed
 ifeq ($(GOHOSTOS),darwin)

--- a/Makefile
+++ b/Makefile
@@ -86,11 +86,6 @@ endif
 
 DOCKERCMD ?= podman
 
-ENVTEST_K8S_VERSION = 1.25.0
-ENVTEST_ASSETS_DIR = $(shell pwd)/testbin
-# Define to override the path to envtest executables.
-KUBEBUILDER_ASSETS ?= $(shell $(ENVTEST_ASSETS_DIR)/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(ENVTEST_ASSETS_DIR) --print path)
-
 all: build
 
 ##@ General
@@ -123,51 +118,47 @@ lint: golangci-bin ## Run configured golangci-lint and pre-commit.sh linters aga
 	testbin/golangci-lint run ./... --config=./.golangci.yaml
 	hack/pre-commit.sh
 
-envtest:
-	mkdir -p $(ENVTEST_ASSETS_DIR)
-	test -s $(ENVTEST_ASSETS_DIR)/setup-envtest || GOBIN=$(ENVTEST_ASSETS_DIR) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-
 test: generate manifests envtest ## Run tests.
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./... -coverprofile cover.out
+	 go test ./... -coverprofile cover.out
 
 test-pvrgl: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus ProtectedVolumeReplicationGroupList
+	 go test ./controllers -coverprofile cover.out  -ginkgo.focus ProtectedVolumeReplicationGroupList
 
 test-obj: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus FakeObjectStorer
+	 go test ./controllers -coverprofile cover.out  -ginkgo.focus FakeObjectStorer
 
 test-vs: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers/volsync -coverprofile cover.out
+	 go test ./controllers/volsync -coverprofile cover.out
 
 test-vrg: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroup
+	 go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroup
 
 test-vrg-pvc: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupPVC
+	 go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupPVC
 
 test-vrg-vr: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupVolRep
+	 go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupVolRep
 
 test-vrg-vs: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupVolSync
+	 go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupVolSync
 
 test-vrg-recipe: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupRecipe
+	 go test ./controllers -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupRecipe
 
 test-vrg-kubeobjects: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus VRG_KubeObjectProtection
+	 go test ./controllers -coverprofile cover.out  -ginkgo.focus VRG_KubeObjectProtection
 
 test-drpc: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus DRPlacementControl
+	 go test ./controllers -coverprofile cover.out  -ginkgo.focus DRPlacementControl
 
 test-drcluster: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers -coverprofile cover.out  -ginkgo.focus DRClusterController
+	 go test ./controllers -coverprofile cover.out  -ginkgo.focus DRClusterController
 
 test-util: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers/util -coverprofile cover.out
+	 go test ./controllers/util -coverprofile cover.out
 
 test-util-pvc: generate manifests envtest
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS) go test ./controllers/util -coverprofile cover.out  -ginkgo.focus PVCS_Util
+	 go test ./controllers/util -coverprofile cover.out  -ginkgo.focus PVCS_Util
 
 coverage:
 	go tool cover -html=cover.out
@@ -269,6 +260,11 @@ operator-sdk: ## Download operator-sdk locally.
 .PHONY: golangci-bin
 golangci-bin: ## Download golangci-lint locally.
 	@hack/install-golangci-lint.sh
+
+.PHONY: envtest
+envtest: ## Download envtest locally.
+	hack/install-setup-envtest.sh
+
 
 ##@ Bundle
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -5,10 +5,8 @@ package controllers_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -128,8 +126,15 @@ var _ = BeforeSuite(func() {
 	ramencontrollers.ControllerType = ramendrv1alpha1.DRHubType
 
 	if _, set := os.LookupEnv("KUBEBUILDER_ASSETS"); !set {
-		Expect(os.Setenv("KUBEBUILDER_ASSETS",
-			fmt.Sprintf("../testbin/k8s/1.25.0-%s-%s", runtime.GOOS, runtime.GOARCH))).To(Succeed())
+		testLog.Info("Setting up KUBEBUILDER_ASSETS for envtest")
+
+		// read content of the file ../testbin/testassets.txt
+		// and set the content as the value of KUBEBUILDER_ASSETS
+		// this is to avoid the need to set KUBEBUILDER_ASSETS
+		// when running the test suite
+		content, err := os.ReadFile("../testbin/testassets.txt")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.Setenv("KUBEBUILDER_ASSETS", string(content))).To(Succeed())
 	}
 
 	rNs, set := os.LookupEnv("POD_NAMESPACE")

--- a/controllers/util/util_suite_test.go
+++ b/controllers/util/util_suite_test.go
@@ -5,10 +5,8 @@ package util_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
@@ -62,8 +60,15 @@ var _ = BeforeSuite(func() {
 
 	By("Setting up KUBEBUILDER_ASSETS for envtest")
 	if _, set := os.LookupEnv("KUBEBUILDER_ASSETS"); !set {
-		Expect(os.Setenv("KUBEBUILDER_ASSETS",
-			fmt.Sprintf("../../testbin/k8s/1.25.0-%s-%s", runtime.GOOS, runtime.GOARCH))).To(Succeed())
+		testLog.Info("Setting up KUBEBUILDER_ASSETS for envtest")
+
+		// read content of the file ../../testbin/testassets.txt
+		// and set the content as the value of KUBEBUILDER_ASSETS
+		// this is to avoid the need to set KUBEBUILDER_ASSETS
+		// when running the test suite
+		content, err := os.ReadFile("../../testbin/testassets.txt")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.Setenv("KUBEBUILDER_ASSETS", string(content))).To(Succeed())
 	}
 
 	By("Bootstrapping test environment")

--- a/controllers/volsync/volsync_suite_test.go
+++ b/controllers/volsync/volsync_suite_test.go
@@ -5,10 +5,8 @@ package volsync_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -77,8 +75,14 @@ var _ = BeforeSuite(func() {
 
 	By("Setting up KUBEBUILDER_ASSETS for envtest")
 	if _, set := os.LookupEnv("KUBEBUILDER_ASSETS"); !set {
-		Expect(os.Setenv("KUBEBUILDER_ASSETS",
-			fmt.Sprintf("../../testbin/k8s/1.25.0-%s-%s", runtime.GOOS, runtime.GOARCH))).To(Succeed())
+
+		// read content of the file ../../testbin/testassets.txt
+		// and set the content as the value of KUBEBUILDER_ASSETS
+		// this is to avoid the need to set KUBEBUILDER_ASSETS
+		// when running the test suite
+		content, err := os.ReadFile("../../testbin/testassets.txt")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.Setenv("KUBEBUILDER_ASSETS", string(content))).To(Succeed())
 	}
 
 	By("bootstrapping test environment")

--- a/hack/install-setup-envtest.sh
+++ b/hack/install-setup-envtest.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+required_version="latest"
+source_url="sigs.k8s.io/controller-runtime/tools/setup-envtest@${required_version}"
+target_dir="${script_dir}/../testbin"
+target_path="${target_dir}/setup-envtest"
+k8s_version="1.25.0"
+
+# The setup-envtest tool has no versioning, so we need to use the latest version.
+# The go install command is fast enough that it can be run every time.
+mkdir -p "${target_dir}"
+GOBIN="${target_dir}" go install "${source_url}"
+
+# Storing the path to the assets in a file so that it can be used by the test files.
+# Making the name of the file version agnostic so that changing the version is easier.
+kubebuilder_assets=$("${target_path}" use "${k8s_version}" --bin-dir "${target_dir}" --print path)
+echo -n "${kubebuilder_assets}" > "${target_dir}/testassets.txt"

--- a/hack/install-setup-envtest.sh
+++ b/hack/install-setup-envtest.sh
@@ -7,7 +7,7 @@ required_version="latest"
 source_url="sigs.k8s.io/controller-runtime/tools/setup-envtest@${required_version}"
 target_dir="${script_dir}/../testbin"
 target_path="${target_dir}/setup-envtest"
-k8s_version="1.25.0"
+k8s_version="1.29.0"
 
 # The setup-envtest tool has no versioning, so we need to use the latest version.
 # The go install command is fast enough that it can be run every time.


### PR DESCRIPTION
This PR updates the setup-envtest version of k8s to 1.29.0.

There are other commits in the PR that bring in a few more Makefile improvements.