### PR TITLE
Check for metro policy using policy clusters

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -476,7 +476,7 @@ func (d *DRPCInstance) checkFailoverPrerequisites(curHomeCluster string) (bool, 
 		err error
 	)
 
-	if isMetroAction(d.drPolicy, d.drClusters, curHomeCluster, d.instance.Spec.FailoverCluster) {
+	if metro, _ := dRPolicySupportsMetro(d.drPolicy, d.drClusters); metro {
 		met, err = d.checkMetroFailoverPrerequisites(curHomeCluster)
 	} else {
 		met = d.checkRegionalFailoverPrerequisites()
@@ -1056,7 +1056,7 @@ func (d *DRPCInstance) validateAndSelectCurrentPrimary(preferredCluster string) 
 func (d *DRPCInstance) readyToSwitchOver(homeCluster string, preferredCluster string) bool {
 	d.log.Info(fmt.Sprintf("Checking if VRG Data is available on cluster %s", homeCluster))
 
-	if isMetroAction(d.drPolicy, d.drClusters, homeCluster, preferredCluster) {
+	if metro, _ := dRPolicySupportsMetro(d.drPolicy, d.drClusters); metro {
 		// check fencing status in the preferredCluster
 		fenced, err := d.checkClusterFenced(preferredCluster, d.drClusters)
 		if err != nil {
@@ -1590,36 +1590,6 @@ func dRPolicySupportsMetro(drpolicy *rmn.DRPolicy, drclusters []rmn.DRCluster) (
 	}
 
 	return supportsMetro, metroMap
-}
-
-func isMetroAction(drpolicy *rmn.DRPolicy, drClusters []rmn.DRCluster, from string, to string) bool {
-	var regionFrom, regionTo rmn.Region
-
-	for _, managedCluster := range rmnutil.DrpolicyClusterNames(drpolicy) {
-		if managedCluster == from {
-			regionFrom = drClusterRegion(drClusters, managedCluster)
-		}
-
-		if managedCluster == to {
-			regionTo = drClusterRegion(drClusters, managedCluster)
-		}
-	}
-
-	return regionFrom == regionTo
-}
-
-func drClusterRegion(drClusters []rmn.DRCluster, cluster string) (region rmn.Region) {
-	for _, drCluster := range drClusters {
-		if drCluster.Name != cluster {
-			continue
-		}
-
-		region = drCluster.Spec.Region
-
-		return
-	}
-
-	return
 }
 
 func (d *DRPCInstance) ensureNamespaceExistsOnManagedCluster(homeCluster string) error {

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -476,7 +476,7 @@ func DRPCsFailingOverToCluster(k8sclient client.Client, log logr.Logger, drclust
 		}
 
 		// Skip if policy is of type metro, fake the from and to cluster
-		if isMetroAction(&drpolicies.Items[drpolicyIdx], drClusters, drClusters[0].GetName(), drClusters[1].GetName()) {
+		if metro, _ := dRPolicySupportsMetro(&drpolicies.Items[drpolicyIdx], drClusters); metro {
 			log.Info("Sync DRPolicy detected, skipping!")
 
 			continue


### PR DESCRIPTION
Current check for metro actions that use isMetroAction passed in the to and from clusters to check equivalence of region values. This would succeed when to and from clusters are the same, which can happen when the preferredCluster and the failoverCluster are the same (Deploy->Failover->Failover).

As a result in a regional DR policy, such a state would enter processing or waiting for fencing to take effect before proceeding with the Failover.

This commit switches to the policy based metro determination instead of the to and from clusters as before to resolve the issue.