### PR TITLE
Fix random failures in e2e job

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,6 +34,9 @@ jobs:
         source ../venv
         drenv delete --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
 
+    - name: Setup libvirt
+      run: test/scripts/setup-libvirt
+
     - name: Start clusters
       working-directory: test
       run: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,6 +11,9 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   NAME_PREFIX: "rdr-"
+  # Avoid random failures in overloaded runner
+  # TODO: more testing.
+  MAX_WORKERS: 1
 
 jobs:
   e2e-rdr:
@@ -41,7 +44,7 @@ jobs:
     - name: Start clusters
       working-directory: test
       run: |
-        drenv start --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
+        drenv start --max-workers ${{ env.MAX_WORKERS }} --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
         cp ~/.config/drenv/${{ env.NAME_PREFIX }}rdr/config.yaml ../e2e/config.yaml
 
     - name: Deploy ramen

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,18 +21,19 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v3
 
+    - name: Install drenv
+      run: pip install -e test
+
+    - name: Install ramenctl
+      run: pip install -e ramenctl
+
     - name: Build ramen-operator container
       run: make docker-build
-
-    - name: Create virtual environment
-      run: make venv
 
     - name: Delete clusters
       if: ${{ always() }}
       working-directory: test
-      run: |
-        source ../venv
-        drenv delete --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
+      run: drenv delete --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
 
     - name: Setup libvirt
       run: test/scripts/setup-libvirt
@@ -40,13 +41,11 @@ jobs:
     - name: Start clusters
       working-directory: test
       run: |
-        source ../venv
         drenv start --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
         cp ~/.config/drenv/${{ env.NAME_PREFIX }}rdr/config.yaml ../e2e/config.yaml
 
     - name: Deploy ramen
       run: |
-        source venv
         ramenctl deploy --name-prefix ${{ env.NAME_PREFIX }} test/envs/regional-dr.yaml
         ramenctl config --name-prefix ${{ env.NAME_PREFIX }} test/envs/regional-dr.yaml
 
@@ -56,6 +55,4 @@ jobs:
     - name: Delete clusters
       if: ${{ always() }}
       working-directory: test
-      run: |
-        source ../venv
-        drenv delete --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
+      run: drenv delete --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,23 +27,32 @@ jobs:
     - name: Create virtual environment
       run: make venv
 
-    - name: Cleanup existing environment
+    - name: Delete clusters
       if: ${{ always() }}
+      working-directory: test
       run: |
-        source venv
-        make destroy-rdr-env
+        source ../venv
+        drenv delete --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
 
-    - name: Run make target e2e-rdr
+    - name: Start clusters
+      working-directory: test
+      run: |
+        source ../venv
+        drenv start --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
+        cp ~/.config/drenv/${{ env.NAME_PREFIX }}rdr/config.yaml ../e2e/config.yaml
+
+    - name: Deploy ramen
       run: |
         source venv
-        make create-rdr-env
-        cp ~/.config/drenv/${{ env.NAME_PREFIX }}rdr/config.yaml e2e/config.yaml
         ramenctl deploy --name-prefix ${{ env.NAME_PREFIX }} test/envs/regional-dr.yaml
         ramenctl config --name-prefix ${{ env.NAME_PREFIX }} test/envs/regional-dr.yaml
-        make e2e-rdr
 
-    - name: Cleanup e2e-rdr
+    - name: Run e2e tests
+      run: make e2e-rdr
+
+    - name: Delete clusters
       if: ${{ always() }}
+      working-directory: test
       run: |
-        source venv
-        make destroy-rdr-env
+        source ../venv
+        drenv delete --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml

--- a/test/addons/kubevirt/test
+++ b/test/addons/kubevirt/test
@@ -62,7 +62,7 @@ def verify_ssh(cluster):
 
     for i in range(retries):
         time.sleep(delay)
-        print(f"Last entries in /var/log/ramen.log (attempt {i+1}/{retries})")
+        print(f"Last entries in /var/log/ramen.log (attempt {i + 1}/{retries})")
         try:
             out = virtctl.ssh(
                 "testvm",

--- a/test/scripts/setup-libvirt
+++ b/test/scripts/setup-libvirt
@@ -1,0 +1,18 @@
+#!/bin/sh -e
+
+default_network_exists() {
+    virsh -c qemu:///system net-list | grep -q default
+}
+
+create_default_network() {
+    virsh -c qemu:///system net-define /usr/share/libvirt/networks/default.xml
+    virsh -c qemu:///system net-autostart default
+    virsh -c qemu:///system net-start default
+}
+
+if default_network_exists; then
+    echo "libvirt default network exists"
+else
+    echo "Creating libvirt default network"
+    create_default_network
+fi


### PR DESCRIPTION
- Limit number of workers per profile
- Eliminate the virtual env in e2e job
- Add setup-libvirt script and use it in e2e job
- More cleanup in e2e job
- Add drenv start --max-workers option
- Fix flake8 error in kubevirt test

Status:
- ocm-controller still fails randomly to clone the remote repo

Builds:
- https://github.com/RamenDR/ramen/actions/runs/8210342798 OK
- https://github.com/RamenDR/ramen/actions/runs/8210618440/attempts/1 FAILED
  - ocm-controller early EOF in git clone
- https://github.com/RamenDR/ramen/actions/runs/8210618440/attempts/2 FAILED
  - ocm-controller early EOF in git clone
- https://github.com/RamenDR/ramen/actions/runs/8210618440/attempts/3 FAILED
  - ocm-controller early EOF in git clone
- https://github.com/RamenDR/ramen/actions/runs/8210618440/attempts/4 FAILED
  - ocm-controller early EOF in git clone
- https://github.com/RamenDR/ramen/actions/runs/8210618440/attempts/5 FAILED
  - timeout waiting for condition=ManagedClusterConditionAvailable
- https://github.com/RamenDR/ramen/actions/runs/8210618440/attempts/6 FAILED
  - ocm-controller early EOF in git clone
- https://github.com/RamenDR/ramen/actions/runs/8210618440/attempts/7 FAILED
  - ocm-controller early EOF in git clone
- https://github.com/RamenDR/ramen/actions/runs/8210618440/attempts/8 OK
- https://github.com/RamenDR/ramen/actions/runs/8210618440/attempts/9 OK
- https://github.com/RamenDR/ramen/actions/runs/8210618440/attempts/10 OK