### PR TITLE
Fix reporting VRG status.State as Secondary across VR and Volsync

### DIFF
--- a/api/v1alpha1/drpolicy_types.go
+++ b/api/v1alpha1/drpolicy_types.go
@@ -11,8 +11,6 @@ import (
 // +kubebuilder:validation:XValidation:rule="has(oldSelf.replicationClassSelector) == has(self.replicationClassSelector)", message="replicationClassSelector is immutable"
 // +kubebuilder:validation:XValidation:rule="has(oldSelf.volumeSnapshotClassSelector) == has(self.volumeSnapshotClassSelector)", message="volumeSnapshotClassSelector is immutable"
 type DRPolicySpec struct {
-	// Important: Run "make" to regenerate code after modifying this file
-
 	// scheduling Interval for replicating Persistent Volume
 	// data to a peer cluster. Interval is typically in the
 	// form <num><m,h,d>. Here <num> is a number, 'm' means
@@ -46,8 +44,6 @@ type DRPolicySpec struct {
 }
 
 // DRPolicyStatus defines the observed state of DRPolicy
-// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-// Important: Run "make" to regenerate code after modifying this file
 type DRPolicyStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/api/v1alpha1/ramenconfig_types.go
+++ b/api/v1alpha1/ramenconfig_types.go
@@ -9,9 +9,6 @@ import (
 	cfg "sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // ControllerType is the type of controller to run
 // +kubebuilder:validation:Enum=dr-hub;dr-cluster
 type ControllerType string

--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -10,8 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Important: Run "make" to regenerate code after modifying this file
-
 // ReplicationState represents the replication operations to be performed on the volume
 type ReplicationState string
 
@@ -137,8 +135,6 @@ type RecipeRef struct {
 }
 
 const KubeObjectProtectionCaptureIntervalDefault = 5 * time.Minute
-
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // VolumeReplicationGroup (VRG) spec declares the desired schedule for data
 // replication and replication state of all PVCs identified via the given
@@ -303,7 +299,6 @@ type KubeObjectProtectionStatus struct {
 }
 
 // VolumeReplicationGroupStatus defines the observed state of VolumeReplicationGroup
-// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 type VolumeReplicationGroupStatus struct {
 	State State `json:"state,omitempty"`
 

--- a/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
@@ -171,10 +171,7 @@ spec:
             - message: volumeSnapshotClassSelector is immutable
               rule: has(oldSelf.volumeSnapshotClassSelector) == has(self.volumeSnapshotClassSelector)
           status:
-            description: |-
-              DRPolicyStatus defines the observed state of DRPolicy
-              INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-              Important: Run "make" to regenerate code after modifying this file
+            description: DRPolicyStatus defines the observed state of DRPolicy
             properties:
               conditions:
                 items:

--- a/config/crd/bases/ramendr.openshift.io_protectedvolumereplicationgrouplists.yaml
+++ b/config/crd/bases/ramendr.openshift.io_protectedvolumereplicationgrouplists.yaml
@@ -626,9 +626,8 @@ spec:
                       - s3Profiles
                       type: object
                     status:
-                      description: |-
-                        VolumeReplicationGroupStatus defines the observed state of VolumeReplicationGroup
-                        INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                      description: VolumeReplicationGroupStatus defines the observed
+                        state of VolumeReplicationGroup
                       properties:
                         conditions:
                           description: Conditions are the list of VRG's summary conditions

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -566,9 +566,8 @@ spec:
             - s3Profiles
             type: object
           status:
-            description: |-
-              VolumeReplicationGroupStatus defines the observed state of VolumeReplicationGroup
-              INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+            description: VolumeReplicationGroupStatus defines the observed state of
+              VolumeReplicationGroup
             properties:
               conditions:
                 description: Conditions are the list of VRG's summary conditions and

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -1857,7 +1857,7 @@ func (d *DRPCInstance) ensureVRGIsSecondaryOnCluster(clusterName string) bool {
 		return false
 	}
 
-	if vrg.Status.State != rmn.SecondaryState {
+	if vrg.Status.State != rmn.SecondaryState || vrg.Status.ObservedGeneration != vrg.Generation {
 		d.log.Info(fmt.Sprintf("VRG on %s has not transitioned to secondary yet. Spec-State/Status-State %s/%s",
 			clusterName, vrg.Spec.ReplicationState, vrg.Status.State))
 

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1735,6 +1735,8 @@ func (r *DRPlacementControlReconciler) updateDRPCStatus(
 		}
 	}
 
+	// TODO: This is too generic, why are all conditions reported for the current generation?
+	// Each condition should choose for itself, no?
 	for i, condition := range drpc.Status.Conditions {
 		if condition.ObservedGeneration != drpc.Generation {
 			drpc.Status.Conditions[i].ObservedGeneration = drpc.Generation

--- a/controllers/protectedvolumereplicationgrouplist_controller_test.go
+++ b/controllers/protectedvolumereplicationgrouplist_controller_test.go
@@ -128,6 +128,12 @@ func vrgStatusStateUpdate(vrgS3, vrgK8s *ramen.VolumeReplicationGroup) {
 		vrgS3.ResourceVersion = vrgK8s.ResourceVersion
 		vrgS3.Status.LastUpdateTime = vrgK8s.Status.LastUpdateTime
 	}
+
+	if vrgS3.Status.State == "" && vrgK8s.Status.State == ramen.UnknownState {
+		vrgS3.Status.State = ramen.UnknownState
+		vrgS3.ResourceVersion = vrgK8s.ResourceVersion
+		vrgS3.Status.LastUpdateTime = vrgK8s.Status.LastUpdateTime
+	}
 }
 
 var _ = Describe("ProtectedVolumeReplicationGroupListController", func() {

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -50,6 +50,7 @@ const (
 
 // VRG condition reasons
 const (
+	VRGConditionReasonUnused                      = "Unused"
 	VRGConditionReasonInitializing                = "Initializing"
 	VRGConditionReasonReplicating                 = "Replicating"
 	VRGConditionReasonReplicated                  = "Replicated"
@@ -117,13 +118,14 @@ func setVRGInitialCondition(conditions *[]metav1.Condition, observedGeneration i
 
 // sets conditions when VRG as Secondary is replicating the data with Primary.
 func setVRGDataReplicatingCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
-	setStatusCondition(conditions, *newVRGDataReplicatingCondition(observedGeneration, message))
+	setStatusCondition(conditions,
+		*newVRGDataReplicatingCondition(observedGeneration, VRGConditionReasonReplicating, message))
 }
 
-func newVRGDataReplicatingCondition(observedGeneration int64, message string) *metav1.Condition {
+func newVRGDataReplicatingCondition(observedGeneration int64, reason, message string) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               VRGConditionTypeDataReady,
-		Reason:             VRGConditionReasonReplicating,
+		Reason:             reason,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionTrue,
 		Message:            message,
@@ -169,6 +171,16 @@ func newVRGAsDataProtectedCondition(observedGeneration int64, message string) *m
 	}
 }
 
+func newVRGAsDataProtectedUnusedCondition(observedGeneration int64, message string) *metav1.Condition {
+	return &metav1.Condition{
+		Type:               VRGConditionTypeDataProtected,
+		Reason:             VRGConditionReasonUnused,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	}
+}
+
 func setVRGAsDataNotProtectedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	setStatusCondition(conditions, *newVRGAsDataNotProtectedCondition(observedGeneration, message))
 }
@@ -199,13 +211,13 @@ func newVRGDataProtectionProgressCondition(observedGeneration int64, message str
 
 // sets conditions when Primary VRG data replication is established
 func setVRGAsPrimaryReadyCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
-	setStatusCondition(conditions, *newVRGAsPrimaryReadyCondition(observedGeneration, message))
+	setStatusCondition(conditions, *newVRGAsPrimaryReadyCondition(observedGeneration, VRGConditionReasonReady, message))
 }
 
-func newVRGAsPrimaryReadyCondition(observedGeneration int64, message string) *metav1.Condition {
+func newVRGAsPrimaryReadyCondition(observedGeneration int64, reason, message string) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               VRGConditionTypeDataReady,
-		Reason:             VRGConditionReasonReady,
+		Reason:             reason,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionTrue,
 		Message:            message,
@@ -293,6 +305,16 @@ func newVRGClusterDataProtectedCondition(observedGeneration int64, message strin
 	}
 }
 
+func newVRGClusterDataProtectedUnusedCondition(observedGeneration int64, message string) *metav1.Condition {
+	return &metav1.Condition{
+		Type:               VRGConditionTypeClusterDataProtected,
+		Reason:             VRGConditionReasonUnused,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	}
+}
+
 // sets conditions when PV cluster data is being protected
 func setVRGClusterDataProtectingCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	setStatusCondition(conditions, *newVRGClusterDataProtectingCondition(observedGeneration, message))
@@ -368,6 +390,7 @@ func setStatusCondition(existingConditions *[]metav1.Condition, newCondition met
 
 	existingCondition.Reason = newCondition.Reason
 	existingCondition.Message = newCondition.Message
+	// TODO: Why not update lastTranTime if the above change?
 
 	if existingCondition.ObservedGeneration != newCondition.ObservedGeneration {
 		existingCondition.ObservedGeneration = newCondition.ObservedGeneration

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -271,7 +271,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			vrgTestBoundPV.promoteVolReps()
-			vrgTestBoundPV.verifyVRGStatusExpectation(true)
+			vrgTestBoundPV.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 		})
 		var pvcNamespacedNamesActual [pvcCount]types.NamespacedName
 		var pvcNamespacedNamesUnqualified, pvcNamespacedNamesQualified []types.NamespacedName
@@ -541,7 +541,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			vrgS3UploadTestCase.promoteVolReps()
-			vrgS3UploadTestCase.verifyVRGStatusExpectation(true)
+			vrgS3UploadTestCase.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 			vrgS3UploadTestCase.verifyCachedUploadError()
 		})
 		Specify("set VRG's S3 profile names to empty", func() {
@@ -575,7 +575,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			vrgVRDeleteEnsureTestCase.promoteVolReps()
-			vrgVRDeleteEnsureTestCase.verifyVRGStatusExpectation(true)
+			vrgVRDeleteEnsureTestCase.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 		})
 		It("ensures orderly cleanup post VolumeReplication deletion", func() {
 			By("Protecting the VolumeReplication resources from deletion")
@@ -647,9 +647,9 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 				v := vrgTestCases[c]
 				v.promoteVolReps()
 				if c != 0 {
-					v.verifyVRGStatusExpectation(true)
+					v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 				} else {
-					v.verifyVRGStatusExpectation(false)
+					v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonUnused)
 				}
 			}
 		})
@@ -680,7 +680,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			vrgEmptySC = newVRGTestCaseCreateAndStart(1, createTestTemplate, true, false)
 		})
 		It("waits for VRG status to match", func() {
-			vrgEmptySC.verifyVRGStatusExpectation(false)
+			vrgEmptySC.verifyVRGStatusExpectation(false, "")
 		})
 		It("cleans up after testing", func() {
 			vrgEmptySC.cleanupStatusAbsent()
@@ -707,7 +707,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			vrgMissingSC = newVRGTestCaseCreateAndStart(1, createTestTemplate, true, false)
 		})
 		It("waits for VRG status to match", func() {
-			vrgMissingSC.verifyVRGStatusExpectation(false)
+			vrgMissingSC.verifyVRGStatusExpectation(false, "")
 		})
 		It("cleans up after testing", func() {
 			vrgMissingSC.cleanupStatusAbsent()
@@ -767,9 +767,9 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 				v := vrgTests[c]
 				v.promoteVolReps()
 				if c != 0 {
-					v.verifyVRGStatusExpectation(true)
+					v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 				} else {
-					v.verifyVRGStatusExpectation(false)
+					v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonUnused)
 				}
 			}
 		})
