### PR TITLE
Workaround for rbd-mirror bug

### DIFF
--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -7,11 +7,15 @@ import base64
 import json
 import os
 import sys
+import time
+
+from contextlib import closing
 
 import yaml
 
 import drenv
 from drenv import ceph
+from drenv import commands
 from drenv import kubectl
 
 POOL_NAME = "replicapool"
@@ -115,37 +119,22 @@ def wait_until_rbd_mirror_is_ready(cluster):
     print(yaml.dump(info, sort_keys=False))
 
 
-def wait_until_pool_mirroring_is_healthy(cluster):
-    print(f"Waiting until ceph mirror daemon is healthy in cluster '{cluster}'")
-    kubectl.wait(
-        "cephblockpools.ceph.rook.io",
-        POOL_NAME,
-        "--for=jsonpath={.status.mirroringStatus.summary.daemon_health}=OK",
-        "--namespace=rook-ceph",
-        # We had random timeouts with 300s.
-        "--timeout=600s",
-        context=cluster,
-    )
+def wait_until_pool_mirroring_is_healthy(cluster, attempts=3):
+    # We have random timeouts when rbd-mirror fail to connect to the peer.
+    # When this happens we can recover by restarting the rbd-mirror daemon.
 
-    print(f"Waiting until ceph mirror is healthy in cluster '{cluster}'")
-    kubectl.wait(
-        "cephblockpools.ceph.rook.io",
-        POOL_NAME,
-        "--for=jsonpath={.status.mirroringStatus.summary.health}=OK",
-        "--namespace=rook-ceph",
-        "--timeout=300s",
-        context=cluster,
-    )
+    for i in range(1, attempts + 1):
+        print(f"Waiting for mirroring health in cluster '{cluster}' ({i}/{attempts})")
+        try:
+            watch_pool_mirroring_status(cluster)
+        except commands.Timeout:
+            if i == attempts:
+                raise
 
-    print(f"Waiting until ceph mirror image is healthy in cluster '{cluster}'")
-    kubectl.wait(
-        "cephblockpools.ceph.rook.io",
-        POOL_NAME,
-        "--for=jsonpath={.status.mirroringStatus.summary.image_health}=OK",
-        "--namespace=rook-ceph",
-        "--timeout=300s",
-        context=cluster,
-    )
+            print(f"Timeout waiting for mirroring health in cluster '{cluster}'")
+            restart_rbd_mirror_daemon(cluster)
+        else:
+            break
 
     status = kubectl.get(
         "cephblockpools.ceph.rook.io",
@@ -156,6 +145,61 @@ def wait_until_pool_mirroring_is_healthy(cluster):
     )
     info = {f"Cluster '{cluster}' ceph block pool status": json.loads(status)}
     print(yaml.dump(info, sort_keys=False))
+
+
+def watch_pool_mirroring_status(cluster, timeout=180):
+    """
+    Watch pool .status.mirroringStatus.summary until mirroring is healthy or
+    the timeout expires.
+    """
+    start = time.monotonic()
+    deadline = start + timeout
+
+    while True:
+        remaining = deadline - time.monotonic()
+        watcher = kubectl.watch(
+            f"cephblockpool/{POOL_NAME}",
+            jsonpath="{.status.mirroringStatus.summary}",
+            namespace="rook-ceph",
+            timeout=remaining,
+            context=cluster,
+        )
+        with closing(watcher):
+            for line in watcher:
+                summary = json.loads(line)
+                print(f"Cluster '{cluster}' mirroring status': {summary}")
+
+                if mirroring_is_healthy(summary):
+                    elapsed = time.monotonic() - start
+                    print(
+                        f"Cluster '{cluster}' mirroring healthy in {elapsed:.2f} seconds"
+                    )
+                    return
+
+
+def mirroring_is_healthy(summary):
+    return (
+        summary["daemon_health"] == "OK"
+        and summary["health"] == "OK"
+        and summary["image_health"] == "OK"
+    )
+
+
+def restart_rbd_mirror_daemon(cluster):
+    # TODO: Get the name from the cluster.
+    deploy = "deploy/rook-ceph-rbd-mirror-a"
+
+    print(f"Restarting {deploy} in cluster '{cluster}'")
+    kubectl.rollout("restart", deploy, "--namespace=rook-ceph", context=cluster)
+
+    print(f"Waiting until {deploy} is rolled out in cluster '{cluster}'")
+    kubectl.rollout(
+        "status",
+        deploy,
+        "--namespace=rook-ceph",
+        "--timeout=120s",
+        context=cluster,
+    )
 
 
 def deploy_vrc_sample(cluster):

