### PR TITLE
filter with default VRC annotation if multiple VRCs detected

### DIFF
--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -668,14 +668,10 @@ func (v *VRGInstance) updatePVCList() error {
 		return nil
 	}
 
-	if !v.vrcUpdated {
-		if err := v.updateReplicationClassList(); err != nil {
-			v.log.Error(err, "Failed to get VolumeReplicationClass list")
+	if err := v.updateReplicationClassList(); err != nil {
+		v.log.Error(err, "Failed to get VolumeReplicationClass list")
 
-			return fmt.Errorf("failed to get VolumeReplicationClass list")
-		}
-
-		v.vrcUpdated = true
+		return fmt.Errorf("failed to get VolumeReplicationClass list")
 	}
 
 	if rmnutil.ResourceIsDeleted(v.instance) {
@@ -699,6 +695,10 @@ func (v *VRGInstance) updatePVCList() error {
 }
 
 func (v *VRGInstance) updateReplicationClassList() error {
+	if v.vrcUpdated {
+		return nil
+	}
+
 	labelSelector := v.instance.Spec.Async.ReplicationClassSelector
 
 	v.log.Info("Fetching VolumeReplicationClass", "labeled", labels.Set(labelSelector.MatchLabels))
@@ -712,6 +712,8 @@ func (v *VRGInstance) updateReplicationClassList() error {
 
 		return fmt.Errorf("failed to list Replication Classes, %w", err)
 	}
+
+	v.vrcUpdated = true
 
 	v.log.Info("Number of Replication Classes", "count", len(v.replClassList.Items))
 


### PR DESCRIPTION
This commit modifies selectVolumeReplicationClass() to
filter VRCs list with default VRC annotation
`replication.storage.openshift.io/volume-replication-class: true`
if multiple VRCs are matched.
This makes sure we select the default VRC when multiple VRCs of
same schedule and provisioner but a special default annotated VRC
is present in the cluster.