### PR TITLE
drcluster: create ramenOps ns on hub and managed cluster

### DIFF
--- a/config/hub/rbac/role.yaml
+++ b/config/hub/rbac/role.yaml
@@ -14,6 +14,16 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -14,6 +14,16 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - list

--- a/controllers/drclusters.go
+++ b/controllers/drclusters.go
@@ -119,6 +119,12 @@ func objectsToDeploy(hubOperatorRamenConfig *rmn.RamenConfig) ([]interface{}, er
 		return nil, err
 	}
 
+	if drClusterOperatorRamenConfig.RamenOpsNamespace != "" {
+		objects = append(objects,
+			util.Namespace(drClusterOperatorRamenConfig.RamenOpsNamespace),
+		)
+	}
+
 	return append(objects,
 		util.Namespace(drClusterOperatorNamespaceName),
 		olmClusterRole,

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -55,6 +55,7 @@ const ReasonDRClustersUnavailable = "DRClustersUnavailable"
 // +kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=list;watch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update
 // +kubebuilder:rbac:groups="policy.open-cluster-management.io",resources=placementbindings,verbs=list;watch
 // +kubebuilder:rbac:groups="policy.open-cluster-management.io",resources=policies,verbs=list;watch
 // +kubebuilder:rbac:groups="",namespace=system,resources=secrets,verbs=get;update

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -72,7 +72,7 @@ const ReasonDRClustersUnavailable = "DRClustersUnavailable"
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.2/pkg/reconcile
 //
-//nolint:cyclop
+//nolint:cyclop,funlen
 func (r *DRPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("DRPolicy", req.NamespacedName.Name, "rid", uuid.New())
 	log.Info("reconcile enter")
@@ -89,6 +89,11 @@ func (r *DRPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	_, ramenConfig, err := ConfigMapGet(ctx, r.APIReader)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("config map get: %w", u.validatedSetFalse("ConfigMapGetFailed", err))
+	}
+
+	if err := util.CreateRamenOpsNamespace(ctx, r.Client, ramenConfig); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to create RamenOpsNamespace: %w",
+			u.validatedSetFalse("NamespaceCreateFailed", err))
 	}
 
 	drclusters := &ramen.DRClusterList{}


### PR DESCRIPTION
To reduce the configuration steps, this PR adds two small enhancements:

1. Creates the ramenOpsNamespace on the hub cluster if that value is set in the ramenConfig.
2. Create the ramenOpsNamespace on the drcluster if the value is set and if deploymentAutomationEnabled is set to true.