### PR TITLE
Decrease timeouts

### DIFF
--- a/test/addons/cdi/start
+++ b/test/addons/cdi/start
@@ -20,7 +20,7 @@ def deploy(cluster):
         "status",
         "deploy/cdi-operator",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 
@@ -34,7 +34,7 @@ def wait(cluster):
         "cdi.cdi.kubevirt.io/cdi",
         "--for=condition=available",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
     print("Waiting until cdi cr finished progressing")

--- a/test/addons/csi-addons/start
+++ b/test/addons/csi-addons/start
@@ -29,7 +29,7 @@ def wait(cluster):
         "status",
         "deploy/csi-addons-controller-manager",
         "--namespace=csi-addons-system",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/demo/start
+++ b/test/addons/demo/start
@@ -28,7 +28,7 @@ print("Waiting until deployment is rolled out")
 kubectl.rollout(
     "status",
     "deployment",
-    "--timeout=600s",
+    "--timeout=120s",
     context=cluster,
 )
 
@@ -37,7 +37,7 @@ kubectl.rollout(
     "status",
     "ingress",
     "--namespace=ingress-nginx",
-    "--timeout=600s",
+    "--timeout=120s",
     context=cluster,
 )
 

--- a/test/addons/example/start
+++ b/test/addons/example/start
@@ -22,7 +22,7 @@ print("Waiting until example deployment is rolled out")
 kubectl.rollout(
     "status",
     "deploy/example-deployment",
-    "--timeout=600s",
+    "--timeout=180s",
     context=cluster,
 )
 
@@ -31,6 +31,6 @@ kubectl.wait(
     "pod",
     "--selector=app=example",
     "--for=condition=Ready",
-    "--timeout=600s",
+    "--timeout=180s",
     context=cluster,
 )

--- a/test/addons/kubevirt/start
+++ b/test/addons/kubevirt/start
@@ -20,7 +20,7 @@ def deploy(cluster):
         "status",
         "deploy/virt-operator",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 
@@ -34,7 +34,7 @@ def wait(cluster):
         "kubevirt.kubevirt.io/kubevirt",
         "--for=condition=available",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/kubevirt/test
+++ b/test/addons/kubevirt/test
@@ -40,7 +40,7 @@ def wait_until_vm_is_ready(cluster):
         "vm/testvm",
         "--for=condition=ready",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=180s",
         context=cluster,
     )
 

--- a/test/addons/minio/start
+++ b/test/addons/minio/start
@@ -20,7 +20,7 @@ def wait(cluster):
         "status",
         "deployment/minio",
         "--namespace=minio",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/ocm-cluster/start
+++ b/test/addons/ocm-cluster/start
@@ -57,7 +57,7 @@ def wait(cluster):
             "status",
             deployment,
             f"--namespace={ADDONS_NAMESPACE}",
-            "--timeout=600s",
+            "--timeout=300s",
             context=cluster,
         )
 
@@ -75,7 +75,7 @@ def wait_for_hub(hub):
             "status",
             deployment,
             f"--namespace={HUB_NAMESPACE}",
-            "--timeout=600s",
+            "--timeout=300s",
             context=hub,
         )
 

--- a/test/addons/ocm-cluster/start
+++ b/test/addons/ocm-cluster/start
@@ -113,7 +113,7 @@ def wait_for_managed_cluster(cluster, hub):
     kubectl.wait(
         f"managedcluster/{cluster}",
         "--for=condition=ManagedClusterConditionAvailable",
-        "--timeout=600s",
+        "--timeout=60s",
         context=hub,
     )
 

--- a/test/addons/ocm-cluster/test
+++ b/test/addons/ocm-cluster/test
@@ -21,7 +21,7 @@ def wait_for_work(cluster, hub):
         "manifestwork/example-manifestwork",
         "--for=condition=applied",
         f"--namespace={cluster}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=hub,
     )
 
@@ -32,7 +32,7 @@ def wait_for_deployment(cluster, hub):
         "manifestwork/example-manifestwork",
         "--for=condition=available",
         f"--namespace={cluster}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=hub,
     )
 
@@ -40,7 +40,7 @@ def wait_for_deployment(cluster, hub):
     kubectl.wait(
         "deploy/example-deployment",
         "--for=condition=available",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
 
@@ -56,7 +56,7 @@ def wait_for_delete_work(cluster, hub):
         "manifestwork/example-manifestwork",
         "--for=delete",
         f"--namespace={cluster}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=hub,
     )
 
