### PR TITLE
Install argocd

### DIFF
--- a/test/addons/argocd/argocd-ns.yaml
+++ b/test/addons/argocd/argocd-ns.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd

--- a/test/addons/argocd/kustomization.yaml
+++ b/test/addons/argocd/kustomization.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# yamllint disable rule:line-length
+---
+resources:
+  - argocd-ns.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/release-2.11/manifests/install.yaml
+
+# In argocd appset DR e2e test, an appset CR will be created that uses placementdecision
+# resource to decide which cluster to deploy application. So here need add role for
+# placementdecision.
+patches:
+  - target:
+      kind: Role
+      name: argocd-applicationset-controller
+    patch: |-
+      - op: add
+        path: /rules/-
+        value:
+          apiGroups:
+          - cluster.open-cluster-management.io
+          resources:
+          - placementdecisions
+          verbs:
+          - get
+          - list
+          - watch

--- a/test/addons/argocd/start
+++ b/test/addons/argocd/start
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+from drenv import temporary_kubeconfig
+from drenv import commands
+from drenv import kubectl
+from drenv import cache
+from drenv import cluster
+
+
+def wait_for_clusters(clusters):
+    for name in clusters:
+        print(f"Waiting until cluster '{name}' is ready")
+        cluster.wait_until_ready(name)
+
+
+def deploy_argocd(cluster):
+    print("Deploying argocd")
+    path = cache.path("addons/argocd-2.11.yaml")
+    cache.fetch(".", path)
+    kubectl.apply("--filename", path, "--namespace", "argocd", context=cluster)
+
+
+def wait_for_deployments(cluster):
+    print("Waiting until all deployments are available")
+    kubectl.wait(
+        "deploy",
+        "--all",
+        "--for=condition=Available",
+        "--namespace=argocd",
+        "--timeout=300s",
+        context=cluster,
+    )
+
+
+def add_clusters(hub, clusters):
+    # need use KUBECONFIG env, switch to hub cluster argocd ns first,
+    # otherwise will hit argocd command bug
+    # see https://github.com/argoproj/argo-cd/issues/14167
+    with temporary_kubeconfig("drenv-argocd-test.") as env:
+        kubeconfig = env["KUBECONFIG"]
+        kubectl.config("use-context", hub, "--kubeconfig", kubeconfig)
+        kubectl.config(
+            "set-context",
+            "--current",
+            "--namespace=argocd",
+            f"--kubeconfig={kubeconfig}",
+        )
+
+        print("Logging in to argocd server on hub")
+        for line in commands.watch("argocd", "login", "--core", env=env):
+            print(line)
+
+        for name in clusters:
+            try:
+                print(f"Adding cluster '{name}' to argocd")
+                commands.run("argocd", "cluster", "add", name, "-y", env=env)
+            except commands.Error as e:
+                # ignore known error "NOAUTH" with "argocd cluster add" after "argocd login --core"
+                # see bug https://github.com/argoproj/argo-cd/issues/18464
+                if e.exitcode != 20 or "NOAUTH" not in e.error:
+                    raise e
+
+
+if len(sys.argv) != 4:
+    print(f"Usage: {sys.argv[0]} hub cluster1 cluster2")
+    sys.exit(1)
+
+hub, *clusters = sys.argv[1:]
+
+wait_for_clusters(clusters)
+deploy_argocd(hub)
+wait_for_deployments(hub)
+add_clusters(hub, clusters)

