### PR TITLE
Increase ocm-controller kustomize timeout

### DIFF
--- a/test/addons/ocm-controller/kustomization.yaml
+++ b/test/addons/ocm-controller/kustomization.yaml
@@ -8,7 +8,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 # The default timeout (27 seconds) is too short when using a slow network.
-- https://github.com/stolostron/multicloud-operators-foundation.git/deploy/foundation/hub/overlays/ocm-controller?ref=main&timeout=300s
+- https://github.com/stolostron/multicloud-operators-foundation.git/deploy/foundation/hub/overlays/ocm-controller?ref=main&timeout=600s
 images:
 - name: quay.io/stolostron/multicloud-manager
   newTag: latest


### PR DESCRIPTION
With the current timeout (300s) we see this failure in the e2e environment:

    drenv.commands.Error: Command failed:
        command: ('kubectl', 'apply', '--context', 'rdr-hub', '--kustomize', './')
        exitcode: 1
        error:
            error: accumulating resources: accumulation
            err='accumulating resources from 'https://github.com/stolostron/
            multicloud-operators-foundation.git/deploy/foundation/hub/
            overlays/ocm-controller?ref=main&timeout=300s':
            URL is a git repository': failed to run '/usr/bin/git fetch
            --depth=1
            https://github.com/stolostron/multicloud-operators-foundation.git
            main': error: RPC failed; curl 18 transfer closed with
            outstanding read data remaining
            error: 8014 bytes of body are still expected
            fetch-pack: unexpected disconnect while reading sideband packet
            fatal: early EOF
            fatal: fetch-pack: invalid index-pack output
            : exit status 128