@@ -66,7 +66,7 @@ def wait_for_delete_deployment(cluster):
     kubectl.wait(
         "deploy/example-deployment",
         "--for=delete",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
 

--- a/test/addons/ocm-controller/start
+++ b/test/addons/ocm-controller/start
@@ -23,7 +23,7 @@ def wait(cluster):
         "status",
         "deploy/ocm-controller",
         "--namespace=open-cluster-management",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/ocm-hub/start
+++ b/test/addons/ocm-hub/start
@@ -68,7 +68,7 @@ def wait(cluster):
                 "status",
                 deployment,
                 f"--namespace={ns}",
-                "--timeout=600s",
+                "--timeout=300s",
                 context=cluster,
             )
 

--- a/test/addons/olm/start
+++ b/test/addons/olm/start
@@ -60,7 +60,7 @@ def wait(cluster):
         "csv/packageserver",
         f"--namespace={NAMESPACE}",
         "--for=jsonpath={.status.phase}=Succeeded",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -111,7 +111,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
         POOL_NAME,
         "--for=jsonpath={.status.mirroringStatus.summary.daemon_health}=OK",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 
@@ -121,7 +121,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
         POOL_NAME,
         "--for=jsonpath={.status.mirroringStatus.summary.health}=OK",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 
@@ -131,7 +131,7 @@ def wait_until_pool_mirroring_is_healthy(cluster):
         POOL_NAME,
         "--for=jsonpath={.status.mirroringStatus.summary.image_health}=OK",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -153,8 +153,8 @@ os.chdir(os.path.dirname(__file__))
 cluster1 = sys.argv[1]
 cluster2 = sys.argv[2]
 
-clear_blocklist(cluster1)
-clear_blocklist(cluster2)
+# clear_blocklist(cluster1)
+# clear_blocklist(cluster2)
 
 cluster1_info = fetch_secret_info(cluster1)
 cluster2_info = fetch_secret_info(cluster2)
@@ -171,7 +171,7 @@ wait_until_pool_mirroring_is_healthy(cluster2)
 deploy_vrc_sample(cluster1)
 deploy_vrc_sample(cluster2)
 
-check_blocklist(cluster1)
-check_blocklist(cluster2)
+# check_blocklist(cluster1)
+# check_blocklist(cluster2)
 
 print("Mirroring was setup successfully")

--- a/test/addons/rbd-mirror/test
+++ b/test/addons/rbd-mirror/test
@@ -174,11 +174,11 @@ os.chdir(os.path.dirname(__file__))
 cluster1 = sys.argv[1]
 cluster2 = sys.argv[2]
 
-check_blocklist(cluster1)
-check_blocklist(cluster2)
+# check_blocklist(cluster1)
+# check_blocklist(cluster2)
 
 test_volume_replication(cluster1, cluster2)
 test_volume_replication(cluster2, cluster1)
 
-check_blocklist(cluster1)
-check_blocklist(cluster2)
+# check_blocklist(cluster1)
+# check_blocklist(cluster2)

--- a/test/addons/rbd-mirror/test
+++ b/test/addons/rbd-mirror/test
@@ -77,7 +77,7 @@ def test_volume_replication(primary, secondary):
         f"pvc/{PVC_NAME}",
         "--for=jsonpath={.status.phase}=Bound",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=primary,
     )
 
@@ -93,7 +93,7 @@ def test_volume_replication(primary, secondary):
         "volumereplication/vr-sample",
         "--for=condition=Completed",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=primary,
     )
 
@@ -102,7 +102,7 @@ def test_volume_replication(primary, secondary):
         "volumereplication/vr-sample",
         "--for=jsonpath={.status.state}=Primary",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=primary,
     )
 

--- a/test/addons/rook-cluster/start
+++ b/test/addons/rook-cluster/start
@@ -35,7 +35,7 @@ def wait(cluster):
         "cephcluster/my-cluster",
         "--for=jsonpath={.status.phase}=Ready",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/rook-operator/start
+++ b/test/addons/rook-operator/start
@@ -29,7 +29,7 @@ def wait(cluster):
         "status",
         "deploy/rook-ceph-operator",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 
@@ -39,7 +39,7 @@ def wait(cluster):
         "--for=jsonpath={.status.phase}=Running",
         "--namespace=rook-ceph",
         "--selector=app=rook-ceph-operator",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/rook-pool/start
