### PR TITLE
Increase the number of drenv workers

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,9 +11,8 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   NAME_PREFIX: "rdr-"
-  # Avoid random failures in overloaded runner
-  # TODO: more testing.
-  MAX_WORKERS: 1
+  # Limit number of drenv workers.
+  MAX_WORKERS: 4
 
 jobs:
   e2e-rdr:


### PR DESCRIPTION
Previously limited to 1 worker per cluster due to various issues. Since the issues are fixed now, we can remove this limit.

| PR | build | start clusters time |
|----|-------|------|
| after #1331 | [build 1](https://github.com/RamenDR/ramen/actions/runs/8631217492/attempts/1) | 11:06 |
| after #1331 | [build 2](https://github.com/RamenDR/ramen/actions/runs/8631217492/attempts/2)  | 10:49 |
| after #1331 | [build 3](https://github.com/RamenDR/ramen/actions/runs/8631217492/attempts/3)  | 10:04 |
| before #1291 | [build 1](https://github.com/RamenDR/ramen/actions/runs/8630771101/attempts/1) | 13:54 |
| before #1291 | [build 2](https://github.com/RamenDR/ramen/actions/runs/8630771101/attempts/2) | 14:40 |
| before #1291 | [build 3](https://github.com/RamenDR/ramen/actions/runs/8630771101/attempts/3) | 14:09 |

Based on #1291 
