### PR TITLE
Optimize drenv for CI lab

### DIFF
--- a/test/addons/cdi/start
+++ b/test/addons/cdi/start
@@ -20,7 +20,7 @@ def deploy(cluster):
         "status",
         "deploy/cdi-operator",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 
@@ -34,7 +34,7 @@ def wait(cluster):
         "cdi.cdi.kubevirt.io/cdi",
         "--for=condition=available",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
     print("Waiting until cdi cr finished progressing")

--- a/test/addons/csi-addons/start
+++ b/test/addons/csi-addons/start
@@ -29,7 +29,7 @@ def wait(cluster):
         "status",
         "deploy/csi-addons-controller-manager",
         "--namespace=csi-addons-system",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/demo/start
+++ b/test/addons/demo/start
@@ -28,7 +28,7 @@ print("Waiting until deployment is rolled out")
 kubectl.rollout(
     "status",
     "deployment",
-    "--timeout=600s",
+    "--timeout=120s",
     context=cluster,
 )
 
@@ -37,7 +37,7 @@ kubectl.rollout(
     "status",
     "ingress",
     "--namespace=ingress-nginx",
-    "--timeout=600s",
+    "--timeout=120s",
     context=cluster,
 )
 

--- a/test/addons/example/start
+++ b/test/addons/example/start
@@ -22,7 +22,7 @@ print("Waiting until example deployment is rolled out")
 kubectl.rollout(
     "status",
     "deploy/example-deployment",
-    "--timeout=600s",
+    "--timeout=180s",
     context=cluster,
 )
 
@@ -31,6 +31,6 @@ kubectl.wait(
     "pod",
     "--selector=app=example",
     "--for=condition=Ready",
-    "--timeout=600s",
+    "--timeout=180s",
     context=cluster,
 )

--- a/test/addons/kubevirt/start
+++ b/test/addons/kubevirt/start
@@ -20,7 +20,7 @@ def deploy(cluster):
         "status",
         "deploy/virt-operator",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 
@@ -34,7 +34,7 @@ def wait(cluster):
         "kubevirt.kubevirt.io/kubevirt",
         "--for=condition=available",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/kubevirt/test
+++ b/test/addons/kubevirt/test
@@ -40,7 +40,7 @@ def wait_until_vm_is_ready(cluster):
         "vm/testvm",
         "--for=condition=ready",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=180s",
         context=cluster,
     )
 

--- a/test/addons/minio/start
+++ b/test/addons/minio/start
@@ -29,7 +29,7 @@ def wait(cluster):
         "status",
         "deployment/minio",
         "--namespace=minio",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/ocm-cluster/start
+++ b/test/addons/ocm-cluster/start
@@ -126,6 +126,13 @@ def wait_for_managed_cluster(cluster, hub):
     # This takes less then a second, but sometimes it never complete, even if waiting 10 minutes.
     start = time.monotonic()
 
+    print(f"Waiting until managed cluster '{cluster}' is created on the hub")
+    drenv.wait_for(
+        f"managedcluster/{cluster}",
+        timeout=60,
+        profile=hub,
+    )
+
     print(f"Waiting until managed cluster '{cluster}' hubAcceptsClient is true")
     kubectl.wait(
         f"managedcluster/{cluster}",

--- a/test/addons/ocm-cluster/start
+++ b/test/addons/ocm-cluster/start
@@ -67,7 +67,7 @@ def wait(cluster):
             "status",
             deployment,
             f"--namespace={ADDONS_NAMESPACE}",
-            "--timeout=600s",
+            "--timeout=300s",
             context=cluster,
         )
 
@@ -89,7 +89,7 @@ def wait_for_hub(hub):
                 "status",
                 deployment,
                 f"--namespace={namespace}",
-                "--timeout=600s",
+                "--timeout=300s",
                 context=hub,
             )
 

