### PR TITLE
Set envtest version than use latest

### DIFF
--- a/hack/install-setup-envtest.sh
+++ b/hack/install-setup-envtest.sh
@@ -3,7 +3,7 @@ set -e
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
-required_version="latest"
+required_version="release-0.17"
 source_url="sigs.k8s.io/controller-runtime/tools/setup-envtest@${required_version}"
 target_dir="${script_dir}/../testbin"
 target_path="${target_dir}/setup-envtest"


### PR DESCRIPTION
latest moved to go 1.22 (for k8s 1.30 requirements), causing envtest failures locally.

Set the version to use, thereby avoiding surprises.