### PR TITLE
Upgrade csi-addon to 0.8.0

### DIFF
--- a/test/addons/csi-addons/start
+++ b/test/addons/csi-addons/start
@@ -9,7 +9,7 @@ import sys
 import drenv
 from drenv import kubectl
 
-VERSION = "v0.7.0"
+VERSION = "v0.8.0"
 BASE_URL = f"https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/{VERSION}/deploy/controller"
 
 


### PR DESCRIPTION
Looking at cluster events

    $ kubectl events -A --context dr1 | grep 'pulled image "quay.io/csiaddons/' csi-addons-system
    ... Successfully pulled image "quay.io/csiaddons/k8s-controller:v0.7.0" ...
    ... Successfully pulled image "quay.io/csiaddons/k8s-sidecar:v0.8.0" ...

we were mixing k8s-controller:v0.7.0 and k8s-sidecar:v0.8.0.

Unfortunately this does not help with the ceph issues (e.g. #1298).

Fixes #1257