### PR TITLE
Help pylint with drenv.commands

### DIFF
--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -217,6 +217,10 @@ def stream(proc, input=None, bufsize=32 << 10, timeout=None):
         except BrokenPipeError:
             pass
 
+    # Use only if input is not None, but it helps pylint.
+    input_view = ""
+    input_offset = 0
+
     with _Selector() as sel:
         for f, src in (proc.stdout, OUT), (proc.stderr, ERR):
             if f and not f.closed:
@@ -224,7 +228,6 @@ def stream(proc, input=None, bufsize=32 << 10, timeout=None):
         if input:
             sel.register(proc.stdin, selectors.EVENT_WRITE)
             input_view = memoryview(input.encode())
-            input_offset = 0
 
         while sel.get_map():
             remaining = _remaining_time(deadline)


### PR DESCRIPTION
Looks like recent change in pylint trigger this incorrect report:

    drenv/commands.py:234:28: E0606: Possibly using variable
    'input_view' before assignment (possibly-used-before-assignment)

This cannot happen since we don't register proc.stdin if input is None, so when we reach this block input_view is assigned. However disabling the check risk missing a real issue in that block.

Lets change the code so pylint can understand it better. This also make it easier to understand for humans. The cost is negligible, adding 2 temporary variables even when they are never used.