### PR TITLE
Add make targets for the creation of rdr dev environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # How to Contribute
 
-The Ramen project in under [Apache 2.0 license](LICENSES/Apache-2.0.txt).
+The Ramen project is under [Apache 2.0 license](LICENSES/Apache-2.0.txt).
 We accept contributions via GitHub pull requests. This document outlines
 some of the conventions related to development workflow to make it
 easier to get your contribution accepted.
@@ -26,64 +26,15 @@ This is my commit message
 Signed-off-by: Random J Developer <random@developer.example.org>
 ```
 
-Git even has a -s command line option to append this automatically to your
-commit message:
+## Coding Style
 
-```
-git commit -s -m 'This is my commit message'
-```
+Ramen project is written in golang and follows the style guidelines dictated by
+the go fmt as well as go vet tools.
 
-If you have already made a commit and forgot to include the sign-off, you can
-amend your last commit to add the sign-off with the following command, which
-can then be force pushed.
-
-```
-git commit --amend -s
-```
+Additionally various golang linters are enforced to ensure consistent coding
+style.
 
 ## Getting Started
 
-1. Fork the repository on GitHub
-1. Read the [install](docs/install.md) guide for build and deploy instructions
-1. Play with the project, submit bugs, submit patches!
-
-## Contribution Flow
-
-This is a rough outline of what a contributor's workflow looks like:
-
-1. Create a branch from where you want to base your work (usually main).
-1. Make your changes and arrange them in readable commits.
-1. Make sure your commit messages are in the proper format (see below).
-1. Push your changes to the branch in your fork of the repository.
-1. Make sure all [tests](docs/testing.md) pass, and add any new [tests](docs/testing.md)
-   as appropriate.
-1. Submit a pull request to the original repository.
-
-## Coding Style
-
-Ramen project is written in golang and follows the style guidelines dictated
-by the go fmt as well as go vet tools.
-
-Additionally various golang linters are enforced to ensure consistent coding
-style, these can be run using, `make lint` and in turn uses [golangci](https://golangci-lint.run/)
-with [this](.golangci.yaml) configuration.
-
-Several other linters are run on the pull request using the
-[pre-commit.sh](hack/pre-commit.sh) script.
-
-### Pull Request Flow
-
-The general flow for a pull request approval process is as follows:
-
-1. Author submits the pull request
-1. Reviewers and maintainers for the applicable code areas review the pull
-   request and provide feedback that the author integrates
-1. Reviewers and/or maintainers signify their LGTM on the pull request
-1. A maintainer approves the pull request based on at least one LGTM from the
-   previous step
-    1. Note that the maintainer can heavily lean on the reviewer for examining
-       the pull request at a finely grained detailed level. The reviewers are
-       trusted members and maintainers can leverage their efforts to reduce
-       their own review burden.
-1. A maintainer merges the pull request into the target branch (main, release,
-   etc.)
+1. Read the [devel-quick-start](docs/devel-quick-start.md) guide for build, test
+   and contributing instructions.

--- a/Makefile
+++ b/Makefile
@@ -119,11 +119,15 @@ lint: golangci-bin ## Run configured golangci-lint and pre-commit.sh linters aga
 	hack/pre-commit.sh
 
 .PHONY: create-rdr-env
-create-rdr-env: ## Create a new rdr environment.
+create-rdr-env: drenv-prereqs ## Create a new rdr environment.
 	./hack/dev-env.sh create
 
-destroy-rdr-env: ## Destroy the existing rdr environment.
+destroy-rdr-env: drenv-prereqs ## Destroy the existing rdr environment.
 	./hack/dev-env.sh destroy
+
+.PHONY: drenv-prereqs
+drenv-prereqs: ## Check the prerequisites for the drenv tool.
+	./hack/check-drenv-prereqs.sh
 
 ##@ Tests
 

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,13 @@ lint: golangci-bin ## Run configured golangci-lint and pre-commit.sh linters aga
 	testbin/golangci-lint run ./... --config=./.golangci.yaml
 	hack/pre-commit.sh
 
+.PHONY: create-rdr-env
+create-rdr-env: ## Create a new rdr environment.
+	./hack/dev-env.sh create
+
+destroy-rdr-env: ## Destroy the existing rdr environment.
+	./hack/dev-env.sh destroy
+
 ##@ Tests
 
 test: generate manifests envtest ## Run all the tests.

--- a/docs/devel-quick-start.md
+++ b/docs/devel-quick-start.md
@@ -5,10 +5,55 @@ SPDX-License-Identifier: Apache-2.0
 
 # Ramen developer quick start guide
 
-This page will help you to set up a development environment for the
-*Ramen* project.
+## Contribution Flow
 
-## What you’ll need
+1. Fork the repository on GitHub
+1. Create a branch from where you want to base your work (usually main).
+1. Make your changes and arrange them in readable commits.
+1. Make sure your commit messages are in the proper format.
+1. Make sure all [tests](docs/testing.md) pass, and add any new [tests](docs/testing.md)
+1. Push your changes to the branch in your fork of the repository.
+   as appropriate.
+1. Submit a pull request to the original repository.
+
+## Getting the source
+
+1. Fork the *Ramen* repository on github
+
+1. Clone the source locally
+
+   ```sh
+   git clone git@github.com:my-github-user/ramen.git
+   ```
+
+1. Add an `upstream` remote, to make it easy to sync your repo from
+   upstream.
+
+   ```sh
+   git remote add upstream https://github.com/RamenDR/ramen.git
+   ```
+
+1. Set up a commit-msg hook to sign off your commits
+
+   *Ramen* requires a `Signed-off-by: My Name <myemail@example.com>`
+   footer in the commit message. To add it automatically to all commits,
+   add this hook:
+
+   ```sh
+   $ cat .git/hooks/commit-msg
+   #!/bin/sh
+   # Add Signed-off-by trailer.
+   sob=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+   git interpret-trailers --in-place --trailer "$sob" "$1"
+   ```
+
+   And make the hook executable:
+
+   ```sh
+   chmod +x .git/hooks/commit-msg
+   ```
+
+## Setting up the environment for development and testing
 
 To set up a *Ramen* development environment you will need to run 3
 Kubernetes clusters. *Ramen* makes this easy using minikube, but you need
@@ -21,129 +66,43 @@ enough resources:
 - Internet connection
 - Linux - tested on *RHEL* 8.6 and *Fedora* 37.
 
-## Getting the source
+### Create and activate python virtual environment
 
-1. Fork the *Ramen* repository on github
+The *Ramen* project uses python tools to create and provision test
+environment and run tests. To create a virtual environment including
+the tools run:
 
-1. Clone the source locally
-
-   ```
-   git clone git@github.com:my-github-user/ramen.git
-   ```
-
-1. Add an `upstream` remote, to make it easy to sync your repo from
-   upstream.
-
-   ```
-   git remote add upstream https://github.com/RamenDR/ramen.git
-   ```
-
-1. Set up a commit-msg hook to sign off your commits
-
-   *Ramen* requires a `Signed-off-by: My Name <myemail@example.com>`
-   footer in the commit message. To add it automatically to all commits,
-   add this hook:
-
-   ```
-   $ cat .git/hooks/commit-msg
-   #!/bin/sh
-   # Add Signed-off-by trailer.
-   sob=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
-   git interpret-trailers --in-place --trailer "$sob" "$1"
-   ```
-
-   And make the hook executable:
-
-   ```
-   chmod +x .git/hooks/commit-msg
-   ```
-
-1. Create python virtual environment
-
-   The *Ramen* project use python tool to create and provision test
-   environment and run tests. The create a virtual environment including
-   the tools run:
-
-   ```
-   make venv
-   ```
-
-   This create a virtual environment in `~/.venv/ramen` and a symbolic
-   link `venv` for activating the environment. To activate the
-   environment use:
-
-That's all! You are ready to submit your first pull request!
-
-## Running the tests
-
-To run all unit tests run:
-
-```
-make test
+```sh
+make venv
 ```
 
