### PR TITLE
linter: run golangci-lint for every module

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,12 @@ jobs:
   golangci:
     name: Golangci Lint
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        directory: [., api]
+        # golangci-lint has a limitation that it doesn't lint subdirectories if
+        # they are a different module.
+        # see https://github.com/golangci/golangci-lint/issues/828
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
@@ -86,6 +92,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.55.2
+          working-directory: ${{ matrix.directory }}
 
   unit-test:
     name: Unit tests

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,11 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 
 .PHONY: lint
 lint: golangci-bin ## Run configured golangci-lint and pre-commit.sh linters against the code.
+# golangci-lint has a limitation that it doesn't lint subdirectories if
+# they are a different module.
+# see https://github.com/golangci/golangci-lint/issues/828
 	testbin/golangci-lint run ./... --config=./.golangci.yaml
+	cd api && ../testbin/golangci-lint run ./... --config=../.golangci.yaml
 	hack/pre-commit.sh
 
 .PHONY: create-rdr-env


### PR DESCRIPTION
golangci-lint has a limitation that it doesn't traverse go modules even if they are subdirectories. We were not running golangci-lint for the api module because of that.