### PR TITLE
Introduce addons cache

### DIFF
--- a/test/addons/ocm-controller/fetch
+++ b/test/addons/ocm-controller/fetch
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from drenv import cache
+
+os.chdir(os.path.dirname(__file__))
+path = cache.path("addons/ocm-controller.yaml")
+cache.fetch(".", path)

--- a/test/addons/ocm-controller/start
+++ b/test/addons/ocm-controller/start
@@ -7,11 +7,14 @@ import os
 import sys
 
 from drenv import kubectl
+from drenv import cache
 
 
 def deploy(cluster):
     print("Deploying ocm controller")
-    kubectl.apply("--kustomize", "./", context=cluster)
+    path = cache.path("addons/ocm-controller.yaml")
+    cache.fetch(".", path)
+    kubectl.apply("--filename", path, context=cluster)
 
 
 def wait(cluster):

--- a/test/drenv/cache.py
+++ b/test/drenv/cache.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+
+from . import commands
+
+
+def path(key):
+    cache_home = os.environ.get("XDG_CACHE_HOME", ".cache")
+    return os.path.expanduser(f"~/{cache_home}/drenv/{key}")
+
+
+def fetch(kustomization_dir, dest, log=print):
+    """
+    Build kustomization and store the output yaml in dest.
+
+    TODO: retry on errors.
+    """
+    if not os.path.exists(dest):
+        log(f"Fetching {dest}")
+        dest_dir = os.path.dirname(dest)
+        os.makedirs(dest_dir, exist_ok=True)
+        tmp = dest + ".tmp"
+        try:
+            _build_kustomization(kustomization_dir, tmp)
+            os.rename(tmp, dest)
+        finally:
+            _silent_remove(tmp)
+
+
+def _build_kustomization(kustomization_dir, dest):
+    with open(dest, "w") as f:
+        args = ["kustomize", "build", kustomization_dir]
+        try:
+            cp = subprocess.run(
+                args,
+                stdout=f,
+                stderr=subprocess.PIPE,
+            )
+        except OSError as e:
+            os.unlink(dest)
+            raise commands.Error(args, f"Could not execute: {e}").with_exception(e)
+
+        if cp.returncode != 0:
+            error = cp.stderr.decode(errors="replace")
+            raise commands.Error(args, error, exitcode=cp.returncode)
+
+        os.fsync(f.fileno())
+
+
+def _silent_remove(path):
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass


### PR DESCRIPTION
We see too many random failures on the lab running the e2e job. The most common error is a git fetch error when applying ocm-controller kustomization. Search shows that there is no way to avoid this error.

This change introduces a cache for kustomization directories, keeping the output of `kustomize build kustomization_dir` locally, and applying the cached resource when starting the addon.

Changes:

- The start hook can now fetch the cahe and apply the cached resource. See ocm-controller for example.

- Add new "fetch" hook, called using the `drenv fetch` command. This can be used to create the cache for all addons implementing this hook periodically (e.g in a cron daily job). See ocm-controller fetch hook for example.

- Add new "clear" command to clear the cache. There is no automatic invalidation based on cache age.

To cache builds itself automatically, but it has to be invalidated manually. To keep the cache fresh, you can run `drenv clear` and `drenv fetch` periodically from a cron job.

The following examples demonstrate how to cache works.

Clearing the cache:

    $ drenv clear envs/regional-dr.yaml
    2024-03-12 22:51:37,001 INFO    [rdr] Clearing cache
    2024-03-12 22:51:37,002 INFO    [rdr] Fetching finishied in 0.00 seconds

Pre-fetching all addons resources implementing the fetch hook:

    $ drenv fetch envs/regional-dr.yaml -v
    2024-03-12 22:51:48,884 INFO    [rdr] Fetching
    2024-03-12 22:51:48,892 INFO    [rdr] Running addons/ocm-controller/fetch
    2024-03-12 22:51:49,041 DEBUG   [rdr] Fetching /home/github/.cache/drenv/addons/ocm-controller.yaml
    2024-03-12 22:52:22,202 INFO    [rdr] addons/ocm-controller/fetch completed in 33.31 seconds
    2024-03-12 22:52:22,203 INFO    [rdr] Fetching finishied in 33.32 seconds

