### PR TITLE
Caching Rook addons resources

### DIFF
--- a/test/addons/rook-cluster/fetch
+++ b/test/addons/rook-cluster/fetch
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from drenv import cache
+
+os.chdir(os.path.dirname(__file__))
+path = cache.path("addons/rook-cluster.yaml")
+cache.fetch(".", path)

--- a/test/addons/rook-cluster/start
+++ b/test/addons/rook-cluster/start
@@ -11,6 +11,7 @@ import yaml
 
 import drenv
 from drenv import kubectl
+from drenv import cache
 
 # The ceph, and ceph-csi iamges are very large (500m each), using larger
 # timeout to avoid timeouts with flaky network.
@@ -19,7 +20,9 @@ TIMEOUT = 600
 
 def deploy(cluster):
     print("Deploying rook ceph cluster")
-    kubectl.apply("--kustomize", ".", context=cluster)
+    path = cache.path("addons/rook-cluster.yaml")
+    cache.fetch(".", path)
+    kubectl.apply("--filename", path, context=cluster)
 
 
 def wait(cluster):

--- a/test/addons/rook-operator/fetch
+++ b/test/addons/rook-operator/fetch
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from drenv import cache
+
+os.chdir(os.path.dirname(__file__))
+path = cache.path("addons/rook-operator.yaml")
+cache.fetch(".", path)

--- a/test/addons/rook-operator/start
+++ b/test/addons/rook-operator/start
@@ -7,11 +7,14 @@ import os
 import sys
 
 from drenv import kubectl
+from drenv import cache
 
 
 def deploy(cluster):
     print("Deploying rook ceph operator")
-    kubectl.apply("--kustomize", ".", context=cluster)
+    path = cache.path("addons/rook-operator.yaml")
+    cache.fetch(".", path)
+    kubectl.apply("--filename", path, context=cluster)
 
 
 def wait(cluster):

--- a/test/addons/rook-toolbox/fetch
+++ b/test/addons/rook-toolbox/fetch
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from drenv import cache
+
+os.chdir(os.path.dirname(__file__))
+path = cache.path("addons/rook-toolbox.yaml")
+cache.fetch(".", path)

--- a/test/addons/rook-toolbox/start
+++ b/test/addons/rook-toolbox/start
@@ -8,11 +8,14 @@ import sys
 
 from drenv import ceph
 from drenv import kubectl
+from drenv import cache
 
 
 def deploy(cluster):
     print("Deploying rook ceph toolbox")
-    kubectl.apply("--kustomize", ".", context=cluster)
+    path = cache.path("addons/rook-toolbox.yaml")
+    cache.fetch(".", path)
+    kubectl.apply("--filename", path, context=cluster)
 
 
 def wait(cluster):


### PR DESCRIPTION
Currently the addons fetch kustomization resources whenever they are started.
This change will start using cache for those resources, so starting an addon can directly use the cached resources.

Changes:
- drenv fetch can be used to fetch resources anytime.
- Starting an addon will first try to fetch resources, then apply the fetched resources. If there is no change, fetch won't do anything, so takes very less time.


Example demonstrating how the cache works:

Fetching of resources for envs/regional-dr.yaml:
```
$ drenv fetch envs/regional-dr.yaml -v
2024-05-02 01:47:48,116 INFO    [rdr] Fetching
2024-05-02 01:47:48,118 DEBUG   [main] Add executor fetch
2024-05-02 01:47:48,119 INFO    [rdr] Running addons/rook-operator/fetch
2024-05-02 01:47:48,127 INFO    [rdr] Running addons/rook-toolbox/fetch
2024-05-02 01:47:48,127 INFO    [rdr] Running addons/rook-cluster/fetch
2024-05-02 01:47:48,137 INFO    [rdr] Running addons/ocm-controller/fetch
2024-05-02 01:47:48,217 DEBUG   [rdr] Fetching /home/abshakya/.cache/drenv/addons/rook-operator.yaml
2024-05-02 01:47:48,237 DEBUG   [rdr] Fetching /home/abshakya/.cache/drenv/addons/rook-cluster.yaml
2024-05-02 01:47:48,240 DEBUG   [rdr] Fetching /home/abshakya/.cache/drenv/addons/ocm-controller.yaml
2024-05-02 01:47:48,243 DEBUG   [rdr] Fetching /home/abshakya/.cache/drenv/addons/rook-toolbox.yaml
2024-05-02 01:47:48,401 INFO    [rdr] addons/rook-toolbox/fetch completed in 0.27 seconds
2024-05-02 01:47:48,417 INFO    [rdr] addons/rook-cluster/fetch completed in 0.29 seconds
2024-05-02 01:47:49,738 INFO    [rdr] addons/rook-operator/fetch completed in 1.62 seconds
2024-05-02 01:48:20,869 INFO    [rdr] addons/ocm-controller/fetch completed in 32.73 seconds
2024-05-02 01:48:20,870 INFO    [rdr] Fetching finishied in 32.75 seconds
2024-05-02 01:48:20,871 DEBUG   [main] Starting shutdown
2024-05-02 01:48:20,871 DEBUG   [main] Shutting down executor fetch
2024-05-02 01:48:20,871 DEBUG   [main] Terminating process group 126967
```

Fetching resources may take different amount of time for different runs. And once fetched, addons can directly use these resources to get started, saving time and escaping the flaky network situation.