--- a/test/addons/ocm-cluster/test
+++ b/test/addons/ocm-cluster/test
@@ -21,7 +21,7 @@ def wait_for_work(cluster, hub):
         "manifestwork/example-manifestwork",
         "--for=condition=applied",
         f"--namespace={cluster}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=hub,
     )
 
@@ -32,7 +32,7 @@ def wait_for_deployment(cluster, hub):
         "manifestwork/example-manifestwork",
         "--for=condition=available",
         f"--namespace={cluster}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=hub,
     )
 
@@ -40,7 +40,7 @@ def wait_for_deployment(cluster, hub):
     kubectl.wait(
         "deploy/example-deployment",
         "--for=condition=available",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
 
@@ -56,7 +56,7 @@ def wait_for_delete_work(cluster, hub):
         "manifestwork/example-manifestwork",
         "--for=delete",
         f"--namespace={cluster}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=hub,
     )
 
@@ -66,7 +66,7 @@ def wait_for_delete_deployment(cluster):
     kubectl.wait(
         "deploy/example-deployment",
         "--for=delete",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
 

--- a/test/addons/ocm-controller/start
+++ b/test/addons/ocm-controller/start
@@ -23,7 +23,7 @@ def wait(cluster):
         "status",
         "deploy/ocm-controller",
         "--namespace=open-cluster-management",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/ocm-hub/start
+++ b/test/addons/ocm-hub/start
@@ -69,7 +69,7 @@ def wait(cluster):
                 "status",
                 deployment,
                 f"--namespace={ns}",
-                "--timeout=600s",
+                "--timeout=300s",
                 context=cluster,
             )
 

--- a/test/addons/olm/start
+++ b/test/addons/olm/start
@@ -60,7 +60,7 @@ def wait(cluster):
         "csv/packageserver",
         f"--namespace={NAMESPACE}",
         "--for=jsonpath={.status.phase}=Succeeded",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -87,7 +87,8 @@ def wait_until_pool_mirroring_is_healthy(cluster):
         POOL_NAME,
         "--for=jsonpath={.status.mirroringStatus.summary.daemon_health}=OK",
         "--namespace=rook-ceph",
-        "--timeout=300s",
+        # We had random timeouts with 300s.
+        "--timeout=600s",
         context=cluster,
     )
 

--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -87,7 +87,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
         POOL_NAME,
         "--for=jsonpath={.status.mirroringStatus.summary.daemon_health}=OK",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 
@@ -97,7 +97,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
         POOL_NAME,
         "--for=jsonpath={.status.mirroringStatus.summary.health}=OK",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 
@@ -107,7 +107,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
         POOL_NAME,
         "--for=jsonpath={.status.mirroringStatus.summary.image_health}=OK",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/rbd-mirror/test
+++ b/test/addons/rbd-mirror/test
@@ -67,7 +67,7 @@ def test_volume_replication(primary, secondary):
         f"pvc/{PVC_NAME}",
         "--for=jsonpath={.status.phase}=Bound",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=primary,
     )
 
@@ -83,7 +83,7 @@ def test_volume_replication(primary, secondary):
         "volumereplication/vr-sample",
         "--for=condition=Completed",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=primary,
     )
 
@@ -92,7 +92,7 @@ def test_volume_replication(primary, secondary):
         "volumereplication/vr-sample",
         "--for=jsonpath={.status.state}=Primary",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=primary,
     )
 

--- a/test/addons/rook-cluster/start
+++ b/test/addons/rook-cluster/start
@@ -35,7 +35,7 @@ def wait(cluster):
         "cephcluster/my-cluster",
         "--for=jsonpath={.status.phase}=Ready",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/rook-cluster/start
+++ b/test/addons/rook-cluster/start
@@ -13,6 +13,10 @@ from drenv import kubectl
 VERSION = "release-1.13"
 BASE_URL = f"https://raw.githubusercontent.com/rook/rook/{VERSION}/deploy/examples"
 
+# The ceph, and ceph-csi iamges are very large (500m each), using larger
+# timeout to avoid timeouts with flaky network.
+TIMEOUT = 600
+
 
 def deploy(cluster):
     print("Deploying rook ceph cluster")
