### PR TITLE
Try to reproduce the rbd-mirror bug

### DIFF
--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -139,7 +139,7 @@ def wait_until_rbd_mirror_is_ready(cluster):
     print(yaml.dump(info, sort_keys=False))
 
 
-def wait_until_pool_mirroring_is_healthy(cluster, attempts=3):
+def wait_until_pool_mirroring_is_healthy(cluster, attempts=1):
     # We have random timeouts when rbd-mirror fail to connect to the peer.
     # When this happens we can recover by restarting the rbd-mirror daemon.
 
@@ -167,7 +167,7 @@ def wait_until_pool_mirroring_is_healthy(cluster, attempts=3):
     print(yaml.dump(info, sort_keys=False))
 
 
-def watch_pool_mirroring_status(cluster, timeout=180):
+def watch_pool_mirroring_status(cluster, timeout=240):
     """
     Watch pool .status.mirroringStatus.summary until mirroring is healthy or
     the timeout expires.

--- a/test/addons/rook-cluster/kustomization.yaml
+++ b/test/addons/rook-cluster/kustomization.yaml
@@ -29,3 +29,7 @@ patchesJson6902:
           enabled: true
           periodicity: daily
           maxLogSize: 50M
+      # Testing fix for https://tracker.ceph.com/issues/65487#note-20
+      - op: replace
+        path: /spec/cephVersion/image
+        value: quay.io/nirsof/ceph:wip-65487-on-18.2.3

--- a/test/addons/rook-toolbox/kustomization.yaml
+++ b/test/addons/rook-toolbox/kustomization.yaml
@@ -5,3 +5,8 @@
 ---
 resources:
   - https://raw.githubusercontent.com/rook/rook/release-1.13/deploy/examples/toolbox.yaml
+images:
+  # Testing fix for https://tracker.ceph.com/issues/65487#note-20
+  - name: quay.io/ceph/ceph
+    newName: quay.io/nirsof/ceph
+    newTag: wip-65487-on-18.2.3

--- a/test/stress-test/run
+++ b/test/stress-test/run
@@ -125,6 +125,9 @@ def run(name, args):
     elapsed = time.monotonic() - start
     passed = cp.returncode == 0
 
+    if not passed:
+        gather_data(name, args)
+
     if passed or not args.exit_first:
         drenv("delete", args.envfile, log, name_prefix=args.name_prefix, check=True)
 
@@ -135,6 +138,14 @@ def run(name, args):
     }
 
 
+def gather_data(name, args):
+    output = os.path.join(args.outdir, name + ".gather")
+    log = os.path.join(args.outdir, name + ".log")
+
+    # TODO: use actual cluster names from envfile.
+    gather("dr1,dr2,hub", output, log)
+
+
 def drenv(command, envfile, log, name_prefix=None, check=False):
     cmd = ["drenv", command, "--verbose"]
     if name_prefix:
@@ -142,6 +153,20 @@ def drenv(command, envfile, log, name_prefix=None, check=False):
     cmd.append(envfile)
     with open(log, "a") as f:
         return subprocess.run(cmd, stderr=f, check=check)
+
+
+def gather(contexts, output, log):
+    cmd = [
+        "kubectl",
+        "gather",
+        "--contexts",
+        contexts,
+        "--directory",
+        output,
+        "--verbose",
+    ]
+    with open(log, "a") as f:
+        return subprocess.run(cmd, stderr=f)
 
 
 def git_info():


### PR DESCRIPTION
Disable retries when we time out waiting for rbd-mirror health.

Bug reproduced[1] after 257 runs.

[1] https://tracker.ceph.com/issues/65487#note-16

Based on #1346 for testing.