### PR TITLE
Minimize kubevirt deployment

### DIFF
--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -152,7 +152,7 @@ enough resources:
 1. Install the `virtctl` tool.
 
    ```
-   curl -L -o virtctl https://github.com/kubevirt/kubevirt/releases/download/v1.2.0/virtctl-v1.2.0-linux-amd64
+   curl -L -o virtctl https://github.com/kubevirt/kubevirt/releases/download/v1.2.1/virtctl-v1.2.1-linux-amd64
    sudo install virtctl /usr/local/bin
    rm virtctl
    ```

--- a/test/README.md
+++ b/test/README.md
@@ -60,7 +60,7 @@ environment.
 1. Install the `virtctl` tool
 
    ```
-   curl -L -o virtctl https://github.com/kubevirt/kubevirt/releases/download/v1.2.0/virtctl-v1.2.0-linux-amd64
+   curl -L -o virtctl https://github.com/kubevirt/kubevirt/releases/download/v1.2.1/virtctl-v1.2.1-linux-amd64
    sudo install virtctl /usr/local/bin
    rm virtctl
    ```

--- a/test/addons/cdi/cr/kustomization.yaml
+++ b/test/addons/cdi/cr/kustomization.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.58.3/cdi-cr.yaml
+  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.59.0/cdi-cr.yaml
 patches:
   # Allow pulling from local insecure registry.
   - target:

--- a/test/addons/cdi/fetch
+++ b/test/addons/cdi/fetch
@@ -9,8 +9,8 @@ from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
 
-path = cache.path("addons/cdi-operator.yaml")
+path = cache.path("addons/cdi-operator-1.59.0.yaml")
 cache.fetch("operator", path)
 
-path = cache.path("addons/cdi-cr.yaml")
+path = cache.path("addons/cdi-cr-1.59.0.yaml")
 cache.fetch("cr", path)

--- a/test/addons/cdi/operator/kustomization.yaml
+++ b/test/addons/cdi/operator/kustomization.yaml
@@ -4,4 +4,4 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.58.3/cdi-operator.yaml
+  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.59.0/cdi-operator.yaml

--- a/test/addons/cdi/start
+++ b/test/addons/cdi/start
@@ -14,7 +14,7 @@ NAMESPACE = "cdi"
 
 def deploy(cluster):
     print("Deploying cdi operator")
-    path = cache.path("addons/cdi-operator.yaml")
+    path = cache.path("addons/cdi-operator-1.59.0.yaml")
     cache.fetch("operator", path)
     kubectl.apply("--filename", path, context=cluster)
 
@@ -28,7 +28,7 @@ def deploy(cluster):
     )
 
     print("Deploying cdi cr")
-    path = cache.path("addons/cdi-cr.yaml")
+    path = cache.path("addons/cdi-cr-1.59.0.yaml")
     cache.fetch("cr", path)
     kubectl.apply("--filename", path, context=cluster)
 

--- a/test/addons/kubevirt/cr/kustomization.yaml
+++ b/test/addons/kubevirt/cr/kustomization.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://raw.githubusercontent.com/nirs/drenv-addons/main/kubevirt/9c3a52d67c6782cd48ae0702df5493f5023a04cc/kubevirt-cr.yaml
+  - https://github.com/kubevirt/kubevirt/releases/download/v1.2.1/kubevirt-cr.yaml
 patches:
   # Incrase certificate duration to avoid certificates renewals while a cluster
   # is suspended and resumed.

--- a/test/addons/kubevirt/cr/kustomization.yaml
+++ b/test/addons/kubevirt/cr/kustomization.yaml
@@ -23,3 +23,15 @@ patches:
               duration: 168h
             server:
               duration: 168h
+  # Use single replica to minimize resource usage.
+  - target:
+      kind: KubeVirt
+      name: kubevirt
+    patch: |-
+      apiVersion: kubevirt.io/v1
+      kind: Kubevirt
+      metadata:
+        name: not-used
+      spec:
+        infra:
+          replicas: 1

--- a/test/addons/kubevirt/fetch
+++ b/test/addons/kubevirt/fetch
@@ -9,8 +9,8 @@ from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
 
-path = cache.path("addons/kubevirt-operator.yaml")
+path = cache.path("addons/kubevirt-operator-1.2.1.yaml")
 cache.fetch("operator", path)
 
-path = cache.path("addons/kubevirt-cr.yaml")
+path = cache.path("addons/kubevirt-cr-1.2.1.yaml")
 cache.fetch("cr", path)

--- a/test/addons/kubevirt/operator/kustomization.yaml
+++ b/test/addons/kubevirt/operator/kustomization.yaml
@@ -4,5 +4,4 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  # TODO: use latest release.
-  - https://raw.githubusercontent.com/nirs/drenv-addons/main/kubevirt/9c3a52d67c6782cd48ae0702df5493f5023a04cc/kubevirt-operator.yaml
+  - https://github.com/kubevirt/kubevirt/releases/download/v1.2.1/kubevirt-operator.yaml

--- a/test/addons/kubevirt/operator/kustomization.yaml
+++ b/test/addons/kubevirt/operator/kustomization.yaml
@@ -5,3 +5,12 @@
 ---
 resources:
   - https://github.com/kubevirt/kubevirt/releases/download/v1.2.1/kubevirt-operator.yaml
+patches:
+  # Use single replica to minimize resource usage.
+  - target:
+      kind: Deployment
+      name: virt-operator
+    patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1

--- a/test/addons/kubevirt/start
+++ b/test/addons/kubevirt/start
@@ -14,7 +14,7 @@ NAMESPACE = "kubevirt"
 
 def deploy(cluster):
     print("Deploying kubevirt operator")
-    path = cache.path("addons/kubevirt-operator.yaml")
+    path = cache.path("addons/kubevirt-operator-1.2.1.yaml")
     cache.fetch("operator", path)
     kubectl.apply("--filename", path, context=cluster)
 
@@ -28,7 +28,7 @@ def deploy(cluster):
     )
 
     print("Deploying kubevirt cr")
-    path = cache.path("addons/kubevirt-cr.yaml")
+    path = cache.path("addons/kubevirt-cr-1.2.1.yaml")
     cache.fetch("cr", path)
     kubectl.apply("--filename", path, context=cluster)
 


### PR DESCRIPTION
Use single replica for kubevirt operator and controller to minimize resources usage.

Based temporarily on #1422 

