### PR TITLE
Improve error reporting when a cluster fails

### DIFF
--- a/test/addons/error/start
+++ b/test/addons/error/start
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import time
+
+time.sleep(1)
+sys.exit("Fake error")

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -120,8 +120,6 @@ def execute(func, profiles, delay=0, max_workers=None, **options):
         def func(profile, **options):
 
     """
-    failed = False
-
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as e:
         futures = {}
 
@@ -134,10 +132,10 @@ def execute(func, profiles, delay=0, max_workers=None, **options):
                 f.result()
             except Exception:
                 logging.exception("[%s] Cluster failed", futures[f])
-                failed = True
-
-    if failed:
-        sys.exit(1)
+                # This is not the great way to terminate since we may leave
+                # running addons scripts, but it is better than running for
+                # many minutes after a failure.
+                os._exit(1)
 
 
 def start_cluster(profile, hooks=(), args=None, **options):

--- a/test/envs/error.yaml
+++ b/test/envs/error.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Environment for testing drenv error handling.
+---
+name: error
+profiles:
+  - name: cluster
+    driver: $vm
+    container_runtime: containerd
+    memory: 2g
+    workers:
+      - addons:
+          - name: error
+      - addons:
+          - name: example


### PR DESCRIPTION
Instead of running for minutes after an error until all other cluster complete, exit on the first error.

On the CI no cleanup is not an issue, since the github runner cleans up child processes. Here is the output from the cleanup job:

```
Cleaning up orphan processes
Terminate orphan process: pid (118311) (python3)
Terminate orphan process: pid (118588) (kubectl)
```

But when running locally nobody does any cleanup.

Status:
- This is an ugly hack, need little rework
- Need a cleaner solution when we have more time