--- a/test/addons/argocd/test
+++ b/test/addons/argocd/test
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+from drenv import temporary_kubeconfig
+from drenv import commands
+from drenv import kubectl
+
+
+def deploy_guestbook(hub, cluster):
+    print(
+        f"Deploying application guestbook-{cluster} in namespace argocd-test on cluster {cluster}"
+    )
+    # need use KUBECONFIG env, switch to hub cluster argocd ns first,
+    # otherwise will hit argocd command bug
+    # see https://github.com/argoproj/argo-cd/issues/14167
+    with temporary_kubeconfig("drenv-argocd-test.") as env:
+        kubeconfig = env["KUBECONFIG"]
+        kubectl.config("use-context", hub, "--kubeconfig", kubeconfig)
+        kubectl.config(
+            "set-context",
+            "--current",
+            "--namespace=argocd",
+            f"--kubeconfig={kubeconfig}",
+        )
+
+        for line in commands.watch(
+            "argocd",
+            "app",
+            "create",
+            f"guestbook-{cluster}",
+            "--repo=https://github.com/argoproj/argocd-example-apps.git",
+            "--path=guestbook",
+            f"--dest-name={cluster}",
+            "--dest-namespace=argocd-test",
+            "--sync-option=CreateNamespace=true",
+            "--sync-policy=automated",
+            env=env,
+        ):
+            print(line)
+
+
+def wait_until_guestbook_is_healthy(hub, cluster):
+    print(f"Waiting application guestbook-{cluster} to be healthy")
+    kubectl.wait(
+        "application",
+        f"guestbook-{cluster}",
+        "--for=jsonpath={.status.health.status}=Healthy",
+        "--namespace=argocd",
+        "--timeout=60s",
+        context=hub,
+    )
+
+
+def undeploy_guestbook(hub, cluster):
+    print(f"Deleting application guestbook-{cluster}")
+    # need use KUBECONFIG env, switch to hub cluster argocd ns first,
+    # otherwise will hit argocd command bug
+    # see https://github.com/argoproj/argo-cd/issues/14167
+    with temporary_kubeconfig("drenv-argocd-test.") as env:
+        kubeconfig = env["KUBECONFIG"]
+        kubectl.config("use-context", hub, "--kubeconfig", kubeconfig)
+        kubectl.config(
+            "set-context",
+            "--current",
+            "--namespace=argocd",
+            f"--kubeconfig={kubeconfig}",
+        )
+
+        for line in commands.watch(
+            "argocd",
+            "app",
+            "delete",
+            f"guestbook-{cluster}",
+            "--yes",
+            "--wait",
+            env=env,
+        ):
+            print(line)
+
+    kubectl.delete("namespace", "argocd-test", context=cluster)
+
+
+if len(sys.argv) != 4:
+    print(f"Usage: {sys.argv[0]} hub cluster1 cluster2")
+    sys.exit(1)
+
+hub = sys.argv[1]
+
+hub, *clusters = sys.argv[1:]
+
+for cluster in clusters:
+    deploy_guestbook(hub, cluster)
+
+for cluster in clusters:
+    wait_until_guestbook_is_healthy(hub, cluster)
+
+for cluster in clusters:
+    undeploy_guestbook(hub, cluster)

--- a/test/envs/argocd.yaml
+++ b/test/envs/argocd.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Environment for testing argocd deployment
+---
+name: argocd
+
+templates:
+  - name: hub
+    driver: "$vm"
+    container_runtime: containerd
+    network: "$network"
+    cpus: 2
+    memory: "4g"
+  - name: cluster
+    driver: "$vm"
+    container_runtime: containerd
+    network: "$network"
+    cpus: 2
+    memory: "2g"
+
+profiles:
+  - name: hub
+    template: hub
+    workers:
+      - addons:
+          - name: argocd
+            args: [hub, dr1, dr2]
+  - name: dr1
+    template: cluster
+  - name: dr2
+    template: cluster

--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -55,6 +55,8 @@ templates:
       - addons:
           - name: submariner
             args: ["hub", "dr1", "dr2"]
+          - name: argocd
+            args: ["hub", "dr1", "dr2"]
 
 profiles:
   - name: "dr1"


### PR DESCRIPTION
This PR installs argocd operator on hub cluster, and enables ability to create argocd application CR and applicationset CR on hub, and the application could be auto deployed to the target dr cluster by argocd controller, using push mode. 