### PR TITLE
Add kubevirt test configuration and examples for OpenShift

### DIFF
--- a/test/configs/kubevirt/vm-dv-odr-regional.yaml
+++ b/test/configs/kubevirt/vm-dv-odr-regional.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+repo: https://github.com/ramendr/ocm-ramen-samples.git
+path: subscription/kubevirt/vm-dv-odr-regional
+branch: main
+name: vm-dv
+namespace: vm-dv
+dr_policy: dr-policy
+pvc_label: vm

--- a/test/configs/kubevirt/vm-dvt-odr-regional.yaml
+++ b/test/configs/kubevirt/vm-dvt-odr-regional.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+repo: https://github.com/ramendr/ocm-ramen-samples.git
+path: subscription/kubevirt/vm-dvt-odr-regional
+branch: main
+name: vm-dvt
+namespace: vm-dvt
+dr_policy: dr-policy
+pvc_label: vm

--- a/test/configs/kubevirt/vm-pvc-odr-regional.yaml
+++ b/test/configs/kubevirt/vm-pvc-odr-regional.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+repo: https://github.com/ramendr/ocm-ramen-samples.git
+path: subscription/kubevirt/vm-pvc-odr-regional
+branch: main
+name: vm-pvc
+namespace: vm-pvc
+dr_policy: dr-policy
+pvc_label: vm

--- a/test/envs/odr.yaml
+++ b/test/envs/odr.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Environment for testing an external OpenShift Regional-DR setup using
+# basic-test.  Assuming that you used `oc login` to get all the clusters in a
+# kubeconfig file used by the test.
+---
+name: perf123
+ramen:
+  hub: perf1
+  clusters: [perf2, perf3]
+  topology: regional-dr
+  features:
+    volsync: true


### PR DESCRIPTION
With the new configuration you can test the kubevirt samples also on OpenShift clusters using basic-test.

Tested with https://github.com/RamenDR/ocm-ramen-samples/pull/51