### PR TITLE
add resources to transformer config

### DIFF
--- a/config/hub/default/k8s/kustomization.yaml
+++ b/config/hub/default/k8s/kustomization.yaml
@@ -31,7 +31,14 @@ transformers:
     path: metadata/labels
   - kind: Service
     path: spec/selector
-
+  - kind: ServiceMonitor
+    path: metadata/labels
+  - kind: ServiceMonitor
+    path: spec/selector/matchLabels
+  - kind: ConfigMap
+    path: metadata/labels
+  - kind: PrometheusRule
+    path: metadata/labels
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type

--- a/config/hub/default/ocp/kustomization.yaml
+++ b/config/hub/default/ocp/kustomization.yaml
@@ -31,6 +31,14 @@ transformers:
     path: metadata/labels
   - kind: Service
     path: spec/selector
+  - kind: ServiceMonitor
+    path: metadata/labels
+  - kind: ServiceMonitor
+    path: spec/selector/matchLabels
+  - kind: ConfigMap
+    path: metadata/labels
+  - kind: PrometheusRule
+    path: metadata/labels  
 
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #-../prometheus


### PR DESCRIPTION
few of the resources were not present under transformer
configurations and because of this, these resources did have
the label `app: ramen-hub`. Adding this makes easier to
filter out ramen specific resources and avoids conflict filtering