### PR TITLE
Add operational-mode annotation to resolve VRG state ambiguity during…

### DIFF
--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -1208,6 +1208,7 @@ func verifyVRGManifestWorkCreatedAsPrimary(namespace, managedCluster string) {
 	Expect(vrg.Name).Should(Equal(DRPCCommonName))
 	Expect(vrg.Spec.PVCSelector.MatchLabels["appclass"]).Should(Equal("gold"))
 	Expect(vrg.Spec.ReplicationState).Should(Equal(rmn.Primary))
+	Expect(vrg.Annotations[controllers.VRGOpModeAnnoKey]).Should(Equal(string(rmn.Primary)))
 
 	// ensure DRPC copied KubeObjectProtection contents to VRG
 	drpc := getLatestDRPC(namespace)
@@ -1721,6 +1722,10 @@ func verifyFailoverToSecondary(placementObj client.Object, toCluster string,
 	decision := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
 	Expect(decision.ClusterName).To(Equal(toCluster))
 	Expect(drpc.GetAnnotations()[controllers.LastAppDeploymentCluster]).To(Equal(toCluster))
+	vrg, err := getVRGFromManifestWork(toCluster, drpc.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
+	Expect(vrg.Spec.ReplicationState).Should(Equal(rmn.Primary))
+	Expect(vrg.Annotations[controllers.VRGOpModeAnnoKey]).Should(Equal(string(rmn.Primary)))
 }
 
 func verifyActionResultForPlacement(placement *clrapiv1beta1.Placement, homeCluster string, plType PlacementType) {


### PR DESCRIPTION
For CephFS PVCs, we need two VRGs: one as primary on the primary cluster and the other as secondary on the failover cluster. If the workload has been relocated from the secondary cluster back to the primary and the primary goes offline, when the DRPC reconciles, it will find the primary inaccessible and will only detect the secondary VRG on the failover cluster. This situation is difficult to resolve because the DRPC can't distinguish between a VRG that is in its final state as secondary and one that is transitioning from primary to secondary. As a result, the PeerReady condition will be turned off, and the user will be unable to failover the application using the UI.

The fix for this is to add a hint so that the DRPC can tell whether the VRG is in its final state or transitioning to primary or secondary. This hint is provided through the use of an annotation.

Fixes: bz-2264765