--- a/test/addons/rook-operator/rook-config-override.yaml
+++ b/test/addons/rook-operator/rook-config-override.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# yamllint disable rule:line-length
+# Based on https://github.com/red-hat-storage/ocs-operator/commit/e39bb415485df8efcfbf8ddee08f545972e7b064
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: rook-config-override
+  namespace: rook-ceph
+data:
+  config: |
+    [client.rbd-mirror.a]
+    debug_ms = 1
+    debug_rbd = 15
+    debug_rbd_mirror = 30
+    [client.rbd-mirror-peer]
+    debug_ms = 1
+    debug_rbd = 15
+    debug_rbd_mirror = 30
+    [mgr]
+    mgr/rbd_support/log_level = debug

--- a/test/addons/rook-operator/rook-config-override.yaml
+++ b/test/addons/rook-operator/rook-config-override.yaml
@@ -16,9 +16,13 @@ data:
     debug_ms = 1
     debug_rbd = 15
     debug_rbd_mirror = 30
+    log_to_file = true
+    log_file = /var/log/ceph/$cluster-$name.log
     [client.rbd-mirror-peer]
     debug_ms = 1
     debug_rbd = 15
     debug_rbd_mirror = 30
+    log_to_file = true
+    log_file = /var/log/ceph/$cluster-$name.log
     [mgr]
     mgr/rbd_support/log_level = debug

--- a/test/addons/rook-operator/start
+++ b/test/addons/rook-operator/start
@@ -44,6 +44,9 @@ def wait(cluster):
         context=cluster,
     )
 
+    print("Applying rook-config-override")
+    kubectl.apply("--filename=rook-config-override.yaml", context=cluster)
+
 
 if len(sys.argv) != 2:
     print(f"Usage: {sys.argv[0]} cluster")

--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -93,7 +93,7 @@ def run(*args, input=None, decode=True):
     return output.decode() if decode else output
 
 
-def watch(*args, input=None):
+def watch(*args, input=None, keepends=False, decode=True):
     """
     Run command args, iterating over lines read from the child process stdout.
 
@@ -142,11 +142,16 @@ def watch(*args, input=None):
                         line = bytes(partial) + line
                         del partial[:]
 
-                    yield line.rstrip().decode()
+                    if not keepends:
+                        line = line.rstrip()
+                    yield line.decode() if decode else line
 
         if partial:
-            yield partial.rstrip().decode()
+            line = bytes(partial)
             del partial[:]
+            if not keepends:
+                line = line.rstrip()
+            yield line.decode() if decode else line
 
     if p.returncode != 0:
         error = error.decode(errors="replace")

--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -6,6 +6,7 @@ import platform
 import selectors
 import subprocess
 import textwrap
+import time
 
 from . import shutdown
 
@@ -57,6 +58,18 @@ class Error(Exception):
         return "".join(lines)
 
 
+class Timeout(Error):
+
+    def __init__(self, command, error):
+        super().__init__(command, error)
+
+
+class StreamTimeout(Exception):
+    """
+    Raised when stream timeout expires.
+    """
+
+
 def run(*args, input=None, decode=True):
     """
     Run command args and return the output of the command.
@@ -93,7 +106,7 @@ def run(*args, input=None, decode=True):
     return output.decode() if decode else output
 
 
-def watch(*args, input=None, keepends=False, decode=True):
+def watch(*args, input=None, keepends=False, decode=True, timeout=None):
     """
     Run command args, iterating over lines read from the child process stdout.
 
@@ -109,9 +122,12 @@ def watch(*args, input=None, keepends=False, decode=True):
     To stop watching early and terminate the process, call close() on the
     returned value.
 
-    Raises Error if creating a child process failed or the child process
-    terminated with non-zero exit code. The error includes all data read from
-    the child process stderr.
+    Raises:
+    - Error if creating a child process failed or the child process
+      terminated with non-zero exit code. The error includes all data read
+      from the child process stderr.
+    - Timeout if the command did not terminate within the specified
+      timeout.
     """
     # Avoid delays in python child process logs.
     env = dict(os.environ)
