### PR TITLE
Simplify disable DR to single step - simpler alternative

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1179,12 +1179,8 @@ func (r *DRPlacementControlReconciler) processDeletion(ctx context.Context,
 	}
 
 	if placementObj != nil && controllerutil.ContainsFinalizer(placementObj, DRPCFinalizer) {
-		// Remove DRPCFinalizer from User PlacementRule/Placement.
-		controllerutil.RemoveFinalizer(placementObj, DRPCFinalizer)
-
-		err := r.Update(ctx, placementObj)
-		if err != nil {
-			return fmt.Errorf("failed to update User PlacementRule/Placement %w", err)
+		if err := r.finalizePlacement(ctx, placementObj); err != nil {
+			return err
 		}
 	}
 
@@ -1338,6 +1334,20 @@ func (r *DRPlacementControlReconciler) getDRPCPlacementRule(ctx context.Context,
 	} else {
 		log.Info("Preferred cluster is configured. Dynamic selection is disabled",
 			"PreferredCluster", drpc.Spec.PreferredCluster)
+	}
+
+	return nil
+}
+
+func (r *DRPlacementControlReconciler) finalizePlacement(
+	ctx context.Context,
+	placementObj client.Object,
+) error {
+	controllerutil.RemoveFinalizer(placementObj, DRPCFinalizer)
+
+	err := r.Update(ctx, placementObj)
+	if err != nil {
+		return fmt.Errorf("failed to update User PlacementRule/Placement %w", err)
 	}
 
 	return nil

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -87,7 +87,6 @@ func DisableProtection(w workloads.Workload, d deployers.Deployer) error {
 
 	name := GetCombinedName(d, w)
 	namespace := name
-	placementName := name
 	drpcName := name
 	client := util.Ctx.Hub.CtrlClient
 
@@ -101,21 +100,7 @@ func DisableProtection(w workloads.Workload, d deployers.Deployer) error {
 		return err
 	}
 
-	if err := waitDRPCDeleted(client, namespace, drpcName); err != nil {
-		return err
-	}
-
-	util.Ctx.Log.Info("get placement " + placementName)
-
-	placement, err := getPlacement(client, namespace, placementName)
-	if err != nil {
-		return err
-	}
-
-	delete(placement.Annotations, OcmSchedulingDisable)
-	util.Ctx.Log.Info("updated placement " + placementName + " annotation")
-
-	return updatePlacement(client, placement)
+	return waitDRPCDeleted(client, namespace, drpcName)
 }
 
 func Failover(w workloads.Workload, d deployers.Deployer) error {

--- a/test/drenv/test.py
+++ b/test/drenv/test.py
@@ -186,20 +186,6 @@ def disable_dr():
         log=debug,
     )
 
-    placement = _lookup_app_resource("placement")
-    if not placement:
-        debug("placement already removed")
-        return
-
-    info("Enabling OCM scheduling for '%s'", placement)
-    kubectl.annotate(
-        placement,
-        {OCM_SCHEDULING_DISABLE: None},
-        namespace=config["namespace"],
-        context=env["hub"],
-        log=debug,
-    )
-
 
 def target_cluster():
     """


### PR DESCRIPTION
This is an allternative for #1469, removing the Placemnt[Rule] changes.

When disabling DR we planned to keep OCM scheduling disabled in all cases, since a Placment[Rule] may be managed by GitOps and any change we made may be overridden.

Enabling OCM scheduling is not only not needed, it is risky and we should actually warn users not to do this, since OCM is does not really support statefull workloads. Changing the placement of such workloads delete the current data and start with a fresh PVCs on new location.

From user point of view, this disabling DR is still single step - deleting the drpc. If they want to start managed the application with OCM (unlikely for stateful application), users will have to make sure the Placment[Rule] matches the current location.

Related ocm-ramen-samples changes:
- https://github.com/RamenDR/ocm-ramen-samples/pull/58

Fixes #1441