### PR TITLE
Add infrastructure for argocd addon

### DIFF
--- a/test/drenv/__init__.py
+++ b/test/drenv/__init__.py
@@ -92,6 +92,27 @@ def kustomization_yaml(yaml):
         yield tmpdir
 
 
+@contextmanager
+def temporary_kubeconfig(prefix="drenv."):
+    """
+    Create a temporary kubeconfig and return an environment with KUBECONFIG
+    pointing to the temporary kubeconfig. The environment can be used to run
+    commands that do unsafe global modifications (use-context, set-context).
+
+    The temporary kubeconfig is deleted when existing from the context.
+
+    Yields the environment dict.
+    """
+    with tempfile.TemporaryDirectory(prefix=prefix) as tmpdir:
+        kubeconfig = os.path.join(tmpdir, "kubeconfig")
+        out = kubectl.config("view", "--output=yaml")
+        with open(kubeconfig, "w") as f:
+            f.write(out)
+        env = dict(os.environ)
+        env["KUBECONFIG"] = kubeconfig
+        yield env
+
+
 def config_dir(name):
     """
     Return configuration directory for profile name. This can be used to

--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -70,7 +70,7 @@ class StreamTimeout(Exception):
     """
 
 
-def run(*args, input=None, decode=True):
+def run(*args, input=None, decode=True, env=None):
     """
     Run command args and return the output of the command.
 
@@ -93,6 +93,7 @@ def run(*args, input=None, decode=True):
                 stdin=subprocess.PIPE if input else None,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                env=env,
             )
         except OSError as e:
             raise Error(args, f"Could not execute: {e}").with_exception(e)
@@ -106,7 +107,7 @@ def run(*args, input=None, decode=True):
     return output.decode() if decode else output
 
 
-def watch(*args, input=None, keepends=False, decode=True, timeout=None):
+def watch(*args, input=None, keepends=False, decode=True, timeout=None, env=None):
     """
     Run command args, iterating over lines read from the child process stdout.
 
@@ -129,8 +130,10 @@ def watch(*args, input=None, keepends=False, decode=True, timeout=None):
     - Timeout if the command did not terminate within the specified
       timeout.
     """
+    if env is None:
+        env = dict(os.environ)
+
     # Avoid delays in python child process logs.
-    env = dict(os.environ)
     env["PYTHONUNBUFFERED"] = "1"
 
     with shutdown.guard():

--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import re
 import subprocess
 from contextlib import contextmanager
@@ -310,6 +311,13 @@ def test_watch_timeout_not_expired():
     assert output == []
 
 
+def test_watch_env():
+    env = dict(os.environ)
+    env["DRENV_COMMAND_TEST"] = "value"
+    output = list(commands.watch("sh", "-c", "echo -n $DRENV_COMMAND_TEST", env=env))
+    assert output == [env["DRENV_COMMAND_TEST"]]
+
+
 # Running commands.
 
 
@@ -388,6 +396,13 @@ def test_run_after_shutdown(monkeypatch):
     monkeypatch.setattr(shutdown, "_started", True)
     with pytest.raises(shutdown.Started):
         commands.run("no-such-command")
+
+
+def test_run_env():
+    env = dict(os.environ)
+    env["DRENV_COMMAND_TEST"] = "value"
+    out = commands.run("sh", "-c", "echo -n $DRENV_COMMAND_TEST", env=env)
+    assert out == env["DRENV_COMMAND_TEST"]
 
 
 # Formatting errors.


### PR DESCRIPTION
Add additional drenv infrastructure needed for the argocd addon, but can be useful for other addons or future code.

- drenv.temporary_kubeconfig() - creating a temporary kubeconfig from the default kubeconfig, and returning an environment dict pointing to the kubeconfig.
- support env= argument in commands.run() and commands.watch() - useful for running commands with modified environment variables.