### PR TITLE
Upgrade minikube to 1.33.0

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -26,6 +26,10 @@ jobs:
     - name: Install drenv
       run: pip install -e test
 
+    - name: Setup drenv
+      working-directory: test
+      run: drenv setup -v
+
     - name: Install ramenctl
       run: pip install -e ramenctl
 
@@ -68,3 +72,8 @@ jobs:
       if: ${{ always() }}
       working-directory: test
       run: drenv delete --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
+
+    - name: Cleanup drenv
+      if: ${{ always() }}
+      working-directory: test
+      run: drenv cleanup -v

--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -97,7 +97,7 @@ enough resources:
    sudo dnf install https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
    ```
 
-   Tested with version v1.31.
+   Tested with version v1.33.0.
 
 1. Validate the installation
 

--- a/hack/make-venv
+++ b/hack/make-venv
@@ -27,6 +27,9 @@ cp coverage.pth $venv/lib/python*/site-packages
 echo "Adding venv symlink..."
 ln -sf $venv/bin/activate venv
 
+echo "Setting up minikube for drenv"
+$venv/bin/drenv setup -v
+
 echo
 echo "To activate the environment run:"
 echo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-pytest
+black
 coverage
 flake8
 pylint
-black
+pytest
+setuptools

--- a/test/README.md
+++ b/test/README.md
@@ -28,7 +28,7 @@ environment.
    ```
 
    You need `minikube` version supporting the `--extra-disks` option.
-   Tested with version v1.31.2.
+   Tested with version v1.33.0.
 
 1. Install the `kubectl` tool. See
    [Install and Set Up kubectl on Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)

--- a/test/README.md
+++ b/test/README.md
@@ -115,6 +115,13 @@ Change directory to the test directory:
 cd test
 ```
 
+To setup up minikube for drenv run once before starting any
+environment:
+
+```
+drenv setup
+```
+
 To start the environment:
 
 ```
@@ -143,17 +150,31 @@ Dumping the file shows how drenv binds templates, expands addons
 arguments, name workers, and applies default values. This can be useful
 to debugging drenv or when writing a new environment file.
 
-Useful options:
+To see all available commands:
 
-- `-v`, `--verbose`: Show verbose logs
-- `-h`, `--help`: Show online help
-- `--name-prefix`: Add prefix to profiles names
+```
+drenv --help
+```
+
+To see help for a command:
+
+```
+drenv start --help
+```
 
 When you are done you can deactivate the virtual environment:
 
 ```
 deactivate
 ```
+
+To clean up minikube changes done by `drenv setup`, run:
+
+```
+drenv cleanup
+```
+
+This should not be needed.
 
 ## The environment file
 

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -26,7 +26,6 @@ from . import minikube
 from . import ramen
 from . import shutdown
 
-CMD_PREFIX = "cmd_"
 ADDONS_DIR = "addons"
 
 executors = []
@@ -39,15 +38,10 @@ def main():
         format="%(asctime)s %(levelname)-7s %(message)s",
     )
 
-    with open(args.filename) as f:
-        env = envfile.load(f, name_prefix=args.name_prefix)
-
-    func = globals()[CMD_PREFIX + args.command]
-
     signal.signal(signal.SIGTERM, handle_termination_signal)
     become_process_group_leader()
     try:
-        func(env, args)
+        args.func(args)
     except Exception:
         logging.exception("Command failed")
         sys.exit(1)
@@ -57,31 +51,72 @@ def main():
 
 
 def parse_args():
-    commands = [n[len(CMD_PREFIX) :] for n in globals() if n.startswith(CMD_PREFIX)]
+    parser = argparse.ArgumentParser(prog="drenv")
 
