### PR TITLE
Modify CEL for DRPolicy to make fields optional

### DIFF
--- a/api/v1alpha1/drpolicy_types.go
+++ b/api/v1alpha1/drpolicy_types.go
@@ -8,6 +8,8 @@ import (
 )
 
 // DRPolicySpec defines the desired state of DRPolicy
+// +kubebuilder:validation:XValidation:rule="has(oldSelf.replicationClassSelector) == has(self.replicationClassSelector)", message="replicationClassSelector is immutable"
+// +kubebuilder:validation:XValidation:rule="has(oldSelf.volumeSnapshotClassSelector) == has(self.volumeSnapshotClassSelector)", message="volumeSnapshotClassSelector is immutable"
 type DRPolicySpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
@@ -23,14 +25,16 @@ type DRPolicySpec struct {
 	// Label selector to identify all the VolumeReplicationClasses.
 	// This selector is assumed to be the same for all subscriptions that
 	// need DR protection. It will be passed in to the VRG when it is created
-	// +kubebuilder:validation:Required
+	//+optional
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="replicationClassSelector is immutable"
 	ReplicationClassSelector metav1.LabelSelector `json:"replicationClassSelector"`
 
 	// Label selector to identify all the VolumeSnapshotClasses.
 	// This selector is assumed to be the same for all subscriptions that
 	// need DR protection. It will be passed in to the VRG when it is created
-	// +kubebuilder:validation:Required
+	//+optional
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="volumeSnapshotClassSelector is immutable"
 	VolumeSnapshotClassSelector metav1.LabelSelector `json:"volumeSnapshotClassSelector"`
 

--- a/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
@@ -163,10 +163,13 @@ spec:
                   rule: self == oldSelf
             required:
             - drClusters
-            - replicationClassSelector
             - schedulingInterval
-            - volumeSnapshotClassSelector
             type: object
+            x-kubernetes-validations:
+            - message: replicationClassSelector is immutable
+              rule: has(oldSelf.replicationClassSelector) == has(self.replicationClassSelector)
+            - message: volumeSnapshotClassSelector is immutable
+              rule: has(oldSelf.volumeSnapshotClassSelector) == has(self.volumeSnapshotClassSelector)
           status:
             description: |-
               DRPolicyStatus defines the observed state of DRPolicy


### PR DESCRIPTION
Initial CEL changes to ensure immutability changed some spec fields to Required. As this causes breakage with other integrations, reverting these to optional.

The move to Required was to ensure immutability when initially empty. A different pattern for the same is now used with Optional and still guaranteeing immutability when initially unset.