### PR TITLE
Downgrade olm back to 0.22

### DIFF
--- a/test/addons/olm/crds/kustomization.yaml
+++ b/test/addons/olm/crds/kustomization.yaml
@@ -3,4 +3,4 @@
 
 ---
 resources:
-  - https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.27.0/crds.yaml
+  - https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.22.0/crds.yaml

--- a/test/addons/olm/operators/kustomization.yaml
+++ b/test/addons/olm/operators/kustomization.yaml
@@ -3,4 +3,4 @@
 
 ---
 resources:
-  - https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.27.0/olm.yaml
+  - https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.22.0/olm.yaml


### PR DESCRIPTION
Since we upgraded, the e2e job is failing[1] (due to a bug in the e2e integration, the job does not fail!). Lets try to go back to olm 0.22 since we know it worked before this change[2].

[1] last good build: https://github.com/RamenDR/ramen/actions/runs/9134579476/job/25120395289
[2] first bad build: https://github.com/RamenDR/ramen/actions/runs/9158274985/job/25177239838