### PR TITLE
The fields in DRPolicy are required in now

### DIFF
--- a/ramenctl/ramenctl/resources/regional-dr/dr-policy.yaml
+++ b/ramenctl/ramenctl/resources/regional-dr/dr-policy.yaml
@@ -10,3 +10,5 @@ spec:
   - $cluster1
   - $cluster2
   schedulingInterval: 1m
+  replicationClassSelector: {}
+  volumeSnapshotClassSelector: {}


### PR DESCRIPTION
The replicationClassSelector and volumeSnapshotClassSelector fields are now made required and immutable since CEL validation was introduced. Therefore, we use these two fields when we have two or more Replication/Snapshot classes that match the driver and need to choose between the two by adding a selector. In this deployment, however, we have only one class, and there is no need to choose the driver.