### PR TITLE
Fix argocd create app idempotency

### DIFF
--- a/test/addons/argocd/test
+++ b/test/addons/argocd/test
@@ -52,7 +52,7 @@ def wait_until_guestbook_is_healthy(hub, cluster):
         f"guestbook-{cluster}",
         "--for=jsonpath={.status.health.status}=Healthy",
         "--namespace=argocd",
-        "--timeout=60s",
+        "--timeout=120s",
         context=hub,
     )
 

--- a/test/addons/argocd/test
+++ b/test/addons/argocd/test
@@ -38,6 +38,8 @@ def deploy_guestbook(hub, cluster):
             "--dest-namespace=argocd-test",
             "--sync-option=CreateNamespace=true",
             "--sync-policy=automated",
+            # Should not be needed, but without this the command is not idempotent.
+            "--upsert",
             env=env,
         ):
             print(line)


### PR DESCRIPTION
If we fail in the middle of the argocd test (e.g. timeout waiting for the test app), the next attempt will fail instead of continuing the test.

I reproduced the issue using this change:

    diff --git a/test/addons/argocd/test b/test/addons/argocd/test
    index b41e7877..9273f805 100755
    --- a/test/addons/argocd/test
    +++ b/test/addons/argocd/test
    @@ -111,10 +111,12 @@ if len(sys.argv) != 4:
     hub, *clusters = sys.argv[1:]

     for cluster in clusters:
         deploy_guestbook(hub, cluster)

    +sys.exit("simulating failure")
    +
     for cluster in clusters:
         wait_until_guestbook_is_healthy(hub, cluster)

     for cluster in clusters:
         undeploy_guestbook(hub, cluster)

Example run reproducing the issue:

    $ addons/argocd/test hub dr1 dr2
    Deploying application guestbook-dr1 in namespace argocd-test on cluster dr1
    application 'guestbook-dr1' created
    Deploying application guestbook-dr2 in namespace argocd-test on cluster dr2
    application 'guestbook-dr2' created
    simulating failure

    $ addons/argocd/test hub dr1 dr2
    Deploying application guestbook-dr1 in namespace argocd-test on cluster dr1
    Traceback (most recent call last):
      File "/home/nsoffer/src/ramen/test/addons/argocd/test", line 114, in <module>
        deploy_guestbook(hub, cluster)
      File "/home/nsoffer/src/ramen/test/addons/argocd/test", line 30, in deploy_guestbook
        for line in commands.watch(
      File "/home/nsoffer/src/ramen/test/drenv/commands.py", line 190, in watch
        raise Error(args, error, exitcode=p.returncode)
    drenv.commands.Error: Command failed:
       command: ('argocd', 'app', 'create', 'guestbook-dr1',
           '--repo=https://github.com/argoproj/argocd-example-apps.git', '--path=guestbook',
           '--dest-name=dr1', '--dest-namespace=argocd-test', '--sync-option=CreateNamespace=true',
           '--sync-policy=automated')
       exitcode: 20
       error:
          time="2024-06-21T17:08:53+03:00" level=fatal msg="rpc error: code = InvalidArgument desc =
          existing application spec is different, use upsert flag to force update"

Adding the --upsert flag fixes the issue.

The command should be idempotent if the desired spec is the same as the existing spec, which should be the case in the test, but for some reason the spec differ. We need to open argocd issue for this.