### PR TITLE
Retry submariner connectivity check

### DIFF
--- a/test/addons/submariner/test
+++ b/test/addons/submariner/test
@@ -198,7 +198,7 @@ def wait_for_dns(cluster, namespace):
             break
 
 
-def test_connectivity(cluster, namespace):
+def test_connectivity(cluster, namespace, timeout=60):
     """
     Test that cluster can access service exported on the other cluster.
 
@@ -207,18 +207,37 @@ def test_connectivity(cluster, namespace):
     """
     dns_name = service_address(namespace)
 
-    print(f"Accessing '{dns_name}' in cluster '{cluster}'")
-    out = kubectl.exec(
-        "test",
-        f"--namespace={namespace}",
-        "--",
-        "curl",
-        "--no-progress-meter",
-        dns_name,
-        context=cluster,
-    )
-    if "Welcome to nginx" not in out:
-        raise RuntimeError(f"Unexpected output: {out}")
+    start = time.monotonic()
+    deadline = start + timeout
+    delay = 1
+
+    while True:
+        print(f"Accessing '{dns_name}' in cluster '{cluster}'")
+        try:
+            out = kubectl.exec(
+                "test",
+                f"--namespace={namespace}",
+                "--",
+                "curl",
+                "--no-progress-meter",
+                dns_name,
+                context=cluster,
+            )
+        except commands.Error as e:
+            if time.monotonic() > deadline:
+                raise
+
+            print(f"Failed to connect: {e}")
+            print(f"Retrying in {delay} seconds")
+            time.sleep(delay)
+            delay = min(delay * 2, 10)
+        else:
+            if "Welcome to nginx" not in out:
+                raise RuntimeError(f"Unexpected output: {out}")
+
+            elapsed = time.monotonic() - start
+            print(f"Access completed in {elapsed:.3f} seconds")
+            break
 
 
 if len(sys.argv) != 4:


### PR DESCRIPTION
Try to fix the connectivity failures in submariner test with retries. This may be enough if the issue is temporary, and if it is not not, this will provide more info to submariner developers.

The issue was not reproduce with submariner 0.17.0.

Tested:
- 200 runs with submariner.yaml - 100% passed
- 100 runs with regional-dr.yaml - 100% passed

Average time for connectivity check in 100 runs of regional-dr.yaml:
```
$ grep 'Access completed' e2e-rdr/out.0{3,4}/*.log | awk '{sum+=$8} END {print sum/NR}'
0.206505
```

Based on #1274 for testing.