### PR TITLE
Update olm to v0.27.0

### DIFF
--- a/test/addons/olm/crds/kustomization.yaml
+++ b/test/addons/olm/crds/kustomization.yaml
@@ -3,4 +3,4 @@
 
 ---
 resources:
-  - https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.22.0/crds.yaml
+  - https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.27.0/crds.yaml

--- a/test/addons/olm/fetch
+++ b/test/addons/olm/fetch
@@ -8,8 +8,8 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-path = cache.path("addons/olm-crds.yaml")
+path = cache.path("addons/olm-crds-0.27.yaml")
 cache.fetch("crds", path)
 
-path = cache.path("addons/olm-operators.yaml")
+path = cache.path("addons/olm-operators-0.27.yaml")
 cache.fetch("operators", path)

--- a/test/addons/olm/operators/kustomization.yaml
+++ b/test/addons/olm/operators/kustomization.yaml
@@ -3,4 +3,4 @@
 
 ---
 resources:
-  - https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.22.0/olm.yaml
+  - https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.27.0/olm.yaml

--- a/test/addons/olm/start
+++ b/test/addons/olm/start
@@ -20,7 +20,7 @@ def deploy(cluster):
     #   The CustomResourceDefinition "clusterserviceversions.operators.coreos.com"
     #   is invalid: metadata.annotations: Too long: must have at most 262144 bytes
     # See https://medium.com/pareture/kubectl-install-crd-failed-annotations-too-long-2ebc91b40c7d
-    path = cache.path("addons/olm-crds.yaml")
+    path = cache.path("addons/olm-crds-0.27.yaml")
     cache.fetch("crds", path)
     kubectl.apply("--filename", path, "--server-side=true", context=cluster)
 
@@ -33,7 +33,7 @@ def deploy(cluster):
     )
 
     print("Deploying olm")
-    path = cache.path("addons/olm-operators.yaml")
+    path = cache.path("addons/olm-operators-0.27.yaml")
     cache.fetch("operators", path)
     kubectl.apply("--filename", path, context=cluster)
 


### PR DESCRIPTION
Upgrade olm version from 0.22.0 to latest stable version 0.27.0

The version 0.27.0 looks stable and is passing all the tests including basic-test/run on local setup.

Fixes: #1411 