-    p = argparse.ArgumentParser(prog="drenv")
-    p.add_argument("-v", "--verbose", action="store_true", help="Be more verbose")
-    p.add_argument(
+    sp = parser.add_subparsers(
+        title="commands",
+        dest="command",
+        required=True,
+    )
+
+    start_parser = add_command(sp, "start", start, help="start an environment")
+    start_parser.add_argument(
         "--skip-tests",
         dest="run_tests",
         action="store_false",
-        help="Skip addons 'test' hooks",
+        help="Do not run addons 'test' hooks",
     )
-    p.add_argument(
+    start_parser.add_argument(
         "--skip-addons",
         dest="run_addons",
         action="store_false",
-        help="Skip addons 'start' and 'stop' hooks",
+        help="Do not run addons 'start' hooks",
     )
-    p.add_argument("command", choices=commands, help="Command to run")
-    p.add_argument("--name-prefix", help="Prefix profile names")
-    p.add_argument(
-        "--max-workers",
-        type=int,
-        help="Maximum number of workers per profile",
+
+    stop_parser = add_command(sp, "stop", stop, help="stop an environment")
+    stop_parser.add_argument(
+        "--skip-addons",
+        dest="run_addons",
+        action="store_false",
+        help="Do not run addons 'stop' hooks",
     )
-    p.add_argument("filename", help="Environment filename")
-    return p.parse_args()
+
+    add_command(sp, "delete", delete, help="delete an environment")
+    add_command(sp, "suspend", suspend, help="suspend virtual machines")
+    add_command(sp, "resume", resume, help="resume virtual machines")
+    add_command(sp, "dump", dump, help="dump an environment yaml")
+    add_command(sp, "fetch", fetch, help="cache environment resources")
+
+    add_command(sp, "clear", clear, help="cleared cached resources", envfile=False)
+    add_command(sp, "setup", setup, help="setup minikube for drenv", envfile=False)
+    add_command(sp, "cleanup", cleanup, help="cleanup minikube", envfile=False)
+
+    return parser.parse_args()
+
+
+def add_command(sp, name, func, help=None, envfile=True):
+    parser = sp.add_parser(name, help=help)
+    parser.add_argument("-v", "--verbose", action="store_true", help="be more verbose")
+    parser.set_defaults(func=func)
+    if envfile:
+        parser.add_argument(
+            "--name-prefix",
+            metavar="PREFIX",
+            help="prefix profile names",
+        )
+        parser.add_argument(
+            "--max-workers",
+            type=int,
+            metavar="N",
+            help="maximum number of workers per profile",
+        )
+        parser.add_argument("filename", help="path to environment file")
+    return parser
+
+
+def load_env(args):
+    with open(args.filename) as f:
+        return envfile.load(f, name_prefix=args.name_prefix)
 
 
 def shutdown_executors():
@@ -127,22 +162,19 @@ def handle_termination_signal(signo, frame):
     sys.exit(1)
 
 
-def cmd_clear(env, args):
+def clear(args):
     start = time.monotonic()
-    logging.info("[%s] Clearing cache", env["name"])
+    logging.info("[main] Clearing cache")
     cache_dir = cache.path("")
     try:
         shutil.rmtree(cache_dir)
     except FileNotFoundError:
         pass
-    logging.info(
-        "[%s] Fetching finishied in %.2f seconds",
-        env["name"],
-        time.monotonic() - start,
-    )
+    logging.info("[main] Cache cleared in %.2f seconds", time.monotonic() - start)
 
 
-def cmd_fetch(env, args):
+def fetch(args):
+    env = load_env(args)
     start = time.monotonic()
     logging.info("[%s] Fetching", env["name"])
     addons = collect_addons(env)
@@ -160,7 +192,8 @@ def cmd_fetch(env, args):
     )
 
 
-def cmd_start(env, args):
+def start(args):
+    env = load_env(args)
     start = time.monotonic()
     logging.info("[%s] Starting environment", env["name"])
 
@@ -191,7 +224,8 @@ def cmd_start(env, args):
     )
 
 
-def cmd_stop(env, args):
+def stop(args):
+    env = load_env(args)
     start = time.monotonic()
     logging.info("[%s] Stopping environment", env["name"])
     hooks = ["stop"] if args.run_addons else []
@@ -203,7 +237,8 @@ def cmd_stop(env, args):
     )
 
 
-def cmd_delete(env, args):
+def delete(args):
+    env = load_env(args)
     start = time.monotonic()
     logging.info("[%s] Deleting environment", env["name"])
     execute(delete_cluster, env["profiles"], "profiles")
@@ -220,19 +255,22 @@ def cmd_delete(env, args):
     )
 
 
-def cmd_suspend(env, args):
+def suspend(args):
+    env = load_env(args)
     logging.info("[%s] Suspending environment", env["name"])
     for profile in env["profiles"]:
         run("virsh", "-c", "qemu:///system", "suspend", profile["name"])
 
 
-def cmd_resume(env, args):
+def resume(args):
+    env = load_env(args)
     logging.info("[%s] Resuming environment", env["name"])
     for profile in env["profiles"]:
         run("virsh", "-c", "qemu:///system", "resume", profile["name"])
 
 
-def cmd_dump(env, args):
+def dump(args):
+    env = load_env(args)
     yaml.dump(env, sys.stdout)
 
 

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -162,6 +162,16 @@ def handle_termination_signal(signo, frame):
     sys.exit(1)
 
 
+def setup(args):
+    logging.info("[main] Setting up minikube for drenv")
+    minikube.setup_files()
+
+
+def cleanup(args):
+    logging.info("[main] Cleaning up minikube")
+    minikube.cleanup_files()
+
+
 def clear(args):
     start = time.monotonic()
     logging.info("[main] Clearing cache")
@@ -321,6 +331,8 @@ def start_cluster(profile, hooks=(), args=None, **options):
             containerd.configure(profile)
         if is_restart:
             restart_failed_deployments(profile)
+        else:
+            minikube.load_files(profile["name"])
 
     if hooks:
         execute(


### PR DESCRIPTION
Minikube 1.33.0 adds useful features, fixes, and performance
improvements, but we could not use it because of a regression in
systemd-resolved[1].
    
A critical change in 1.33.0 is upgrading the kernel to 5.10.207. This
version fixes bad bug with minikube 1.32.0, when qemu assertion fails
while starting a kubevirt VM[2] on newer Intel CPUs (i7-12700k).

This change:
- Rework command line parsing so we can add global commands that do not use an environment file
- Add setup command for configuring minikube for drenv
- Add cleanup command to remove changes done in setup

drenv configuration includes:
- Increase sysctl fs.ionotify limits to avoid random errors when starting kubevirt VMs
  - https://github.com/kubernetes/minikube/pull/18832
- Disable DNSSEC in systemd-resolved, which breaks pulling images from some registries
  - https://github.com/kubernetes/minikube/pull/18830

With the new configuration we can upgrade to minikube 1.33.0, and Alex can run drenv
kubevirt environment without manual hacks.
   
When the configuration changes are released in minikube, we can remove the code in 
drenv.minikube, but I would keep the infrastructure for adding and loading configuration
so in the next time we have an issue we will have easy way fix.
 
[1] https://github.com/kubernetes/minikube/issues/18705
[2] https://gitlab.com/qemu-project/qemu/-/issues/237