@@ -133,7 +149,7 @@ def watch(*args, input=None, keepends=False, decode=True):
         error = bytearray()
         partial = bytearray()
 
-        for src, data in stream(p, input=input):
+        for src, data in stream(p, input=input, timeout=timeout):
             if src is ERR:
                 error += data
             else:
@@ -160,6 +176,9 @@ def watch(*args, input=None, keepends=False, decode=True):
     except GeneratorExit:
         p.kill()
         return
+    except StreamTimeout as e:
+        p.kill()
+        raise Timeout(args, "Timed watching command").with_exception(e)
     finally:
         p.wait()
 
@@ -168,7 +187,7 @@ def watch(*args, input=None, keepends=False, decode=True):
         raise Error(args, error, exitcode=p.returncode)
 
 
-def stream(proc, input=None, bufsize=32 << 10):
+def stream(proc, input=None, bufsize=32 << 10, timeout=None):
     """
     Stream data from process stdout and stderr.
 
@@ -182,6 +201,11 @@ def stream(proc, input=None, bufsize=32 << 10):
     Yields either (OUT, data) or (ERR, data) read from proc stdout and stderr.
     Returns when both streams are closed.
     """
+    if timeout is None:
+        deadline = None
+    else:
+        deadline = time.monotonic() + timeout
+
     if input:
         if proc.stdin is None:
             raise RuntimeError("Cannot stream input: proc.stdin is None")
@@ -203,7 +227,8 @@ def stream(proc, input=None, bufsize=32 << 10):
             input_offset = 0
 
         while sel.get_map():
-            for key, event in sel.select():
+            remaining = _remaining_time(deadline)
+            for key, event in sel.select(remaining):
                 if key.fileobj is proc.stdin:
                     # Stream data from caller to child process.
                     chunk = input_view[input_offset : input_offset + _PIPE_BUF]
@@ -225,3 +250,14 @@ def stream(proc, input=None, bufsize=32 << 10):
                         continue
 
                     yield key.data, data
+
+
+def _remaining_time(deadline):
+    if deadline is None:
+        return None
+
+    now = time.monotonic()
+    if now >= deadline:
+        raise StreamTimeout
+
+    return deadline - now

--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -272,6 +272,22 @@ def test_watch_after_shutdown(monkeypatch):
         list(commands.watch("no-such-command"))
 
 
+def test_watch_some():
+    # This command terminate with non-zero exit code, but we care only about
+    # getting the first 2 lines and ignore the rest of the output and the exit
+    # code.
+    cmd = ("sh", "-c", "echo line 1; echo line 2; sleep 10; echo line 3; exit 1")
+    output = []
+
+    watcher = commands.watch(*cmd)
+    for line in watcher:
+        output.append(line)
+        if len(output) == 2:
+            watcher.close()
+
+    assert output == ["line 1", "line 2"]
+
+
 # Running commands.
 
 

--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -242,6 +242,21 @@ def test_watch_non_ascii():
     assert output == ["\u05d0"]
 
 
+def test_watch_keepends():
+    output = list(commands.watch("echo", "output", keepends=True))
+    assert output == ["output\n"]
+
+
+def test_watch_no_decode():
+    output = list(commands.watch("echo", b"output", decode=False))
+    assert output == [b"output"]
+
+
+def test_watch_keepends_no_decode():
+    output = list(commands.watch("echo", b"output", keepends=True, decode=False))
+    assert output == [b"output\n"]
+
+
 def test_watch_invalid_utf8():
     script = """
 import os

--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -124,6 +124,18 @@ def test_stream_no_stdout_stderr():
     assert stream == []
 
 
+def test_stream_timeout_expired():
+    with run("true") as p:
+        with pytest.raises(commands.StreamTimeout):
+            list(commands.stream(p, timeout=0.0))
+
+
+def test_stream_timeout_not_expired():
+    with run("true") as p:
+        stream = list(commands.stream(p, timeout=1.0))
+    assert stream == []
+
+
 # Watching commands.
 
 
@@ -286,6 +298,16 @@ def test_watch_some():
             watcher.close()
 
     assert output == ["line 1", "line 2"]
+
+
+def test_watch_timeout():
+    with pytest.raises(commands.Timeout):
+        list(commands.watch("true", timeout=0.0))
+
+
+def test_watch_timeout_not_expired():
+    output = list(commands.watch("true", timeout=1.0))
+    assert output == []
 
 
 # Running commands.

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -3,6 +3,8 @@
 
 from . import commands
 
+JSONPATH_NEWLINE = '{"\\n"}'
+
 
 def version(context=None, output=None):
     """
