### PR TITLE
Remove flannel cni from kubevirt envs

### DIFF
--- a/test/envs/kubevirt.yaml
+++ b/test/envs/kubevirt.yaml
@@ -13,7 +13,6 @@ profiles:
         io.containerd.grpc.v1.cri:
           device_ownership_from_security_context: true
     network: $network
-    cni: flannel
     cpus: 4
     memory: "8g"
     addons:

--- a/test/envs/regional-dr-kubevirt.yaml
+++ b/test/envs/regional-dr-kubevirt.yaml
@@ -21,7 +21,6 @@ templates:
         io.containerd.grpc.v1.cri:
           device_ownership_from_security_context: true
     network: "$network"
-    cni: flannel
     cpus: 4
     memory: "8g"
     extra_disks: 1


### PR DESCRIPTION
This was added based on kubevirt minikube quick start guide[1], but it seems to be outdated. Minikube default cni works fine for both kubevirt.yaml and regional-dr-kubevirt.yaml.

[1] https://kubevirt.io/quickstart_minikube/