+++ b/test/addons/rook-pool/start
@@ -32,7 +32,7 @@ def wait(cluster):
         "cephblockpool/replicapool",
         "--for=jsonpath={.status.phase}=Ready",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 
@@ -41,7 +41,7 @@ def wait(cluster):
         "cephblockpool/replicapool",
         "--for=jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}=pool-peer-token-replicapool",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/rook-toolbox/start
+++ b/test/addons/rook-toolbox/start
@@ -24,7 +24,7 @@ def wait(cluster):
         "status",
         "deploy/rook-ceph-tools",
         "--namespace=rook-ceph",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/submariner/start
+++ b/test/addons/submariner/start
@@ -79,7 +79,7 @@ def wait_for_deployments(cluster, names, namespace):
             "status",
             deployment,
             f"--namespace={namespace}",
-            "--timeout=600s",
+            "--timeout=180s",
             context=cluster,
         )
 

--- a/test/addons/submariner/test
+++ b/test/addons/submariner/test
@@ -98,7 +98,7 @@ def wait_for_service(cluster, namespace):
         f"deploy/{SERVICE}",
         "--for=condition=Available",
         f"--namespace={namespace}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
 
@@ -109,7 +109,7 @@ def wait_for_pod(cluster, namespace):
         "pod/test",
         "--for=condition=Ready",
         f"--namespace={namespace}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
 
@@ -130,7 +130,7 @@ def wait_for_service_export(cluster, namespace):
         f"serviceexports/{SERVICE}",
         "--for=condition=Ready",
         f"--namespace={namespace}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
     exports = kubectl.describe(

--- a/test/addons/velero/test
+++ b/test/addons/velero/test
@@ -24,7 +24,7 @@ def test(cluster):
         "status",
         "deploy/nginx-deployment",
         "--namespace=nginx-example",
-        "--timeout=600s",
+        "--timeout=180s",
         context=cluster,
     )
 
@@ -47,7 +47,7 @@ def test(cluster):
         "status",
         "deploy/nginx-deployment",
         "--namespace=nginx-example",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
 

--- a/test/addons/volsync/start
+++ b/test/addons/volsync/start
@@ -50,7 +50,7 @@ def wait_for_deployment(cluster):
         "status",
         f"deploy/{DEPLOYMENT}",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/volsync/test
+++ b/test/addons/volsync/test
@@ -34,7 +34,7 @@ def wait_for_application(cluster):
         "status",
         f"deploy/{DEPLOY}",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
 
@@ -47,7 +47,7 @@ def wait_for_replication_destination(cluster):
         "replicationdestination/busybox-dst",
         "--for=condition=Synchronizing=True",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
 
@@ -84,7 +84,7 @@ def setup_replication_service(cluster1, cluster2):
         f"serviceexports/{VOLSYNC_SERVICE}",
         "--for=condition=Ready",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster2,
     )
 
@@ -119,7 +119,7 @@ def run_replication(cluster):
         "replicationsource/busybox-src",
         "--for=jsonpath={.status.lastManualSync}=replication-1",
         f"--namespace={NAMESPACE}",
-        "--timeout=600s",
+        "--timeout=120s",
         context=cluster,
     )
     out = kubectl.get(

--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -17,6 +17,7 @@ templates:
     driver: "$vm"
     container_runtime: containerd
     network: "$network"
+    cpus: 4
     memory: "6g"
     extra_disks: 1
     disk_size: "50g"
@@ -44,6 +45,7 @@ templates:
     driver: "$vm"
     container_runtime: containerd
     network: "$network"
+    cpus: 2
     memory: "4g"
     workers:
       - addons:


### PR DESCRIPTION
Increasing the timeouts is harmful - it makes failures twice slower.
Since we have retries now, it is better to keep the previous timeout
and retry quicker.

Testing shows small increase in success rate:

```
run     cpus  runs  passed  failed  success(%)  time(s)
-------------------------------------------------------
before     4    50      44       6         88     28571
after      4    50      45       5         90     28353
```

And large dcrease in time spend on failed runs:

```
run     success(s)   fail(s)    total(s)
----------------------------------------
before       24471     4100        28571
after        25760     2593        28353
```

So the conclusions on this system is that we don't need longer timeouts,
and shorter timeouts help to recover faster from errors by retying.

This does not mean that we don't have some bad timeouts that need to be
increased, but this should be done based on data.

Based on #1267 temporarily.