### PR TITLE
Improve envtest execution time

### DIFF
--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -2650,7 +2650,7 @@ func verifyDRPCStateAndProgression(expectedAction rmn.DRAction, expectedPhase rm
 		progression = drpc.Status.Progression
 
 		return phase == expectedPhase && progression == exptectedPorgression
-	}, timeout, time.Millisecond*1000).Should(BeTrue(),
+	}, timeout, interval).Should(BeTrue(),
 		fmt.Sprintf("Phase has not been updated yet! Phase:%s Expected:%s - progression:%s exptected:%s",
 			phase, expectedPhase, progression, exptectedPorgression))
 

--- a/controllers/drpolicy_controller.go
+++ b/controllers/drpolicy_controller.go
@@ -15,9 +15,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -34,6 +36,7 @@ type DRPolicyReconciler struct {
 	Log               logr.Logger
 	Scheme            *runtime.Scheme
 	ObjectStoreGetter ObjectStoreGetter
+	RateLimiter       *workqueue.RateLimiter
 }
 
 // ReasonValidationFailed is set when the DRPolicy could not be validated or is not valid
@@ -399,7 +402,14 @@ func (u *drpolicyUpdater) finalizerRemove() error {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DRPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	controller := ctrl.NewControllerManagedBy(mgr)
+	if r.RateLimiter != nil {
+		controller.WithOptions(ctrlcontroller.Options{
+			RateLimiter: *r.RateLimiter,
+		})
+	}
+
+	return controller.
 		For(&ramen.DRPolicy{}).
 		Watches(
 			&corev1.ConfigMap{},

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -52,6 +52,7 @@ type VolumeReplicationGroupReconciler struct {
 	Scheme         *runtime.Scheme
 	eventRecorder  *rmnutil.EventReporter
 	kubeObjects    kubeobjects.RequestsManager
+	RateLimiter    *workqueue.RateLimiter
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -68,6 +69,10 @@ func (r *VolumeReplicationGroupReconciler) SetupWithManager(
 		//nolint: gomnd
 		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 	)
+	if r.RateLimiter != nil {
+		rateLimiter = *r.RateLimiter
+	}
+
 	objectToReconcileRequestsMapper := objectToReconcileRequestsMapper{reader: r.Client, log: ctrl.Log}
 	ctrlBuilder := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(ctrlcontroller.Options{

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	vrgtimeout   = time.Second * 9
+	vrgtimeout   = time.Second
 	vrginterval  = time.Millisecond * 10
 	letters      = "abcdefghijklmnopqrstuxwxyz"
 	namespaceLen = 5


### PR DESCRIPTION
Envtests eat up time in their Consistently and Eventually clauses

This is set to 10s (in most cases), because we want to ensure that a few reconciles (or at least > 1) are complete for a Consistently clause. Similarly for an Eventually clause more than one reconcile is complete to ensure desired state is reached.

NOTE: Eventually will take time only on failures, as otherwise once a reconcile runs it would exit with success if the conditions are met. Consistently on the other hand will delay succesful tests always.

The timeout set is to address the exponential backoffs for retries, such that if a reconcile is backed off by more than a few seconds we still have enough time for a reconcile to run and cause the test to pass as needed.

This delay is fixed by this commit to ensure reconciles do not exponentially backoff for all reconcilers, and that we can set up the rate limiter for reconciles to a more standard tick.

As the delay is static (recocile every 100ms), the timeouts for the Eventually and Consistently clauses can be reduced (in this commit to 1 second).

This improves overall run time of envtests from about ~210s to about ~110s (this will differ based on the machine used to run tests)