### PR TITLE
Failover of cephfs discovered app workload fails

### DIFF
--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -1591,11 +1591,13 @@ var _ = Describe("VolSync_Handler", func() {
 		})
 
 		It("Should delete an RD when it belongs to the VRG", func() {
-			rdToDelete1 := rdSpecList[3].ProtectedPVC.Name // rd name should == pvc name
-			Expect(vsHandler.DeleteRD(rdToDelete1)).To(Succeed())
+			rdToDelete1 := rdSpecList[3].ProtectedPVC.Name        // rd name should == pvc name
+			rdToDeleteNs1 := rdSpecList[3].ProtectedPVC.Namespace // rd namespace should == pvc namespace
+			Expect(vsHandler.DeleteRD(rdToDelete1, rdToDeleteNs1)).To(Succeed())
 
-			rdToDelete2 := rdSpecList[5].ProtectedPVC.Name // rd name should == pvc name
-			Expect(vsHandler.DeleteRD(rdToDelete2)).To(Succeed())
+			rdToDelete2 := rdSpecList[5].ProtectedPVC.Name        // rd name should == pvc name
+			rdToDeleteNS2 := rdSpecList[5].ProtectedPVC.Namespace // rd namespace should == pvc namespace
+			Expect(vsHandler.DeleteRD(rdToDelete2, rdToDeleteNS2)).To(Succeed())
 
 			remainingRDs := &volsyncv1alpha1.ReplicationDestinationList{}
 			Eventually(func() int {
@@ -1611,8 +1613,9 @@ var _ = Describe("VolSync_Handler", func() {
 		})
 
 		It("Should not delete an RD when it does not belong to the VRG", func() {
-			rdToDelete := rdSpecListOtherOwner[1].ProtectedPVC.Name // rd name should == pvc name
-			Expect(vsHandler.DeleteRD(rdToDelete)).To(Succeed())    // Should not return err
+			rdToDelete := rdSpecListOtherOwner[1].ProtectedPVC.Name            // rd name should == pvc name
+			rdToDeleteNs := rdSpecListOtherOwner[1].ProtectedPVC.Namespace     // rd namespace should == pvc namespace
+			Expect(vsHandler.DeleteRD(rdToDelete, rdToDeleteNs)).To(Succeed()) // Should not return err
 
 			// No RDs should have been deleted
 			remainingRDs := &volsyncv1alpha1.ReplicationDestinationList{}
@@ -1743,11 +1746,13 @@ var _ = Describe("VolSync_Handler", func() {
 		})
 
 		It("Should delete an RS when it belongs to the VRG", func() {
-			rsToDelete1 := rsSpecList[3].ProtectedPVC.Name // rs name should == pvc name
-			Expect(vsHandler.DeleteRS(rsToDelete1)).To(Succeed())
+			rsToDelete1 := rsSpecList[3].ProtectedPVC.Name        // rs name should == pvc name
+			rsToDeleteNs1 := rsSpecList[3].ProtectedPVC.Namespace // rs namespace should == pvc namespace
+			Expect(vsHandler.DeleteRS(rsToDelete1, rsToDeleteNs1)).To(Succeed())
 
-			rsToDelete2 := rsSpecList[5].ProtectedPVC.Name // rs name should == pvc name
-			Expect(vsHandler.DeleteRS(rsToDelete2)).To(Succeed())
+			rsToDelete2 := rsSpecList[5].ProtectedPVC.Name        // rs name should == pvc name
+			rsToDeleteNs2 := rsSpecList[5].ProtectedPVC.Namespace // rs namespace should == pvc namespace
+			Expect(vsHandler.DeleteRS(rsToDelete2, rsToDeleteNs2)).To(Succeed())
 
 			remainingRSs := &volsyncv1alpha1.ReplicationSourceList{}
 			Eventually(func() int {
@@ -1758,8 +1763,9 @@ var _ = Describe("VolSync_Handler", func() {
 		})
 
 		It("Should not delete an RS when it does not belong to the VRG", func() {
-			rsToDelete := rsSpecListOtherOwner[1].ProtectedPVC.Name // rs name should == pvc name
-			Expect(vsHandler.DeleteRS(rsToDelete)).To(Succeed())    // Should not return err
+			rsToDelete := rsSpecListOtherOwner[1].ProtectedPVC.Name            // rs name should == pvc name
+			rsToDeleteNs := rsSpecListOtherOwner[1].ProtectedPVC.Namespace     // rs namespace should == pvc namespace
+			Expect(vsHandler.DeleteRS(rsToDelete, rsToDeleteNs)).To(Succeed()) // Should not return err
 
 			// No RSs should have been deleted
 			remainingRSs := &volsyncv1alpha1.ReplicationSourceList{}

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -516,7 +516,8 @@ var _ = Describe("VolSync_Handler", func() {
 								Namespace: testNamespace.GetName(),
 								Labels: map[string]string{
 									// Need to simulate that it's owned by our VRG by using our label
-									volsync.VRGOwnerLabel: owner.GetName(),
+									volsync.VRGOwnerNameLabel:      owner.GetName(),
+									volsync.VRGOwnerNamespaceLabel: owner.GetNamespace(),
 								},
 							},
 							Spec: volsyncv1alpha1.ReplicationSourceSpec{},
@@ -571,7 +572,8 @@ var _ = Describe("VolSync_Handler", func() {
 						Expect(*createdRD.Spec.RsyncTLS.StorageClassName).To(Equal(testStorageClassName))
 						Expect(*createdRD.Spec.RsyncTLS.VolumeSnapshotClassName).To(Equal(testVolumeSnapshotClassName))
 						Expect(createdRD.Spec.Trigger).To(BeNil()) // No schedule should be set
-						Expect(createdRD.GetLabels()).To(HaveKeyWithValue(volsync.VRGOwnerLabel, owner.GetName()))
+						Expect(createdRD.GetLabels()).To(HaveKeyWithValue(volsync.VRGOwnerNameLabel, owner.GetName()))
+						Expect(createdRD.GetLabels()).To(HaveKeyWithValue(volsync.VRGOwnerNamespaceLabel, owner.GetNamespace()))
 						Expect(*createdRD.Spec.RsyncTLS.ServiceType).To(Equal(volsync.DefaultRsyncServiceType))
 
 						// Check that the secret has been updated to have our vrg as owner
@@ -829,7 +831,8 @@ var _ = Describe("VolSync_Handler", func() {
 									Namespace: testNamespace.GetName(),
 									Labels: map[string]string{
 										// Need to simulate that it's owned by our VRG by using our label
-										volsync.VRGOwnerLabel: owner.GetName(),
+										volsync.VRGOwnerNameLabel:      owner.GetName(),
+										volsync.VRGOwnerNamespaceLabel: owner.GetNamespace(),
 									},
 								},
 								Spec: volsyncv1alpha1.ReplicationDestinationSpec{},
@@ -922,7 +925,8 @@ var _ = Describe("VolSync_Handler", func() {
 							Expect(createdRS.Spec.Trigger).To(Equal(&volsyncv1alpha1.ReplicationSourceTriggerSpec{
 								Schedule: &expectedCronSpecSchedule,
 							}))
-							Expect(createdRS.GetLabels()).To(HaveKeyWithValue(volsync.VRGOwnerLabel, owner.GetName()))
+							Expect(createdRS.GetLabels()).To(HaveKeyWithValue(volsync.VRGOwnerNameLabel, owner.GetName()))
+							Expect(createdRS.GetLabels()).To(HaveKeyWithValue(volsync.VRGOwnerNamespaceLabel, owner.GetNamespace()))
 						})
 
 						It("Should create an ReplicationSource if one does not exist", func() {

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -776,6 +776,12 @@ func (v *VRGInstance) processForDeletion() ctrl.Result {
 		return ctrl.Result{Requeue: true}
 	}
 
+	if err := v.cleanupResources(); err != nil {
+		v.log.Info("Cleanup owned resources failed", "error", err)
+
+		return ctrl.Result{Requeue: true}
+	}
+
 	if !containsString(v.instance.ObjectMeta.Finalizers, vrgFinalizerName) {
 		v.log.Info("Finalizer missing from resource", "finalizer", vrgFinalizerName)
 

--- a/controllers/vrg_volsync.go
+++ b/controllers/vrg_volsync.go
@@ -425,3 +425,24 @@ func (v *VRGInstance) disownPVCs() error {
 
 	return nil
 }
+
+// cleanupResources this function deleted all PS, PD and VolumeSnapshots from its owner (VRG)
+func (v *VRGInstance) cleanupResources() error {
+	for idx := range v.volSyncPVCs {
+		pvc := &v.volSyncPVCs[idx]
+
+		if err := v.volSyncHandler.DeleteRS(pvc.Name, pvc.Namespace); err != nil {
+			return err
+		}
+
+		if err := v.volSyncHandler.DeleteRD(pvc.Name, pvc.Namespace); err != nil {
+			return err
+		}
+
+		if err := v.volSyncHandler.DeleteSnapshots(pvc.Namespace); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
The problem is happening only when we are using discovered apps. After deploying the discovered app workload, failover was started and failed. VRG is reporting the following error:

failed to add owner/label to snapshot busybox-pvc-16-20240528120125
        (cross-namespace owner references are disallowed, owner's namespace openshift-dr-ops,
        obj's namespace app-busybox-cephfs-1)

The solution is to add owneref only when the VRG is not in the admin namespace (in our case VRG is in openshift-dr-ops namespace, which is admin namespace, so setting owner must be skipped). 

We are still adding the label do-not-delete to snapshot though

Fixed: https://bugzilla.redhat.com/show_bug.cgi?id=2283633