### PR TITLE
Simplify disable DR to single step

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1179,12 +1179,8 @@ func (r *DRPlacementControlReconciler) processDeletion(ctx context.Context,
 	}
 
 	if placementObj != nil && controllerutil.ContainsFinalizer(placementObj, DRPCFinalizer) {
-		// Remove DRPCFinalizer from User PlacementRule/Placement.
-		controllerutil.RemoveFinalizer(placementObj, DRPCFinalizer)
-
-		err := r.Update(ctx, placementObj)
-		if err != nil {
-			return fmt.Errorf("failed to update User PlacementRule/Placement %w", err)
+		if err := r.finalizePlacement(ctx, placementObj); err != nil {
+			return err
 		}
 	}
 
@@ -1338,6 +1334,20 @@ func (r *DRPlacementControlReconciler) getDRPCPlacementRule(ctx context.Context,
 	} else {
 		log.Info("Preferred cluster is configured. Dynamic selection is disabled",
 			"PreferredCluster", drpc.Spec.PreferredCluster)
+	}
+
+	return nil
+}
+
+func (r *DRPlacementControlReconciler) finalizePlacement(
+	ctx context.Context,
+	placementObj client.Object,
+) error {
+	controllerutil.RemoveFinalizer(placementObj, DRPCFinalizer)
+
+	err := r.Update(ctx, placementObj)
+	if err != nil {
+		return fmt.Errorf("failed to update User PlacementRule/Placement %w", err)
 	}
 
 	return nil

--- a/controllers/util/placement.go
+++ b/controllers/util/placement.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"reflect"
+
+	"github.com/go-logr/logr"
+	clrapiv1beta1 "github.com/open-cluster-management-io/api/cluster/v1beta1"
+	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// FinalizePlacement prepares a Placement for scheduling by OCM.
+// NOTE: We Keep the cluster.open-cluster-management.io/experimental-scheduling-disable: "true"
+// annotation as is, so if the placment is managed by gitops and our changes are overridden, OCM
+// will not change the placement, resulting in data loss. Since we change user owned resource, we
+// log every spec change.
+func FinalizePlacement(p *clrapiv1beta1.Placement, cluster string, log logr.Logger) {
+	var desiredNumberOfClusters int32 = 1
+
+	if p.Spec.NumberOfClusters == nil || *p.Spec.NumberOfClusters != desiredNumberOfClusters {
+		log.Info("NOTE: modifying Placement numberOfClusters to 1",
+			"namespace", p.Namespace, "placementrule", p.Name)
+
+		p.Spec.NumberOfClusters = &desiredNumberOfClusters
+	}
+
+	var desiredPredicates []clrapiv1beta1.ClusterPredicate
+
+	if cluster != "" {
+		desiredPredicates = []clrapiv1beta1.ClusterPredicate{
+			{
+				RequiredClusterSelector: clrapiv1beta1.ClusterSelector{
+					LabelSelector: metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "name",
+								Operator: "In",
+								Values:   []string{cluster},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	if !reflect.DeepEqual(p.Spec.Predicates, desiredPredicates) {
+		log.Info("NOTE: modifying placement predicates to select current cluster",
+			"namespace", p.Namespace, "placement", p.Name, "cluster", cluster)
+
+		p.Spec.Predicates = desiredPredicates
+	}
+}
+
+// FinalizePlacementRule prepares a PlacementRule for scheduling by OCM.
+// NOTE: We keep schedulerName: ramen as is, so if the placment rule is managed by gitops and our
+// changes are overridden, OCM will not change the placement, resulting in data loss. Since we
+// change user owned resource, we log every spec change.
+func FinalizePlacementRule(pr *plrv1.PlacementRule, cluster string, log logr.Logger) {
+	var desiredClusterReplicas int32 = 1
+
+	if pr.Spec.ClusterReplicas == nil || *pr.Spec.ClusterReplicas != desiredClusterReplicas {
+		log.Info("NOTE: modifying PlacementRule clusterReplicas to 1",
+			"namespace", pr.Namespace, "placementrule", pr.Name)
+
+		pr.Spec.ClusterReplicas = &desiredClusterReplicas
+	}
+
+	var desiredClusterSelector *metav1.LabelSelector
+
+	if cluster != "" {
+		desiredClusterSelector = &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "name",
+					Operator: "In",
+					Values:   []string{cluster},
+				},
+			},
+		}
+	}
+
+	if !reflect.DeepEqual(pr.Spec.ClusterSelector, desiredClusterSelector) {
+		log.Info("NOTE: modifying PlacementRule clusterSelector to select current cluster",
+			"namespace", pr.Namespace, "placementrule", pr.Name, "cluster", cluster)
+
+		pr.Spec.ClusterSelector = desiredClusterSelector
+	}
+}

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -87,7 +87,6 @@ func DisableProtection(w workloads.Workload, d deployers.Deployer) error {
 
 	name := GetCombinedName(d, w)
 	namespace := name
-	placementName := name
 	drpcName := name
 	client := util.Ctx.Hub.CtrlClient
 
@@ -101,21 +100,7 @@ func DisableProtection(w workloads.Workload, d deployers.Deployer) error {
 		return err
 	}
 
-	if err := waitDRPCDeleted(client, namespace, drpcName); err != nil {
-		return err
-	}
-
-	util.Ctx.Log.Info("get placement " + placementName)
-
-	placement, err := getPlacement(client, namespace, placementName)
-	if err != nil {
-		return err
-	}
-
-	delete(placement.Annotations, OcmSchedulingDisable)
-	util.Ctx.Log.Info("updated placement " + placementName + " annotation")
-
-	return updatePlacement(client, placement)
+	return waitDRPCDeleted(client, namespace, drpcName)
 }
 
 func Failover(w workloads.Workload, d deployers.Deployer) error {

--- a/test/drenv/test.py
+++ b/test/drenv/test.py
@@ -186,20 +186,6 @@ def disable_dr():
         log=debug,
     )
 
-    placement = _lookup_app_resource("placement")
-    if not placement:
-        debug("placement already removed")
-        return
-
-    info("Enabling OCM scheduling for '%s'", placement)
-    kubectl.annotate(
-        placement,
-        {OCM_SCHEDULING_DISABLE: None},
-        namespace=config["namespace"],
-        context=env["hub"],
-        log=debug,
-    )
-
 
 def target_cluster():
     """


### PR DESCRIPTION
Instead of manual steps, ramen modifies the Plagement[Rule] to make it safe after disabling DR.

Changes:
- Extract finalizePlacement method
- Simplify disable DR to one step
- Remove unneeded placement changes in basic-test
- Remove unneeded placement changes in e2e

Tested:
- [x] deployment rbd rdr after enabling-dr - no predicates
- [x] deployment rbd rdr after enabling-dr - same predicates 
- [x] deployment rbd rdr after relocate - different predicates 
- [x] deployment rbd rdr after relocate - same predicates
- [x] deployment rbd rdr after failover - different predicates 
- [x] deployment rbd rdr after failover - same predicates 
- [x] deployment rbd rdr during relocate - placement decision is empty

[simplify-disable-dr.tar.gz](https://github.com/user-attachments/files/15971401/simplify-disable-dr.tar.gz)

Not tested:
- metro - we don't have environment for testingm, and it should not be needed for this change
- cephfs - unneeded and tested in e2e
- appset based deployment - unneeded
- discovered deployment rbd rdr - unneeded
- placementrule - we don't have sample for testing, the only change is the function modifying the resource.

Related ocm-ramen-samples changes:
- https://github.com/RamenDR/ocm-ramen-samples/pull/58


Fixes #1441