@@ -35,7 +39,7 @@ def wait(cluster):
         "cephcluster/my-cluster",
         "--for=jsonpath={.status.phase}=Ready",
         "--namespace=rook-ceph",
-        "--timeout=300s",
+        f"--timeout={TIMEOUT}s",
         context=cluster,
     )
 

--- a/test/addons/rook-operator/start
+++ b/test/addons/rook-operator/start
@@ -29,7 +29,8 @@ def wait(cluster):
         "status",
         "deploy/rook-ceph-operator",
         "--namespace=rook-ceph",
-        "--timeout=300s",
+        # We had random timeout with 300s.
+        "--timeout=600s",
         context=cluster,
     )
 

--- a/test/addons/rook-operator/start
+++ b/test/addons/rook-operator/start
@@ -29,7 +29,7 @@ def wait(cluster):
         "status",
         "deploy/rook-ceph-operator",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 
@@ -39,7 +39,7 @@ def wait(cluster):
         "--for=jsonpath={.status.phase}=Running",
         "--namespace=rook-ceph",
         "--selector=app=rook-ceph-operator",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/rook-pool/start
+++ b/test/addons/rook-pool/start
@@ -32,7 +32,7 @@ def wait(cluster):
         "cephblockpool/replicapool",
         "--for=jsonpath={.status.phase}=Ready",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 
@@ -41,7 +41,7 @@ def wait(cluster):
         "cephblockpool/replicapool",
         "--for=jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}=pool-peer-token-replicapool",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/rook-toolbox/start
+++ b/test/addons/rook-toolbox/start
@@ -24,7 +24,7 @@ def wait(cluster):
         "status",
         "deploy/rook-ceph-tools",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/submariner/start
+++ b/test/addons/submariner/start
@@ -79,7 +79,7 @@ def wait_for_deployments(cluster, names, namespace):
             "status",
             deployment,
             f"--namespace={namespace}",
-            "--timeout=600s",
+            "--timeout=180s",
             context=cluster,
         )
 

--- a/test/addons/submariner/test
+++ b/test/addons/submariner/test
@@ -98,7 +98,7 @@ def wait_for_service(cluster, namespace):
         f"deploy/{SERVICE}",
         "--for=condition=Available",
         f"--namespace={namespace}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
 
@@ -109,7 +109,7 @@ def wait_for_pod(cluster, namespace):
         "pod/test",
         "--for=condition=Ready",
         f"--namespace={namespace}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
 
@@ -130,7 +130,7 @@ def wait_for_service_export(cluster, namespace):
         f"serviceexports/{SERVICE}",
         "--for=condition=Ready",
         f"--namespace={namespace}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
     exports = kubectl.describe(

--- a/test/addons/submariner/test
+++ b/test/addons/submariner/test
@@ -162,14 +162,16 @@ def service_address(namespace):
     return f"{SERVICE}.{namespace}.svc.clusterset.local"
 
 
-def wait_for_dns(cluster, namespace):
+def wait_for_dns(cluster, namespace, timeout=240):
     """
     Unfortunatley even when we wait for eveything, DNS lookup can fail for more
     than 60 seconds after deploying submariner on a new cluster. After the
     initial DNS always succceeds on the first try.
+
+    We see random failures with 120 seconds timeout, trying 240.
     """
     start = time.monotonic()
-    deadline = start + 120
+    deadline = start + timeout
     dns_name = service_address(namespace)
     delay = 1
 

--- a/test/addons/submariner/test
+++ b/test/addons/submariner/test
@@ -98,7 +98,7 @@ def wait_for_service(cluster, namespace):
         f"deploy/{SERVICE}",
         "--for=condition=Available",
         f"--namespace={namespace}",
-        "--timeout=120s",
+        "--timeout=300s",
         context=cluster,
     )
 
@@ -109,7 +109,7 @@ def wait_for_pod(cluster, namespace):
         "pod/test",
         "--for=condition=Ready",
         f"--namespace={namespace}",