-To run only part of the test suite you can use one of the `test-*`
-targets, for example:
+This creates a virtual environment in `~/.venv/ramen` and a symbolic
+link `venv` for activating the environment.
 
-```
-make test-vrg-vr
-```
+Activate the python virtual environment:
 
-To open an HTML coverage report in the default browser run:
-
-```
-make coverage
-```
-
-The coverage report depends on the tests ran before inspecting the
-coverage.
-
-## Setting up the `drenv` tool
-
-*Ramen* uses the `drenv` tool to build a development environment
-quickly. Please follow the
-[Setup instructions](../test/README.md#setup)
-to set up the `drenv` tool.
-
-## Starting the test environment
-
-Before using the `drenv` tool to start a test environment, you need to
-activate the python virtual environment:
-
-```
+```sh
 source venv
 ```
 
-*Ramen* supports many configurations, but the only development
-environment available now is the `regional-dr.yaml`. This environment
-simulates a Regional DR setup, when the managed clusters are located in
-different zones (e.g. US, Europe) and storage is replicated
-asynchronously. This environment includes 3 clusters - a hub cluster
-(`hub`), and 2 managed clusters (`dr1`, `dr2`) using `Ceph` storage.
+### Create the environment
 
-To start the environment, run:
+You can run the make target `create-rdr-env` to create a 3 cluster environment
+for suitable for Regional DR. This will create 3 minikube clusters, and install
+the necessary components for the Ramen operator to run.
 
-```
-cd test
-drenv start envs/regional-dr.yaml
-```
+This uses `drenv` tool to setup the environment. Refer to
+[drenv readme](../test/README.md#setup) for more details.
 
-Starting takes at least 5 minutes, depending on your machine and
-internet connection.
-
-You can inspect the environment using kubectl, for example:
-
-```
-kubectl get deploy -A --context hub
-kubectl get deploy -A --context dr1
-kubectl get deploy -A --context dr2
+```sh
+make create-rdr-env
 ```
 
 ## Building the ramen operator image
 
 Build the *Ramen* operator container image:
 
-```
+```sh
 make docker-build
 ```
 
@@ -151,78 +110,39 @@ This builds the image `quay.io/ramendr/ramen-operator:latest`
 
 ## Deploying the ramen operator
 
-To deploy the *Ramen* operator in the test environment:
-
-```
-ramenctl deploy test/envs/regional-dr.yaml
-```
-
-## Configure the ramen operator on the hub
-
-Ramen need to be configured to know about the managed clusters and the
-s3 endpoints. To configure the ramen operator for test environment:
-
-```
-ramenctl config test/envs/regional-dr.yaml
-```
-
-For more info on the `ramenctl` tool see
+You can either deploy the *Ramen* operator using the make targets or use the
+`ramenctl` tool. For more info on the `ramenctl` tool see
 [ramenctl/README.md](../ramenctl/README.md).
 
-## Running system tests
+- Using `ramenctl`
 
-At this point *Ramen* is ready to protect workloads in your cluster, and
-you are ready for testing basic flows.
+    Ensure python virtual environment is active as `ramenctl` is a python tool.
+    The default name-prefix in the make target `create-rdr-env` is `rdr-`, we
+    will use the same in the `ramenctl` commands.
 
-To run basic tests using regional-dr environment run:
+    - Deploy the *Ramen* operator in the environment using `ramenctl`.
 
-```
-test/basic-test/run test/envs/regional-dr.yaml
-```
+     ```sh
+     ramenctl deploy --name-prefix rdr- test/envs/regional-dr.yaml
+     ```
 
-This test:
+    - Ramen needs to be configured to know about the managed clusters and the s3
+   endpoints. Configure the ramen operator for environment.
 
-1. Deploys an application using
-   [ocm-ramen-samples repo](https://github.com/RamenDR/ocm-ramen-samples)
-1. Enables DR for the application
-1. Fails over the application to the other cluster
-1. Relocates the application back to the original cluster
-1. Disables DR for the application
-1. Undeploys the application
+    ```sh
+    ramenctl config --name-prefix rdr- test/envs/regional-dr.yaml
+    ```
 
-If needed, you can run one or more steps form this test, for example to
-deploy and enable DR run:
+## Testing Ramen
 
-```
-env=$PWD/test/envs/regional-dr.yaml
-test/basic-test/deploy $env
-test/basic-test/enable-dr $env
-```
-
-At this point you can run run manually failover, relocate one or more
-times as needed:
-
-```
-for i in $(seq 3); do
-    test/basic-test/relocate $env
-done
-```
-
-To clean up run:
-
-```
-test/basic-test/undeploy $env
-```
-
-For more info on writing such tests see
-[test/README.md](../test/README.md).
+- Read the [testing](./testing.md) guide for test instructions.
 
 ## Undeploying the ramen operator
 
 If you want to clean up your environment, you can unconfigure *Ramen* and
 undeploy it.
 
-```
-ramenctl unconfig test/envs/regional-dr.yaml
-ramenctl undeploy test/envs/regional-dr.yaml
+```sh
+ramenctl unconfig --name-prefix rdr- test/envs/regional-dr.yaml
+ramenctl undeploy --name-prefix rdr- test/envs/regional-dr.yaml
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,9 +5,50 @@ SPDX-License-Identifier: Apache-2.0
 
 # Testing
 
-## **Under construction**
+## Unit tests and Integration tests
 
-## Using interfaces to mock in testing
+The unit and integration tests for the controller code are written using the
+`ginkgo` and `gomega` testing frameworks. The tests are written in the
+`*_test.go` files in the `controllers` directory.
+
+By default, the tests are run against a single kubernetes api
+server(<https://github.com/kubernetes-sigs/controller-runtime/tree/main/tools/setup-envtest>)
+provided by the controller-runtime project.
+
+The test framework uses mock interfaces for the components that aren't installed
+in the test environment, like ocm, s3 and csi. These mock interfaces are used to
+fake a success or failure from the components to test the controller code.
+
+```sh
+$ make test
+hack/install-setup-envtest.sh
+go test ./... -coverprofile cover.out
+        github.com/ramendr/ramen                coverage: 0.0% of statements
+        github.com/ramendr/ramen/controllers/kubeobjects                coverage: 0.0% of statements
+        github.com/ramendr/ramen/controllers/argocd             coverage: 0.0% of statements
+        github.com/ramendr/ramen/controllers/kubeobjects/velero         coverage: 0.0% of statements
+ok      github.com/ramendr/ramen/controllers    205.468s        coverage: 66.6% of statements
+ok      github.com/ramendr/ramen/controllers/util       9.911s  coverage: 21.8% of statements
+ok      github.com/ramendr/ramen/controllers/volsync    26.089s coverage: 57.3% of statements
+```
+
+Explore other `test-` targets that test a subset of the controller code.
+
+### Coverage
+
+The tests are run with coverage enabled. You can see the coverage report by
+running the coverage target.
+
+To open an HTML coverage report in the default browser run:
+
+```sh
+make coverage
+```
+
+The coverage report depends on the tests ran before inspecting the
+coverage.
+
+### Using interfaces to mock in testing
 
 It is always useful to run the unit or integration tests without setting up
 external dependencies. If the communication to the external components is done
@@ -18,3 +59,52 @@ tests.
 ![](interfaces.png?raw=true)
 
 The above picture shows the interfaces that are used in Ramen today.
+
+## End-to-end tests
+
+The end-to-end testing framework isn't implemented yet. However, we have a basic
+test that you can use to test the basic flows of Ramen. `basic-test` requires
+the python virtual environment to be activated.
+
+To run basic tests using the regional-dr environment run:
+
+```sh
+test/basic-test/run test/envs/regional-dr.yaml
+```
+
+This test:
+
+1. Deploys an application using
+   [ocm-ramen-samples repo](https://github.com/RamenDR/ocm-ramen-samples)
+1. Enables DR for the application
+1. Fails over the application to the other cluster
+1. Relocates the application back to the original cluster
+1. Disables DR for the application
+1. Undeploys the application
+
+If needed, you can run one or more steps form this test, for example to
+deploy and enable DR run:
+
+```sh
+env=$PWD/test/envs/regional-dr.yaml
+test/basic-test/deploy $env
+test/basic-test/enable-dr $env
+```
+
+At this point you can run run manually failover, relocate one or more
+times as needed:
+
+```sh
+for i in $(seq 3); do
+    test/basic-test/relocate $env
+done
+```
+
+To clean up run:
+
+```sh
+test/basic-test/undeploy $env
+```
+
+For more info on writing such tests see
+[test/README.md](../test/README.md).

--- a/hack/check-drenv-prereqs.sh
+++ b/hack/check-drenv-prereqs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+if ! groups "$USER" | grep -qw libvirt; then
+  echo "Error: User is not part of the libvirt group."
+  exit 1
+fi
+
+commands=("minikube" "kubectl" "clusteradm" "subctl" "velero" "helm" "virtctl"
+"virt-host-validate")
+
+for cmd in "${commands[@]}"; do
+  if ! command -v "$cmd" &> /dev/null; then
+    echo "Error: $cmd could not be found in PATH."
+    exit 1
+  fi
+done
+
+if ! virt-host-validate qemu -q; then
+  echo "Error: 'virt-host-validate qemu' did not return 0."
+  exit 1
+fi
+
+echo "All prerequisites met for drenv"

--- a/hack/dev-env.sh
+++ b/hack/dev-env.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+RDR_NAME_PREFIX=${RDR_NAME_PREFIX:-rdr}
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+
+if [[ $1 != "create" && $1 != "destroy" ]]; then
+    echo "Usage: $0 create|destroy"
+    exit 1
+fi
+
+if [[ "$VIRTUAL_ENV" == "" ]]; then
+  echo "Virtual environment not activated"
+  echo "Run the following command and try again"
+  echo "make venv && source venv"
+  exit 1
+fi
+
+cd "$script_dir"/..
+cd test
+
+if [[ $1 == "create" ]]; then
+    drenv start --name-prefix "${RDR_NAME_PREFIX}"- envs/regional-dr.yaml
+fi
+
+if [[ $1 == "destroy" ]]; then
+    drenv delete --name-prefix "${RDR_NAME_PREFIX}"- envs/regional-dr.yaml
+fi


### PR DESCRIPTION
In this PR, we have the following changes:

- Add makefile targets for creation and deletion of RDR dev environments
- Add a checker script the ensures all the tools used by drenv during the RDR environment are installed.
- Update the documentation such that Contributing guide introduces the guidelines and workflows for contributing, devel-quick-start guide details the workflow and testing guide has the information on testing processes.