### PR TITLE
DRPolicy: add default values

### DIFF
--- a/api/v1alpha1/drpolicy_types.go
+++ b/api/v1alpha1/drpolicy_types.go
@@ -25,6 +25,7 @@ type DRPolicySpec struct {
 	// need DR protection. It will be passed in to the VRG when it is created
 	//+optional
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:={}
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="replicationClassSelector is immutable"
 	ReplicationClassSelector metav1.LabelSelector `json:"replicationClassSelector"`
 
@@ -33,6 +34,7 @@ type DRPolicySpec struct {
 	// need DR protection. It will be passed in to the VRG when it is created
 	//+optional
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:={}
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="volumeSnapshotClassSelector is immutable"
 	VolumeSnapshotClassSelector metav1.LabelSelector `json:"volumeSnapshotClassSelector"`
 

--- a/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
@@ -51,6 +51,7 @@ spec:
                 - message: drClusters is immutable
                   rule: self == oldSelf
               replicationClassSelector:
+                default: {}
                 description: |-
                   Label selector to identify all the VolumeReplicationClasses.
                   This selector is assumed to be the same for all subscriptions that
@@ -112,6 +113,7 @@ spec:
                 - message: schedulingInterval is immutable
                   rule: self == oldSelf
               volumeSnapshotClassSelector:
+                default: {}
                 description: |-
                   Label selector to identify all the VolumeSnapshotClasses.
                   This selector is assumed to be the same for all subscriptions that


### PR DESCRIPTION
add empty default values to replicationClassSelector and volumeSnapshotClassSelector fields using
kubebuilder CRD validation rules