### PR TITLE
Update Protected condition to report true for Sync DR cases

### DIFF
--- a/controllers/protected_condition.go
+++ b/controllers/protected_condition.go
@@ -158,8 +158,7 @@ func updateVRGDataProtectedAsPrimary(drpc *rmn.DRPlacementControl,
 
 	if condition != nil && condition.ObservedGeneration == vrg.Generation {
 		// VRGConditionReasonReplicating reason is unique to VR based volumes
-		if condition.Reason == VRGConditionReasonReplicating && condition.Status == metav1.ConditionFalse &&
-			vrg.Spec.Async != nil {
+		if condition.Reason == VRGConditionReasonReplicating && condition.Status == metav1.ConditionFalse {
 			return !updated
 		}
 


### PR DESCRIPTION
When DataProtected is false with reason Replicating for Sync DR we still report Protected as false. This is corrected with this commit.

In the Sync DR case we update DataProtected with reason VRGConditionReasonReady but, the actual update to the condition in setPVCDataProtectedCondition overrides this back to reason Replicating, with status as false.

While the above seems counterintuitive the fix is to address the Protected condition for sync DR, as otherwise constant alerts regarding the protection status is fired, due to it remaining false always.

The condition DataProtected is not corrected to true, which needs to be tracked and ensured for its correctness.