### PR TITLE
Replace deprecated  patchesJson6902

### DIFF
--- a/test/addons/rook-cluster/kustomization.yaml
+++ b/test/addons/rook-cluster/kustomization.yaml
@@ -5,7 +5,7 @@
 ---
 resources:
   - https://raw.githubusercontent.com/rook/rook/release-1.13/deploy/examples/cluster-test.yaml
-patchesJson6902:
+patches:
   - target:
       kind: CephCluster
       name: my-cluster

--- a/test/addons/rook-operator/kustomization.yaml
+++ b/test/addons/rook-operator/kustomization.yaml
@@ -7,7 +7,8 @@ resources:
   - https://raw.githubusercontent.com/rook/rook/release-1.13/deploy/examples/crds.yaml
   - https://raw.githubusercontent.com/rook/rook/release-1.13/deploy/examples/common.yaml
   - https://raw.githubusercontent.com/rook/rook/release-1.13/deploy/examples/operator.yaml
-patchesJson6902:
+
+patches:
   - target:
       kind: ConfigMap
       name: rook-ceph-operator-config
@@ -19,8 +20,6 @@ patchesJson6902:
       - op: add
         path: /data/CSI_ENABLE_OMAP_GENERATOR
         value: 'true'
-
-patches:
   # Disable to avoid random failures when restaring the enviroment.
   #   failed to call webhook:
   #   Post "https://rook-ceph-admission-controller.rook-ceph.svc:443/


### PR DESCRIPTION
Use patches instead of patchesJson6902 for rook addons kustomizations
To avoid "'patchesJson6902' is deprecated" warning when running kustomize.

Fixes: #1336