### PR TITLE
Improve rook deployment and logging

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,9 @@
 [flake8]
-# TODO: modify the code to elimiante the ignores.
-# E501: line to long.
-# E203 whitespace before ':' to accept black code style
-ignore = E501,E203
+# These warnings and errors are ignored to accept black code style:
+# - E501: line to long
+# - E203 whitespace before ':'
+# - W503: line break before binary operator
+ignore = E501,E203,W503
 
 show_source = true
 statistics = true

--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -11,9 +11,17 @@ import sys
 import yaml
 
 import drenv
+from drenv import ceph
 from drenv import kubectl
 
 POOL_NAME = "replicapool"
+
+
+def log_blocklist(cluster):
+    blocklist = ceph.list_osd_blocklist(cluster)
+    if blocklist:
+        info = {f"Cluster '{cluster}' ceph osd blocklist": blocklist}
+        print(yaml.dump(info, sort_keys=False))
 
 
 def fetch_secret_info(cluster):
@@ -178,6 +186,9 @@ configure_rbd_mirroring(cluster2, cluster1_info)
 
 wait_until_rbd_mirror_is_ready(cluster1)
 wait_until_rbd_mirror_is_ready(cluster2)
+
+log_blocklist(cluster1)
+log_blocklist(cluster2)
 
 wait_until_pool_mirroring_is_healthy(cluster1)
 wait_until_pool_mirroring_is_healthy(cluster2)

--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -8,6 +8,8 @@ import json
 import os
 import sys
 
+import yaml
+
 import drenv
 from drenv import kubectl
 
@@ -80,6 +82,31 @@ def configure_rbd_mirroring(cluster, peer_info):
     )
 
 
+def wait_until_rbd_mirror_is_ready(cluster):
+    print(f"Waiting until rbd mirror is ready in cluster '{cluster}'")
+    drenv.wait_for(
+        "cephrbdmirror/my-rbd-mirror",
+        output="jsonpath={.status.phase}",
+        namespace="rook-ceph",
+        profile=cluster,
+    )
+    kubectl.wait(
+        "cephrbdmirror/my-rbd-mirror",
+        "--for=jsonpath={.status.phase}=Ready",
+        "--namespace=rook-ceph",
+        "--timeout=300s",
+        context=cluster,
+    )
+    status = kubectl.get(
+        "cephrbdmirror/my-rbd-mirror",
+        "--output=jsonpath={.status}",
+        "--namespace=rook-ceph",
+        context=cluster,
+    )
+    info = {f"Cluster '{cluster}' rbd mirror status": json.loads(status)}
+    print(yaml.dump(info, sort_keys=False))
+
+
 def wait_until_pool_mirroring_is_healthy(cluster):
     print(f"Waiting until ceph mirror daemon is healthy in cluster '{cluster}'")
     kubectl.wait(
@@ -138,6 +165,9 @@ configure_rbd_mirroring(cluster1, cluster2_info)
 
 print(f"Setting up mirroring from '{cluster1}' to '{cluster2}'")
 configure_rbd_mirroring(cluster2, cluster1_info)
+
+wait_until_rbd_mirror_is_ready(cluster1)
+wait_until_rbd_mirror_is_ready(cluster2)
 
 wait_until_pool_mirroring_is_healthy(cluster1)
 wait_until_pool_mirroring_is_healthy(cluster2)

--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -139,6 +139,16 @@ def wait_until_pool_mirroring_is_healthy(cluster):
         context=cluster,
     )
 
+    status = kubectl.get(
+        "cephblockpools.ceph.rook.io",
+        POOL_NAME,
+        "--output=jsonpath={.status}",
+        "--namespace=rook-ceph",
+        context=cluster,
+    )
+    info = {f"Cluster '{cluster}' ceph block pool status": json.loads(status)}
+    print(yaml.dump(info, sort_keys=False))
+
 
 def deploy_vrc_sample(cluster):
     print(f"Applying vrc sample in cluster '{cluster}'")

