### PR TITLE
Terminate child processes on error

### DIFF
--- a/test/addons/error/start
+++ b/test/addons/error/start
@@ -6,5 +6,9 @@
 import sys
 import time
 
-time.sleep(1)
-sys.exit("Fake error")
+duration = float(sys.argv[1])
+
+print(f"Error addon will fail in {duration} seconds")
+time.sleep(duration)
+
+sys.exit("Error addon failed")

--- a/test/addons/sleep/start
+++ b/test/addons/sleep/start
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from drenv import commands
+
+duration = sys.argv[1]
+
+print(f"Sleep addon waiting {duration} seconds")
+commands.run("sleep", duration)
+
+print("Sleep addon finished normally")

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -101,11 +101,9 @@ def cmd_start(env, args):
     if args.run_tests:
         hooks.append("test")
 
-    # Delaying `minikube start` ensures cluster start order.
     execute(
         start_cluster,
         env["profiles"],
-        delay=1,
         hooks=hooks,
         args=args,
     )
@@ -168,7 +166,7 @@ def cmd_dump(env, args):
     yaml.dump(env, sys.stdout)
 
 
-def execute(func, profiles, delay=0, max_workers=None, **options):
+def execute(func, profiles, max_workers=None, **options):
     """
     Execute func in parallel for every profile.
 
@@ -182,7 +180,6 @@ def execute(func, profiles, delay=0, max_workers=None, **options):
 
         for p in profiles:
             futures[e.submit(func, p, **options)] = p["name"]
-            time.sleep(delay)
 
         for f in concurrent.futures.as_completed(futures):
             try:

--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -7,6 +7,8 @@ import selectors
 import subprocess
 import textwrap
 
+from . import shutdown
+
 OUT = "out"
 ERR = "err"
 
@@ -71,20 +73,23 @@ def run(*args, input=None):
     terminated with non-zero exit code. The error includes all data read from
     the child process stdout and stderr.
     """
-    try:
-        cp = subprocess.run(
-            args,
-            input=input.encode() if input else None,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-    except OSError as e:
-        raise Error(args, f"Could not execute: {e}").with_exception(e)
+    with shutdown.guard():
+        try:
+            p = subprocess.Popen(
+                args,
+                stdin=subprocess.PIPE if input else None,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except OSError as e:
+            raise Error(args, f"Could not execute: {e}").with_exception(e)
 
-    output = cp.stdout.decode()
-    if cp.returncode != 0:
-        error = cp.stderr.decode(errors="replace")
-        raise Error(args, error, exitcode=cp.returncode, output=output)
+    output, error = p.communicate(input=input.encode() if input else None)
+
+    output = output.decode()
+    if p.returncode != 0:
+        error = error.decode(errors="replace")
+        raise Error(args, error, exitcode=p.returncode, output=output)
 
     return output
 
@@ -109,16 +114,17 @@ def watch(*args, input=None):
     env = dict(os.environ)
     env["PYTHONUNBUFFERED"] = "1"
 
-    try:
-        p = subprocess.Popen(
-            args,
-            stdin=subprocess.PIPE if input else None,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=env,
-        )
-    except OSError as e:
-        raise Error(args, f"Could not execute: {e}").with_exception(e)
+    with shutdown.guard():
+        try:
+            p = subprocess.Popen(
+                args,
+                stdin=subprocess.PIPE if input else None,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+            )
+        except OSError as e:
+            raise Error(args, f"Could not execute: {e}").with_exception(e)
 
     with p:
         error = bytearray()

--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 import pytest
 
 from drenv import commands
+from drenv import shutdown
 
 # Streaming data from commands.
 
@@ -250,6 +251,12 @@ os.write(1, bytes([0xff]))
         list(commands.watch("python3", "-c", script))
 
 
+def test_watch_after_shutdown(monkeypatch):
+    monkeypatch.setattr(shutdown, "_started", True)
+    with pytest.raises(shutdown.Started):
+        list(commands.watch("no-such-command"))
+
+
 # Running commands.
 
 
@@ -317,6 +324,12 @@ os.write(1, bytes([0xff]))
 """
     with pytest.raises(UnicodeDecodeError):
         commands.run("python3", "-c", script)
+
+
+def test_run_after_shutdown(monkeypatch):
+    monkeypatch.setattr(shutdown, "_started", True)
+    with pytest.raises(shutdown.Started):
+        commands.run("no-such-command")
 
 
 # Formatting errors.

--- a/test/drenv/shutdown.py
+++ b/test/drenv/shutdown.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import threading
+
+from contextlib import contextmanager
+
+_lock = threading.Lock()
+_started = False
+
+
+class Started(Exception):
+    """
+    Raised when an operation is cancelled due to shutdown.
+    """
+
+
+def start():
+    global _started
+    with _lock:
+        logging.debug("[main] Starting shutdown")
+        _started = True
+
+
+def started():
+    with _lock:
+        return _started
+
+
+@contextmanager
+def guard():
+    with _lock:
+        if _started:
+            raise Started
+        yield

--- a/test/envs/error.yaml
+++ b/test/envs/error.yaml
@@ -4,13 +4,55 @@
 # Environment for testing drenv error handling.
 ---
 name: error
-profiles:
+templates:
   - name: cluster
     driver: $vm
     container_runtime: containerd
     memory: 2g
+profiles:
+  - name: c1
+    template: cluster
     workers:
       - addons:
           - name: error
+            args: ["10.0"]
+          - name: sleep
+            args: ["60"]
       - addons:
-          - name: example
+          - name: sleep
+            args: ["10.0"]
+          - name: sleep
+            args: ["60"]
+      - addons:
+          - name: sleep
+            args: ["10.0"]
+          - name: sleep
+            args: ["60"]
+      - addons:
+          - name: sleep
+            args: ["10.0"]
+          - name: sleep
+            args: ["60"]
+  - name: c2
+    template: cluster
+    workers:
+      - addons:
+          - name: sleep
+            args: ["10.0"]
+          - name: sleep
+            args: ["60"]
+      - addons:
+          - name: sleep
+            args: ["10.0"]
+          - name: sleep
+            args: ["60"]
+      - addons:
+          - name: sleep
+            args: ["10.0"]
+          - name: sleep
+            args: ["60"]
+      - addons:
+          - name: sleep
+            args: ["10.0"]
+          - name: sleep
+            args: ["60"]


### PR DESCRIPTION
The recent change to fail quickly on errors was missing proper cleanup. This change ensure that all child processes and child processes created by them are terminate when drenv terminates normally or after errors.