### PR TITLE
drenv: Add kustomize requirement to docs and check-drenv-prereqs.sh

### DIFF
--- a/hack/check-drenv-prereqs.sh
+++ b/hack/check-drenv-prereqs.sh
@@ -7,7 +7,7 @@ if ! groups "$USER" | grep -qw libvirt; then
 fi
 
 commands=("minikube" "kubectl" "clusteradm" "subctl" "velero" "helm" "virtctl"
-"virt-host-validate")
+"virt-host-validate" "kustomize")
 
 for cmd in "${commands[@]}"; do
   if ! command -v "$cmd" &> /dev/null; then

--- a/test/README.md
+++ b/test/README.md
@@ -63,6 +63,11 @@ environment.
    for the details.
    Tested with version v1.0.1.
 
+1. Install the `kustomize` tool. See
+   [kustomize installation](https://kubectl.docs.kubernetes.io/installation/kustomize/)
+   for the details.
+   Tested with version v5.3.0.
+
 ### Testing that drenv is healthy
 
 Run this script to make sure `drenv` works:


### PR DESCRIPTION
After #1239 we need kustomize for drenv to work. Adding the doc and hack script requirements.