### PR TITLE
Introducing cache for kubevirt and cdi addons

### DIFF
--- a/test/addons/cdi/fetch
+++ b/test/addons/cdi/fetch
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from drenv import cache
+
+os.chdir(os.path.dirname(__file__))
+
+path = cache.path("addons/cdi-operator.yaml")
+cache.fetch("operator", path)
+
+path = cache.path("addons/cdi-cr.yaml")
+cache.fetch("cr", path)

--- a/test/addons/cdi/start
+++ b/test/addons/cdi/start
@@ -7,13 +7,16 @@ import os
 import sys
 
 from drenv import kubectl
+from drenv import cache
 
 NAMESPACE = "cdi"
 
 
 def deploy(cluster):
     print("Deploying cdi operator")
-    kubectl.apply("--kustomize=operator", context=cluster)
+    path = cache.path("addons/cdi-operator.yaml")
+    cache.fetch("operator", path)
+    kubectl.apply("--filename", path, context=cluster)
 
     print("Waiting until cdi-operator is rolled out")
     kubectl.rollout(
@@ -25,7 +28,9 @@ def deploy(cluster):
     )
 
     print("Deploying cdi cr")
-    kubectl.apply("--kustomize=cr", context=cluster)
+    path = cache.path("addons/cdi-cr.yaml")
+    cache.fetch("cr", path)
+    kubectl.apply("--filename", path, context=cluster)
 
 
 def wait(cluster):

--- a/test/addons/kubevirt/fetch
+++ b/test/addons/kubevirt/fetch
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from drenv import cache
+
+os.chdir(os.path.dirname(__file__))
+
+path = cache.path("addons/kubevirt-operator.yaml")
+cache.fetch("operator", path)
+
+path = cache.path("addons/kubevirt-cr.yaml")
+cache.fetch("cr", path)

--- a/test/addons/kubevirt/start
+++ b/test/addons/kubevirt/start
@@ -7,13 +7,16 @@ import os
 import sys
 
 from drenv import kubectl
+from drenv import cache
 
 NAMESPACE = "kubevirt"
 
 
 def deploy(cluster):
     print("Deploying kubevirt operator")
-    kubectl.apply("--kustomize=operator", context=cluster)
+    path = cache.path("addons/kubevirt-operator.yaml")
+    cache.fetch("operator", path)
+    kubectl.apply("--filename", path, context=cluster)
 
     print("Waiting until virt-operator is rolled out")
     kubectl.rollout(
@@ -25,7 +28,9 @@ def deploy(cluster):
     )
 
     print("Deploying kubevirt cr")
-    kubectl.apply("--kustomize=cr", context=cluster)
+    path = cache.path("addons/kubevirt-cr.yaml")
+    cache.fetch("cr", path)
+    kubectl.apply("--filename", path, context=cluster)
 
 
 def wait(cluster):


### PR DESCRIPTION
This change caches resources for kubevirt and cdi addon resources, using the fetch command or whenever the addons are started.

When network is flaky and fetching resources is not possible, we can still build the addons using the cached resources.
Even in normal scenario, addons can be built quickly using the cached resources, so it provides some optimisation.

Example demonstrating how the cache works:

If cache is clean, starting an addon fetch the resources:
```
$ addons/kubevirt/start kubevirt
Deploying kubevirt operator
Fetching /home/abhijeet/.cache/drenv/addons/kubevirt-operator.yaml
namespace/kubevirt unchanged
customresourcedefinition.apiextensions.k8s.io/kubevirts.kubevirt.io unchanged
serviceaccount/kubevirt-operator unchanged
role.rbac.authorization.k8s.io/kubevirt-operator unchanged
clusterrole.rbac.authorization.k8s.io/kubevirt-operator unchanged
clusterrole.rbac.authorization.k8s.io/kubevirt.io:operator unchanged
rolebinding.rbac.authorization.k8s.io/kubevirt-operator-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/kubevirt-operator unchanged
priorityclass.scheduling.k8s.io/kubevirt-cluster-critical configured
deployment.apps/virt-operator configured
Waiting until virt-operator is rolled out
deployment "virt-operator" successfully rolled out
Deploying kubevirt cr
Fetching /home/abhijeet/.cache/drenv/addons/kubevirt-cr.yaml
kubevirt.kubevirt.io/kubevirt unchanged
Waiting until kubevirt cr is available
kubevirt.kubevirt.io/kubevirt condition met
```

If resources are already cached, starting an addon using the cached resources without accessing the network:
```
$ addons/kubevirt/start kubevirt
Deploying kubevirt operator
namespace/kubevirt unchanged
customresourcedefinition.apiextensions.k8s.io/kubevirts.kubevirt.io unchanged
serviceaccount/kubevirt-operator unchanged
role.rbac.authorization.k8s.io/kubevirt-operator unchanged
clusterrole.rbac.authorization.k8s.io/kubevirt-operator unchanged
clusterrole.rbac.authorization.k8s.io/kubevirt.io:operator unchanged
rolebinding.rbac.authorization.k8s.io/kubevirt-operator-rolebinding unchanged
clusterrolebinding.rbac.authorization.k8s.io/kubevirt-operator unchanged
priorityclass.scheduling.k8s.io/kubevirt-cluster-critical configured
deployment.apps/virt-operator configured
Waiting until virt-operator is rolled out
deployment "virt-operator" successfully rolled out
Deploying kubevirt cr
kubevirt.kubevirt.io/kubevirt unchanged
Waiting until kubevirt cr is available
kubevirt.kubevirt.io/kubevirt condition met
```


Comparison of working with and without cache:
(After running these for a total of around 120 times at different hours of the day)

Running kubevirt addon:
Command used: `addons/kubevirt/start <cluster name>`
```
without cache:
  Average time taken: 4.55s
  Min time taken: 3.122s (11:02am IST)
  Max time taken: 15.317s (3:32pm IST)
  
with cache:
  Average time taken: 2.38s
  Min time taken: 2.11s (1:02pm IST)
  Max time taken: 4.02s (12:24am IST)
```
So on an average, running kubevirt addon with cache saves us 2.17s.


Running cdi addon 
Command used: `addons/cdi/start <cluster name>`
```
without cache:
  Average time taken: 9.24s
  Min time taken: 7.48s (11:52am IST)
  Max time taken: 20.68s (4:32pm IST)
  
with cache:
  Average time taken: 5.98s
  Min time taken: 2.73s (3:42pm IST)
  Max time taken: 8.84s (5:12pm IST)
```
So on an average, running cdi addon with cache saves us 3.26s.


Fetching kubevirt env:
Command Used: `drenv fetch envs/kubevirt.yaml`
It fetches all resources in parallel and saves us time.
```
Average time taken: 5.44s
Min time taken: 3.84s (12:42pm IST)
Max time taken: 11.85s (4:02pm IST)
```


And, this is how we cache the resources for kubevirt and cdi:
```
$ tree -sh ~/.cache/drenv/
[   20]  /home/abhijeet/.cache/drenv/
└── [  104]  addons
    ├── [  517]  cdi-cr.yaml
    ├── [ 298K]  cdi-operator.yaml
    ├── [  367]  kubevirt-cr.yaml
    └── [ 409K]  kubevirt-operator.yaml
```
