### PR TITLE
Using S3 Storage to Recover lastGroupSyncTime After Hub Recovery

### DIFF
--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -170,7 +170,6 @@ type PlacementDecision struct {
 // VRGResourceMeta represents the VRG resource.
 type VRGResourceMeta struct {
 	// Kind is the kind of the Kubernetes resource.
-	// +optional
 	Kind string `json:"kind"`
 
 	// Name is the name of the Kubernetes resource.
@@ -183,7 +182,13 @@ type VRGResourceMeta struct {
 	Generation int64 `json:"generation"`
 
 	// List of PVCs that are protected by the VRG resource
+	//+optional
 	ProtectedPVCs []string `json:"protectedpvcs,omitempty"`
+
+	// ResourceVersion is a value used to identify the version of the
+	// VRG resource object
+	//+optional
+	ResourceVersion string `json:"resourceVersion,omitempty"`
 }
 
 // VRGConditions represents the conditions of the resources deployed on a

--- a/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
@@ -535,8 +535,14 @@ spec:
                         items:
                           type: string
                         type: array
+                      resourceVersion:
+                        description: |-
+                          ResourceVersion is a value used to identify the version of the
+                          VRG resource object
+                        type: string
                     required:
                     - generation
+                    - kind
                     - name
                     - namespace
                     type: object

--- a/controllers/drcluster_mmode.go
+++ b/controllers/drcluster_mmode.go
@@ -110,7 +110,7 @@ func (u *drclusterInstance) mModeActivationsRequired() (map[string]ramen.Storage
 
 // getVRGs is a helper function to get the VRGs for the passed in DRPC and DRPolicy association
 func (u *drclusterInstance) getVRGs(drpcCollection DRPCAndPolicy) (map[string]*ramen.VolumeReplicationGroup, error) {
-	drClusters, err := getDRClusters(u.ctx, u.client, drpcCollection.drPolicy)
+	drClusters, err := GetDRClusters(u.ctx, u.client, drpcCollection.drPolicy)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
After a Hub recovery, the `DRPC` status is not restored, resulting in the loss of the `lastGroupSyncTime` information, which cannot be reconstructed if the primary cluster is also down. To address this issue, use an `S3` store to recover the lost information.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2275320