### PR TITLE
golangci: remove deprecated linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -99,7 +99,7 @@ linters:
     - bidichk
     - bodyclose
     - cyclop
-    - deadcode
+    # - deadcode
     - decorder
     #  - depguard
     - dogsled
@@ -119,7 +119,7 @@ linters:
     - gocyclo
     - gofmt
     - gofumpt
-    - golint
+    # - golint
     - gomnd
     - gomodguard
     - goprintffuncname
@@ -127,7 +127,7 @@ linters:
     - gosimple
     - govet
     - grouper
-    - ifshort
+    # - ifshort
     - importas
     - ineffassign
     - interfacebloat
@@ -135,7 +135,7 @@ linters:
     - logrlint
     - maintidx
     - makezero
-    - maligned
+    # - maligned
     - misspell
     #  - nakedret
     - nestif
@@ -149,9 +149,9 @@ linters:
     - reassign
     - revive
     - rowserrcheck
-    - scopelint
+    # - scopelint
     - sqlclosecheck
-    - structcheck
+    # - structcheck
     - stylecheck
     - tenv
     - testpackage
@@ -162,7 +162,7 @@ linters:
     - unparam
     - unused
     - usestdlibvars
-    - varcheck
+    # - varcheck
     #  - wastedassign
     - whitespace
     - wsl


### PR DESCRIPTION
Signed-off-by: rakeshgm <rakeshgm@redhat.com>