### PR TITLE
Simplify the drpc status update logic

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -69,7 +69,7 @@ func (d *DRPCInstance) startProcessing() bool {
 	done, processingErr := d.processPlacement()
 
 	if d.shouldUpdateStatus() || d.statusUpdateTimeElapsed() {
-		if err := d.reconciler.updateDRPCStatus(d.ctx, d.instance, d.userPlacement, d.log); err != nil {
+		if err := d.updateDRPCStatus(); err != nil {
 			errMsg := fmt.Sprintf("error from update DRPC status: %v", err)
 			if processingErr != nil {
 				errMsg += fmt.Sprintf(", error from process placement: %v", processingErr)


### PR DESCRIPTION
We were storing savedInstanceStatus in two places; DRPCInstance and DRPlacementControlReconciler.

In this PR, we move the creation of the DRPCInstance earlier in the Reconcile() so that we can use it to store the savedInstanceStatus in it.
    
This is also more correct because the DRPlacementControlReconciler is a long lived object and we shouldn't store information related to a single reconcile there.
    