### PR TITLE
Fix Race Condition and Standardize Resource Metadata Handling

### DIFF
--- a/controllers/drcluster_controller.go
+++ b/controllers/drcluster_controller.go
@@ -593,11 +593,16 @@ func (u *drclusterInstance) statusUpdate() error {
 const drClusterFinalizerName = "drclusters.ramendr.openshift.io/ramen"
 
 func (u *drclusterInstance) addLabelsAndFinalizers() error {
-	return util.GenericAddLabelsAndFinalizers(u.ctx, u.object, drClusterFinalizerName, u.client, u.log)
+	return util.NewResourceUpdater(u.object).
+		AddLabel(util.OCMBackupLabelKey, util.OCMBackupLabelValue).
+		AddFinalizer(drClusterFinalizerName).
+		Update(u.ctx, u.client)
 }
 
 func (u *drclusterInstance) finalizerRemove() error {
-	return util.GenericFinalizerRemove(u.ctx, u.object, drClusterFinalizerName, u.client, u.log)
+	return util.NewResourceUpdater(u.object).
+		RemoveFinalizer(drClusterFinalizerName).
+		Update(u.ctx, u.client)
 }
 
 // TODO:

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -385,11 +385,16 @@ func (u *drpolicyUpdater) statusUpdate() error {
 const drPolicyFinalizerName = "drpolicies.ramendr.openshift.io/ramen"
 
 func (u *drpolicyUpdater) addLabelsAndFinalizers() error {
-	return util.GenericAddLabelsAndFinalizers(u.ctx, u.object, drPolicyFinalizerName, u.client, u.log)
+	return util.NewResourceUpdater(u.object).
+		AddLabel(util.OCMBackupLabelKey, util.OCMBackupLabelValue).
+		AddFinalizer(drPolicyFinalizerName).
+		Update(u.ctx, u.client)
 }
 
 func (u *drpolicyUpdater) finalizerRemove() error {
-	return util.GenericFinalizerRemove(u.ctx, u.object, drPolicyFinalizerName, u.client, u.log)
+	return util.NewResourceUpdater(u.object).
+		RemoveFinalizer(drPolicyFinalizerName).
+		Update(u.ctx, u.client)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/util/misc.go
+++ b/controllers/util/misc.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,39 +18,62 @@ const (
 	OCMBackupLabelValue string = "ramen"
 )
 
-func GenericAddLabelsAndFinalizers(
-	ctx context.Context,
-	object client.Object,
-	finalizerName string,
-	client client.Client,
-	log logr.Logger,
-) error {
-	labelAdded := AddLabel(object, OCMBackupLabelKey, OCMBackupLabelValue)
-	finalizerAdded := AddFinalizer(object, finalizerName)
-
-	if finalizerAdded || labelAdded {
-		log.Info("finalizer or label add")
-
-		return client.Update(ctx, object)
-	}
-
-	return nil
+type ResourceUpdater struct {
+	obj         client.Object
+	objModified bool
+	err         error
 }
 
-func GenericFinalizerRemove(
-	ctx context.Context,
-	object client.Object,
-	finalizerName string,
-	client client.Client,
-	log logr.Logger,
-) error {
-	finalizerCount := len(object.GetFinalizers())
-	controllerutil.RemoveFinalizer(object, finalizerName)
+func NewResourceUpdater(obj client.Object) *ResourceUpdater {
+	return &ResourceUpdater{
+		obj:         obj,
+		objModified: false,
+		err:         nil,
+	}
+}
 
-	if len(object.GetFinalizers()) != finalizerCount {
-		log.Info("finalizer remove")
+func (u *ResourceUpdater) AddLabel(key, value string) *ResourceUpdater {
+	added := AddLabel(u.obj, key, value)
 
-		return client.Update(ctx, object)
+	u.objModified = u.objModified || added
+
+	return u
+}
+
+func (u *ResourceUpdater) AddFinalizer(finalizerName string) *ResourceUpdater {
+	added := AddFinalizer(u.obj, finalizerName)
+
+	u.objModified = u.objModified || added
+
+	return u
+}
+
+func (u *ResourceUpdater) AddOwner(owner metav1.Object, scheme *runtime.Scheme) *ResourceUpdater {
+	added, err := AddOwnerReference(u.obj, owner, scheme)
+	if err != nil {
+		u.err = err
+	}
+
+	u.objModified = u.objModified || added
+
+	return u
+}
+
+func (u *ResourceUpdater) RemoveFinalizer(finalizerName string) *ResourceUpdater {
+	finalizersUpdated := controllerutil.RemoveFinalizer(u.obj, finalizerName)
+
+	u.objModified = u.objModified || finalizersUpdated
+
+	return u
+}
+
+func (u *ResourceUpdater) Update(ctx context.Context, client client.Client) error {
+	if u.err != nil {
+		return u.err
+	}
+
+	if u.objModified {
+		return client.Update(ctx, u.obj)
 	}
 
 	return nil

--- a/controllers/util/misc.go
+++ b/controllers/util/misc.go
@@ -5,8 +5,11 @@ package util
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -88,6 +91,19 @@ func AddAnnotation(obj client.Object, key, value string) bool {
 	}
 
 	return !added
+}
+
+func AddOwnerReference(obj, owner metav1.Object, scheme *runtime.Scheme) (bool, error) {
+	currentOwnerRefs := obj.GetOwnerReferences()
+
+	err := controllerutil.SetOwnerReference(owner, obj, scheme)
+	if err != nil {
+		return false, err
+	}
+
+	ownerAdded := !reflect.DeepEqual(obj.GetOwnerReferences(), currentOwnerRefs)
+
+	return ownerAdded, nil
 }
 
 func AddFinalizer(obj client.Object, finalizer string) bool {

--- a/controllers/util/misc.go
+++ b/controllers/util/misc.go
@@ -97,6 +97,27 @@ func AddLabel(obj client.Object, key, value string) bool {
 	return !labelAdded
 }
 
+func HasLabel(obj client.Object, key string) bool {
+	labels := obj.GetLabels()
+	for k := range labels {
+		if k == key {
+			return true
+		}
+	}
+
+	return false
+}
+
+func HasLabelWithValue(obj client.Object, key string, value string) bool {
+	labels := obj.GetLabels()
+	for k, v := range labels {
+		if k == key && v == value {
+			return true
+		}
+	}
+	return false
+}
+
 func AddAnnotation(obj client.Object, key, value string) bool {
 	const added = true
 

--- a/controllers/util/misc.go
+++ b/controllers/util/misc.go
@@ -115,6 +115,7 @@ func HasLabelWithValue(obj client.Object, key string, value string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 


### PR DESCRIPTION
This pull request addresses a race condition where the label volsync `do-not-delete` was added prematurely to the `VolumeSnapshot` resource before it was properly owned. In such cases, during a Rollback operation, a new snapshot could be created, resulting in the previous one to get orphaned.

Additionally, this PR includes an initial cleanup commit aimed at standardizing the addition and removal of resource metadata, laying the groundwork for more refactoring in the future.

Fixes: [2267907](https://bugzilla.redhat.com/show_bug.cgi?id=2267907)