@@ -129,6 +131,50 @@ def wait(*args, context=None, log=print):
     Run kubectl wait ... logging progress messages.
     """
     _watch("wait", *args, context=context, log=log)
+
+
+def watch(
+    resource,
+    jsonpath="{}",
+    namespace=None,
+    timeout=None,
+    context=None,
+):
+    """
+    Run kubectl get --watch --output={jsonpath} ... iterating over lines from
+    kubectl stdout.
+
+    The resource argument may be kind ("pod") or a single resource
+    ("pod/pod-name").
+
+    Since watch waits for a complete line, a JSONPATH_NEWLINE is added to
+    specified jsonpath argument unless the jsonpath already ends with one.
+
+    Iteration stops when the timeout expires, or the underlying kubectl command
+    terminated with a zero exit code.
+
+    To end watching early, call close() on the return value.
+
+    Raises:
+    - commands.Error if starting kubectl failed.
+    - comamnds.Timeout if timeout has expired.
+    """
+    if not jsonpath.endswith(JSONPATH_NEWLINE):
+        jsonpath += JSONPATH_NEWLINE
+
+    cmd = [
+        "kubectl",
+        "get",
+        resource,
+        "--watch",
+        f"--output=jsonpath={jsonpath}",
+    ]
+    if namespace:
+        cmd.append(f"--namespace={namespace}")
+    if context:
+        cmd.append(f"--context={context}")
+
+    return commands.watch(*cmd, timeout=timeout)
 
 
 def _run(cmd, *args, context=None):

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -66,11 +66,13 @@ def patch(*args, context=None, log=print):
     _watch("patch", *args, context=context, log=log)
 
 
-def label(name, value, overwrite=False, context=None, log=print):
+def label(resource, label, overwrite=False, context=None, log=print):
     """