-        "--timeout=120s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/velero/test
+++ b/test/addons/velero/test
@@ -24,7 +24,7 @@ def test(cluster):
         "status",
         "deploy/nginx-deployment",
         "--namespace=nginx-example",
-        "--timeout=600s",
+        "--timeout=180s",
         context=cluster,
     )
 
@@ -47,7 +47,7 @@ def test(cluster):
         "status",
         "deploy/nginx-deployment",
         "--namespace=nginx-example",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
 

--- a/test/addons/volsync/start
+++ b/test/addons/volsync/start
@@ -50,7 +50,7 @@ def wait_for_deployment(cluster):
         "status",
         f"deploy/{DEPLOYMENT}",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/volsync/test
+++ b/test/addons/volsync/test
@@ -34,7 +34,7 @@ def wait_for_application(cluster):
         "status",
         f"deploy/{DEPLOY}",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
 
@@ -47,7 +47,7 @@ def wait_for_replication_destination(cluster):
         "replicationdestination/busybox-dst",
         "--for=condition=Synchronizing=True",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
 
@@ -84,7 +84,7 @@ def setup_replication_service(cluster1, cluster2):
         f"serviceexports/{VOLSYNC_SERVICE}",
         "--for=condition=Ready",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster2,
     )
 
@@ -119,7 +119,7 @@ def run_replication(cluster):
         "replicationsource/busybox-src",
         "--for=jsonpath={.status.lastManualSync}=replication-1",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
     out = kubectl.get(

--- a/test/drenv/cluster.py
+++ b/test/drenv/cluster.py
@@ -28,7 +28,7 @@ def status(name):
     return READY
 
 
-def wait_until_ready(name, timeout=300):
+def wait_until_ready(name, timeout=600):
     """
     Wait until a cluster is ready.
 

--- a/test/envs/kubevirt.yaml
+++ b/test/envs/kubevirt.yaml
@@ -14,6 +14,7 @@ profiles:
           device_ownership_from_security_context: true
     network: $network
     cni: flannel
+    cpus: 4
     memory: "8g"
     addons:
       - csi-hostpath-driver

--- a/test/envs/regional-dr-kubevirt.yaml
+++ b/test/envs/regional-dr-kubevirt.yaml
@@ -22,7 +22,7 @@ templates:
           device_ownership_from_security_context: true
     network: "$network"
     cni: flannel
-    cpus: 3
+    cpus: 4
     memory: "8g"
     extra_disks: 1
     disk_size: "50g"
@@ -50,6 +50,7 @@ templates:
     container_runtime: containerd
     network: "$network"
     cni: flannel
+    cpus: 2
     memory: "4g"
     workers:
       - addons:

--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -17,6 +17,7 @@ templates:
     driver: "$vm"
     container_runtime: containerd
     network: "$network"
+    cpus: 4
     memory: "6g"
     extra_disks: 1
     disk_size: "50g"
@@ -44,6 +45,7 @@ templates:
     driver: "$vm"
     container_runtime: containerd
     network: "$network"
+    cpus: 2
     memory: "4g"
     workers:
       - addons:


### PR DESCRIPTION
Optimize drenv for faster and more reliable builds in the CI lab.

- Increase number of cpus in the managed clusters
- Minimize timeouts for faster failures, so retries will start faster
- Increase specific timeouts that proved to be too short, preventing slow retry.
- Fix the way we wait for managedcluster after joining a managed cluster to the hub.

Tested on bare metal machine in the CI lab on libvirt vm on our new bare metal server.

Tested on top of:

- #1267 
- #1303
- #1302 
- #1301 
- #1300
- #1267 
- #1299 
- #1291
- #1319
- #1320
- #1321

Last runs stats:

```
$ stress-test/run -r 50 envs/regional-dr.yaml 
[50/50] 50 passed, 0 failed, rate: 100.0%, time/run: 547.6s
```

Fixes #1295 
Fixes #1296 