### PR TITLE
Add volsync support for MultiNamespace

### DIFF
--- a/controllers/util/objectmeta.go
+++ b/controllers/util/objectmeta.go
@@ -4,7 +4,9 @@
 package util
 
 import (
+	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -22,4 +24,11 @@ func ObjectMetaEmbedded(objectMeta *metav1.ObjectMeta) metav1.ObjectMeta {
 // Return true if resource was marked for deletion.
 func ResourceIsDeleted(obj client.Object) bool {
 	return !obj.GetDeletionTimestamp().IsZero()
+}
+
+func ProtectedPVCNamespacedName(pvc ramen.ProtectedPVC) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: pvc.Namespace,
+		Name:      pvc.Name,
+	}
 }

--- a/controllers/volsync/vshandler.go
+++ b/controllers/volsync/vshandler.go
@@ -70,10 +70,12 @@ type VSHandler struct {
 	defaultCephFSCSIDriverName  string
 	destinationCopyMethod       volsyncv1alpha1.CopyMethodType
 	volumeSnapshotClassList     *snapv1.VolumeSnapshotClassList
+	vrgInAdminNamespace         bool
 }
 
 func NewVSHandler(ctx context.Context, client client.Client, log logr.Logger, owner metav1.Object,
 	asyncSpec *ramendrv1alpha1.VRGAsyncSpec, defaultCephFSCSIDriverName string, copyMethod string,
+	adminNamespaceVRG bool,
 ) *VSHandler {
 	vsHandler := &VSHandler{
 		ctx:                        ctx,
@@ -83,6 +85,7 @@ func NewVSHandler(ctx context.Context, client client.Client, log logr.Logger, ow
 		defaultCephFSCSIDriverName: defaultCephFSCSIDriverName,
 		destinationCopyMethod:      volsyncv1alpha1.CopyMethodType(copyMethod),
 		volumeSnapshotClassList:    nil, // Do not initialize until we need it
+		vrgInAdminNamespace:        adminNamespaceVRG,
 	}
 
 	if asyncSpec != nil {

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -1764,7 +1764,11 @@ var _ = Describe("VolSync_Handler", func() {
 	Describe("Prepare PVC for final sync", func() {
 		Context("When the PVC does not exist", func() {
 			It("Should assume preparationForFinalSync is complete", func() {
-				pvcPreparationComplete, err := vsHandler.TakePVCOwnership("this-pvc-does-not-exist")
+				pvcNamespacedName := types.NamespacedName{
+					Name:      "this-pvc-does-not-exist",
+					Namespace: testNamespace.GetName(),
+				}
+				pvcPreparationComplete, err := vsHandler.TakePVCOwnership(pvcNamespacedName)
 				Expect(err).To(HaveOccurred())
 				Expect(kerrors.IsNotFound(err)).To(BeTrue())
 				Expect(pvcPreparationComplete).To(BeFalse())
@@ -1791,7 +1795,12 @@ var _ = Describe("VolSync_Handler", func() {
 			var pvcPreparationErr error
 
 			JustBeforeEach(func() {
-				pvcPreparationComplete, pvcPreparationErr = vsHandler.TakePVCOwnership(testPVC.GetName())
+				pvcNamespacedName := types.NamespacedName{
+					Name:      testPVC.GetName(),
+					Namespace: testPVC.GetNamespace(),
+				}
+
+				pvcPreparationComplete, pvcPreparationErr = vsHandler.TakePVCOwnership(pvcNamespacedName)
 
 				// In all cases at this point we should expect that the PVC has ownership taken over by our owner VRG
 				Eventually(func() bool {

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -87,7 +87,7 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 			var vsHandler *volsync.VSHandler
 
 			BeforeEach(func() {
-				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec, "none", "Snapshot")
+				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec, "none", "Snapshot", false)
 			})
 
 			It("GetVolumeSnapshotClasses() should find all volume snapshot classes", func() {
@@ -116,7 +116,7 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 					},
 				}
 
-				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec, "none", "Snapshot")
+				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec, "none", "Snapshot", false)
 			})
 
 			It("GetVolumeSnapshotClasses() should find matching volume snapshot classes", func() {
@@ -159,7 +159,7 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 					},
 				}
 
-				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec, "none", "Snapshot")
+				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec, "none", "Snapshot", false)
 			})
 
 			It("GetVolumeSnapshotClasses() should find matching volume snapshot classes", func() {
@@ -216,7 +216,7 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 
 			// Initialize a vshandler
 			vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec,
-				"openshift-storage.cephfs.csi.ceph.com", "Snapshot")
+				"openshift-storage.cephfs.csi.ceph.com", "Snapshot", false)
 		})
 
 		JustBeforeEach(func() {
@@ -431,7 +431,7 @@ var _ = Describe("VolSync_Handler", func() {
 		Expect(ownerCm.GetName()).NotTo(BeEmpty())
 		owner = ownerCm
 
-		vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, owner, asyncSpec, "none", "Snapshot")
+		vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, owner, asyncSpec, "none", "Snapshot", false)
 	})
 
 	AfterEach(func() {
@@ -653,7 +653,7 @@ var _ = Describe("VolSync_Handler", func() {
 				var vsHandler *volsync.VSHandler
 
 				BeforeEach(func() {
-					vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, owner, asyncSpec, "none", "Direct")
+					vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, owner, asyncSpec, "none", "Direct", false)
 				})
 
 				It("PrecreateDestPVCIfEnabled() should return CopyMethod Snapshot and App PVC name", func() {
@@ -1461,7 +1461,7 @@ var _ = Describe("VolSync_Handler", func() {
 			Expect(k8sClient.Create(ctx, otherOwnerCm)).To(Succeed())
 			Expect(otherOwnerCm.GetName()).NotTo(BeEmpty())
 			otherVSHandler := volsync.NewVSHandler(ctx, k8sClient, logger, otherOwnerCm, asyncSpec,
-				"none", "Snapshot")
+				"none", "Snapshot", false)
 
 			for i := 0; i < 2; i++ {
 				otherOwnerRdSpec := ramendrv1alpha1.VolSyncReplicationDestinationSpec{
@@ -1651,7 +1651,7 @@ var _ = Describe("VolSync_Handler", func() {
 			Expect(k8sClient.Create(ctx, otherOwnerCm)).To(Succeed())
 			Expect(otherOwnerCm.GetName()).NotTo(BeEmpty())
 			otherVSHandler := volsync.NewVSHandler(ctx, k8sClient, logger, otherOwnerCm, asyncSpec,
-				"none", "Snapshot")
+				"none", "Snapshot", false)
 
 			for i := 0; i < 2; i++ {
 				otherOwnerRsSpec := ramendrv1alpha1.VolSyncReplicationSourceSpec{

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -465,6 +465,7 @@ var _ = Describe("VolSync_Handler", func() {
 				JustBeforeEach(func() {
 					// Run ReconcileRD
 					var err error
+					rdSpec.ProtectedPVC.Namespace = testNamespace.GetName()
 					returnedRD, err = vsHandler.ReconcileRD(rdSpec)
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -483,6 +484,7 @@ var _ = Describe("VolSync_Handler", func() {
 			Context("When the psk secret for volsync exists (will be pushed down by drpc from hub", func() {
 				var dummyPSKSecret *corev1.Secret
 				JustBeforeEach(func() {
+					rdSpec.ProtectedPVC.Namespace = testNamespace.GetName()
 					// Create a dummy volsync psk secret so the reconcile can proceed properly
 					dummyPSKSecret = &corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
@@ -653,6 +655,7 @@ var _ = Describe("VolSync_Handler", func() {
 				var vsHandler *volsync.VSHandler
 
 				BeforeEach(func() {
+					rdSpec.ProtectedPVC.Namespace = testNamespace.GetName()
 					vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, owner, asyncSpec, "none", "Direct", false)
 				})
 
@@ -703,6 +706,7 @@ var _ = Describe("VolSync_Handler", func() {
 					// Run ReconcileRD
 					var err error
 					var finalSyncCompl bool
+					rsSpec.ProtectedPVC.Namespace = testNamespace.GetName()
 					finalSyncCompl, returnedRS, err = vsHandler.ReconcileRS(rsSpec, false)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(finalSyncCompl).To(BeFalse())
@@ -722,6 +726,7 @@ var _ = Describe("VolSync_Handler", func() {
 			Context("When the psk secret for volsync exists (will be pushed down by drpc from hub", func() {
 				var dummyPSKSecret *corev1.Secret
 				JustBeforeEach(func() {
+					rsSpec.ProtectedPVC.Namespace = testNamespace.GetName()
 					// Create a dummy volsync psk secret so the reconcile can proceed properly
 					dummyPSKSecret = &corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1102,6 +1107,7 @@ var _ = Describe("VolSync_Handler", func() {
 			rdSpec = ramendrv1alpha1.VolSyncReplicationDestinationSpec{
 				ProtectedPVC: ramendrv1alpha1.ProtectedPVC{
 					Name:               pvcName,
+					Namespace:          testNamespace.GetName(),
 					ProtectedByVolSync: true,
 					StorageClassName:   &testStorageClassName,
 					Resources: corev1.VolumeResourceRequirements{
@@ -1438,6 +1444,7 @@ var _ = Describe("VolSync_Handler", func() {
 				rdSpec := ramendrv1alpha1.VolSyncReplicationDestinationSpec{
 					ProtectedPVC: ramendrv1alpha1.ProtectedPVC{
 						Name:               pvcNamePrefix + strconv.Itoa(i),
+						Namespace:          testNamespace.GetName(),
 						ProtectedByVolSync: true,
 						StorageClassName:   &testStorageClassName,
 						Resources: corev1.VolumeResourceRequirements{
@@ -1467,6 +1474,7 @@ var _ = Describe("VolSync_Handler", func() {
 				otherOwnerRdSpec := ramendrv1alpha1.VolSyncReplicationDestinationSpec{
 					ProtectedPVC: ramendrv1alpha1.ProtectedPVC{
 						Name:               pvcNamePrefixOtherOwner + strconv.Itoa(i),
+						Namespace:          testNamespace.GetName(),
 						ProtectedByVolSync: true,
 						StorageClassName:   &testStorageClassName,
 						Resources: corev1.VolumeResourceRequirements{
@@ -1632,6 +1640,7 @@ var _ = Describe("VolSync_Handler", func() {
 				rsSpec := ramendrv1alpha1.VolSyncReplicationSourceSpec{
 					ProtectedPVC: ramendrv1alpha1.ProtectedPVC{
 						Name:               pvcNamePrefix + strconv.Itoa(i),
+						Namespace:          testNamespace.GetName(),
 						ProtectedByVolSync: true,
 						StorageClassName:   &testStorageClassName,
 					},
@@ -1657,6 +1666,7 @@ var _ = Describe("VolSync_Handler", func() {
 				otherOwnerRsSpec := ramendrv1alpha1.VolSyncReplicationSourceSpec{
 					ProtectedPVC: ramendrv1alpha1.ProtectedPVC{
 						Name:               pvcNamePrefixOtherOwner + strconv.Itoa(i),
+						Namespace:          testNamespace.GetName(),
 						ProtectedByVolSync: true,
 						StorageClassName:   &testStorageClassName,
 					},

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -427,9 +427,11 @@ func (r *VolumeReplicationGroupReconciler) Reconcile(ctx context.Context, req ct
 	}
 
 	v.ramenConfig = ramenConfig
+	adminNamespaceVRG := vrgInAdminNamespace(v.instance, v.ramenConfig)
+
 	v.volSyncHandler = volsync.NewVSHandler(ctx, r.Client, log, v.instance,
 		v.instance.Spec.Async, cephFSCSIDriverNameOrDefault(v.ramenConfig),
-		volSyncDestinationCopyMethodOrDefault(v.ramenConfig))
+		volSyncDestinationCopyMethodOrDefault(v.ramenConfig), adminNamespaceVRG)
 
 	if v.instance.Status.ProtectedPVCs == nil {
 		v.instance.Status.ProtectedPVCs = []ramendrv1alpha1.ProtectedPVC{}

--- a/controllers/vrg_status_pvcs.go
+++ b/controllers/vrg_status_pvcs.go
@@ -50,17 +50,6 @@ func FindProtectedPvcAndIndex(
 	return nil, len(vrg.Status.ProtectedPVCs)
 }
 
-func (v *VRGInstance) findFirstProtectedPVCWithName(pvcName string) *ramen.ProtectedPVC {
-	for index := range v.instance.Status.ProtectedPVCs {
-		protectedPVC := &v.instance.Status.ProtectedPVCs[index]
-		if protectedPVC.Name == pvcName {
-			return protectedPVC
-		}
-	}
-
-	return nil
-}
-
 func (v *VRGInstance) vrgStatusPvcNamespacesSetIfUnset() {
 	vrg := v.instance
 

--- a/controllers/vrg_volsync.go
+++ b/controllers/vrg_volsync.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
+	"github.com/ramendr/ramen/controllers/util"
 	"github.com/ramendr/ramen/controllers/volsync"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,7 +139,8 @@ func (v *VRGInstance) reconcilePVCAsVolSyncPrimary(pvc corev1.PersistentVolumeCl
 		ProtectedPVC: *protectedPVC,
 	}
 
-	err := v.volSyncHandler.PreparePVC(pvc.Name, v.instance.Spec.PrepareForFinalSync,
+	err := v.volSyncHandler.PreparePVC(util.ProtectedPVCNamespacedName(*protectedPVC),
+		v.instance.Spec.PrepareForFinalSync,
 		v.volSyncHandler.IsCopyMethodDirect())
 	if err != nil {
 		return true
@@ -321,7 +323,7 @@ func (v *VRGInstance) buildDataProtectedCondition() *metav1.Condition {
 			}
 
 			// Check now if we have synced up at least once for this PVC
-			rsDataProtected, err := v.volSyncHandler.IsRSDataProtected(protectedPVC.Name)
+			rsDataProtected, err := v.volSyncHandler.IsRSDataProtected(protectedPVC.Name, protectedPVC.Namespace)
 			if err != nil || !rsDataProtected {
 				ready = false
 

--- a/controllers/vrg_volsync.go
+++ b/controllers/vrg_volsync.go
@@ -33,7 +33,7 @@ func (v *VRGInstance) restorePVsAndPVCsForVolSync() (int, error) {
 		if err != nil {
 			v.log.Info(fmt.Sprintf("Unable to ensure PVC %v -- err: %v", rdSpec, err))
 
-			protectedPVC := v.findFirstProtectedPVCWithName(rdSpec.ProtectedPVC.Name)
+			protectedPVC := FindProtectedPVC(v.instance, rdSpec.ProtectedPVC.Namespace, rdSpec.ProtectedPVC.Name)
 			if protectedPVC == nil {
 				protectedPVC = &ramendrv1alpha1.ProtectedPVC{}
 				rdSpec.ProtectedPVC.DeepCopyInto(protectedPVC)
@@ -48,7 +48,7 @@ func (v *VRGInstance) restorePVsAndPVCsForVolSync() (int, error) {
 
 		numPVsRestored++
 
-		protectedPVC := v.findFirstProtectedPVCWithName(rdSpec.ProtectedPVC.Name)
+		protectedPVC := FindProtectedPVC(v.instance, rdSpec.ProtectedPVC.Namespace, rdSpec.ProtectedPVC.Name)
 		if protectedPVC == nil {
 			protectedPVC = &ramendrv1alpha1.ProtectedPVC{}
 			rdSpec.ProtectedPVC.DeepCopyInto(protectedPVC)
@@ -123,7 +123,7 @@ func (v *VRGInstance) reconcilePVCAsVolSyncPrimary(pvc corev1.PersistentVolumeCl
 		Resources:          pvc.Spec.Resources,
 	}
 
-	protectedPVC := v.findFirstProtectedPVCWithName(pvc.Name)
+	protectedPVC := FindProtectedPVC(v.instance, pvc.Namespace, pvc.Name)
 	if protectedPVC == nil {
 		protectedPVC = newProtectedPVC
 		v.instance.Status.ProtectedPVCs = append(v.instance.Status.ProtectedPVCs, *protectedPVC)

--- a/controllers/vrg_volsync_test.go
+++ b/controllers/vrg_volsync_test.go
@@ -281,6 +281,7 @@ var _ = Describe("VolumeReplicationGroupVolSyncController", func() {
 						{
 							ProtectedPVC: ramendrv1alpha1.ProtectedPVC{
 								Name:               "testingpvc-a",
+								Namespace:          testNamespace.GetName(),
 								ProtectedByVolSync: true,
 								StorageClassName:   &storageClassName,
 								AccessModes:        testAccessModes,
@@ -291,6 +292,7 @@ var _ = Describe("VolumeReplicationGroupVolSyncController", func() {
 						{
 							ProtectedPVC: ramendrv1alpha1.ProtectedPVC{
 								Name:               "testingpvc-b",
+								Namespace:          testNamespace.GetName(),
 								ProtectedByVolSync: true,
 								StorageClassName:   &storageClassName,
 								AccessModes:        testAccessModes,


### PR DESCRIPTION
This PR adds MultiNamespace support for volsync based regional DR.

Changes

- [X] Create the secret for volsync in the namespace where the PVC is. Until now, the namespace of the VRG and the namespace of the PVC were both the same and therefore we used the namespace of the VRG for the secret creation. When multiNamespace mode is enabled, the VRG resides in the ramenOps namespace and the PVC in one of the protectedNamespace.
- [X] Pass around the namespace of the PVC to all the functions which need it. Again this is required because the namespace of the VRG may not be the namespace of the PVC in multiNamespace mode.
- [X] Add a boolean to the VSHandler struct to store the information about VRG's location.
- [X] Skip setting owner reference on objects when the VRG is in the ramenOps namespace. This is ok for now as the cleanup of the resources is a manual task when multiNamespace mode is being used for a VRG. 