### PR TITLE
drenv: use local copied resources for ocm-controller

### DIFF
--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -28,11 +28,9 @@ templates:
           - name: rook-cluster
           - name: rook-pool
           - name: rook-toolbox
-      - addons:
           - name: ocm-cluster
             args: ["$name", "hub"]
           - name: recipe
-      - addons:
           - name: csi-addons
           - name: olm
           - name: minio
@@ -48,22 +46,7 @@ templates:
           - name: ocm-controller
           - name: cert-manager
           - name: olm
-      - addons:
-          - name: submariner
-            args: ["hub", "dr1", "dr2"]
 
 profiles:
-  - name: "dr1"
-    template: "dr-cluster"
-  - name: "dr2"
-    template: "dr-cluster"
   - name: "hub"
     template: "hub-cluster"
-
-workers:
-  - addons:
-      - name: rbd-mirror
-        args: ["dr1", "dr2"]
-  - addons:
-      - name: volsync
-        args: ["dr1", "dr2"]


### PR DESCRIPTION
The `kubectl apply -k` command fails for the ocm-controller addon when it is run in a slow network environment. I have tried various git config options to see if that prevents github.com from terminating the git connections but none have worked.

This PR is a big hack to workaround the problem. This is to start a conversation about fixing the problem with a better solution; in the worst case we will have to merge this hack.