@@ -816,7 +816,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			v.promoteVolReps()
-			v.verifyVRGStatusExpectation(true)
+			v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 		})
 		It("protects kube objects", func() { kubeObjectProtectionValidate(vrgStatusTests) })
 		It("cleans up after testing", func() {
@@ -851,7 +851,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		It("waits for VRG status to match", func() {
 			v := vrgStatus2Tests[0]
 			v.promoteVolReps()
-			v.verifyVRGStatusExpectation(true)
+			v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 		})
 		It("protects kube objects", func() { kubeObjectProtectionValidate(vrgStatus2Tests) })
 		It("cleans up after testing", func() {
@@ -897,7 +897,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			v.promoteVolReps()
-			v.verifyVRGStatusExpectation(true)
+			v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 		})
 		It("protects kube objects", func() { kubeObjectProtectionValidate(vrgStatus3Tests) })
 		It("cleans up after testing", func() {
@@ -930,7 +930,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			v := vrgScheduleTests[0]
-			v.verifyVRGStatusExpectation(false)
+			v.verifyVRGStatusExpectation(false, "")
 		})
 		// It("protects kube objects", func() { kubeObjectProtectionValidate(vrgScheduleTests) })
 		It("cleans up after testing", func() {
@@ -952,7 +952,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		scProvisioner:          "manual.storage.com",
 		replicationClassLabels: map[string]string{"protection": "ramen"},
 	}
-	Context("schedule tests schedue does not match", func() {
+	Context("schedule tests schedule does not match", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
 			vrgScheduleTest2Template.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
 			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest2Template, true, true)
@@ -964,7 +964,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			v := vrgSchedule2Tests[0]
-			v.verifyVRGStatusExpectation(false)
+			v.verifyVRGStatusExpectation(false, "")
 		})
 		// It("protects kube objects", func() { kubeObjectProtectionValidate(vrgSchedule2Tests) })
 		It("cleans up after testing", func() {
@@ -998,7 +998,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			v := vrgSchedule3Tests[0]
-			v.verifyVRGStatusExpectation(false)
+			v.verifyVRGStatusExpectation(false, "")
 		})
 		// It("protects kube objects", func() { kubeObjectProtectionValidate(vrgSchedule3Tests) })
 		It("cleans up after testing", func() {
@@ -1534,7 +1534,7 @@ func (v *vrgTest) isAnyPVCProtectedByVolSync(vrg *ramendrv1alpha1.VolumeReplicat
 	return false
 }
 
-func (v *vrgTest) verifyVRGStatusExpectation(expectedStatus bool) {
+func (v *vrgTest) verifyVRGStatusExpectation(expectedStatus bool, reason string) {
 	Eventually(func() bool {
 		vrg := v.getVRG()
 		dataReadyCondition := meta.FindStatusCondition(
@@ -1548,11 +1548,9 @@ func (v *vrgTest) verifyVRGStatusExpectation(expectedStatus bool) {
 			// secondary. Validate that as well.
 			switch vrg.Spec.ReplicationState {
 			case ramendrv1alpha1.Primary:
-				return dataReadyCondition.Status == metav1.ConditionTrue && dataReadyCondition.Reason ==
-					vrgController.VRGConditionReasonReady
+				return dataReadyCondition.Status == metav1.ConditionTrue && dataReadyCondition.Reason == reason
 			case ramendrv1alpha1.Secondary:
-				return dataReadyCondition.Status == metav1.ConditionTrue && dataReadyCondition.Reason ==
-					vrgController.VRGConditionReasonReplicating
+				return dataReadyCondition.Status == metav1.ConditionTrue && dataReadyCondition.Reason == reason
 			}
 		}
 
@@ -2005,7 +2003,7 @@ func (v *vrgTest) waitForVRCountToMatch(vrCount int) {
 func (v *vrgTest) promoteVolReps() {
 	v.promoteVolRepsAndDo(func(index, count int) {
 		// VRG should not be ready until last VolRep is ready.
-		v.verifyVRGStatusExpectation(index == count-1)
+		v.verifyVRGStatusExpectation(index == count-1, vrgController.VRGConditionReasonReady)
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -100,8 +100,4 @@ require (
 // replace directives to accommodate for stolostron
 replace k8s.io/client-go v12.0.0+incompatible => k8s.io/client-go v0.29.0
 
-replace (
-	github.com/open-cluster-management-io/api => open-cluster-management.io/api v0.10.0
-	github.com/openshift/hive => github.com/openshift/hive v1.1.17-0.20220223000051-b1c8fa5853b1
-	github.com/openshift/hive/apis => github.com/openshift/hive/apis v0.0.0-20220221165319-b389a65758da
-)
+replace github.com/open-cluster-management-io/api => open-cluster-management.io/api v0.10.0


### PR DESCRIPTION
Currently we report Secondary only based on the DataReady condition.
This is fine for volsync cases where DataProtected for Secondary is a
dont-care/nil, whereas for volrep we need to ensure that we reach
full data sync before we declare Secondary status.

As DRPC checks the status.State of VRG to decide that a full sync is
achieved before rolling out the workload to the new primary, correcting
the reported state from VRG for these corner cases.

Discovered as part of code review and as part of working towards the
Protected condition.

Fixed VRG to report status.State considering required conditions.