### PR TITLE
vrg: don't watch velero CRs unless CRDs are installed

### DIFF
--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -264,6 +264,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -40,6 +40,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apps.open-cluster-management.io
   resources:
   - placementrules

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/ramendr/ramen/controllers/util"
 	Recipe "github.com/ramendr/recipe/api/v1alpha1"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -211,6 +212,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = argocdv1alpha1hack.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = apiextensions.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	// +kubebuilder:scaffold:scheme
 

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -377,6 +377,7 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ramendr.openshift.io,resources=recipes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=list;watch
+// +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/exp/maps" // TODO replace with "maps" in go1.21+
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,13 +47,14 @@ import (
 // VolumeReplicationGroupReconciler reconciles a VolumeReplicationGroup object
 type VolumeReplicationGroupReconciler struct {
 	client.Client
-	APIReader      client.Reader
-	Log            logr.Logger
-	ObjStoreGetter ObjectStoreGetter
-	Scheme         *runtime.Scheme
-	eventRecorder  *rmnutil.EventReporter
-	kubeObjects    kubeobjects.RequestsManager
-	RateLimiter    *workqueue.RateLimiter
+	APIReader           client.Reader
+	Log                 logr.Logger
+	ObjStoreGetter      ObjectStoreGetter
+	Scheme              *runtime.Scheme
+	eventRecorder       *rmnutil.EventReporter
+	kubeObjects         kubeobjects.RequestsManager
+	RateLimiter         *workqueue.RateLimiter
+	veleroCRsAreWatched bool
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -73,7 +75,6 @@ func (r *VolumeReplicationGroupReconciler) SetupWithManager(
 		rateLimiter = *r.RateLimiter
 	}
 
-	objectToReconcileRequestsMapper := objectToReconcileRequestsMapper{reader: r.Client, log: ctrl.Log}
 	ctrlBuilder := ctrl.NewControllerManagedBy(mgr).
 		WithOptions(ctrlcontroller.Options{
 			MaxConcurrentReconciles: getMaxConcurrentReconciles(r.Log),
@@ -107,10 +108,9 @@ func (r *VolumeReplicationGroupReconciler) SetupWithManager(
 	}
 
 	r.kubeObjects = velero.RequestsManager{}
+
 	if !ramenConfig.KubeObjectProtection.Disabled {
-		r.Log.Info("Kube object protection enabled; watch kube objects requests")
-		recipesWatch(ctrlBuilder, objectToReconcileRequestsMapper)
-		kubeObjectsRequestsWatch(ctrlBuilder, r.Scheme, r.kubeObjects)
+		ctrlBuilder = r.addKubeObjectsOwnsAndWatches(ctrlBuilder)
 	} else {
 		r.Log.Info("Kube object protection disabled; don't watch kube objects requests")
 	}
@@ -387,6 +387,7 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.0/pkg/reconcile
+// nolint: funlen
 func (r *VolumeReplicationGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("VolumeReplicationGroup", req.NamespacedName, "rid", uuid.New())
 
@@ -428,6 +429,12 @@ func (r *VolumeReplicationGroupReconciler) Reconcile(ctx context.Context, req ct
 
 	v.ramenConfig = ramenConfig
 	adminNamespaceVRG := vrgInAdminNamespace(v.instance, v.ramenConfig)
+
+	if adminNamespaceVRG && !r.veleroCRsAreWatched {
+		return ctrl.Result{},
+			fmt.Errorf("VRG {%s/%s} with kube object protection doesn't work if velero/oadp is not installed. "+
+				"Please install velero/oadp and restart the operator", v.instance.Namespace, v.instance.Name)
+	}
 
 	v.volSyncHandler = volsync.NewVSHandler(ctx, r.Client, log, v.instance,
 		v.instance.Spec.Async, cephFSCSIDriverNameOrDefault(v.ramenConfig),
@@ -1509,6 +1516,44 @@ func (r *VolumeReplicationGroupReconciler) addVolsyncOwnsAndWatches(ctrlBuilder 
 			handler.EnqueueRequestsFromMapFunc(r.RSMapFunc),
 			builder.WithPredicates(rmnutil.CreateOrDeleteOrResourceVersionUpdatePredicate{}),
 		)
+
+	return ctrlBuilder
+}
+
+func (r *VolumeReplicationGroupReconciler) addKubeObjectsOwnsAndWatches(ctrlBuilder *builder.Builder) *builder.Builder {
+	r.Log.Info("Kube object protection enabled; watch kube objects requests")
+
+	// Find if velero CRDs are present in the cluster
+	veleroCRDs := []string{
+		"backups.velero.io",
+		"backupstoragelocations.velero.io",
+		"restores.velero.io",
+	}
+
+	missingCRDs := false
+
+	for _, crd := range veleroCRDs {
+		installedCRD := &apiextensionsv1.CustomResourceDefinition{}
+		if err := r.APIReader.Get(context.TODO(), types.NamespacedName{Name: crd}, installedCRD); err != nil {
+			r.Log.Info("Cannot fetch Velero CRD", "CRD", crd, "error", err)
+
+			missingCRDs = true
+		}
+	}
+
+	if missingCRDs {
+		r.Log.Info("Cannot fetch Velero CRD; Kubernetes object protection won't work unless Velero/OADP is installed")
+
+		return ctrlBuilder
+	}
+
+	kubeObjectsRequestsWatch(ctrlBuilder, r.Scheme, r.kubeObjects)
+
+	// watch for recipe objects
+	objectToReconcileRequestsMapper := objectToReconcileRequestsMapper{reader: r.Client, log: ctrl.Log}
+	recipesWatch(ctrlBuilder, objectToReconcileRequestsMapper)
+
+	r.veleroCRsAreWatched = true
 
 	return ctrlBuilder
 }

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/time v0.3.0
 	k8s.io/api v0.29.0
+	k8s.io/apiextensions-apiserver v0.28.3
 	k8s.io/apimachinery v0.29.0
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/component-base v0.29.0
@@ -88,7 +89,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apiextensions-apiserver v0.28.3 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	open-cluster-management.io/api v0.11.1-0.20230905055724-cf1ead467a83 // indirect

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	uberzap "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -96,6 +97,8 @@ func configureController(ramenConfig *ramendrv1alpha1.RamenConfig) error {
 			controllers.ControllerType, ramendrv1alpha1.DRHubType, ramendrv1alpha1.DRClusterType)
 	}
 
+	setupLog.Info("controller type", "type", controllers.ControllerType)
+
 	if controllers.ControllerType == ramendrv1alpha1.DRHubType {
 		utilruntime.Must(plrv1.AddToScheme(scheme))
 		utilruntime.Must(ocmworkv1.AddToScheme(scheme))
@@ -111,6 +114,7 @@ func configureController(ramenConfig *ramendrv1alpha1.RamenConfig) error {
 		utilruntime.Must(volsyncv1alpha1.AddToScheme(scheme))
 		utilruntime.Must(snapv1.AddToScheme(scheme))
 		utilruntime.Must(recipe.AddToScheme(scheme))
+		utilruntime.Must(apiextensions.AddToScheme(scheme))
 	}
 
 	return nil


### PR DESCRIPTION
Throw error in the reconcile function if velero is not installed and a
kube object protection VRG is created.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>