### PR TITLE
Add simple gather tool

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -21,6 +21,7 @@ sources := $(wildcard \
 	*/undeploy \
 	*/failover \
 	*/relocate \
+	scripts/gather \
 )
 
 all: flake8 pylint black test coverage

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -6,6 +6,21 @@ from . import commands
 JSONPATH_NEWLINE = '{"\\n"}'
 
 
+def api_resources(verbs=None, namespaced=None, output=None, context=None):
+    """
+    Run kubectl api-resources and return the output.
+    """
+    args = []
+    if verbs:
+        args.append(f"--verbs={_join(verbs)}")
+    if namespaced is not None:
+        value = "true" if namespaced else "false"
+        args.append(f"--namespaced={value}")
+    if output:
+        args.append(f"--output={output}")
+    return _run("api-resources", *args, context=context)
+
+
 def version(context=None, output=None):
     """
     Return local and server version info. Useful for testing connectivity to
@@ -192,3 +207,7 @@ def _watch(cmd, *args, input=None, context=None, log=print):
     cmd.extend(args)
     for line in commands.watch(*cmd, input=input):
         log(line)
+
+
+def _join(items):
+    return ",".join(items)

--- a/test/drenv/minikube.py
+++ b/test/drenv/minikube.py
@@ -100,8 +100,18 @@ def cp(profile, src, dst):
     _watch("cp", src, dst, profile=profile)
 
 
-def ssh(profile, command):
-    _watch("ssh", command, profile=profile)
+def ssh(profile, command, node=None):
+    if node is None:
+        node = profile
+    return _run("ssh", "--node", node, command, profile=profile)
+
+
+def ssh_key(profile):
+    return _run("ssh-key", profile=profile).rstrip()
+
+
+def ip(profile):
+    return _run("ip", profile=profile).rstrip()
 
 
 def _run(command, *args, profile=None, output=None):

--- a/test/scripts/gather
+++ b/test/scripts/gather
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import concurrent.futures
+import json
+import logging
+import os
+import subprocess
+import threading
+import time
+
+from collections import deque
+from contextlib import closing
+
+import yaml
+
+from drenv import ceph
+from drenv import commands
+from drenv import kubectl
+from drenv import minikube
+
+
+# Main directories
+CLUSTER = "cluster"
+NAMESPACES = "namespaces"
+COMMANDS = "commands"
+
+
+def main():
+    args = parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)-7s [%(threadName)s] %(message)s",
+    )
+
+    threading.current_thread().name = args.context
+    logging.info("Gathering data from cluster %s", args.context)
+    start = time.monotonic()
+
+    g = Gatherer(args.context, args.output, args.workers)
+    g.gather()
+
+    elapsed = time.monotonic() - start
+    logging.info("Gathered data in %.3f seconds", elapsed)
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "context",
+        help="cluster context to gather data from",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        default="gather",
+        help="directory for storing gathered data (default gather)",
+    )
+    p.add_argument(
+        "-w",
+        "--workers",
+        type=int,
+        default=6,
+        help="number of workers (default 6)",
+    )
+    p.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="enable verbose logs",
+    )
+    return p.parse_args()
+
+
+class Executor:
+
+    def __init__(self, workers, prefix):
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=workers,
+            thread_name_prefix=prefix,
+        )
+        self._futures = deque()
+
+    def submit(self, func, *args, **kw):
+        f = self._executor.submit(func, *args, **kw)
+        self._futures.append(f)
+
+    def wait(self):
+        while self._futures:
+            f = self._futures.popleft()
+            try:
+                f.result()
+            except Exception:
+                logging.exception("Gather error")
+
+    def close(self):
+        self._executor.shutdown()
+
+
+class Gatherer:
+
+    def __init__(self, context, target, workers):
+        self._context = context
+        self._target = os.path.join(target, context)
+        self._executor = Executor(workers, context)
+
+    def gather(self):
+        with closing(self._executor):
+            for kind in self._list_api_resources():
+                self._executor.submit(self._gather_api_resources, kind)
+            self._executor.wait()
+
+    def _list_api_resources(self):
+        logging.debug("Listing API resources")
+        start = time.monotonic()
+
+        out = kubectl.api_resources(
+            verbs=["list"],
+            output="name",
+            context=self._context,
+        )
+        res = out.splitlines()
+
+        elapsed = time.monotonic() - start
+        logging.debug("Listed %d API resources in %.3f seconds", len(res), elapsed)
+        return res
+
+    def _gather_api_resources(self, kind):
+        logging.debug("Gathering %s", kind)
+        start = time.monotonic()
+
+        # Function for extra processing of this resource kind (e.g. _do_pods).
+        do_func = getattr(self, "_do_" + kind.replace(".", "_"), None)
+
+        items = self._list_resources(kind)
+        for res in items:
+            self._dump_resource(kind, res)
+            if do_func:
+                self._executor.submit(do_func, res)
+
+        elapsed = time.monotonic() - start
+        logging.debug("%d %s gathered in %.3f seconds", len(items), kind, elapsed)
+
+    def _list_resources(self, kind):
+        logging.debug("Listing %s", kind)
+        start = time.monotonic()
+
+        out = kubectl.get(
+            kind,
+            "--output=json",
+            "--all-namespaces",
+            context=self._context,
+        )
+        res = json.loads(out)
+        items = res["items"]
+
+        elapsed = time.monotonic() - start
+        logging.debug("Listed %d %s in %.3f seconds", len(items), kind, elapsed)
+
+        return items
+
+    def _dump_resource(self, kind, res):
+        name = res["metadata"]["name"]
+        namespace = res["metadata"].get("namespace")
+        if namespace:
+            res_dir = self._create_dir(self._target, NAMESPACES, namespace, kind)
+        else:
+            res_dir = self._create_dir(self._target, CLUSTER, kind)
+        filename = os.path.join(res_dir, name + ".yaml")
+        with open(filename, "w") as f:
+            yaml.dump(res, f)
+
+    # Processing special resoruces.
+
+    def _do_pods(self, pod):
+        namespace = pod["metadata"]["namespace"]
+        name = pod["metadata"]["name"]
+        logging.debug("Gathering pod %s/%s", namespace, name)
+
+        for container in (c["name"] for c in pod["spec"]["containers"]):
+            logs_dir = self._create_dir(
+                self._target, NAMESPACES, namespace, "pods", name, container
+            )
+            self._gather_logs(logs_dir, namespace, name, container)
+            self._gather_logs(logs_dir, namespace, name, container, previous=True)
+
+    def _gather_logs(self, logs_dir, namespace, pod, container, previous=False):
+        which = "previous" if previous else "current"
+        logging.debug(
+            "Gathering %s logs for %s/%s/%s", which, namespace, pod, container
+        )
+        start = time.monotonic()
+
+        filename = os.path.join(logs_dir, f"{which}.log")
+
+        # We don't use drenv.kubectl since it does not support redirection yet.
+        cmd = [
+            "kubectl",
+            "logs",
+            pod,
+            f"--namespace={namespace}",
+            f"--container={container}",
+            "--ignore-errors",
+        ]
+        if previous:
+            cmd.append("--previous")
+        cmd.append(f"--context={self._context}")
+
+        with open(filename, "w") as f:
+            cp = subprocess.run(cmd, stdout=f, stderr=subprocess.PIPE)
+
+        if cp.returncode != 0:
+            # Log the error, we don't fail the entire operation.
+            error = cp.stderr.decode().strip()
+            logging.warning(
+                "Cannot gather %s logs for %s/%s/%s: %s",
+                which,
+                namespace,
+                pod,
+                container,
+                error,
+            )
+
+        elapsed = time.monotonic() - start
+        logging.debug(
+            "%s logs for %s/%s/%s gathered in %.3f seconds",
+            which,
+            namespace,
+            pod,
+            container,
+            elapsed,
+        )
+
+    def _do_cephclusters_ceph_rook_io(self, cephcluster):
+        name = cephcluster["metadata"]["name"]
+        namespace = cephcluster["metadata"]["namespace"]
+        logging.debug("Gathering cephcluster %s/%s", namespace, name)
+        self._gather_ceph_command("ceph", "status")
+        self._gather_ceph_command("ceph", "osd", "blocklist", "ls")
+
+    def _gather_ceph_command(self, *cmd):
+        description = " ".join(cmd)
+        logging.debug("Gathering ceph command '%s'", description)
+        start = time.monotonic()
+
+        out = ceph.tool(self._context, *cmd)
+        base_dir = self._create_dir(self._target, COMMANDS)
+        filename = os.path.join(base_dir, "-".join(cmd))
+        with open(filename, "w") as f:
+            f.write(out)
+
+        elapsed = time.monotonic() - start
+        logging.debug(
+            "Ceph command '%s' gathered in %.3f seconds", description, elapsed
+        )
+
+    def _do_nodes(self, node):
+        node_name = node["metadata"]["name"]
+        logging.debug("Gathering node %s", node_name)
+        node_dir = self._create_dir(self._target, CLUSTER, "nodes", node_name)
+
+        if self._node_has_rook_ceph_log(node_name):
+            self._gather_node_rook_ceph_logs(node_dir, node)
+
+    def _gather_node_rook_ceph_logs(self, node_dir, node):
+        node_name = node["metadata"]["name"]
+        node_address = node["status"]["addresses"][0]["address"]
+        logging.debug("Gathering node %s rook-ceph logs", node_name)
+        start = time.monotonic()
+
+        log_dir = self._create_dir(node_dir, "rook-ceph", "log")
+
+        # TODO: works only for minikube cluster.
+        ssh_key = minikube.ssh_key(self._context)
+        try:
+            scp(
+                "docker",
+                node_address,
+                "/data/rook/rook-ceph/log/*.log*",
+                log_dir,
+                identity_file=ssh_key,
+            )
+        except commands.Error as e:
+            logging.warning(
+                "Error gathering node %s rook-ceph logs: %r",
+                node_name,
+                e.error.strip(),
+            )
+
+        elapsed = time.monotonic() - start
+        logging.debug(
+            "Node %s rook-ceph logs gathered in %.3f seconds", node_name, elapsed
+        )
+
+    def _node_has_rook_ceph_log(self, node_name):
+        logging.debug("Checking if node %s has rook-ceph logs", node_name)
+        start = time.monotonic()
+
+        script = "if test -d /data/rook/rook-ceph/log; then echo -n yes; fi"
+        try:
+            # TODO: works only for minikube cluster.
+            result = minikube.ssh(self._context, script, node=node_name) == "yes"
+        except commands.Error as e:
+            logging.warning(
+                "Error checking if node %s has rook-ceph logs: %r",
+                node_name,
+                e.error.strip(),
+            )
+            result = False
+
+        elapsed = time.monotonic() - start
+        logging.debug(
+            "Checking node %s rook-ceph logs completed in %.3f seconds",
+            node_name,
+            elapsed,
+        )
+
+        return result
+
+    # Helpers
+
+    def _create_dir(self, base, *names):
+        path = os.path.join(base, *names)
+        os.makedirs(path, exist_ok=True)
+        return path
+
+
+def scp(user, host, source, target, identity_file=None):
+    cmd = ["scp", "-B", "-q", "-o", "StrictHostKeyChecking=no"]
+    if identity_file:
+        cmd.extend(("-i", identity_file))
+    cmd.append(f"{user}@{host}:{source}")
+    cmd.append(target)
+    return commands.run(*cmd)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/scripts/gather
+++ b/test/scripts/gather
@@ -41,7 +41,7 @@ def main():
     logging.info("Gathering data from cluster %s", args.context)
     start = time.monotonic()
 
-    g = Gatherer(args.context, args.output, args.workers)
+    g = Gatherer(args.context, args.output, args.workers, namespace=args.namespace)
     g.gather()
 
     elapsed = time.monotonic() - start
@@ -53,6 +53,11 @@ def parse_args():
     p.add_argument(
         "context",
         help="cluster context to gather data from",
+    )
+    p.add_argument(
+        "-n",
+        "--namespace",
+        help="gather only specified namespace",
     )
     p.add_argument(
         "-o",
@@ -103,10 +108,11 @@ class Executor:
 
 class Gatherer:
 
-    def __init__(self, context, target, workers):
+    def __init__(self, context, target, workers, namespace=None):
         self._context = context
         self._target = os.path.join(target, context)
         self._executor = Executor(workers, context)
+        self._namespace = namespace
 
     def gather(self):
         with closing(self._executor):
@@ -121,13 +127,20 @@ class Gatherer:
         out = kubectl.api_resources(
             verbs=["list"],
             output="name",
+            namespaced=True if self._namespace else None,
             context=self._context,
         )
-        res = out.splitlines()
+        items = set(out.splitlines())
+
+        if self._namespace:
+            # olm bug? - returned for *every namespace* when listing by namespace.
+            # https://github.com/operator-framework/operator-lifecycle-manager/issues/2932
+            items.discard("packagemanifests.packages.operators.coreos.com")
 
         elapsed = time.monotonic() - start
-        logging.debug("Listed %d API resources in %.3f seconds", len(res), elapsed)
-        return res
+        logging.debug("Listed %d API resources in %.3f seconds", len(items), elapsed)
+
+        return items
 
     def _gather_api_resources(self, kind):
         logging.debug("Gathering %s", kind)
@@ -149,12 +162,14 @@ class Gatherer:
         logging.debug("Listing %s", kind)
         start = time.monotonic()
 
-        out = kubectl.get(
-            kind,
-            "--output=json",
-            "--all-namespaces",
-            context=self._context,
-        )
+        args = [kind]
+        if self._namespace:
+            args.append(f"--namespace={self._namespace}")
+        else:
+            args.append("--all-namespaces")
+        args.append("--output=json")
+
+        out = kubectl.get(*args, context=self._context)
         res = json.loads(out)
         items = res["items"]
 


### PR DESCRIPTION
The tool gathers all api resources and pod container logs from specified
clusters.

For every api resource, the tool gathers all resources and dump them into:

- cluster-scope: output/{context}/cluster/{kind}/{name}.yaml
- namespace-scope: output/{context}/namespaces/{namespace}/{kind}/{name}.yaml

If the _do_kind() method exist for a resource kind, the function is called to
do more processing.

We have special processing for:

- pods: Gather current and previous logs for all containers
- cephclusters.ceph.rook.io: Gather ceph commands reporting ceph health
- nodes: Gather rook-ceph logs from the node

Extra data collected for a resource is stored in a directory near the resource
yaml:

Example pod data:

    gather/
      dr1/
        namespaces/
          rook-ceph/
            pods/
              rook-ceph-rbd-mirror-a-58b8454f67-9lx5c/
                rbd-mirror/
                  current.log
                  previous.log
                log-collector/
                  current.log
                  previous.log
              rook-ceph-rbd-mirror-a-58b8454f67-9lx5c.yaml

Example node data:

    gather/
      dr1/
        cluster/
          nodes/
            dr1/
              rook-ceph/
                log/
                  1319a92b-2ab0-4e58-8d74-c81e5edab5c1-client.rbd-mirror-peer.log
                  1319a92b-2ab0-4e58-8d74-c81e5edab5c1-client.rbd-mirror-peer.log.1.gz
                  ceph-client.ceph-exporter.log
                  ceph-client.rbd-mirror.a.log
                  ceph-client.rbd-mirror.a.log.1.gz
            dr1.yaml

Commands output is stored in a special "commands" directory under the cluster
directory:

    gather/
      dr1/
        commands/
          ceph-status
          ceph-osd-blocklist-ls

## Example usage - entire env

Example run on a regional DR environment with one protected application
runnning for 90 minutes:

    $ scripts/gather dr1
    2024-04-20 19:48:12,929 INFO    [dr1] Gathering data from cluster dr1
    2024-04-20 19:48:25,343 INFO    [dr1] Gathered data in 12.413 seconds

    $ scripts/gather dr2
    2024-04-20 19:48:38,688 INFO    [dr2] Gathering data from cluster dr2
    2024-04-20 19:48:51,138 INFO    [dr2] Gathered data in 12.450 seconds

    $ scripts/gather hub
    2024-04-20 19:48:56,486 INFO    [hub] Gathering data from cluster hub
    2024-04-20 19:49:05,338 INFO    [hub] Gathered data in 8.852 seconds

    $ du -sh gather/*
    41M     gather/dr1
    40M     gather/dr2
    16M     gather/hub

    $ tar czf gather.tar.gz gather

    $ du -h gather.tar.gz
    12M     gather.tar.gz

## Example usage single - namespace

    $ scripts/gather dr1 -n deployment-rbd -o gather-deployment-rbd.1
    2024-04-20 21:07:41,712 INFO    [dr1] Gathering data from cluster dr1
    2024-04-20 21:07:43,695 INFO    [dr1] Gathered data in 1.984 seconds

    $ scripts/gather dr1 -n deployment-rbd -o gather-deployment-rbd.2
    2024-04-20 21:45:39,691 INFO    [dr1] Gathering data from cluster dr1
    2024-04-20 21:45:41,865 INFO    [dr1] Gathered data in 2.174 seconds

    $ diff -ur gather-deployment-rbd.1 gather-deployment-rbd.2
    ...

## Example tarballs

- entire env: [gather.tar.gz](https://github.com/RamenDR/ramen/files/15049118/gather.tar.gz)
- single namespace in single cluster: [gather-deployment-rbd.1.tar.gz](https://github.com/RamenDR/ramen/files/15049400/gather-deployment-rbd.1.tar.gz)


## Status

- [x] Gather namespaced resources
- [x] Gather cluster scope resources
- [x] Gather logs from all pods
- [x] Gather all rook-ceph logs from node (#1346)
- [x] Support hub (no rook-ceph)
- [ ] More rook-ceph commands
- [ ] Collect info from nodes?
- [ ] Collect submariner health info?

Fixes #1283