### PR TITLE
Replace csi-host-path-driver with rook-cephfs

### DIFF
--- a/test/addons/cdi/dv/dv.yaml
+++ b/test/addons/cdi/dv/dv.yaml
@@ -10,7 +10,7 @@ spec:
   storage:
     accessModes:
       - ReadWriteMany
-    storageClassName: csi-hostpath-sc
+    storageClassName: rook-ceph-block
     resources:
       requests:
         storage: 128Mi

--- a/test/addons/cdi/pvc/pvc.yaml
+++ b/test/addons/cdi/pvc/pvc.yaml
@@ -16,5 +16,5 @@ spec:
   resources:
     requests:
       storage: 128Mi
-  storageClassName: csi-hostpath-sc
+  storageClassName: rook-ceph-block
   volumeMode: Block

--- a/test/addons/volsync/destination/replication-dst.yaml
+++ b/test/addons/volsync/destination/replication-dst.yaml
@@ -12,8 +12,8 @@ spec:
     copyMethod: Snapshot
     capacity: 1Gi
     accessModes: [ReadWriteOnce]
-    storageClassName: csi-hostpath-sc
-    volumeSnapshotClassName: csi-hostpath-snapclass
+    storageClassName: rook-cephfs
+    volumeSnapshotClassName: csi-cephfsplugin-snapclass
     moverSecurityContext:
       runAsUser: 10000
       runAsGroup: 10000

--- a/test/addons/volsync/source/pvc.yaml
+++ b/test/addons/volsync/source/pvc.yaml
@@ -11,7 +11,7 @@ metadata:
     appname: busybox
 spec:
   accessModes: [ReadWriteOnce]
-  storageClassName: csi-hostpath-sc
+  storageClassName: rook-cephfs
   resources:
     requests:
       storage: 1Gi

--- a/test/addons/volsync/source/replication-src.yaml
+++ b/test/addons/volsync/source/replication-src.yaml
@@ -15,7 +15,7 @@ spec:
     keySecret: volsync-rsync-tls-busybox-dst
     address: volsync-rsync-tls-dst-busybox-dst.busybox.svc.clusterset.local
     copyMethod: Snapshot
-    volumeSnapshotClassName: csi-hostpath-snapclass
+    volumeSnapshotClassName: csi-cephfsplugin-snapclass
     moverSecurityContext:
       runAsUser: 10000
       runAsGroup: 10000

--- a/test/envs/kubevirt.yaml
+++ b/test/envs/kubevirt.yaml
@@ -15,10 +15,14 @@ profiles:
     network: $network
     cpus: 4
     memory: "8g"
-    addons:
-      - csi-hostpath-driver
+    extra_disks: 1
+    disk_size: "50g"
     workers:
       - addons:
-          - name: kubevirt
-      - addons:
+          - name: rook-operator
+          - name: rook-cluster
+          - name: rook-toolbox
+          - name: rook-pool
           - name: cdi
+      - addons:
+          - name: kubevirt

--- a/test/envs/regional-dr-hubless.yaml
+++ b/test/envs/regional-dr-hubless.yaml
@@ -22,13 +22,13 @@ templates:
     disk_size: "50g"
     addons:
       - volumesnapshots
-      - csi-hostpath-driver
     workers:
       - addons:
           - name: rook-operator
           - name: rook-cluster
           - name: rook-toolbox
           - name: rook-pool
+          - name: rook-cephfs
       - addons:
           - name: csi-addons
           - name: olm

--- a/test/envs/regional-dr-kubevirt.yaml
+++ b/test/envs/regional-dr-kubevirt.yaml
@@ -25,18 +25,16 @@ templates:
     memory: "8g"
     extra_disks: 1
     disk_size: "50g"
-    addons:
-      - csi-hostpath-driver
     workers:
       - addons:
           - name: rook-operator
           - name: rook-cluster
           - name: rook-toolbox
           - name: rook-pool
+          - name: cdi
       - addons:
           - name: ocm-cluster
             args: ["$name", "hub"]
-          - name: cdi
           - name: recipe
       - addons:
           - name: csi-addons

--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -21,11 +21,10 @@ templates:
     memory: "6g"
     extra_disks: 1
     disk_size: "50g"
-    addons:
-      - volumesnapshots
-      - csi-hostpath-driver
     feature_gates:
       - StatefulSetAutoDeletePVC=true
+    addons:
+      - volumesnapshots
     workers:
       - addons:
           - name: rook-operator

--- a/test/envs/rook.yaml
+++ b/test/envs/rook.yaml
@@ -14,12 +14,15 @@ templates:
     memory: "6g"
     extra_disks: 1
     disk_size: "50g"
+    addons:
+      - volumesnapshots
     workers:
       - addons:
           - name: rook-operator
           - name: rook-cluster
           - name: rook-toolbox
           - name: rook-pool
+          - name: rook-cephfs
       - addons:
           - name: csi-addons
 

--- a/test/envs/volsync.yaml
+++ b/test/envs/volsync.yaml
@@ -10,7 +10,6 @@ templates:
     driver: $vm
     container_runtime: containerd
     network: $network
-    cni: kindnet
     memory: 2g
     workers:
       - addons:
@@ -20,12 +19,17 @@ templates:
     driver: $vm
     container_runtime: containerd
     network: $network
-    cni: kindnet
-    memory: 4g
+    memory: 6g
+    extra_disks: 1
     disk_size: 50g
     addons:
       - volumesnapshots
-      - csi-hostpath-driver
+    workers:
+      - addons:
+          - name: rook-operator
+          - name: rook-cluster
+          - name: rook-toolbox
+          - name: rook-cephfs
 
 profiles:
   - name: hub


### PR DESCRIPTION
We added csi-hostpath-driver as a quick temporary solution until we have
cephfs storage. Now that we have it, we can replace csi-hostpath-driver
with rook-ceph and enjoy much faster start time in particular in the e2e
lab.

This change:
- Replace csi-host-path-driver with rook-cephfs in kubevirt environments
- Remove the unused volumesnapshots minikube addon in kubevirt environments 
- Add rook-cephfs to the rook development environment
- Replace csi-hostpath-driver with rook-cephfs in volsync addon, and remove it from regional-dr environments

With this change start time is up to 1.9 times faster:

| env          | local before | local after | lab before | lab after |
|--------------|--------------|-------------|------------|-----------|
| regional-dr  |          636 |         426 |        780 |       427 |
| volsync      |          261 |         352 |        520 |       395 |
| rdr-kubevirt |          600 |         475 |        920 |       603 |
| kubevirt     |          270 |         230 |        603 |       312 |
