### PR TITLE
Streamline building the ramen container image in e2e

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,9 +30,6 @@ jobs:
     - name: Install ramenctl
       run: pip install -e ramenctl
 
-    - name: Build ramen-operator container
-      run: make docker-build
-
     - name: Delete clusters
       if: ${{ always() }}
       working-directory: test
@@ -49,6 +46,9 @@ jobs:
         command: |
           cd test
           drenv start --max-workers ${{ env.MAX_WORKERS }} --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
+
+    - name: Build ramen-operator container
+      run: make docker-build
 
     - name: Deploy ramen
       run: ramenctl deploy --name-prefix ${{ env.NAME_PREFIX }} test/envs/regional-dr.yaml

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ test-drenv: ## Run drenv tests.
 test-ramenctl: ## Run ramenctl tests.
 	$(MAKE) -C ramenctl
 
-e2e-rdr: generate manifests docker-build ## Run rdr-e2e tests.
+e2e-rdr: generate manifests ## Run rdr-e2e tests.
 	./e2e/rdr-e2e.sh
 
 coverage:


### PR DESCRIPTION
- Build the container just before we need it
- Remove pointless rebuild in make e2e-rdr