### PR TITLE
E2e workflow tweaks

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -51,13 +51,18 @@ jobs:
           drenv start --max-workers ${{ env.MAX_WORKERS }} --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
 
     - name: Deploy ramen
-      run: |
-        ramenctl deploy --name-prefix ${{ env.NAME_PREFIX }} test/envs/regional-dr.yaml
-        ramenctl config --name-prefix ${{ env.NAME_PREFIX }} test/envs/regional-dr.yaml
+      run: ramenctl deploy --name-prefix ${{ env.NAME_PREFIX }} test/envs/regional-dr.yaml
+
+    - name: Configure ramen
+      uses: nick-fields/retry@v3
+      with:
+        timeout_seconds: 60
+        max_attempts: 3
+        command: ramenctl config --name-prefix ${{ env.NAME_PREFIX }} test/envs/regional-dr.yaml
 
     - name: Run e2e tests
       run: |
-        cp ~/.config/drenv/${{ env.NAME_PREFIX }}rdr/config.yaml ../e2e/config.yaml
+        cp ~/.config/drenv/${{ env.NAME_PREFIX }}rdr/config.yaml e2e/config.yaml
         make e2e-rdr
 
     - name: Delete clusters

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -49,7 +49,6 @@ jobs:
         command: |
           cd test
           drenv start --max-workers ${{ env.MAX_WORKERS }} --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
-          cp ~/.config/drenv/${{ env.NAME_PREFIX }}rdr/config.yaml ../e2e/config.yaml
 
     - name: Deploy ramen
       run: |
@@ -57,7 +56,9 @@ jobs:
         ramenctl config --name-prefix ${{ env.NAME_PREFIX }} test/envs/regional-dr.yaml
 
     - name: Run e2e tests
-      run: make e2e-rdr
+      run: |
+        cp ~/.config/drenv/${{ env.NAME_PREFIX }}rdr/config.yaml ../e2e/config.yaml
+        make e2e-rdr
 
     - name: Delete clusters
       if: ${{ always() }}


### PR DESCRIPTION
- Move "copy drenv e2e config" to "run e2e tests" step
- split ramenctl deploy and config
- retry ramenctl config on errors