### PR TITLE
Do not Set Metrics when DRPC is being deleted

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1666,6 +1666,7 @@ func (r *DRPlacementControlReconciler) getStatusCheckDelay(
 	return time.Until(beforeProcessing.Add(StatusCheckDelay))
 }
 
+//nolint:cyclop
 func (r *DRPlacementControlReconciler) updateDRPCStatus(
 	ctx context.Context, drpc *rmn.DRPlacementControl, userPlacement client.Object, log logr.Logger,
 ) error {
@@ -1681,9 +1682,12 @@ func (r *DRPlacementControlReconciler) updateDRPCStatus(
 		r.updateResourceCondition(drpc, clusterDecision.ClusterName, vrgNamespace, log)
 	}
 
-	if err := r.setDRPCMetrics(ctx, drpc, log); err != nil {
-		// log the error but do not return the error
-		log.Info("failed to set drpc metrics", "errMSg", err)
+	// do not set metrics if DRPC is being deleted
+	if !isBeingDeleted(drpc, userPlacement) {
+		if err := r.setDRPCMetrics(ctx, drpc, log); err != nil {
+			// log the error but do not return the error
+			log.Info("failed to set drpc metrics", "errMSg", err)
+		}
 	}
 
 	for i, condition := range drpc.Status.Conditions {


### PR DESCRIPTION
When the request for DRPC to delete is received, we remove the finalizer and then delete the metrics. The object is then processed for deletion. The API server may not delete immediately and it may take some time for garbage collection to complete the request. Ramen may get the reconcile call again for which Ramen may get the DRPC object which is the deletion state. At this point, we try to set the metrics with zero value and alerts are being fired. The fix here is that metrics will only be set if DRPC is not being deleted

[Bug: 2264435](https://bugzilla.redhat.com/show_bug.cgi?id=2264435)