### PR TITLE
Fail e2e workflow if tests failed

### DIFF
--- a/e2e/e2e-rdr.sh
+++ b/e2e/e2e-rdr.sh
@@ -6,5 +6,3 @@
 echo "Running tests..."
 
 go test -kubeconfig-c1 ~/.config/drenv/rdr-rdr/kubeconfigs/rdr-dr1  -kubeconfig-c2 ~/.config/drenv/rdr-rdr/kubeconfigs/rdr-dr2 -kubeconfig-hub ~/.config/drenv/rdr-rdr/kubeconfigs/rdr-hub -timeout 0 -v "$@"
-
-exit 0


### PR DESCRIPTION
Now that that we have basic test running, we want to fail the workflow if the tests failed. Without this  people assumes code changes are passed the tests.