### PR TITLE
Increase rate limits during tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,9 @@ endif
 
 DOCKERCMD ?= podman
 
+# You can use this to pass ginkgo arguments to test targets (e.g. -ginkgo.no-color)
+GINKGO_ARGS ?=
+
 all: build
 
 ##@ General
@@ -138,55 +141,55 @@ drenv-prereqs: ## Check the prerequisites for the drenv tool.
 ##@ Tests
 
 test: generate manifests envtest ## Run all the tests.
-	 go test ./... -coverprofile cover.out
+	 go test ./... -coverprofile cover.out $(GINKGO_ARGS)
 
 test-pvrgl: generate manifests envtest ## Run ProtectedVolumeReplicationGroupList tests.
-	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus ProtectedVolumeReplicationGroupList
+	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus ProtectedVolumeReplicationGroupList $(GINKGO_ARGS)
 
 test-obj: generate manifests envtest ## Run ObjectStorer tests.
-	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus FakeObjectStorer
+	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus FakeObjectStorer $(GINKGO_ARGS)
 
 test-vs: generate manifests envtest ## Run VolumeSync tests.
-	 go test ./internal/controller/volsync -coverprofile cover.out
+	 go test ./internal/controller/volsync -coverprofile cover.out $(GINKGO_ARGS)
 
 test-vrg: generate manifests envtest ## Run VolumeReplicationGroup tests.
-	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroup
+	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroup $(GINKGO_ARGS)
 
 test-vrg-pvc: generate manifests envtest ## Run VolumeReplicationGroupPVC tests.
-	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupPVC
+	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupPVC $(GINKGO_ARGS)
 
 test-vrg-vr: generate manifests envtest ## Run VolumeReplicationGroupVolRep tests.
-	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupVolRep
+	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupVolRep $(GINKGO_ARGS)
 
 test-vrg-vs: generate manifests envtest ## Run VolumeReplicationGroupVolSync tests.
-	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupVolSync
+	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupVolSync $(GINKGO_ARGS)
 
 test-vrg-recipe: generate manifests envtest ## Run VolumeReplicationGroupRecipe tests.
-	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupRecipe
+	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupRecipe $(GINKGO_ARGS)
 
 test-vrg-kubeobjects: generate manifests envtest ## Run VolumeReplicationGroupKubeObjects tests.
-	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus VRG_KubeObjectProtection
+	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus VRG_KubeObjectProtection $(GINKGO_ARGS)
 
 test-drpc: generate manifests envtest ## Run DRPlacementControl tests.
-	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus DRPlacementControl
+	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus DRPlacementControl $(GINKGO_ARGS)
 
 test-drcluster: generate manifests envtest ## Run DRCluster tests.
-	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus DRClusterController
+	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus DRClusterController $(GINKGO_ARGS)
 
 test-drpolicy: generate manifests envtest ## Run DRPolicy tests.
-	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus DRPolicyController
+	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus DRPolicyController $(GINKGO_ARGS)
 
 test-drclusterconfig: generate manifests envtest ## Run DRClusterConfig tests.
-	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus DRClusterConfig
+	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus DRClusterConfig $(GINKGO_ARGS)
 
 test-util: generate manifests envtest ## Run util tests.
-	 go test ./internal/controller/util -coverprofile cover.out
+	 go test ./internal/controller/util -coverprofile cover.out $(GINKGO_ARGS)
 
 test-util-pvc: generate manifests envtest ## Run util-pvc tests.
-	 go test ./internal/controller/util -coverprofile cover.out  -ginkgo.focus PVCS_Util
+	 go test ./internal/controller/util -coverprofile cover.out  -ginkgo.focus PVCS_Util $(GINKGO_ARGS)
 
 test-kubeobjects: ## Run kubeobjects tests.
-	 go test ./internal/controller/kubeobjects -coverprofile cover.out  -ginkgo.focus Kubeobjects
+	 go test ./internal/controller/kubeobjects -coverprofile cover.out  -ginkgo.focus Kubeobjects $(GINKGO_ARGS)
 
 test-drenv: ## Run drenv tests.
 	$(MAKE) -C test

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -331,6 +332,7 @@ var _ = BeforeSuite(func() {
 
 	rateLimiter := workqueue.NewTypedMaxOfRateLimiter(
 		workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](10*time.Millisecond, 100*time.Millisecond),
+		&workqueue.TypedBucketRateLimiter[reconcile.Request]{Limiter: rate.NewLimiter(rate.Limit(50), 500)},
 	)
 
 	Expect((&ramencontrollers.DRClusterReconciler{


### PR DESCRIPTION
We used the defaults which may be too low. In VRG controller we allow up to 10 events per seconds, with burst of up to 100 events per seconds. This may be enough for the tests, but since we use very low minimum internal, we may be blocked by the rate limiter and fail after 1 second timeout. To avoid this, use 5 times higher limits.

Local test logs:

- [test-stress-100-before.log](https://github.com/user-attachments/files/15902859/test-stress-100-before.log)
- [test-stress-100.log](https://github.com/user-attachments/files/15902866/test-stress-100.log)