### PR TITLE
config: add configuration field to enable volsync support for discovered apps

### DIFF
--- a/api/v1alpha1/ramenconfig_types.go
+++ b/api/v1alpha1/ramenconfig_types.go
@@ -147,7 +147,8 @@ type RamenConfig struct {
 
 	MultiNamespace struct {
 		// Enables feature to protect resources in namespaces other than VRG's
-		FeatureEnabled bool `json:"FeatureEnabled,omitempty"`
+		FeatureEnabled   bool `json:"FeatureEnabled,omitempty"`
+		VolsyncSupported bool `json:"volsyncSupported,omitempty"`
 	} `json:"multiNamespace,omitempty"`
 
 	// Unprotect deleted or deselected PVCs

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -976,6 +976,10 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 		log.Info("volsync is set to disabled")
 	}
 
+	if !d.volSyncDisabled && drpcInAdminNamespace(drpc, ramenConfig) {
+		d.volSyncDisabled = !ramenConfig.MultiNamespace.VolsyncSupported
+	}
+
 	// Save the instance status
 	d.instance.Status.DeepCopyInto(&d.savedInstanceStatus)
 


### PR DESCRIPTION
The discovered apps feature still has issues when used with volsync in regional DR setups. We need a way to disable it by default on fresh installations.

This PR adds a configuration option under MultiNamespace section in the ramen config for volsync support which is kept false by default.