### PR TITLE
drenv: Add distribution to drenv metadata

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -487,6 +487,8 @@ $ drenv delete envs/example.yaml
     - `hub`: the context of hub cluster, null if there is no hub
     - `clusters`: list of managed clusters contexts
     - `topology`: either "regional-dr" or "metro-dr"
+    - `distribution`: kubernetes distribution name. Use "k8s" for minikube
+      clusters, "ocp" for OpenShift clusters.
     - `features`: featrues provided by this environment
         - `volsync`: true if volsync is available
 

--- a/test/README.md
+++ b/test/README.md
@@ -481,6 +481,15 @@ $ drenv delete envs/example.yaml
 
 ### The environment file format
 
+- `name`: environment name, used for logging
+
+- `ramen`: ramen metadata
+    - `hub`: the context of hub cluster, null if there is no hub
+    - `clusters`: list of managed clusters contexts
+    - `topology`: either "regional-dr" or "metro-dr"
+    - `features`: featrues provided by this environment
+        - `volsync`: true if volsync is available
+
 - `templates`: templates for creating new profiles.
     - `name`: profile name.
     - `external`: true if this is existing external cluster. In this

--- a/test/envs/e2e.yaml
+++ b/test/envs/e2e.yaml
@@ -8,6 +8,7 @@ name: "e2e"
 ramen:
   hub: hub
   clusters: [dr1, dr2]
+  distribution: k8s
   topology: regional-dr
 
 templates:

--- a/test/envs/ocm.yaml
+++ b/test/envs/ocm.yaml
@@ -8,6 +8,7 @@ name: "ocm"
 ramen:
   hub: hub
   clusters: [dr1, dr2]
+  distribution: "k8s"
 
 templates:
   - name: "hub-cluster"

--- a/test/envs/ocm.yaml
+++ b/test/envs/ocm.yaml
@@ -5,6 +5,10 @@
 ---
 name: "ocm"
 
+ramen:
+  hub: hub
+  clusters: [dr1, dr2]
+
 templates:
   - name: "hub-cluster"
     driver: "$vm"

--- a/test/envs/regional-dr-hubless.yaml
+++ b/test/envs/regional-dr-hubless.yaml
@@ -9,6 +9,7 @@ ramen:
   hub: null
   clusters: [dr1, dr2]
   topology: regional-dr
+  distribution: k8s
   features:
     volsync: true
 

--- a/test/envs/regional-dr-kubevirt.yaml
+++ b/test/envs/regional-dr-kubevirt.yaml
@@ -9,6 +9,7 @@ ramen:
   hub: hub
   clusters: [dr1, dr2]
   topology: regional-dr
+  distribution: k8s
   features:
     volsync: false
 

--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -9,6 +9,7 @@ ramen:
   hub: hub
   clusters: [dr1, dr2]
   topology: regional-dr
+  distribution: k8s
   features:
     volsync: true
 

--- a/test/envs/rook.yaml
+++ b/test/envs/rook.yaml
@@ -8,6 +8,7 @@ name: "rook"
 ramen:
   hub: null
   clusters: [dr1, dr2]
+  distribution: "k8s"
 
 templates:
   - name: "dr-cluster"

--- a/test/envs/rook.yaml
+++ b/test/envs/rook.yaml
@@ -5,6 +5,10 @@
 ---
 name: "rook"
 
+ramen:
+  hub: null
+  clusters: [dr1, dr2]
+
 templates:
   - name: "dr-cluster"
     driver: "$vm"


### PR DESCRIPTION
This can be used to do the right thing for ocp or k8s clusters in tests or tools using environment files.