### PR TITLE
drpc: Get the ramen config earlier in the reconcile cycle

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -59,6 +59,7 @@ type DRPCInstance struct {
 	userPlacement        client.Object
 	vrgs                 map[string]*rmn.VolumeReplicationGroup
 	vrgNamespace         string
+	ramenConfig          *rmn.RamenConfig
 	mwu                  rmnutil.MWUtil
 }
 

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -722,10 +722,14 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// then the DRPC should be deleted as well. The least we should do here is to clean up DPRC.
 		err := r.processDeletion(ctx, drpc, placementObj, logger)
 		if err != nil {
-			// update drpc progression only on err
 			logger.Info(fmt.Sprintf("Error in deleting DRPC: (%v)", err))
 
-			return ctrl.Result{}, r.setProgressionAndUpdate(ctx, drpc, rmn.ProgressionDeleting)
+			statusErr := r.setProgressionAndUpdate(ctx, drpc, rmn.ProgressionDeleting)
+			if statusErr != nil {
+				err = fmt.Errorf("drpc deletion failed: %w and status update failed: %w", err, statusErr)
+			}
+
+			return ctrl.Result{}, err
 		}
 
 		return ctrl.Result{}, nil


### PR DESCRIPTION
We are going to add new options in the ramen config that determine how we interpret the placement object. Therefore, we get the ramen config earlier in the reconcile function.

Also, we will have to inspect the config in the later part of the reconcile logic so store it in the drpc instance.