### PR TITLE
Improve ocm addons

### DIFF
--- a/test/addons/ocm-cluster/example-manifestwork.yaml
+++ b/test/addons/ocm-cluster/example-manifestwork.yaml
@@ -36,4 +36,12 @@ spec:
               containers:
                 - name: busybox
                   image: quay.io/nirsof/busybox:stable
-                  command: ["sleep", "60"]
+                  command:
+                    - sh
+                    - -c
+                    - |
+                      trap exit TERM
+                      while true; do
+                          sleep 10 &
+                          wait
+                      done

--- a/test/addons/ocm-cluster/start
+++ b/test/addons/ocm-cluster/start
@@ -52,8 +52,8 @@ HUB_DEPLOYMENTS = {
 def deploy(cluster, hub):
     wait_for_hub(hub)
     join_cluster(cluster, hub)
-    label_cluster(cluster, hub)
     wait_for_managed_cluster(cluster, hub)
+    label_cluster(cluster, hub)
     enable_addons(cluster, hub)
 
 

--- a/test/addons/ocm-cluster/start
+++ b/test/addons/ocm-cluster/start
@@ -28,16 +28,25 @@ ADDONS = (
 )
 
 ADDONS_NAMESPACE = "open-cluster-management-agent-addon"
-HUB_NAMESPACE = "open-cluster-management-hub"
-
-# These are deployed when running "clusteradm init" on the hub.
-# We wait for them before we try to join the hub.
-HUB_DEPLOYMENTS = (
-    "cluster-manager-placement-controller",
-    "cluster-manager-registration-controller",
-    "cluster-manager-registration-webhook",
-    "cluster-manager-work-webhook",
-)
+# These are deployed when running "addons/ocm-hub/start" on the hub.  We wait
+# for them before we try to join the hub.
+HUB_DEPLOYMENTS = {
+    "open-cluster-management": (
+        "cluster-manager",
+        "governance-policy-addon-controller",
+        "governance-policy-propagator",
+        "multicluster-operators-appsub-summary",
+        "multicluster-operators-channel",
+        "multicluster-operators-placementrule",
+        "multicluster-operators-subscription",
+    ),
+    "open-cluster-management-hub": (
+        "cluster-manager-placement-controller",
+        "cluster-manager-registration-controller",
+        "cluster-manager-registration-webhook",
+        "cluster-manager-work-webhook",
+    ),
+}
 
 
 def deploy(cluster, hub):
@@ -66,18 +75,22 @@ def wait_for_hub(hub):
     print(f"Waiting until cluster '{hub}' is ready")
 
     cluster.wait_until_ready(hub)
-    drenv.wait_for(f"namespace/{HUB_NAMESPACE}", profile=hub)
 
-    for name in HUB_DEPLOYMENTS:
-        deployment = f"deploy/{name}"
-        drenv.wait_for(deployment, namespace=HUB_NAMESPACE, profile=hub)
-        kubectl.rollout(
-            "status",
-            deployment,
-            f"--namespace={HUB_NAMESPACE}",
-            "--timeout=600s",
-            context=hub,
-        )
+    for namespace, deployments in HUB_DEPLOYMENTS.items():
+        print(f"Waiting until namespace '{namespace}' is created on cluster '{hub}'")
+        drenv.wait_for(f"namespace/{namespace}", profile=hub)
+
+        for name in deployments:
+            deployment = f"deploy/{name}"
+            print(f"Waiting until deplyment '{name}' is rolled out on cluster '{hub}'")
+            drenv.wait_for(deployment, namespace=namespace, profile=hub)
+            kubectl.rollout(
+                "status",
+                deployment,
+                f"--namespace={namespace}",
+                "--timeout=600s",
+                context=hub,
+            )
 
 
 def join_cluster(cluster, hub):

--- a/test/addons/ocm-cluster/start
+++ b/test/addons/ocm-cluster/start
@@ -6,6 +6,7 @@
 import json
 import os
 import sys
+import time
 
 import drenv
 from drenv import cluster
@@ -122,13 +123,32 @@ def label_cluster(cluster, hub):
 
 
 def wait_for_managed_cluster(cluster, hub):
-    print("Waiting until managed cluster is available")
+    # This takes less then a second, but sometimes it never complete, even if waiting 10 minutes.
+    start = time.monotonic()
+
+    print(f"Waiting until managed cluster '{cluster}' hubAcceptsClient is true")
     kubectl.wait(
         f"managedcluster/{cluster}",
-        "--for=condition=ManagedClusterConditionAvailable",
-        "--timeout=600s",
+        "--for=jsonpath={.spec.hubAcceptsClient}=true",
+        "--timeout=60s",
         context=hub,
     )
+
+    for condition in (
+        "HubAcceptedManagedCluster",
+        "ManagedClusterJoined",
+        "ManagedClusterConditionAvailable",
+    ):
+        print(f"Waiting for managed cluster '{cluster}' condition {condition}")
+        kubectl.wait(
+            f"managedcluster/{cluster}",
+            f"--for=condition={condition}",
+            "--timeout=60s",
+            context=hub,
+        )
+
+    elapsed = time.monotonic() - start
+    print(f"managed cluster '{cluster}' became available in {elapsed:.2f} seconds")
 
 
 def enable_addons(cluster, hub):

--- a/test/addons/ocm-hub/start
+++ b/test/addons/ocm-hub/start
@@ -23,6 +23,7 @@ ADDONS = (
 
 DEPLOYMENTS = {
     "open-cluster-management": (
+        "cluster-manager",
         "governance-policy-addon-controller",
         "governance-policy-propagator",
         "multicluster-operators-appsub-summary",


### PR DESCRIPTION
Fix the way we wait for deployment on the hub, and the way we wait until the hub is ready on the managed clusters.

Fix the way we wait for managed cluster after join so we fail fast when the system is broken instead of waiting 10 minutes before retrying. Our retry in the CI will recover quickly if the system can recover.

Unfortunately this does not avoid the timeout when waiting for the managed cluster, this is an ocm bug and we don't have a working workaround for it.

Part of #1294 