### PR TITLE
Wait until pool reports mirroring site name

### DIFF
--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -41,12 +41,11 @@ def fetch_secret_info(cluster):
     info = {}
 
     print(f"Getting mirroring info site name for cluster '{cluster}'")
-    info["name"] = kubectl.get(
-        "cephblockpools.ceph.rook.io",
-        POOL_NAME,
-        "--output=jsonpath={.status.mirroringInfo.site_name}",
-        "--namespace=rook-ceph",
-        context=cluster,
+    info["name"] = drenv.wait_for(
+        f"cephblockpools.ceph.rook.io/{POOL_NAME}",
+        output="jsonpath={.status.mirroringInfo.site_name}",
+        namespace="rook-ceph",
+        profile=cluster,
     )
 
     print(f"Getting rbd mirror boostrap peer secret name for cluster '{cluster}'")


### PR DESCRIPTION
This is a common random failure in stress tests:

    drenv.commands.Error: Command failed:
        command: ('kubectl', 'apply', '--context', '003-dr1', '--filename=-', '--namespace=rook-ceph')
        exitcode: 1
        error:
            error: error when retrieving current configuration of:
            Resource: "/v1, Resource=secrets", GroupVersionKind: "/v1, Kind=Secret"
            Name: "", Namespace: "rook-ceph"
            from server for: "STDIN": resource name may not be empty

Empty name can happen if getting the ceph pool

    jsonpath={.status.mirroringInfo.site_name}

returned empty string, which may happen if some component of the jsonpath was missing.

Now we wait until the value is not empty or the timeout expires, before generating the rbd mirror secret. This should eliminate the error.

I could reproduce the issue after 41 runs in a VM on a bare metal machine in the e2e lab:

We waited 14.35 seconds until jsonpath={.status.mirroringInfo.site_name} returned non empty value:

    2024-03-21 15:51:20,714 DEBUG   [001-rdr/0] 'cephblockpools.ceph.rook.io/replicapool' output='jsonpath={.status.mirroringInfo.site_name}' found in 14.35 seconds

After that we configured rbd mirroring and the pool was ready in 9 seconds.

    2024-03-21 15:51:20,714 DEBUG   [001-rdr/0] Getting rbd mirror boostrap peer secret name for cluster '001-dr2'
    2024-03-21 15:51:20,817 DEBUG   [001-rdr/0] Getting secret pool-peer-token-replicapool token for cluster '001-dr2'
    2024-03-21 15:51:21,357 DEBUG   [001-rdr/0] Setting up mirroring from '001-dr1' to '001-dr2'
    2024-03-21 15:51:21,357 DEBUG   [001-rdr/0] Applying rbd mirror secret in cluster '001-dr2'
    2024-03-21 15:51:21,541 DEBUG   [001-rdr/0] secret/b2116d14-f8d7-43c3-867b-7c940d55a4e4 created
    2024-03-21 15:51:21,546 DEBUG   [001-rdr/0] Configure peers for cluster '001-dr2'
    2024-03-21 15:51:21,648 DEBUG   [001-rdr/0] cephblockpool.ceph.rook.io/replicapool patched
    2024-03-21 15:51:21,654 DEBUG   [001-rdr/0] Apply rbd mirror to cluster '001-dr2'
    2024-03-21 15:51:21,796 DEBUG   [001-rdr/0] cephrbdmirror.ceph.rook.io/my-rbd-mirror created
    2024-03-21 15:52:28,951 DEBUG   [001-rdr/0] Waiting until ceph mirror daemon is healthy in cluster '001-dr2'
    2024-03-21 15:52:29,173 DEBUG   [001-rdr/0] cephblockpool.ceph.rook.io/replicapool condition met
    2024-03-21 15:52:29,178 DEBUG   [001-rdr/0] Waiting until ceph mirror is healthy in cluster '001-dr2'
    2024-03-21 15:52:29,386 DEBUG   [001-rdr/0] cephblockpool.ceph.rook.io/replicapool condition met
    2024-03-21 15:52:29,392 DEBUG   [001-rdr/0] Waiting until ceph mirror image is healthy in cluster '001-dr2'
    2024-03-21 15:52:29,616 DEBUG   [001-rdr/0] cephblockpool.ceph.rook.io/replicapool condition met

Before this change setting the secret would fail.

I also did not see any timeouts waiting for the pool to become healthy after 50 builds, hopefully that issue was related to the same problem.