### PR TITLE
Adopt any orphan VRGs found via views before starting reconciliation

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -17,7 +17,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
 
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
@@ -865,9 +864,7 @@ func (d *DRPCInstance) ensureCleanupAndVolSyncReplicationSetup(srcCluster string
 			srcCluster, ok))
 	}
 
-	clusterToSkip := srcCluster
-
-	err = d.EnsureCleanup(clusterToSkip)
+	err = d.EnsureCleanup(srcCluster)
 	if err != nil {
 		return err
 	}
@@ -1285,9 +1282,7 @@ func (d *DRPCInstance) vrgExistsAndPrimary(targetCluster string) bool {
 }
 
 func (d *DRPCInstance) mwExistsAndPlacementUpdated(targetCluster string) (bool, error) {
-	vrgMWName := d.mwu.BuildManifestWorkName(rmnutil.MWTypeVRG)
-
-	_, err := d.mwu.FindManifestWork(vrgMWName, targetCluster)
+	_, err := d.mwu.FindManifestWorkByType(rmnutil.MWTypeVRG, targetCluster)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return false, nil
@@ -1792,10 +1787,7 @@ func (d *DRPCInstance) ensureVRGManifestWorkOnClusterDeleted(clusterName string)
 
 	const done = true
 
-	mwName := d.mwu.BuildManifestWorkName(rmnutil.MWTypeVRG)
-	mw := &ocmworkv1.ManifestWork{}
-
-	err := d.reconciler.Get(d.ctx, types.NamespacedName{Name: mwName, Namespace: clusterName}, mw)
+	mw, err := d.mwu.FindManifestWorkByType(rmnutil.MWTypeVRG, clusterName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return done, nil

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -30,6 +30,9 @@ const (
 	DRPCNameAnnotation      = "drplacementcontrol.ramendr.openshift.io/drpc-name"
 	DRPCNamespaceAnnotation = "drplacementcontrol.ramendr.openshift.io/drpc-namespace"
 
+	// Annotation that stores the UID of DRPC that created the resource on the managed cluster using a ManifestWork
+	DRPCUIDAnnotation = "drplacementcontrol.ramendr.openshift.io/drpc-uid"
+
 	// Annotation for the last cluster on which the application was running
 	LastAppDeploymentCluster = "drplacementcontrol.ramendr.openshift.io/last-app-deployment-cluster"
 
@@ -1520,6 +1523,7 @@ func (d *DRPCInstance) generateVRG(dstCluster string, repState rmn.ReplicationSt
 			Annotations: map[string]string{
 				DestinationClusterAnnotationKey: dstCluster,
 				DoNotDeletePVCAnnotation:        d.instance.GetAnnotations()[DoNotDeletePVCAnnotation],
+				DRPCUIDAnnotation:               string(d.instance.UID),
 			},
 		},
 		Spec: rmn.VolumeReplicationGroupSpec{

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -11,13 +11,11 @@ import (
 
 	"github.com/go-logr/logr"
 	clrapiv1beta1 "github.com/open-cluster-management-io/api/cluster/v1beta1"
-	ocmworkv1 "github.com/open-cluster-management/api/work/v1"
 	errorswrapper "github.com/pkg/errors"
 	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
 
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
 	rmnutil "github.com/ramendr/ramen/controllers/util"
@@ -1261,7 +1259,7 @@ func (d *DRPCInstance) getVRGFromManifestWork(clusterName string) (*rmn.VolumeRe
 		return nil, fmt.Errorf("%w", err)
 	}
 
-	vrg, err := d.extractVRGFromManifestWork(mw)
+	vrg, err := rmnutil.ExtractVRGFromManifestWork(mw)
 	if err != nil {
 		return nil, err
 	}
@@ -2076,22 +2074,6 @@ func (d *DRPCInstance) updateVRGToRunFinalSync(clusterName string) error {
 		vrg.Name, clusterName))
 
 	return nil
-}
-
-func (d *DRPCInstance) extractVRGFromManifestWork(mw *ocmworkv1.ManifestWork) (*rmn.VolumeReplicationGroup, error) {
-	if len(mw.Spec.Workload.Manifests) == 0 {
-		return nil, fmt.Errorf("invalid VRG ManifestWork for type: %s", mw.Name)
-	}
-
-	vrgClientManifest := &mw.Spec.Workload.Manifests[0]
-	vrg := &rmn.VolumeReplicationGroup{}
-
-	err := yaml.Unmarshal(vrgClientManifest.RawExtension.Raw, &vrg)
-	if err != nil {
-		return nil, fmt.Errorf("unable to unmarshal VRG object (%w)", err)
-	}
-
-	return vrg, nil
 }
 
 func (d *DRPCInstance) updateManifestWork(clusterName string, vrg *rmn.VolumeReplicationGroup) error {

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -953,6 +953,12 @@ func (r *DRPlacementControlReconciler) reconcileDRPCInstance(d *DRPCInstance, lo
 		beforeProcessing = *d.instance.Status.LastUpdateTime
 	}
 
+	if !ensureVRGsManagedByDRPC(d.log, d.mwu, d.vrgs, d.instance, d.vrgNamespace) {
+		log.Info("Requeing... VRG adoption in progress")
+
+		return ctrl.Result{Requeue: true}, nil
+	}
+
 	requeue := d.startProcessing()
 	log.Info("Finished processing", "Requeue?", requeue)
 
@@ -1158,14 +1164,6 @@ func (r *DRPlacementControlReconciler) finalizeDRPC(ctx context.Context, drpc *r
 		return fmt.Errorf("failed to get DRPolicy while finalizing DRPC (%w)", err)
 	}
 
-	// delete manifestworks (VRGs)
-	for _, drClusterName := range rmnutil.DrpolicyClusterNames(drPolicy) {
-		err := mwu.DeleteManifestWorksForCluster(drClusterName)
-		if err != nil {
-			return fmt.Errorf("%w", err)
-		}
-	}
-
 	drClusters, err := getDRClusters(ctx, r.Client, drPolicy)
 	if err != nil {
 		return fmt.Errorf("failed to get drclusters. Error (%w)", err)
@@ -1175,6 +1173,18 @@ func (r *DRPlacementControlReconciler) finalizeDRPC(ctx context.Context, drpc *r
 	vrgs, _, _, err := getVRGsFromManagedClusters(r.MCVGetter, drpc, drClusters, vrgNamespace, log)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve VRGs. We'll retry later. Error (%w)", err)
+	}
+
+	if !ensureVRGsManagedByDRPC(r.Log, mwu, vrgs, drpc, vrgNamespace) {
+		return fmt.Errorf("VRG adoption in progress")
+	}
+
+	// delete manifestworks (VRGs)
+	for _, drClusterName := range rmnutil.DrpolicyClusterNames(drPolicy) {
+		err := mwu.DeleteManifestWorksForCluster(drClusterName)
+		if err != nil {
+			return fmt.Errorf("%w", err)
+		}
 	}
 
 	if len(vrgs) != 0 {
@@ -2282,6 +2292,21 @@ func (r *DRPlacementControlReconciler) determineDRPCState(
 		return Stop, "", err
 	}
 
+	mwu := rmnutil.MWUtil{
+		Client:          r.Client,
+		APIReader:       r.APIReader,
+		Ctx:             ctx,
+		Log:             log,
+		InstName:        drpc.Name,
+		TargetNamespace: vrgNamespace,
+	}
+
+	if !ensureVRGsManagedByDRPC(log, mwu, vrgs, drpc, vrgNamespace) {
+		msg := "VRG adoption in progress"
+
+		return Stop, msg, nil
+	}
+
 	// IF 2 clusters queried, and both queries failed, then STOP
 	if successfullyQueriedClusterCount == 0 {
 		msg := "Stop - Number of clusters queried is 0"
@@ -2421,4 +2446,175 @@ func (r *DRPlacementControlReconciler) determineDRPCState(
 	msg := "Failover is allowed - User intervention is required"
 
 	return AllowFailover, msg, nil
+}
+
+// ensureVRGsManagedByDRPC ensures that VRGs reported by ManagedClusterView are managed by the current instance of
+// DRPC. This is done using the DRPC UID annotation on the viewed VRG matching the current DRPC UID and if not
+// creating or updating the exisiting ManifestWork for the VRG.
+// Returns a bool indicating true if VRGs are managed by the current DRPC resource
+func ensureVRGsManagedByDRPC(
+	log logr.Logger,
+	mwu rmnutil.MWUtil,
+	vrgs map[string]*rmn.VolumeReplicationGroup,
+	drpc *rmn.DRPlacementControl,
+	vrgNamespace string,
+) bool {
+	ensured := true
+
+	for cluster, viewVRG := range vrgs {
+		if rmnutil.ResourceIsDeleted(viewVRG) {
+			log.Info("VRG reported by view undergoing deletion, during adoption")
+
+			continue
+		}
+
+		if viewVRG.GetAnnotations() != nil {
+			if v, ok := viewVRG.Annotations[DRPCUIDAnnotation]; ok && v == string(drpc.UID) {
+				continue
+			}
+		}
+
+		adopted := adoptVRG(log, mwu, viewVRG, cluster, drpc, vrgNamespace)
+
+		ensured = ensured && adopted
+	}
+
+	return ensured
+}
+
+// adoptVRG creates or updates the VRG ManifestWork to ensure that the current DRPC is managing the VRG resource
+// Returns a bool indicating if adoption was completed (which is mostly false except when VRG MW is deleted)
+func adoptVRG(
+	log logr.Logger,
+	mwu rmnutil.MWUtil,
+	viewVRG *rmn.VolumeReplicationGroup,
+	cluster string,
+	drpc *rmn.DRPlacementControl,
+	vrgNamespace string,
+) bool {
+	adopted := true
+
+	mw, err := mwu.FindManifestWorkByType(rmnutil.MWTypeVRG, cluster)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			log.Info("error fetching VRG ManifestWork during adoption", "error", err)
+
+			return !adopted
+		}
+
+		adoptOrphanVRG(log, mwu, viewVRG, cluster, drpc, vrgNamespace)
+
+		return !adopted
+	}
+
+	if rmnutil.ResourceIsDeleted(mw) {
+		log.Info("VRG ManifestWork found deleted during adoption")
+
+		return adopted
+	}
+
+	vrg, err := rmnutil.ExtractVRGFromManifestWork(mw)
+	if err != nil {
+		log.Info("error extracting VRG from ManifestWork during adoption", "error", err)
+
+		return !adopted
+	}
+
+	// NOTE: upgrade use case, to add DRPC UID for existing VRG MW
+	adoptExistingVRGManifestWork(log, mwu, vrg, cluster, drpc, vrgNamespace)
+
+	return !adopted
+}
+
+// adoptExistingVRGManifestWork updates an existing VRG ManifestWork as managed by the current DRPC resource
+func adoptExistingVRGManifestWork(
+	log logr.Logger,
+	mwu rmnutil.MWUtil,
+	vrg *rmn.VolumeReplicationGroup,
+	cluster string,
+	drpc *rmn.DRPlacementControl,
+	vrgNamespace string,
+) {
+	if vrg.GetAnnotations() == nil {
+		vrg.Annotations = make(map[string]string)
+	}
+
+	if v, ok := vrg.Annotations[DRPCUIDAnnotation]; ok && v == string(drpc.UID) {
+		// Annotation may already be set but not reflected on the resource view yet
+		return
+	}
+
+	vrg.Annotations[DRPCUIDAnnotation] = string(drpc.UID)
+
+	annotations := make(map[string]string)
+	annotations[DRPCNameAnnotation] = drpc.Name
+	annotations[DRPCNamespaceAnnotation] = drpc.Namespace
+
+	err := mwu.CreateOrUpdateVRGManifestWork(drpc.Name, vrgNamespace, cluster, *vrg, annotations)
+	if err != nil {
+		log.Info("error updating VRG via ManifestWork during adoption", "error", err)
+	}
+}
+
+// adoptOpphanVRG creates a missing ManifestWork for a VRG found via a ManagedClusterView
+func adoptOrphanVRG(
+	log logr.Logger,
+	mwu rmnutil.MWUtil,
+	viewVRG *rmn.VolumeReplicationGroup,
+	cluster string,
+	drpc *rmn.DRPlacementControl,
+	vrgNamespace string,
+) {
+	annotations := make(map[string]string)
+	annotations[DRPCNameAnnotation] = drpc.Name
+	annotations[DRPCNamespaceAnnotation] = drpc.Namespace
+
+	// Adopt the namespace as well
+	err := mwu.CreateOrUpdateNamespaceManifest(drpc.Name, vrgNamespace, cluster, annotations)
+	if err != nil {
+		log.Info("error creating namespace via ManifestWork during adoption", "error", err)
+
+		return
+	}
+
+	vrg := constructVRGFromView(viewVRG)
+	if vrg.GetAnnotations() == nil {
+		vrg.Annotations = make(map[string]string)
+	}
+
+	vrg.Annotations[DRPCUIDAnnotation] = string(drpc.UID)
+
+	if err := mwu.CreateOrUpdateVRGManifestWork(
+		drpc.Name, vrgNamespace,
+		cluster, *vrg, annotations); err != nil {
+		log.Info("error creating VRG via ManifestWork during adoption", "error", err)
+	}
+}
+
+// constructVRGFromView selectively constructs a VRG from a view, using its spec and only those annotations that
+// would be set by the hub on the ManifestWork
+func constructVRGFromView(viewVRG *rmn.VolumeReplicationGroup) *rmn.VolumeReplicationGroup {
+	vrg := &rmn.VolumeReplicationGroup{
+		TypeMeta: metav1.TypeMeta{Kind: "VolumeReplicationGroup", APIVersion: "ramendr.openshift.io/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      viewVRG.Name,
+			Namespace: viewVRG.Namespace,
+		},
+	}
+
+	viewVRG.Spec.DeepCopyInto(&vrg.Spec)
+
+	for k, v := range viewVRG.GetAnnotations() {
+		switch k {
+		case DestinationClusterAnnotationKey:
+			fallthrough
+		case DoNotDeletePVCAnnotation:
+			fallthrough
+		case DRPCUIDAnnotation:
+			rmnutil.AddAnnotation(vrg, k, v)
+		default:
+		}
+	}
+
+	return vrg
 }

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -2463,7 +2463,8 @@ func ensureVRGsManagedByDRPC(
 
 	for cluster, viewVRG := range vrgs {
 		if rmnutil.ResourceIsDeleted(viewVRG) {
-			log.Info("VRG reported by view undergoing deletion, during adoption")
+			log.Info("VRG reported by view undergoing deletion, during adoption",
+				"cluster", cluster, "namespace", viewVRG.Namespace, "name", viewVRG.Name)
 
 			continue
 		}
@@ -2497,7 +2498,7 @@ func adoptVRG(
 	mw, err := mwu.FindManifestWorkByType(rmnutil.MWTypeVRG, cluster)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			log.Info("error fetching VRG ManifestWork during adoption", "error", err)
+			log.Info("error fetching VRG ManifestWork during adoption", "error", err, "cluster", cluster)
 
 			return !adopted
 		}
@@ -2508,14 +2509,14 @@ func adoptVRG(
 	}
 
 	if rmnutil.ResourceIsDeleted(mw) {
-		log.Info("VRG ManifestWork found deleted during adoption")
+		log.Info("VRG ManifestWork found deleted during adoption", "cluster", cluster)
 
 		return adopted
 	}
 
 	vrg, err := rmnutil.ExtractVRGFromManifestWork(mw)
 	if err != nil {
-		log.Info("error extracting VRG from ManifestWork during adoption", "error", err)
+		log.Info("error extracting VRG from ManifestWork during adoption", "error", err, "cluster", cluster)
 
 		return !adopted
 	}
@@ -2535,12 +2536,17 @@ func adoptExistingVRGManifestWork(
 	drpc *rmn.DRPlacementControl,
 	vrgNamespace string,
 ) {
+	log.Info("adopting existing VRG ManifestWork", "cluster", cluster, "namespace", vrg.Namespace, "name", vrg.Name)
+
 	if vrg.GetAnnotations() == nil {
 		vrg.Annotations = make(map[string]string)
 	}
 
 	if v, ok := vrg.Annotations[DRPCUIDAnnotation]; ok && v == string(drpc.UID) {
 		// Annotation may already be set but not reflected on the resource view yet
+		log.Info("detected VRGs DRPC UID annotation as existing",
+			"cluster", cluster, "namespace", vrg.Namespace, "name", vrg.Name)
+
 		return
 	}
 
@@ -2552,7 +2558,7 @@ func adoptExistingVRGManifestWork(
 
 	err := mwu.CreateOrUpdateVRGManifestWork(drpc.Name, vrgNamespace, cluster, *vrg, annotations)
 	if err != nil {
-		log.Info("error updating VRG via ManifestWork during adoption", "error", err)
+		log.Info("error updating VRG via ManifestWork during adoption", "error", err, "cluster", cluster)
 	}
 }
 
@@ -2565,6 +2571,9 @@ func adoptOrphanVRG(
 	drpc *rmn.DRPlacementControl,
 	vrgNamespace string,
 ) {
+	log.Info("adopting orphaned VRG ManifestWork",
+		"cluster", cluster, "namespace", viewVRG.Namespace, "name", viewVRG.Name)
+
 	annotations := make(map[string]string)
 	annotations[DRPCNameAnnotation] = drpc.Name
 	annotations[DRPCNamespaceAnnotation] = drpc.Namespace
@@ -2572,7 +2581,7 @@ func adoptOrphanVRG(
 	// Adopt the namespace as well
 	err := mwu.CreateOrUpdateNamespaceManifest(drpc.Name, vrgNamespace, cluster, annotations)
 	if err != nil {
-		log.Info("error creating namespace via ManifestWork during adoption", "error", err)
+		log.Info("error creating namespace via ManifestWork during adoption", "error", err, "cluster", cluster)
 
 		return
 	}
@@ -2587,7 +2596,7 @@ func adoptOrphanVRG(
 	if err := mwu.CreateOrUpdateVRGManifestWork(
 		drpc.Name, vrgNamespace,
 		cluster, *vrg, annotations); err != nil {
-		log.Info("error creating VRG via ManifestWork during adoption", "error", err)
+		log.Info("error creating VRG via ManifestWork during adoption", "error", err, "cluster", cluster)
 	}
 }
 

--- a/controllers/drplacementcontrolvolsync.go
+++ b/controllers/drplacementcontrolvolsync.go
@@ -248,7 +248,7 @@ func (d *DRPCInstance) updateVRGSpec(clusterName string, tgtVRG *rmn.VolumeRepli
 
 	d.log.Info(fmt.Sprintf("Updating VRG ownedby MW %s for cluster %s", mw.Name, clusterName))
 
-	vrg, err := d.extractVRGFromManifestWork(mw)
+	vrg, err := rmnutil.ExtractVRGFromManifestWork(mw)
 	if err != nil {
 		d.log.Error(err, "failed to update VRG state")
 
@@ -345,7 +345,7 @@ func (d *DRPCInstance) ResetVolSyncRDOnPrimary(clusterName string) error {
 
 	d.log.Info(fmt.Sprintf("Resetting RD VRG ownedby MW %s for cluster %s", mw.Name, clusterName))
 
-	vrg, err := d.extractVRGFromManifestWork(mw)
+	vrg, err := rmnutil.ExtractVRGFromManifestWork(mw)
 	if err != nil {
 		d.log.Error(err, "failed to extract VRG state")
 

--- a/controllers/util/mw_util.go
+++ b/controllers/util/mw_util.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/apis/csiaddons/v1alpha1"
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
@@ -559,4 +560,20 @@ func (mwu *MWUtil) DeleteManifestWork(mwName, mwNamespace string) error {
 	}
 
 	return nil
+}
+
+func ExtractVRGFromManifestWork(mw *ocmworkv1.ManifestWork) (*rmn.VolumeReplicationGroup, error) {
+	if len(mw.Spec.Workload.Manifests) == 0 {
+		return nil, fmt.Errorf("invalid VRG ManifestWork for type: %s", mw.Name)
+	}
+
+	vrgClientManifest := &mw.Spec.Workload.Manifests[0]
+	vrg := &rmn.VolumeReplicationGroup{}
+
+	err := yaml.Unmarshal(vrgClientManifest.RawExtension.Raw, &vrg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal VRG object (%w)", err)
+	}
+
+	return vrg, nil
 }

--- a/controllers/util/mw_util.go
+++ b/controllers/util/mw_util.go
@@ -23,9 +23,6 @@ import (
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	dto "github.com/prometheus/client_model/go"
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
-
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/apis/csiaddons/v1alpha1"
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
 )
@@ -562,68 +559,4 @@ func (mwu *MWUtil) DeleteManifestWork(mwName, mwNamespace string) error {
 	}
 
 	return nil
-}
-
-func GetMetricValueSingle(name string, mfType dto.MetricType) (float64, error) {
-	mf, err := getMetricFamilyFromRegistry(name)
-	if err != nil {
-		return 0.0, fmt.Errorf("GetMetricValueSingle returned error finding MetricFamily: %w", err)
-	}
-
-	val, err := getMetricValueFromMetricFamilyByType(mf, mfType)
-	if err != nil {
-		return 0.0, fmt.Errorf("GetMetricValueSingle returned error finding Value: %w", err)
-	}
-
-	return val, nil
-}
-
-func getMetricFamilyFromRegistry(name string) (*dto.MetricFamily, error) {
-	metricsFamilies, err := metrics.Registry.Gather() // TODO: see if this can be made more generic
-	if err != nil {
-		return nil, fmt.Errorf("found error during Gather step of getMetricFamilyFromRegistry: %w", err)
-	}
-
-	if len(metricsFamilies) == 0 {
-		return nil, fmt.Errorf("couldn't get metricsFamilies from Prometheus Registry")
-	}
-
-	// TODO: find out if there's a better way to search than linear scan
-	for i := 0; i < len(metricsFamilies); i++ {
-		if *metricsFamilies[i].Name == name {
-			return metricsFamilies[i], nil
-		}
-	}
-
-	return nil, fmt.Errorf(fmt.Sprint("couldn't find MetricFamily with name", name))
-}
-
-func getMetricValueFromMetricFamilyByType(mf *dto.MetricFamily, mfType dto.MetricType) (float64, error) {
-	if *mf.Type != mfType {
-		return 0.0, fmt.Errorf("getMetricValueFromMetricFamilyByType passed invalid type. Wanted %s, got %s",
-			string(mfType), string(*mf.Type))
-	}
-
-	if len(mf.Metric) != 1 {
-		return 0.0, fmt.Errorf("getMetricValueFromMetricFamilyByType only supports Metric length=1")
-	}
-
-	switch mfType {
-	case dto.MetricType_COUNTER:
-		return *mf.Metric[0].Counter.Value, nil
-	case dto.MetricType_GAUGE:
-		return *mf.Metric[0].Gauge.Value, nil
-	case dto.MetricType_HISTOGRAM:
-		// Count is more useful for testing over Sum; get Sum elsewhere if needed
-		return float64(*mf.Metric[0].Histogram.SampleCount), nil
-	case dto.MetricType_GAUGE_HISTOGRAM:
-		fallthrough
-	case dto.MetricType_SUMMARY:
-		fallthrough
-	case dto.MetricType_UNTYPED:
-		fallthrough
-	default:
-		return 0.0, fmt.Errorf("getMetricValueFromMetricFamilyByType doesn't support type %s yet. Implement this",
-			string(mfType))
-	}
 }

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/operator-framework/api v0.17.6
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
-	github.com/prometheus/client_model v0.4.0
 	github.com/ramendr/ramen/api v0.0.0-20240117171503-e11c56eac24d
 	github.com/ramendr/recipe v0.0.0-20230817160432-729dc7fd8932
 	github.com/stolostron/multicloud-operators-foundation v0.0.0-20220824091202-e9cd9710d009
@@ -69,6 +68,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/prometheus/client_model v0.4.0 // indirect
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect


### PR DESCRIPTION
Adoption ensures that there is a ManifestWork that manages the VRG
resource on the ManagedCluster.

In the case of hub recovery, we would find VRGs on the managed cluster
without any ManifestWork for the same on the hub. This change ensures
that such missing ManifestWork is created on the hub by the current
DRPC resource.

It does this by storing the DRPC resource UID as an annotation on the
created VRG, and on any discrepency ensures that the current DRPC creates
a manifest work for the VRG on the new hub.

The case for upgrade is also handled, where a manifest work may be present
but without the DRPC UID annotation on it.

Fixes: #1204 