### PR TITLE
Implement DRClusterConfig reconciler to create required ClusterClaims

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,9 @@ test-drcluster: generate manifests envtest ## Run DRCluster tests.
 test-drpolicy: generate manifests envtest ## Run DRPolicy tests.
 	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus DRPolicyController
 
+test-drclusterconfig: generate manifests envtest ## Run DRClusterConfig tests.
+	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus DRClusterConfig
+
 test-util: generate manifests envtest ## Run util tests.
 	 go test ./internal/controller/util -coverprofile cover.out
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -174,6 +174,7 @@ func setupReconcilersCluster(mgr ctrl.Manager, ramenConfig *ramendrv1alpha1.Rame
 	if err := (&controllers.DRClusterConfigReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
+		Log:    ctrl.Log.WithName("controllers").WithName("DRClusterConfig"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DRClusterConfig")
 		os.Exit(1)

--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -138,6 +138,17 @@ rules:
   - update
   - watch
 - apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
+  - clusterclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - ramendr.openshift.io
   resources:
   - drclusterconfigs

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -88,6 +88,17 @@ rules:
 - apiGroups:
   - cluster.open-cluster-management.io
   resources:
+  - clusterclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - cluster.open-cluster-management.io
+  resources:
   - managedclusters
   verbs:
   - get

--- a/hack/test/0000_02_clusters.open-cluster-management.io_clusterclaims.crd.yaml
+++ b/hack/test/0000_02_clusters.open-cluster-management.io_clusterclaims.crd.yaml
@@ -1,0 +1,63 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterclaims.cluster.open-cluster-management.io
+spec:
+  group: cluster.open-cluster-management.io
+  names:
+    kind: ClusterClaim
+    listKind: ClusterClaimList
+    plural: clusterclaims
+    singular: clusterclaim
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterClaim represents cluster information that a managed cluster claims
+          ClusterClaims with well known names include,
+           1. id.k8s.io, it contains a unique identifier for the cluster.
+           2. clusterset.k8s.io, it contains an identifier that relates the cluster
+              to the ClusterSet in which it belongs.
+
+
+          ClusterClaims created on a managed cluster will be collected and saved into
+          the status of the corresponding ManagedCluster on hub.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the attributes of the ClusterClaim.
+            properties:
+              value:
+                description: Value is a claim-dependent string
+                maxLength: 1024
+                minLength: 1
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/internal/controller/drclusterconfig_controller.go
+++ b/internal/controller/drclusterconfig_controller.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"golang.org/x/time/rate"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -25,6 +26,9 @@ const (
 	drCConfigFinalizerName = "drclusterconfigs.ramendr.openshift.io/ramen"
 
 	maxReconcileBackoff = 5 * time.Minute
+
+	// Prefixes for various ClusterClaims
+	ccSCPrefix = "storage.class"
 )
 
 // DRClusterConfigReconciler reconciles a DRClusterConfig object
@@ -62,22 +66,35 @@ func (r *DRClusterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	return r.processCreateOrUpdate(ctx, log, drCConfig)
 }
 
+// processDeletion ensures all cluster claims created by drClusterConfig are deleted, before removing the finalizer on
+// the resource itself
 func (r *DRClusterConfigReconciler) processDeletion(
 	ctx context.Context,
 	log logr.Logger,
 	drCConfig *ramen.DRClusterConfig,
 ) (ctrl.Result, error) {
+	if err := r.pruneClusterClaims(ctx, log, []string{}); err != nil {
+		return ctrl.Result{Requeue: true}, err
+	}
+
 	if err := util.NewResourceUpdater(drCConfig).
 		RemoveFinalizer(drCConfigFinalizerName).
 		Update(ctx, r.Client); err != nil {
-		log.Info("Failed to remove finalizer for DRClusterConfig resource", "error", err)
-
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{Requeue: true},
+			fmt.Errorf("failed to remove finalizer for DRClusterConfig resource, %w", err)
 	}
 
 	return ctrl.Result{}, nil
 }
 
+// pruneClusterClaims will prune all ClusterClaims created by drClusterConfig that are not in the
+// passed in survivor list
+func (r *DRClusterConfigReconciler) pruneClusterClaims(ctx context.Context, log logr.Logger, survivors []string) error {
+	return nil
+}
+
+// processCreateOrUpdate protects the resource with a finalizer and creates ClusterClaims for various storage related
+// classes in the cluster. It would finally prune stale ClusterClaims from previous reconciliations.
 func (r *DRClusterConfigReconciler) processCreateOrUpdate(
 	ctx context.Context,
 	log logr.Logger,
@@ -86,12 +103,65 @@ func (r *DRClusterConfigReconciler) processCreateOrUpdate(
 	if err := util.NewResourceUpdater(drCConfig).
 		AddFinalizer(drCConfigFinalizerName).
 		Update(ctx, r.Client); err != nil {
-		log.Info("Failed to add finalizer for DRClusterConfig resource", "error", err)
+		return ctrl.Result{Requeue: true}, fmt.Errorf("failed to add finalizer for DRClusterConfig resource, %w", err)
+	}
 
-		return ctrl.Result{Requeue: true}, nil
+	allSurvivors := []string{}
+
+	survivors, err := r.createSCClusterClaims(ctx, log)
+	if err != nil {
+		return ctrl.Result{Requeue: true}, err
+	}
+
+	allSurvivors = append(allSurvivors, survivors...)
+
+	if err := r.pruneClusterClaims(ctx, log, allSurvivors); err != nil {
+		return ctrl.Result{Requeue: true}, err
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// createSCClusterClaims lists all StorageClasses and creates ClusterClaims for them
+func (r *DRClusterConfigReconciler) createSCClusterClaims(
+	ctx context.Context,
+	log logr.Logger,
+) ([]string, error) {
+	claims := []string{}
+
+	sClasses := &storagev1.StorageClassList{}
+	if err := r.Client.List(ctx, sClasses); err != nil {
+		return nil, fmt.Errorf("failed to list StorageClasses, %w", err)
+	}
+
+	for i := range sClasses.Items {
+		// TODO: If something is labeled later is there an Update event?
+		if !util.HasLabel(&sClasses.Items[i], StorageIDLabel) {
+			continue
+		}
+
+		if err := r.ensureClusterClaim(ctx, log, ccSCPrefix, sClasses.Items[i].GetName()); err != nil {
+			return nil, err
+		}
+
+		claims = append(claims, claimName(ccSCPrefix, sClasses.Items[i].GetName()))
+	}
+
+	return claims, nil
+}
+
+// ensureClusterClaim is a generic ClusterClaim creation function, that create a claim named "prefix.name", with
+// the passed in name as the ClusterClaim spec.Value
+func (r *DRClusterConfigReconciler) ensureClusterClaim(
+	ctx context.Context,
+	log logr.Logger,
+	prefix, name string,
+) error {
+	return nil
+}
+
+func claimName(prefix, name string) string {
+	return prefix + "." + name
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/drclusterconfig_controller.go
+++ b/internal/controller/drclusterconfig_controller.go
@@ -11,6 +11,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
 )
 
@@ -18,25 +20,21 @@ import (
 type DRClusterConfigReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	Log    logr.Logger
 }
 
-//+kubebuilder:rbac:groups=ramendr.openshift.io,resources=drclusterconfigs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=ramendr.openshift.io,resources=drclusterconfigs/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=ramendr.openshift.io,resources=drclusterconfigs/finalizers,verbs=update
+//nolint:lll
+// +kubebuilder:rbac:groups=ramendr.openshift.io,resources=drclusterconfigs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=ramendr.openshift.io,resources=drclusterconfigs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=ramendr.openshift.io,resources=drclusterconfigs/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the DRClusterConfig object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.3/pkg/reconcile
 func (r *DRClusterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
-	// TODO(user): your logic here
+	log := r.Log.WithValues("name", req.NamespacedName.Name, "rid", uuid.New())
+	log.Info("reconcile enter")
+
+	defer log.Info("reconcile exit")
 
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/drclusterconfig_controller.go
+++ b/internal/controller/drclusterconfig_controller.go
@@ -39,6 +39,10 @@ type DRClusterConfigReconciler struct {
 // +kubebuilder:rbac:groups=ramendr.openshift.io,resources=drclusterconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ramendr.openshift.io,resources=drclusterconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=ramendr.openshift.io,resources=drclusterconfigs/finalizers,verbs=update
+// +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=replication.storage.openshift.io,resources=volumereplicationclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=get;list;watch;create;update;delete
 
 func (r *DRClusterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("name", req.NamespacedName.Name, "rid", uuid.New())

--- a/internal/controller/drclusterconfig_controller.go
+++ b/internal/controller/drclusterconfig_controller.go
@@ -5,22 +5,34 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	"golang.org/x/time/rate"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
+	ramen "github.com/ramendr/ramen/api/v1alpha1"
+	"github.com/ramendr/ramen/internal/controller/util"
+)
+
+const (
+	drCConfigFinalizerName = "drclusterconfigs.ramendr.openshift.io/ramen"
+
+	maxReconcileBackoff = 5 * time.Minute
 )
 
 // DRClusterConfigReconciler reconciles a DRClusterConfig object
 type DRClusterConfigReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
-	Log    logr.Logger
+	Scheme      *runtime.Scheme
+	Log         logr.Logger
+	RateLimiter *workqueue.RateLimiter
 }
 
 //nolint:lll
@@ -29,19 +41,71 @@ type DRClusterConfigReconciler struct {
 // +kubebuilder:rbac:groups=ramendr.openshift.io,resources=drclusterconfigs/finalizers,verbs=update
 
 func (r *DRClusterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
-
 	log := r.Log.WithValues("name", req.NamespacedName.Name, "rid", uuid.New())
 	log.Info("reconcile enter")
 
 	defer log.Info("reconcile exit")
+
+	drCConfig := &ramen.DRClusterConfig{}
+	if err := r.Client.Get(ctx, req.NamespacedName, drCConfig); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("get: %w", err))
+	}
+
+	if util.ResourceIsDeleted(drCConfig) {
+		return r.processDeletion(ctx, log, drCConfig)
+	}
+
+	return r.processCreateOrUpdate(ctx, log, drCConfig)
+}
+
+func (r *DRClusterConfigReconciler) processDeletion(
+	ctx context.Context,
+	log logr.Logger,
+	drCConfig *ramen.DRClusterConfig,
+) (ctrl.Result, error) {
+	if err := util.NewResourceUpdater(drCConfig).
+		RemoveFinalizer(drCConfigFinalizerName).
+		Update(ctx, r.Client); err != nil {
+		log.Info("Failed to remove finalizer for DRClusterConfig resource", "error", err)
+
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *DRClusterConfigReconciler) processCreateOrUpdate(
+	ctx context.Context,
+	log logr.Logger,
+	drCConfig *ramen.DRClusterConfig,
+) (ctrl.Result, error) {
+	if err := util.NewResourceUpdater(drCConfig).
+		AddFinalizer(drCConfigFinalizerName).
+		Update(ctx, r.Client); err != nil {
+		log.Info("Failed to add finalizer for DRClusterConfig resource", "error", err)
+
+		return ctrl.Result{Requeue: true}, nil
+	}
 
 	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DRClusterConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&ramendrv1alpha1.DRClusterConfig{}).
-		Complete(r)
+	controller := ctrl.NewControllerManagedBy(mgr)
+
+	rateLimiter := workqueue.NewMaxOfRateLimiter(
+		workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, maxReconcileBackoff),
+		// defaults from client-go
+		//nolint: gomnd
+		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+	)
+
+	if r.RateLimiter != nil {
+		rateLimiter = *r.RateLimiter
+	}
+
+	return controller.WithOptions(ctrlcontroller.Options{
+		RateLimiter: rateLimiter,
+	}).For(&ramen.DRClusterConfig{}).Complete(r)
 }

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -48,6 +48,7 @@ import (
 	Recipe "github.com/ramendr/recipe/api/v1alpha1"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	clrapiv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	// +kubebuilder:scaffold:imports
 )
@@ -210,6 +211,9 @@ var _ = BeforeSuite(func() {
 	Expect(velero.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	err = clrapiv1beta1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = clusterv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = argocdv1alpha1hack.AddToScheme(scheme.Scheme)


### PR DESCRIPTION
Part of https://github.com/RamenDR/ramen/pull/1403

This implements creation of ClusterClaims for the various classes detected on the ManagedCluster that is also marked via a DRClusterConfig as a DR peer.

Future considerations:

- Add a basic status (say status.Message and observedGeneration) to DRClusterConfig reflecting success or failure of reconciliation
- Add required CEL immutability rules to DRClusterConfig, as certain fields should not be changed once created (e.g `clusterID`)
- DRClusterConfig can check s3 accessibility and report issues regarding the same, closing the gap for S3 validation on the ManagedCluster
- Add any required `clusterID` validation