### PR TITLE
Separate build container and make venv steps

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,17 +21,20 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v3
 
+    - name: Build ramen-operator container
+      run: make docker-build
+
+    - name: Create virtual environment
+      run: make venv
+
     - name: Cleanup existing environment
       if: ${{ always() }}
       run: |
-        make venv
         source venv
         make destroy-rdr-env
 
     - name: Run make target e2e-rdr
       run: |
-        make docker-build
-        make venv
         source venv
         make create-rdr-env
         cp ~/.config/drenv/${{ env.NAME_PREFIX }}rdr/config.yaml e2e/config.yaml
@@ -42,6 +45,5 @@ jobs:
     - name: Cleanup e2e-rdr
       if: ${{ always() }}
       run: |
-        make venv
         source venv
         make destroy-rdr-env


### PR DESCRIPTION
Move `make venv` and `make docker-build` to their own step to clean up the job output and avoid pointless operations.

This way the usually uninteresting details of these operations are folded under a descriptive name.

## Example output

![Screenshot from 2024-03-07 23-29-13](https://github.com/RamenDR/ramen/assets/395026/ffc67157-0b00-491e-9c82-380bbcce6a70)