### PR TITLE
Caching resources for recipe and csi addons

### DIFF
--- a/test/addons/csi-addons/fetch
+++ b/test/addons/csi-addons/fetch
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from drenv import cache
+
+os.chdir(os.path.dirname(__file__))
+path = cache.path("addons/csi-addons.yaml")
+cache.fetch(".", path)

--- a/test/addons/csi-addons/kustomization.yaml
+++ b/test/addons/csi-addons/kustomization.yaml
@@ -3,10 +3,10 @@
 
 ---
 resources:
-  - ${base_url}/crds.yaml
-  - ${base_url}/rbac.yaml
-  - ${base_url}/setup-controller.yaml
+  - https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/v0.8.0/deploy/controller/crds.yaml
+  - https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/v0.8.0/deploy/controller/rbac.yaml
+  - https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/v0.8.0/deploy/controller/setup-controller.yaml
 
 images:
   - name: quay.io/csiaddons/k8s-controller
-    newTag: ${image_tag}
+    newTag: v0.8.0

--- a/test/addons/csi-addons/start
+++ b/test/addons/csi-addons/start
@@ -7,11 +7,14 @@ import os
 import sys
 
 from drenv import kubectl
+from drenv import cache
 
 
 def deploy(cluster):
     print("Deploying csi addon for volume replication")
-    kubectl.apply("--kustomize", ".", context=cluster)
+    path = cache.path("addons/csi-addons.yaml")
+    cache.fetch(".", path)
+    kubectl.apply("--filename", path, context=cluster)
 
 
 def wait(cluster):

--- a/test/addons/csi-addons/start
+++ b/test/addons/csi-addons/start
@@ -6,21 +6,12 @@
 import os
 import sys
 
-import drenv
 from drenv import kubectl
-
-VERSION = "v0.8.0"
-BASE_URL = f"https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/{VERSION}/deploy/controller"
 
 
 def deploy(cluster):
     print("Deploying csi addon for volume replication")
-    with drenv.kustomization(
-        "kustomization.yaml",
-        base_url=BASE_URL,
-        image_tag=VERSION,
-    ) as kustomization:
-        kubectl.apply("--kustomize", kustomization, context=cluster)
+    kubectl.apply("--kustomize", ".", context=cluster)
 
 
 def wait(cluster):

--- a/test/addons/recipe/fetch
+++ b/test/addons/recipe/fetch
@@ -4,18 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import sys
 
-from drenv import kubectl
 from drenv import cache
 
-if len(sys.argv) != 2:
-    sys.exit(f"Usage: {sys.argv[0]} cluster")
-
 os.chdir(os.path.dirname(__file__))
-cluster = sys.argv[1]
-
-print("Deploying recipe crd")
 path = cache.path("addons/recipe.yaml")
 cache.fetch(".", path)
-kubectl.apply("--filename", path, context=cluster)

--- a/test/addons/recipe/kustomization.yaml
+++ b/test/addons/recipe/kustomization.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+resources:
+  - https://github.com/RamenDR/recipe.git/config/crd?ref=main&timeout=120s

--- a/test/addons/recipe/start
+++ b/test/addons/recipe/start
@@ -15,8 +15,4 @@ os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 print("Deploying recipe crd")
-kubectl.apply(
-    "--kustomize",
-    "https://github.com/RamenDR/recipe.git/config/crd?ref=main&timeout=120s",
-    context=cluster,
-)
+kubectl.apply("--kustomize", ".", context=cluster)


### PR DESCRIPTION
Currently the csi-addon fetch kustomization resources whenever started. While, recipe addon do not use kustomization, this change introduces that. Also, this change will start using cache for those resources, so starting addons can directly use the cached resources.

Changes:
- update csi-addon kustomization to start using static kustomization now.
- cache csi-addon kustomization resources
- recipe start using kustomization for its resources
- cache recipe kustomization resources

Working:
- drenv fetch can be used to fetch resources anytime.
- Starting an addon will first try to fetch resources, then apply the fetched resources. If there is no change, fetch won't do anything, so takes very less time. Hence, starting an addon with cached resources is faster.

Example demonstrating how the cache works:

Fetching of resources for envs/regional-dr.yaml:
```
$ drenv fetch envs/regional-dr.yaml -v
2024-05-02 14:38:38,743 INFO    [rdr] Fetching
2024-05-02 14:38:38,745 DEBUG   [main] Add executor fetch
2024-05-02 14:38:38,746 INFO    [rdr] Running addons/rook-operator/fetch
2024-05-02 14:38:38,752 INFO    [rdr] Running addons/rook-cluster/fetch
2024-05-02 14:38:38,753 INFO    [rdr] Running addons/rook-toolbox/fetch
2024-05-02 14:38:38,759 INFO    [rdr] Running addons/csi-addons/fetch
2024-05-02 14:38:38,760 INFO    [rdr] Running addons/recipe/fetch
2024-05-02 14:38:38,764 INFO    [rdr] Running addons/ocm-controller/fetch
2024-05-02 14:38:38,872 DEBUG   [rdr] Fetching /home/abshakya/.cache/drenv/addons/rook-operator.yaml
2024-05-02 14:38:38,872 DEBUG   [rdr] Fetching /home/abshakya/.cache/drenv/addons/rook-cluster.yaml
2024-05-02 14:38:38,873 DEBUG   [rdr] Fetching /home/abshakya/.cache/drenv/addons/rook-toolbox.yaml
2024-05-02 14:38:38,881 DEBUG   [rdr] Fetching /home/abshakya/.cache/drenv/addons/ocm-controller.yaml
2024-05-02 14:38:38,885 DEBUG   [rdr] Fetching /home/abshakya/.cache/drenv/addons/csi-addons.yaml
2024-05-02 14:38:38,900 DEBUG   [rdr] Fetching /home/abshakya/.cache/drenv/addons/recipe.yaml
2024-05-02 14:38:39,115 INFO    [rdr] addons/rook-cluster/fetch completed in 0.36 seconds
2024-05-02 14:38:39,181 INFO    [rdr] addons/csi-addons/fetch completed in 0.42 seconds
2024-05-02 14:38:39,367 INFO    [rdr] addons/rook-toolbox/fetch completed in 0.61 seconds
2024-05-02 14:38:39,766 INFO    [rdr] addons/rook-operator/fetch completed in 1.02 seconds
2024-05-02 14:38:41,792 INFO    [rdr] addons/recipe/fetch completed in 3.03 seconds
2024-05-02 14:38:48,042 INFO    [rdr] addons/ocm-controller/fetch completed in 9.28 seconds
2024-05-02 14:38:48,043 INFO    [rdr] Fetching finishied in 9.30 seconds
2024-05-02 14:38:48,043 DEBUG   [main] Starting shutdown
2024-05-02 14:38:48,044 DEBUG   [main] Shutting down executor fetch
2024-05-02 14:38:48,044 DEBUG   [main] Terminating process group 131907
```

Fetching resources may take different amount of time for different runs. And once fetched, addons can directly use these resources to get started, saving time and escaping the flaky network situation.