Fetching again does nothing since the resource already exists:

    $ drenv fetch envs/regional-dr.yaml -v
    2024-03-12 22:52:27,423 INFO    [rdr] Fetching
    2024-03-12 22:52:27,427 INFO    [rdr] Running addons/ocm-controller/fetch
    2024-03-12 22:52:27,591 INFO    [rdr] addons/ocm-controller/fetch completed in 0.16 seconds
    2024-03-12 22:52:27,592 INFO    [rdr] Fetching finishied in 0.17 seconds

Staring an addon uses the cached resources without accessing the network:

    $ addons/ocm-controller/start hub
    Deploying ocm controller
    customresourcedefinition.apiextensions.k8s.io/clusterclaims.hive.openshift.io configured
    customresourcedefinition.apiextensions.k8s.io/clusterdeployments.hive.openshift.io configured
    customresourcedefinition.apiextensions.k8s.io/clusterpools.hive.openshift.io configured
    customresourcedefinition.apiextensions.k8s.io/managedclusteractions.action.open-cluster-management.io configured
    customresourcedefinition.apiextensions.k8s.io/managedclusterimageregistries.imageregistry.open-cluster-management.io configured
    customresourcedefinition.apiextensions.k8s.io/managedclusterinfos.internal.open-cluster-management.io configured
    customresourcedefinition.apiextensions.k8s.io/managedclusterviews.view.open-cluster-management.io configured
    serviceaccount/ocm-foundation-sa unchanged
    clusterrole.rbac.authorization.k8s.io/managed-cluster-workmgr unchanged
    clusterrole.rbac.authorization.k8s.io/open-cluster-management:ocm:foundation unchanged
    clusterrolebinding.rbac.authorization.k8s.io/open-cluster-management:ocm:foundation unchanged
    deployment.apps/ocm-controller unchanged
    clustermanagementaddon.addon.open-cluster-management.io/work-manager unchanged
    Waiting for ocm controller rollout
    deployment "ocm-controller" successfully rolled out

Drop the cache:

    $ drenv clear envs/regional-dr.yaml -v
    2024-03-12 22:52:50,418 INFO    [rdr] Clearing cache
    2024-03-12 22:52:50,419 INFO    [rdr] Fetching finishied in 0.00 seconds

Staring an addon fetch the resources again transparently:

    $ addons/ocm-controller/start hub
    Deploying ocm controller
    Fetching /home/github/.cache/drenv/addons/ocm-controller.yaml
    customresourcedefinition.apiextensions.k8s.io/clusterclaims.hive.openshift.io configured
    customresourcedefinition.apiextensions.k8s.io/clusterdeployments.hive.openshift.io configured
    customresourcedefinition.apiextensions.k8s.io/clusterpools.hive.openshift.io configured
    customresourcedefinition.apiextensions.k8s.io/managedclusteractions.action.open-cluster-management.io configured
    customresourcedefinition.apiextensions.k8s.io/managedclusterimageregistries.imageregistry.open-cluster-management.io configured
    customresourcedefinition.apiextensions.k8s.io/managedclusterinfos.internal.open-cluster-management.io configured
    customresourcedefinition.apiextensions.k8s.io/managedclusterviews.view.open-cluster-management.io configured
    serviceaccount/ocm-foundation-sa unchanged
    clusterrole.rbac.authorization.k8s.io/managed-cluster-workmgr unchanged
    clusterrole.rbac.authorization.k8s.io/open-cluster-management:ocm:foundation unchanged
    clusterrolebinding.rbac.authorization.k8s.io/open-cluster-management:ocm:foundation unchanged
    deployment.apps/ocm-controller unchanged
    clustermanagementaddon.addon.open-cluster-management.io/work-manager unchanged
    Waiting for ocm controller rollout
    deployment "ocm-controller" successfully rolled out