### PR TITLE
Upgrade minikube to v1.33.1

### DIFF
--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -97,7 +97,7 @@ enough resources:
    sudo dnf install https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
    ```
 
-   Tested with version v1.33.0.
+   Tested with version v1.33.1.
 
 1. Validate the installation
 

--- a/test/README.md
+++ b/test/README.md
@@ -28,7 +28,7 @@ environment.
    ```
 
    You need `minikube` version supporting the `--extra-disks` option.
-   Tested with version v1.33.0.
+   Tested with version v1.33.1.
 
 1. Install the `kubectl` tool. See
    [Install and Set Up kubectl on Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)

--- a/test/README.md
+++ b/test/README.md
@@ -27,7 +27,6 @@ environment.
    sudo dnf install https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
    ```
 
-   You need `minikube` version supporting the `--extra-disks` option.
    Tested with version v1.33.1.
 
 1. Install the `kubectl` tool. See

--- a/test/setup.py
+++ b/test/setup.py
@@ -21,6 +21,7 @@ setuptools.setup(
     install_requires=[
         "PyYAML",
         "toml",
+        "packaging",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This version includes the fixes we added for 1.33.0, and it applies them earlier so we don't need to setup anything and load configuration after a cluster starts.

To make this transparent for drenv users, we skip the unneeded setup based on minikube version. Reloading files and cleanup already skip if files were not configured.