### PR TITLE
Fix regional DR kubevirt env config

### DIFF
--- a/test/envs/regional-dr-kubevirt.yaml
+++ b/test/envs/regional-dr-kubevirt.yaml
@@ -10,7 +10,7 @@ ramen:
   clusters: [dr1, dr2]
   topology: regional-dr
   features:
-    volsync: false
+    volsync: true
 
 templates:
   - name: "dr-cluster"
@@ -25,12 +25,15 @@ templates:
     memory: "8g"
     extra_disks: 1
     disk_size: "50g"
+    addons:
+      - volumesnapshots
     workers:
       - addons:
           - name: rook-operator
           - name: rook-cluster
           - name: rook-toolbox
           - name: rook-pool
+          - name: rook-cephfs
           - name: cdi
       - addons:
           - name: ocm-cluster
@@ -53,6 +56,8 @@ templates:
           - name: ocm-hub
           - name: ocm-controller
           - name: olm
+          - name: submariner
+            args: ["hub", "dr1", "dr2"]
 
 profiles:
   - name: "dr1"
@@ -65,4 +70,7 @@ profiles:
 workers:
   - addons:
       - name: rbd-mirror
+        args: ["dr1", "dr2"]
+  - addons:
+      - name: volsync
         args: ["dr1", "dr2"]


### PR DESCRIPTION
Today volsync is required to start up some of the ramen controllers:
```
2024-06-02T12:04:48.162Z	ERROR	controller-runtime.source.EventHandler	source/kind.go:68	failed to get informer from cache	{"error": "failed to get API group resources: unable to retrieve the complete list of server APIs: volsync.backube/v1alpha1: the server could not find the requested resource"}
```
which is an issue because some time ago volsync was disabled (https://github.com/RamenDR/ramen/pull/1213/commits/43266c52d171406ba9417346084594d67fe1efef).

Related - https://github.com/kubernetes-sigs/controller-runtime/issues/2456