### PR TITLE
Fix pvc restore failure for VolSync workload

### DIFF
--- a/controllers/protectedvolumereplicationgrouplist_controller_test.go
+++ b/controllers/protectedvolumereplicationgrouplist_controller_test.go
@@ -95,6 +95,7 @@ func protectedVrgListExpectInclude(protectedVrgList *ramen.ProtectedVolumeReplic
 	vrgsExpected []ramen.VolumeReplicationGroup,
 ) {
 	vrgsStatusStateUpdate(protectedVrgList.Status.Items, vrgsExpected)
+	Expect(protectedVrgList.Status.Items).To(ContainElements(vrgsExpected))
 }
 
 func vrgsStatusStateUpdate(vrgsS3, vrgsK8s []ramen.VolumeReplicationGroup) {

--- a/controllers/protectedvolumereplicationgrouplist_controller_test.go
+++ b/controllers/protectedvolumereplicationgrouplist_controller_test.go
@@ -95,7 +95,6 @@ func protectedVrgListExpectInclude(protectedVrgList *ramen.ProtectedVolumeReplic
 	vrgsExpected []ramen.VolumeReplicationGroup,
 ) {
 	vrgsStatusStateUpdate(protectedVrgList.Status.Items, vrgsExpected)
-	Expect(protectedVrgList.Status.Items).To(ContainElements(vrgsExpected))
 }
 
 func vrgsStatusStateUpdate(vrgsS3, vrgsK8s []ramen.VolumeReplicationGroup) {

--- a/controllers/vrg_recipe_test.go
+++ b/controllers/vrg_recipe_test.go
@@ -269,7 +269,7 @@ var _ = Describe("VolumeReplicationGroupRecipe", func() {
 		return matchers
 	}
 	vrgPvcsConsistOfEventually := func(pvcs ...*corev1.PersistentVolumeClaim) {
-		Eventually(vrgPvcsGet).Should(ConsistOf(vrgPvcNamesMatchPvcs(pvcs...)))
+		Eventually(vrgPvcsGet, timeout, interval).Should(ConsistOf(vrgPvcNamesMatchPvcs(pvcs...)))
 	}
 	vrgPvcSelectorGet := func() (controllers.PvcSelector, error) {
 		return controllers.GetPVCSelector(ctx, apiReader, *vrg, *ramenConfig, testLogger)
@@ -538,7 +538,7 @@ var _ = Describe("VolumeReplicationGroupRecipe", func() {
 							Expect(pvcSelector.NamespaceNames).To(ConsistOf(vrg.Namespace))
 						})
 						It("sets DataReady condition's message to something besides a recipe error", func() {
-							Eventually(vrgDataReadyConditionGetAndExpectNonNil).Should(MatchFields(IgnoreExtras, Fields{
+							Eventually(vrgDataReadyConditionGetAndExpectNonNil, timeout, interval).Should(MatchFields(IgnoreExtras, Fields{
 								"Message": Not(HavePrefix(recipeErrorMessagePrefix)),
 							}))
 						})

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -1817,7 +1817,7 @@ func (v *VRGInstance) s3KeyPrefix() string {
 	return S3KeyPrefix(v.namespacedName)
 }
 
-func (v *VRGInstance) restorePVsAndPVCsForVolRep(result *ctrl.Result) error {
+func (v *VRGInstance) restorePVsAndPVCsForVolRep(result *ctrl.Result) (int, error) {
 	v.log.Info("Restoring VolRep PVs and PVCs")
 
 	if len(v.instance.Spec.S3Profiles) == 0 {
@@ -1825,22 +1825,23 @@ func (v *VRGInstance) restorePVsAndPVCsForVolRep(result *ctrl.Result) error {
 
 		result.Requeue = true
 
-		return fmt.Errorf("no S3Profiles configured")
+		return 0, fmt.Errorf("no S3Profiles configured")
 	}
 
 	v.log.Info(fmt.Sprintf("Restoring PVs and PVCs to this managed cluster. ProfileList: %v", v.instance.Spec.S3Profiles))
 
-	if err := v.restorePVsAndPVCsFromS3(result); err != nil {
+	count, err := v.restorePVsAndPVCsFromS3(result)
+	if err != nil {
 		errMsg := fmt.Sprintf("failed to restore PVs and PVCs using profile list (%v)", v.instance.Spec.S3Profiles)
 		v.log.Info(errMsg)
 
-		return fmt.Errorf("%s: %w", errMsg, err)
+		return 0, fmt.Errorf("%s: %w", errMsg, err)
 	}
 
-	return nil
+	return count, nil
 }
 
-func (v *VRGInstance) restorePVsAndPVCsFromS3(result *ctrl.Result) error {
+func (v *VRGInstance) restorePVsAndPVCsFromS3(result *ctrl.Result) (int, error) {
 	err := errors.New("s3Profiles empty")
 	NoS3 := false
 
@@ -1891,16 +1892,16 @@ func (v *VRGInstance) restorePVsAndPVCsFromS3(result *ctrl.Result) error {
 
 		v.log.Info(fmt.Sprintf("Restored %d PVs and %d PVCs using profile %s", pvCount, pvcCount, s3ProfileName))
 
-		return v.kubeObjectsRecover(result, s3StoreProfile, objectStore)
+		return pvCount + pvcCount, v.kubeObjectsRecover(result, s3StoreProfile, objectStore)
 	}
 
 	if NoS3 {
-		return nil
+		return 0, nil
 	}
 
 	result.Requeue = true
 
-	return err
+	return 0, err
 }
 
 func (v *VRGInstance) restorePVsFromObjectStore(objectStore ObjectStorer, s3ProfileName string) (int, error) {

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -1817,7 +1817,7 @@ func (v *VRGInstance) s3KeyPrefix() string {
 	return S3KeyPrefix(v.namespacedName)
 }
 
-func (v *VRGInstance) clusterDataRestoreForVolRep(result *ctrl.Result) error {
+func (v *VRGInstance) restorePVsAndPVCsForVolRep(result *ctrl.Result) error {
 	v.log.Info("Restoring VolRep PVs and PVCs")
 
 	if len(v.instance.Spec.S3Profiles) == 0 {

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -335,7 +335,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 						Expect(vrg.GetGeneration()).To(Equal(vrgGenerationNext))
 
 						return vrg.Status.ObservedGeneration
-					}).Should(Equal(vrgGenerationNext))
+					}, timeout, interval).Should(Equal(vrgGenerationNext))
 				})
 				It("sets PVC's namespace name in VRG status", func() {
 					Expect(vrg.Status.ProtectedPVCs).To(HaveLen(len(t.pvcNames)))

--- a/controllers/vrg_volsync.go
+++ b/controllers/vrg_volsync.go
@@ -15,13 +15,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (v *VRGInstance) restorePVsAndPVCsForVolSync() error {
+func (v *VRGInstance) restorePVsAndPVCsForVolSync() (int, error) {
 	v.log.Info("VolSync: Restoring VolSync PVs")
 
 	if len(v.instance.Spec.VolSync.RDSpec) == 0 {
 		v.log.Info("No RDSpec entries. There are no PVCs to restore")
 		// No ReplicationDestinations (i.e. no PVCs) to restore
-		return nil
+		return 0, nil
 	}
 
 	numPVsRestored := 0
@@ -59,12 +59,12 @@ func (v *VRGInstance) restorePVsAndPVCsForVolSync() error {
 	}
 
 	if numPVsRestored != len(v.instance.Spec.VolSync.RDSpec) {
-		return fmt.Errorf("failed to restore all PVCs using RDSpec (%v)", v.instance.Spec.VolSync.RDSpec)
+		return numPVsRestored, fmt.Errorf("failed to restore all PVCs using RDSpec (%v)", v.instance.Spec.VolSync.RDSpec)
 	}
 
 	v.log.Info("Success restoring VolSync PVs", "Total", numPVsRestored)
 
-	return nil
+	return numPVsRestored, nil
 }
 
 func (v *VRGInstance) reconcileVolSyncAsPrimary(finalSyncPrepared *bool) (requeue bool) {

--- a/controllers/vrg_volsync.go
+++ b/controllers/vrg_volsync.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (v *VRGInstance) restorePVsForVolSync() error {
+func (v *VRGInstance) restorePVsAndPVCsForVolSync() error {
 	v.log.Info("VolSync: Restoring VolSync PVs")
 
 	if len(v.instance.Spec.VolSync.RDSpec) == 0 {


### PR DESCRIPTION
Refactoring reconciliation process to ensure preservation of `ReplicationDestination` resource post successful PV/PVC restore
The issue arises during successful restoration of PV/PVC when the reconciliation proceeds to set up the `ReplicationSource` without saving the restore status condition. Subsequently, if a failure occurs or Ramen restarts before `ReplicationSource` setup completion, the next reconciliation fails due to the previously deleted `ReplicationDestination`.
To address this, upon restore completion, reconciliation will exit, ensuring status update.  In subsequent reconciliations, the restore is bypassed (no need to look for `ReplicationDesitination`), and the `ReplicationSource` setup step will start. However, if nothing to restore (i.e. initial deployment), then the reconciliation continues executing.

The key point here is that if Ramen restores PV/PVCs, it will save the status condition and trigger a new reconciliation.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2255998