### PR TITLE
Lower s3timeout to reasonable duration

### DIFF
--- a/controllers/s3utils.go
+++ b/controllers/s3utils.go
@@ -28,9 +28,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// We have seen that the valid errors from the s3 servers take up to 2 minutes.
-// Let the timeout be greater than that.
-var s3Timeout = time.Second * 125
+// We have seen that valid errors from the S3 servers can take up to 2 minutes to timeout.
+// let's reduce this timeout to a more reasonable duration.
+// TODO: Preferably, make the s3 timeout configurable
+var s3Timeout = time.Second * 12
 
 // Example usage:
 // func example_code() {


### PR DESCRIPTION
This PR addresses this: https://bugzilla.redhat.com/show_bug.cgi?id=2264767#c4
Adjusted the `s3Timeout` to a more reasonable duration. This change has been tested locally and in the QE system.  It seems to have resolved the problem.  Here are the results of testing on the QE system:

1. **Before the change (2mins connection timeout) shows the error as** `i/o timeout`
```
2024-03-04T12:08:06.014Z        ERROR   controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_vrgobject.go:47 VRG Kube object protect error   {"VolumeReplicationGroup": {"name":"rbd-sub-busybox12-placement-1-drpc","namespace":"busybox-workloads-12"}, "rid": "6a12f929-0145-4f75-9667-53d54656baf9", "State": "primary", "profile": "s3profile-amagrawa-new-c1-ocs-storagecluster", "error": "failed to upload data of odrbucket-65debfc420d5:busybox-workloads-12/rbd-sub-busybox12-placement-1-drpc/v1alpha1.VolumeReplicationGroup/a, RequestError: send request failed\ncaused by: Put \"https://s3-openshift-storage.apps.amagrawa-new-c1.qe.rh-ocs.com/odrbucket-65debfc420d5/busybox-workloads-12/rbd-sub-busybox12-placement-1-drpc/v1alpha1.VolumeReplicationGroup/a\": dial tcp 10.1.161.126:443: i/o timeout"}
```

2. **After the change (12secs connection timeout) shows the error as** `context deadline exceeded`
```
2024-03-05T13:54:50.721Z        ERROR   controllers.VolumeReplicationGroup.vrginstance  controllers/vrg_vrgobject.go:47 VRG Kube object protect error   {"VolumeReplicationGroup": {"name":"rbd-appset-busybox3-placement-drpc","namespace":"busybox-workloads-3"}, "rid": "bb430937-0346-4433-b536-c7167f979f21", "State": "primary", "profile": "s3profile-amagrawa-new-c1-ocs-storagecluster", "error": "failed to upload data of odrbucket-65debfc420d5:busybox-workloads-3/rbd-appset-busybox3-placement-drpc/v1alpha1.VolumeReplicationGroup/a, RequestCanceled: request context canceled\ncaused by: context deadline exceeded"}
```

3. **Before the change, we can see from the image below that Ramen pod keeps restarting every few minutes**
<img width="1500" alt="image" src="https://github.com/RamenDR/ramen/assets/38288784/c994a074-0ca8-44d1-b0ac-0c3d8e23ff5e">

4. **After the change, we can see from the image below that Rame pods stopped restarting (for the last 6h26m)**
<img width="1507" alt="image" src="https://github.com/RamenDR/ramen/assets/38288784/1d61a96d-bc3a-4335-95bc-51af672cb538">
