### PR TITLE
Addons cache

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -651,6 +651,7 @@ simpler and faster to work with a minimal environment.
 - `kubevirt.yaml` - for testing kubevirt and cdi addons
 - `minio.yaml` - for testing `minio` deployment
 - `ocm.yaml` - for testing `ocm` deployment
+- `olm.yaml` - for testing `olm` deployment
 - `rook.yaml` - for testing `rook` deployment
 - `submariner.yaml` - for testing `submariner` deployment
 - `velero.yaml` - for testing `velero` deployment

--- a/test/addons/olm/crds/kustomization.yaml
+++ b/test/addons/olm/crds/kustomization.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+resources:
+  - https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.27.0/crds.yaml

--- a/test/addons/olm/fetch
+++ b/test/addons/olm/fetch
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from drenv import cache
+
+os.chdir(os.path.dirname(__file__))
+path = cache.path("addons/olm-crds.yaml")
+cache.fetch("crds", path)
+
+path = cache.path("addons/olm-operators.yaml")
+cache.fetch("operators", path)

--- a/test/addons/olm/operators/kustomization.yaml
+++ b/test/addons/olm/operators/kustomization.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+resources:
+  - https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.27.0/olm.yaml

--- a/test/addons/olm/start
+++ b/test/addons/olm/start
@@ -9,7 +9,7 @@ import sys
 import drenv
 from drenv import kubectl
 
-VERSION = "v0.22.0"
+VERSION = "v0.27.0"
 BASE_URL = f"https://github.com/operator-framework/operator-lifecycle-manager/releases/download/{VERSION}"
 NAMESPACE = "olm"
 

--- a/test/addons/olm/start
+++ b/test/addons/olm/start
@@ -9,8 +9,6 @@ import sys
 import drenv
 from drenv import kubectl
 
-VERSION = "v0.27.0"
-BASE_URL = f"https://github.com/operator-framework/operator-lifecycle-manager/releases/download/{VERSION}"
 NAMESPACE = "olm"
 
 
@@ -21,21 +19,17 @@ def deploy(cluster):
     #   The CustomResourceDefinition "clusterserviceversions.operators.coreos.com"
     #   is invalid: metadata.annotations: Too long: must have at most 262144 bytes
     # See https://medium.com/pareture/kubectl-install-crd-failed-annotations-too-long-2ebc91b40c7d
-    kubectl.apply(
-        f"--filename={BASE_URL}/crds.yaml",
-        "--server-side=true",
-        context=cluster,
-    )
+    kubectl.apply("--kustomize", "crds", "--server-side=true", context=cluster)
 
     print("Waiting until cdrs are established")
     kubectl.wait(
         "--for=condition=established",
-        f"--filename={BASE_URL}/crds.yaml",
+        "--filename=https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.27.0/crds.yaml",
         context=cluster,
     )
 
     print("Deploying olm")
-    kubectl.apply("--filename", f"{BASE_URL}/olm.yaml", context=cluster)
+    kubectl.apply("--kustomize", "operators", context=cluster)
 
 
 def wait(cluster):

--- a/test/addons/olm/start
+++ b/test/addons/olm/start
@@ -8,6 +8,7 @@ import sys
 
 import drenv
 from drenv import kubectl
+from drenv import cache
 
 NAMESPACE = "olm"
 
@@ -19,17 +20,22 @@ def deploy(cluster):
     #   The CustomResourceDefinition "clusterserviceversions.operators.coreos.com"
     #   is invalid: metadata.annotations: Too long: must have at most 262144 bytes
     # See https://medium.com/pareture/kubectl-install-crd-failed-annotations-too-long-2ebc91b40c7d
-    kubectl.apply("--kustomize", "crds", "--server-side=true", context=cluster)
+    path = cache.path("addons/olm-crds.yaml")
+    cache.fetch("crds", path)
+    kubectl.apply("--filename", path, "--server-side=true", context=cluster)
 
     print("Waiting until cdrs are established")
     kubectl.wait(
         "--for=condition=established",
-        "--filename=https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.27.0/crds.yaml",
+        "--filename",
+        path,
         context=cluster,
     )
 
     print("Deploying olm")
-    kubectl.apply("--kustomize", "operators", context=cluster)
+    path = cache.path("addons/olm-operators.yaml")
+    cache.fetch("operators", path)
+    kubectl.apply("--filename", path, context=cluster)
 
 
 def wait(cluster):

--- a/test/envs/olm.yaml
+++ b/test/envs/olm.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Environment for testing olm deployment.
+---
+name: olm
+
+profiles:
+  - name: c1
+    driver: $vm
+    container_runtime: containerd
+    memory: 2g
+    workers:
+      - addons:
+          - name: olm


### PR DESCRIPTION
Currently, olm addon do not use kustomization, so introducing that. Also, this change will start using cache for those resources, so starting addons can directly use the cached resources.

Changes:
- upgrade olm version to v0.27.0
- Add a new single cluster env for olm
- Use kustomization for olm resources
- Cache the kustomization resources

Example demonstrating how the cache works:

Fetching of resources for envs/olm.yaml:
```
$ drenv fetch envs/olm.yaml
2024-05-20 00:51:53,536 INFO    [olm] Fetching
2024-05-20 00:51:53,538 INFO    [olm] Running addons/olm/fetch
2024-05-20 00:51:58,611 INFO    [olm] addons/olm/fetch completed in 5.07 seconds
2024-05-20 00:51:58,611 INFO    [olm] Fetching finishied in 5.08 seconds
```
Fetching resources may take different amount of time for different runs. And once fetched, addons can directly use these resources to get started, saving time taken to fetch the resources(~5sec in this case) and escaping any network failure situation.

Size of the cache, the drenv directory tree:
```
$ tree -h ~/.cache/drenv/
[   20]  /home/abshakya/.cache/drenv/
└── [   53]  addons
    ├── [ 1.2M]  olm-crds.yaml
    └── [  10K]  olm-operators.yaml
```


Fixes: #1337 
Fixes: #1260 