--- a/test/addons/rook-cluster/start
+++ b/test/addons/rook-cluster/start
@@ -3,8 +3,11 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
 import sys
+
+import yaml
 
 import drenv
 from drenv import kubectl
@@ -42,6 +45,15 @@ def wait(cluster):
         f"--timeout={TIMEOUT}s",
         context=cluster,
     )
+
+    out = kubectl.get(
+        "cephcluster/my-cluster",
+        "--output=jsonpath={.status}",
+        "--namespace=rook-ceph",
+        context=cluster,
+    )
+    info = {"ceph cluster status": json.loads(out)}
+    print(yaml.dump(info, sort_keys=False))
 
 
 if len(sys.argv) != 2:

--- a/test/addons/rook-pool/start
+++ b/test/addons/rook-pool/start
@@ -3,8 +3,11 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
 import sys
+
+import yaml
 
 import drenv
 from drenv import kubectl
@@ -44,6 +47,15 @@ def wait(cluster):
         "--timeout=300s",
         context=cluster,
     )
+
+    out = kubectl.get(
+        "cephblockpool/replicapool",
+        "--output=jsonpath={.status}",
+        "--namespace=rook-ceph",
+        context=cluster,
+    )
+    info = {"ceph pool status": json.loads(out)}
+    print(yaml.dump(info, sort_keys=False))
 
 
 if len(sys.argv) != 2:

--- a/test/addons/rook-toolbox/start
+++ b/test/addons/rook-toolbox/start
@@ -6,6 +6,7 @@
 import os
 import sys
 
+from drenv import ceph
 from drenv import kubectl
 
 # Update this when upgrading rook.
@@ -27,6 +28,9 @@ def wait(cluster):
         "--timeout=300s",
         context=cluster,
     )
+
+    print("ceph status:")
+    print(ceph.tool(cluster, "ceph", "status").rstrip())
 
 
 if len(sys.argv) != 2:

--- a/test/envs/regional-dr-hubless.yaml
+++ b/test/envs/regional-dr-hubless.yaml
@@ -27,8 +27,8 @@ templates:
       - addons:
           - name: rook-operator
           - name: rook-cluster
-          - name: rook-pool
           - name: rook-toolbox
+          - name: rook-pool
       - addons:
           - name: csi-addons
           - name: olm

--- a/test/envs/regional-dr-kubevirt.yaml
+++ b/test/envs/regional-dr-kubevirt.yaml
@@ -32,8 +32,8 @@ templates:
       - addons:
           - name: rook-operator
           - name: rook-cluster
-          - name: rook-pool
           - name: rook-toolbox
+          - name: rook-pool
       - addons:
           - name: ocm-cluster
             args: ["$name", "hub"]

--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -30,8 +30,8 @@ templates:
       - addons:
           - name: rook-operator
           - name: rook-cluster
-          - name: rook-pool
           - name: rook-toolbox
+          - name: rook-pool
       - addons:
           - name: ocm-cluster
             args: ["$name", "hub"]

--- a/test/envs/rook.yaml
+++ b/test/envs/rook.yaml
@@ -18,8 +18,8 @@ templates:
       - addons:
           - name: rook-operator
           - name: rook-cluster
-          - name: rook-pool
           - name: rook-toolbox
+          - name: rook-pool
       - addons:
           - name: csi-addons
 

--- a/test/envs/rook.yaml
+++ b/test/envs/rook.yaml
@@ -10,6 +10,7 @@ templates:
     driver: "$vm"
     container_runtime: containerd
     network: "$network"
+    cpus: 4
     memory: "6g"
     extra_disks: 1
     disk_size: "50g"


### PR DESCRIPTION
Improve the way we wait for rook component and log rook and ceph state during deployment. Hopefully this will make it easier to understand random failures in unattended builds.