-    Run kubectl label ... logging progress messages.
+    Run kubectl resource label ... logging progress messages.
+
+    Set label="name=value" to set a label, label="name-" to remove a label.
     """
-    args = ["label", name, value]
+    args = ["label", resource, label]
     if overwrite:
         args.append("--overwrite")
     _watch(*args, context=context, log=log)

--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -100,7 +100,7 @@ def test_annotate(tmpenv, capsys):
 
     print(f"Adding new annotation {annotation}")
     kubectl.annotate(pod, {annotation: "old"}, context=tmpenv.profile)
-    assert _get_annotations(pod)[annotation] == "old"
+    assert _get_annotations(pod, tmpenv.profile)[annotation] == "old"
 
     print(f"Overwirting annotation {annotation}")
     kubectl.annotate(
@@ -109,11 +109,11 @@ def test_annotate(tmpenv, capsys):
         overwrite=True,
         context=tmpenv.profile,
     )
-    assert _get_annotations(pod)[annotation] == "new"
+    assert _get_annotations(pod, tmpenv.profile)[annotation] == "new"
 
     print(f"Removing annotation {annotation}")
     kubectl.annotate(pod, {annotation: None}, context=tmpenv.profile)
-    assert annotation not in _get_annotations(pod)
+    assert annotation not in _get_annotations(pod, tmpenv.profile)
 
 
 def test_delete(tmpenv, capsys):
@@ -124,8 +124,12 @@ def test_delete(tmpenv, capsys):
     assert out.strip() == f'pod "{name}" deleted'
 
 
-def _get_annotations(resource):
-    out = kubectl.get(resource, "--output=jsonpath={.metadata.annotations}")
+def _get_annotations(resource, context):
+    out = kubectl.get(
+        resource,
+        "--output=jsonpath={.metadata.annotations}",
+        context=context,
+    )
     if out == "":
         return {}
     return json.loads(out)

--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -4,7 +4,11 @@
 import os
 import json
 import secrets
+from contextlib import closing
 
+import pytest
+
+from drenv import commands
 from drenv import kubectl
 
 EXAMPLE_DEPLOYMENT = os.path.join("addons", "example", "deployment.yaml")
@@ -122,6 +126,117 @@ def test_delete(tmpenv, capsys):
     out, err = capsys.readouterr()
     _, name = pod.split("/", 1)
     assert out.strip() == f'pod "{name}" deleted'
+
+
+def test_watch(tmpenv):
+    pod_name = kubectl.get(
+        "pod",
+        "--output=jsonpath={.items[0].metadata.name}",
+        context=tmpenv.profile,
+    )
+    print("pod_name:", pod_name)
+    watcher = kubectl.watch(f"pod/{pod_name}", context=tmpenv.profile)
+    for line in watcher:
+        pod = json.loads(line)
+        print("pod:", pod)
+        watcher.close()
+
+    assert pod["metadata"]["name"] == pod_name
+
+
+def test_watch_leaf(tmpenv):
+    pod_name = kubectl.get(
+        "pod",
+        "--output=jsonpath={.items[0].metadata.name}",
+        context=tmpenv.profile,
+    )
+    print("pod_name:", pod_name)
+    watcher = kubectl.watch(
+        f"pod/{pod_name}",
+        jsonpath="{.metadata.name}",
+        context=tmpenv.profile,
+    )
+    for line in watcher:
+        print("line:", line)
+        watcher.close()
+
+    assert line == pod_name
+
+
+def test_watch_jsonpath(tmpenv):
+    pod_name = kubectl.get(
+        "pod",
+        "--output=jsonpath={.items[0].metadata.name}",
+        context=tmpenv.profile,
+    )
+    print("pod_name:", pod_name)
+    container_name = kubectl.get(
+        f"pod/{pod_name}",
+        "--output=jsonpath={.spec.containers[0].name}",
+        context=tmpenv.profile,
+    )
+    print("container_name:", container_name)
+    watcher = kubectl.watch(
+        f"pod/{pod_name}",
+        jsonpath="{.spec.containers[0]}",
+        context=tmpenv.profile,
+    )
+    for line in watcher:
+        container = json.loads(line)
+        print("container:", container)
+        watcher.close()
+
+    assert container["name"] == container_name
+
+
+def test_watch_events(tmpenv):
+    deploy = "deploy/example-deployment"
+    label = f"test-{secrets.token_hex(8)}"
+    watcher = kubectl.watch(
+        deploy,
+        jsonpath="{.metadata.labels}",
+        timeout=1,
+        context=tmpenv.profile,
+    )
+    with closing(watcher):
+        line = next(watcher)
+        labels = json.loads(line)
+        print("labels:", labels)
+
+        # Add a label and wait for event.
+        kubectl.label(deploy, f"{label}=true", context=tmpenv.profile)
+        line = next(watcher)
+        labels = json.loads(line)
+        print("labels:", labels)
+        assert labels[label] == "true"
+
+        # Remove the label and wait for event with the label removed.
+        kubectl.label(deploy, f"{label}-", context=tmpenv.profile)
+        for i in range(3):
+            line = next(watcher)
+            labels = json.loads(line)
+            print("labels:", labels)
+            if label not in labels:
+                break
+        else:
+            raise RuntimeError("Timeout waiting for event")
+
+
+def test_watch_timeout(tmpenv):
+    output = []
+    with pytest.raises(commands.Timeout):
+        watcher = kubectl.watch(
+            "deploy/example-deployment",
+            jsonpath="{.metadata.name}",
+            timeout=0.5,
+            context=tmpenv.profile,
+        )
+        for name in watcher:
+            print("line:", name)
+            output.append(name)
+
+    # We should get at least the initial state.
+    assert output[0] == "example-deployment"
 
 
 def _get_annotations(resource, context):


### PR DESCRIPTION
We have random timeout when waiting for mirroring health. When this happens rbd-mirror fails to connect to the ceph mon but the system does not recover from the error. Restarting the rbd-mirror daemon fixes the issue.

This change:
- Adds infrastructure for watching commands with a timeout
- Add debug logs for rbd-mirror, requested in https://tracker.ceph.com/issues/65487
- Watch mirroring health, and restart the rbd-mirror on  timeout

Restarting the rbd-mirror may not be needed in the future when the root cause is found and fixed.

Fixes #1332