### PR TITLE
Updating docs to give install instructions for virtctl v1.2.0

### DIFF
--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -151,7 +151,7 @@ enough resources:
 
 1. Install the `virtctl` tool.
    Working Example:
-   
+
    ```
    curl -L -O https://github.com/kubevirt/kubevirt/releases/download/v1.2.0/virtctl-v1.2.0-linux-amd64
    sudo install /tmp/virtctl-v1.2.0-linux-amd64 /usr/local/bin/virtctl

--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -154,14 +154,10 @@ enough resources:
    
    ```
    curl -L -O https://github.com/kubevirt/kubevirt/releases/download/v1.2.0/virtctl-v1.2.0-linux-amd64
+   sudo install /tmp/virtctl-v1.2.0-linux-amd64 /usr/local/bin/virtctl
+   sudo rm /tmp/virtctl-v1.2.0-linux-amd64
    ```
-   
-   After download completes for `virtctl` issue this command.
 
-   ```
-   sudo install virtctl-v1.2.0-linux-amd64 /usr/local/bin/virtctl
-   ```
-   
    See
    [virtctl install](https://kubevirt.io/quickstart_minikube/#virtctl)
    for more details.

--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -151,14 +151,17 @@ enough resources:
 
 1. Install the `virtctl` tool.
    Working Example:
+   
    ```
    curl -L -O https://github.com/kubevirt/kubevirt/releases/download/v1.2.0/virtctl-v1.2.0-linux-amd64
    ```
+   
    After download completes for `virtctl` issue this command.
 
    ```
-   sudo install virtctl /usr/local/bin
+   sudo install virtctl-v1.2.0-linux-amd64 /usr/local/bin/virtctl
    ```
+   
    See
    [virtctl install](https://kubevirt.io/quickstart_minikube/#virtctl)
    for more details.

--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -149,21 +149,19 @@ enough resources:
    for the details.
    Tested with version v1.12.0.
 
-1. Install the `virtctl` tool. See
-   [virtctl install](https://kubevirt.io/quickstart_minikube/#virtctl)
-   for the details.
-   Tested with version v1.0.1.
+1. Install the `virtctl` tool.
+   Working Example:
+   ```
+   curl -L -O https://github.com/kubevirt/kubevirt/releases/download/v1.2.0/virtctl-v1.2.0-linux-amd64
+   ```
+   After download completes for `virtctl` issue this command.
 
    ```
-   curl -L -o virtctl https://github.com/kubevirt/kubevirt/releases/download/v1.0.1/virtctl-v1.0.1-linux-amd64
-   ```
-
-   After download completes for `virtctl` issue these commands.
-
-   ```
-   chmod +x virtctl
    sudo install virtctl /usr/local/bin
    ```
+   See
+   [virtctl install](https://kubevirt.io/quickstart_minikube/#virtctl)
+   for more details.
 
 1. Install `mc` tool
 

--- a/test/README.md
+++ b/test/README.md
@@ -60,14 +60,13 @@ environment.
 
 1. Install the `virtctl` tool.
    Working Example:
+ 
    ```
    curl -L -O https://github.com/kubevirt/kubevirt/releases/download/v1.2.0/virtctl-v1.2.0-linux-amd64
+   sudo install /tmp/virtctl-v1.2.0-linux-amd64 /usr/local/bin/virtctl
+   sudo rm /tmp/virtctl-v1.2.0-linux-amd64
    ```
-   After download completes for `virtctl` issue this command.
 
-   ```
-   sudo install virtctl /usr/local/bin
-   ```
    See
    [virtctl install](https://kubevirt.io/quickstart_minikube/#virtctl)
    for more details.

--- a/test/README.md
+++ b/test/README.md
@@ -58,10 +58,19 @@ environment.
    See [Installing Helm](https://helm.sh/docs/intro/install/) for other options.
    Tested with version v3.11.
 
-1. Install the `virtctl` tool. See
+1. Install the `virtctl` tool.
+   Working Example:
+   ```
+   curl -L -O https://github.com/kubevirt/kubevirt/releases/download/v1.2.0/virtctl-v1.2.0-linux-amd64
+   ```
+   After download completes for `virtctl` issue this command.
+
+   ```
+   sudo install virtctl /usr/local/bin
+   ```
+   See
    [virtctl install](https://kubevirt.io/quickstart_minikube/#virtctl)
-   for the details.
-   Tested with version v1.0.1.
+   for more details.
 
 1. Install `mc` tool
 

--- a/test/README.md
+++ b/test/README.md
@@ -60,7 +60,7 @@ environment.
 
 1. Install the `virtctl` tool.
    Working Example:
- 
+
    ```
    curl -L -O https://github.com/kubevirt/kubevirt/releases/download/v1.2.0/virtctl-v1.2.0-linux-amd64
    sudo install /tmp/virtctl-v1.2.0-linux-amd64 /usr/local/bin/virtctl


### PR DESCRIPTION
Our docs should give working instructions for virtctl v1.2.0(Currently its v1.0.1 in the docs) - we can point to the virtctl docs for more info at the end.