### PR TITLE
Update CDI to version 1.58.3

### DIFF
--- a/test/addons/cdi/cr/kustomization.yaml
+++ b/test/addons/cdi/cr/kustomization.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://raw.githubusercontent.com/nirs/drenv-addons/main/cdi/dabbcbed1618d1ec970135b4c0a8b692c2dd60b6/cdi-cr.yaml
+  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.58.3/cdi-cr.yaml
 patches:
   # Allow pulling from local insecure registry.
   - target:

--- a/test/addons/cdi/operator/kustomization.yaml
+++ b/test/addons/cdi/operator/kustomization.yaml
@@ -4,5 +4,4 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  # TODO: use latest release.
-  - https://raw.githubusercontent.com/nirs/drenv-addons/main/cdi/dabbcbed1618d1ec970135b4c0a8b692c2dd60b6/cdi-operator.yaml
+  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.58.3/cdi-operator.yaml


### PR DESCRIPTION
This version includes data volume PVC adoption feature[1] required for
DR flows, and fix[2] for regression introduced by the first one.

[1] https://github.com/kubevirt/containerized-data-importer/pull/3029
[2] https://github.com/kubevirt/containerized-data-importer/pull/3136