### PR TITLE
Create drenv specific libvirt default network

### DIFF
--- a/test/scripts/network.xml
+++ b/test/scripts/network.xml
@@ -1,0 +1,10 @@
+<network>
+  <name>default</name>
+  <bridge name='virbr0'/>
+  <forward/>
+  <ip address='192.168.22.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.22.2' end='192.168.22.254'/>
+    </dhcp>
+  </ip>
+</network>

--- a/test/scripts/setup-libvirt
+++ b/test/scripts/setup-libvirt
@@ -1,11 +1,13 @@
 #!/bin/sh -e
 
+base=$(dirname $0)
+
 default_network_exists() {
     virsh -c qemu:///system net-list | grep -q default
 }
 
 create_default_network() {
-    virsh -c qemu:///system net-define /usr/share/libvirt/networks/default.xml
+    virsh -c qemu:///system net-define $base/network.xml
     virsh -c qemu:///system net-autostart default
     virsh -c qemu:///system net-start default
 }


### PR DESCRIPTION
When running drenv in a libvirt VM using the default network (192.168.122.1/24) on the host, we cannot use same network inside the guest. Use drenv specific network (192.168.22.1/25) instead. This can be fail if the network is used, bu this is unlikely.

Fixes #1297