### PR TITLE
Update rook version from 1.12 to 1.13

### DIFF
--- a/test/addons/rook-cluster/start
+++ b/test/addons/rook-cluster/start
@@ -10,7 +10,7 @@ import drenv
 from drenv import kubectl
 
 # Update this when upgrading rook.
-VERSION = "release-1.12"
+VERSION = "release-1.13"
 BASE_URL = f"https://raw.githubusercontent.com/rook/rook/{VERSION}/deploy/examples"
 
 

--- a/test/addons/rook-operator/start
+++ b/test/addons/rook-operator/start
@@ -10,7 +10,7 @@ import drenv
 from drenv import kubectl
 
 # Update this when upgrading rook.
-VERSION = "release-1.12"
+VERSION = "release-1.13"
 BASE_URL = f"https://raw.githubusercontent.com/rook/rook/{VERSION}/deploy/examples"
 
 

--- a/test/addons/rook-toolbox/start
+++ b/test/addons/rook-toolbox/start
@@ -9,7 +9,7 @@ import sys
 from drenv import kubectl
 
 # Update this when upgrading rook.
-VERSION = "release-1.12"
+VERSION = "release-1.13"
 BASE_URL = f"https://raw.githubusercontent.com/rook/rook/{VERSION}/deploy/examples"
 
 


### PR DESCRIPTION
This current rook version fails to take latest ci changes. This commit updates the rook version.