### PR TITLE
Removing OCM Backup Label from the namespace ManifestWork

### DIFF
--- a/controllers/drplacementcontrolvolsync.go
+++ b/controllers/drplacementcontrolvolsync.go
@@ -297,7 +297,7 @@ func (d *DRPCInstance) createVolSyncDestManifestWork(clusterToSkip string) error
 			continue
 		}
 
-		err := d.ensureNamespaceExistsOnManagedCluster(dstCluster)
+		err := d.ensureNamespaceManifestWork(dstCluster)
 		if err != nil {
 			return fmt.Errorf("creating ManifestWork couldn't ensure namespace '%s' on cluster %s exists",
 				d.instance.Namespace, dstCluster)

--- a/controllers/util/mw_util.go
+++ b/controllers/util/mw_util.go
@@ -284,9 +284,7 @@ func (mwu *MWUtil) CreateOrUpdateNamespaceManifest(
 	manifestWork := mwu.newManifestWork(
 		mwName,
 		managedClusterNamespace,
-		map[string]string{
-			OCMBackupLabelKey: OCMBackupLabelValue,
-		},
+		map[string]string{},
 		manifests,
 		annotations)
 


### PR DESCRIPTION
Remove the OCM label to prevent backing up the workload namespace ManifestWork resource from the hub recovery backup

Related to this Jira: https://issues.redhat.com/browse/ACM-9780