### PR TITLE
Retry drenv start

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -42,10 +42,14 @@ jobs:
       run: test/scripts/setup-libvirt
 
     - name: Start clusters
-      working-directory: test
-      run: |
-        drenv start --max-workers ${{ env.MAX_WORKERS }} --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
-        cp ~/.config/drenv/${{ env.NAME_PREFIX }}rdr/config.yaml ../e2e/config.yaml
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 20
+        max_attempts: 3
+        command: |
+          cd test
+          drenv start --max-workers ${{ env.MAX_WORKERS }} --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
+          cp ~/.config/drenv/${{ env.NAME_PREFIX }}rdr/config.yaml ../e2e/config.yaml
 
     - name: Deploy ramen
       run: |

--- a/test/addons/error/start
+++ b/test/addons/error/start
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import time
+
+time.sleep(1)
+sys.exit("Fake error")

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -120,8 +120,6 @@ def execute(func, profiles, delay=0, max_workers=None, **options):
         def func(profile, **options):
 
     """
-    failed = False
-
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as e:
         futures = {}
 
@@ -134,10 +132,10 @@ def execute(func, profiles, delay=0, max_workers=None, **options):
                 f.result()
             except Exception:
                 logging.exception("[%s] Cluster failed", futures[f])
-                failed = True
-
-    if failed:
-        sys.exit(1)
+                # This is not the great way to terminate since we may leave
+                # running addons scripts, but it is better than running for
+                # many minutes after a failure.
+                os._exit(1)
 
 
 def start_cluster(profile, hooks=(), args=None, **options):

--- a/test/envs/error.yaml
+++ b/test/envs/error.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Environment for testing drenv error handling.
+---
+name: error
+profiles:
+  - name: cluster
+    driver: $vm
+    container_runtime: containerd
+    memory: 2g
+    workers:
+      - addons:
+          - name: error
+      - addons:
+          - name: example


### PR DESCRIPTION
We are dealing with random in the lab running the e2e job. Until we fix all the known and unknown issues, we can retry the `drenv start` command to recover from failures. Staring a partly built environment is much quicker so this should increase our success rate to acceptable level.

The build shows that the first attempt failed in 18 minutes, and the second attempt succeeded in 12 minutes. The entire step completed in 30 minutes, which is horrible, but better than failing and requiring manual re-run.

Builds:
- https://github.com/RamenDR/ramen/actions/runs/8265462325/attempts/1 OK
- https://github.com/RamenDR/ramen/actions/runs/8265462325/attempts/2 OK 

Both builds would fail without the retry.

Based on #1238 since with current code failures are too slow to test this.