### PR TITLE
Return information only if primary VRG is found during initial deploy…

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -275,12 +275,15 @@ func (d *DRPCInstance) getCachedVRG(clusterName string) *rmn.VolumeReplicationGr
 }
 
 func (d *DRPCInstance) isVRGAlreadyDeployedElsewhere(clusterToSkip string) (string, bool) {
-	for clusterName := range d.vrgs {
+	for clusterName, vrg := range d.vrgs {
 		if clusterName == clusterToSkip {
 			continue
 		}
 
-		return clusterName, true
+		// We are checking for the initial deployment. Only return the cluster if the VRG on it is primary.
+		if isVRGPrimary(vrg) {
+			return clusterName, true
+		}
 	}
 
 	return "", false


### PR DESCRIPTION
Discussed [this PR](https://github.com/RamenDR/ramen/pull/1431) with @ShyamsundarR and concluded that it is more complex and poses a risk of introducing hidden bugs. Therefore, we will leave it open for future versions. For version 4.16, we intend to implement a straightforward fix that addresses the specific instance of the issue we have identified. A comprehensive, global solution will be considered for later updates.

When the primary cluster is down and the workload is in the initial deployment that is targeted for volsync, the DRPC might mistakenly think the VRG on the secondary cluster is the primary one. This code hasn't changed since VolSync was introduced. The original code expected only one primary VRG between the two clusters. The fix is straightforward: for the initial deployment, only return the cluster if the primary VRG is found; otherwise, return `not found`.