### PR TITLE
drenv: wait before checking for blocklist after vrc test

### DIFF
--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -7,6 +7,7 @@ import base64
 import json
 import os
 import sys
+import time
 
 import drenv
 from drenv import ceph
@@ -170,6 +171,8 @@ wait_until_pool_mirroring_is_healthy(cluster2)
 
 deploy_vrc_sample(cluster1)
 deploy_vrc_sample(cluster2)
+
+time.sleep(30)
 
 check_blocklist(cluster1)
 check_blocklist(cluster2)


### PR DESCRIPTION
In the rbd mirror addon, we create sample vrc and delete it. After that step a blocklist is seen in the osd blocklist list command.

This blocklist fails the rbd mirror setup. The interesting thing is that a sleep of 30 seconds seems to be fixing the problem. We need to debug the issue and find a better fix for it.