### PR TITLE
config: add dependency on velero CRDs

### DIFF
--- a/config/dr-cluster/manifests/bases/ramen_dr_cluster.clusterserviceversion.yaml
+++ b/config/dr-cluster/manifests/bases/ramen_dr_cluster.clusterserviceversion.yaml
@@ -21,6 +21,26 @@ spec:
       kind: VolumeReplicationGroup
       name: volumereplicationgroups.ramendr.openshift.io
       version: v1alpha1
+    required:
+    - name: backups.velero.io
+      description: Backup is a Velero resource that represents the capture of
+          Kubernetes cluster state at a point in time (API objects and
+          associated volume state)
+      displayName: Backup
+      kind: Backup
+      version: v1
+    - name: restores.velero.io
+      description: Restore is a Velero resource that represents the application
+          of resources from a Velero backup to a target Kubernetes cluster
+      displayName: Restore
+      kind: Restore
+      version: v1
+    - name: backupstoragelocations.velero.io
+      description: BackupStorageLocation is a location where Velero stores
+      backup objects
+      displayName: Backup Storage Location
+      kind: BackupStorageLocation
+      version: v1
   description: Ramen is a disaster-recovery orchestrator for stateful applications
     across a set of peer kubernetes clusters which are deployed and managed using
     open-cluster-management (OCM) and provides cloud-native interfaces to orchestrate


### PR DESCRIPTION
The ramen-dr-cluster operator crashes if the velero CRDs aren't installed in the kubernetes cluster. This PR adds a dependency on the velero CRDs to prevent the crash. This will also ensure that a OLM update for Ramen is blocked until the CRDs are available.