### PR TITLE
VRG: Select select right VRC or VSC from the list of PeerClasses when multiple storageClasses are present.

### DIFF
--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -69,6 +69,8 @@ const (
 	VRGConditionReasonVolSyncFinalSyncInProgress  = "Syncing"
 	VRGConditionReasonVolSyncFinalSyncComplete    = "Synced"
 	VRGConditionReasonClusterDataAnnotationFailed = "AnnotationFailed"
+	VRGConditionReasonPeerClassNotFound           = "PeerClassNotFound"
+	VRGConditionReasonStorageIDNotFound           = "StorageIDNotFound"
 )
 
 const clusterDataProtectedTrueMessage = "Kube objects protected"
@@ -262,6 +264,28 @@ func setVRGDataErrorUnknownCondition(conditions *[]metav1.Condition, observedGen
 	setStatusCondition(conditions, metav1.Condition{
 		Type:               VRGConditionTypeDataReady,
 		Reason:             VRGConditionReasonErrorUnknown,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionUnknown,
+		Message:            message,
+	})
+}
+
+// sets condition when PV storageID not found
+func setVRGDataStorageIDNotFoundCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               VRGConditionTypeDataReady,
+		Reason:             VRGConditionReasonStorageIDNotFound,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionUnknown,
+		Message:            message,
+	})
+}
+
+// sets condition when PeerClass is not found
+func setVRGDataPeerClassNotFoundCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               VRGConditionTypeDataReady,
+		Reason:             VRGConditionReasonPeerClassNotFound,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionUnknown,
 		Message:            message,

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -60,6 +60,9 @@ const (
 
 	OwnerNameAnnotation      = "ramendr.openshift.io/owner-name"
 	OwnerNamespaceAnnotation = "ramendr.openshift.io/owner-namespace"
+
+	// StorageClass label
+	StorageIDLabel = "ramendr.openshift.io/storageid"
 )
 
 type VSHandler struct {
@@ -1441,7 +1444,9 @@ func (v *VSHandler) getVolumeSnapshotClassFromPVCStorageClass(storageClass *stor
 	var matchedVolumeSnapshotClassName string
 
 	for _, volumeSnapshotClass := range volumeSnapshotClasses {
-		if volumeSnapshotClass.Driver == storageClass.Provisioner {
+		sIDFromSnapClass := volumeSnapshotClass.GetLabels()[StorageIDLabel]
+		if volumeSnapshotClass.Driver == storageClass.Provisioner &&
+			sIDFromSnapClass == storageClass.GetLabels()[StorageIDLabel] {
 			// Match the first one where driver/provisioner == the storage class provisioner
 			// But keep looping - if we find the default storageVolumeClass, use it instead
 			if matchedVolumeSnapshotClassName == "" || isDefaultVolumeSnapshotClass(volumeSnapshotClass) {

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -15,7 +15,7 @@ import (
 
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
 	"github.com/google/uuid"
-	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
+	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"github.com/ramendr/ramen/internal/controller/kubeobjects"
 	"github.com/ramendr/ramen/internal/controller/kubeobjects/velero"
 	"golang.org/x/exp/maps" // TODO replace with "maps" in go1.21+

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -857,7 +857,7 @@ func (v *VRGInstance) separatePVCsUsingStorageClassProvisioner(pvcList *corev1.P
 
 		switch len(v.instance.Spec.Async.PeerClasses) {
 		case 0:
-			v.log.Info("validate using sc provisioner")
+			v.log.Info("validate using only sc provisioner")
 
 			replicationClassMatchFound := false
 

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -908,12 +908,18 @@ func (v *VRGInstance) findReplicationClassUsingPeerClasses(peerClasses []ramendr
 
 	// this check is needed because we use storageID to compare with other VRC or VSC
 	if _, ok := storageClass.Labels[StorageIDLabel]; !ok {
-		return nil, fmt.Errorf("storageID label not found in storageClass for PVC %s", pvc.Name)
+		msg := fmt.Sprintf("storageID label not found in storageClass for PVC %s", pvc.Name)
+		v.updatePVCDataReadyCondition(pvc.Namespace, pvc.Name, VRGConditionReasonStorageIDNotFound, msg)
+
+		return nil, fmt.Errorf(msg)
 	}
 
 	peerClass := v.findPeerClassMatchingSC(peerClasses, *scName)
 	if peerClass == nil {
-		return nil, fmt.Errorf("peerClass matching storageClass %s not found for async PVC", *scName)
+		msg := fmt.Sprintf("peerClass matching storageClass %s not found for async PVC", *scName)
+		v.updatePVCDataReadyCondition(pvc.Namespace, pvc.Name, VRGConditionReasonPeerClassNotFound, msg)
+
+		return nil, fmt.Errorf(msg)
 	}
 
 	replicationClass := v.findMatchingReplicationClass(peerClass, storageClass, pvc)

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -1279,13 +1279,6 @@ func (v *VRGInstance) selectVolumeReplicationClass(
 			namespacedName, err)
 	}
 
-	sID, found := storageClass.GetLabels()[StorageIDLabel]
-	if !found {
-		return nil, fmt.Errorf("missing storageID label in storageclass of pvc %s", namespacedName)
-	}
-
-	peerClasses := len(v.instance.Spec.Async.PeerClasses)
-
 	matchingReplicationClassList := []*volrep.VolumeReplicationClass{}
 
 	for index := range v.replClassList.Items {
@@ -1308,13 +1301,13 @@ func (v *VRGInstance) selectVolumeReplicationClass(
 
 		// if peerClass exist, continue to check if SID matches, or skip the check and proceed
 		// to append to matchingReplicationClassList
-		if peerClasses != 0 {
+		if len(v.instance.Spec.Async.PeerClasses) != 0 {
 			sIDFromReplicationClass, exists := replicationClass.GetLabels()[StorageIDLabel]
 			if !exists {
 				continue
 			}
 
-			if sIDFromReplicationClass != sID {
+			if sIDFromReplicationClass != storageClass.GetLabels()[StorageIDLabel] {
 				continue
 			}
 		}

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -1742,6 +1742,10 @@ func setPVCDataReadyCondition(protectedPVC *ramendrv1alpha1.ProtectedPVC, reason
 		setVRGDataProgressingCondition(&protectedPVC.Conditions, observedGeneration, message)
 	case reason == VRGConditionReasonErrorUnknown:
 		setVRGDataErrorUnknownCondition(&protectedPVC.Conditions, observedGeneration, message)
+	case reason == VRGConditionReasonPeerClassNotFound:
+		setVRGDataPeerClassNotFoundCondition(&protectedPVC.Conditions, observedGeneration, message)
+	case reason == VRGConditionReasonStorageIDNotFound:
+		setVRGDataStorageIDNotFoundCondition(&protectedPVC.Conditions, observedGeneration, message)
 	default:
 		// if appropriate reason is not provided, then treat it as an unknown condition.
 		message = "Unknown reason: " + reason

--- a/internal/controller/vrg_volrep_test.go
+++ b/internal/controller/vrg_volrep_test.go
@@ -564,7 +564,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		}
 		It("sets up PVCs, PVs and VRGs (with s3 stores that fail ObjectStore get)", func() {
 			vrgS3storeGetTemplate.s3Profiles = []string{s3Profiles[bucketInvalidS3ProfileNumber2].S3ProfileName}
-			vrgS3StoreGetTestCase = newVRGTestCaseCreateAndStart(2, vrgS3storeGetTemplate, true, false)
+			vrgS3StoreGetTestCase = newVRGTestCaseCreateAndStart(2, vrgS3storeGetTemplate, true, false, true)
 		})
 		It("waits for VRG status to match", func() {
 			vrgS3StoreGetTestCase.verifyVRGStatusCondition(vrgController.VRGConditionTypeClusterDataReady, false)
@@ -595,7 +595,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		}
 		It("sets up PVCs, PVs and VRGs (with s3 stores that fail uploads)", func() {
 			vrgsS3UploadTestTemplate.s3Profiles = []string{s3Profiles[uploadErrorS3ProfileNumber].S3ProfileName}
-			vrgS3UploadTestCase = newVRGTestCaseCreateAndStart(3, vrgsS3UploadTestTemplate, true, false)
+			vrgS3UploadTestCase = newVRGTestCaseCreateAndStart(3, vrgsS3UploadTestTemplate, true, false, true)
 		})
 		It("waits for VRG to create a VR for each PVC", func() {
 			expectedVRCount := len(vrgS3UploadTestCase.pvcNames)
@@ -633,7 +633,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		}
 		It("sets up PVCs, PVs and VRGs (with s3 stores that fail uploads)", func() {
 			vrgVRDeleteEnsureTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
-			vrgVRDeleteEnsureTestCase = newVRGTestCaseCreateAndStart(1, vrgVRDeleteEnsureTestTemplate, true, false)
+			vrgVRDeleteEnsureTestCase = newVRGTestCaseCreateAndStart(1, vrgVRDeleteEnsureTestTemplate, true, false, true)
 		})
 		It("waits for VRG to create a VR for each PVC", func() {
 			expectedVRCount := len(vrgVRDeleteEnsureTestCase.pvcNames)
@@ -857,7 +857,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 				vrcLabels := genVRCLabels(replicationIDs[c], storageID, "ramen")
 				createTestTemplate.storageIDLabels = storageIDLabel
 				createTestTemplate.replicationClassLabels = vrcLabels
-				v := newVRGTestCaseCreateAndStart(c, createTestTemplate, true, false)
+				v := newVRGTestCaseCreateAndStart(c, createTestTemplate, true, false, true)
 				vrgTestCases = append(vrgTestCases, v)
 			}
 		})
@@ -907,7 +907,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		It("sets up PVCs, PVs and VRGs - with nil/empty StorageClassName", func() {
 			vrgEmptySCTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
 			vrgEmptySCTemplate.volsyncEnabled = true
-			vrgEmptySC = newVRGTestCaseCreateAndStart(1, vrgEmptySCTemplate, true, false)
+			vrgEmptySC = newVRGTestCaseCreateAndStart(1, vrgEmptySCTemplate, true, false, true)
 		})
 		It("waits for VRG status to match", func() {
 			vrgEmptySC.verifyVRGStatusExpectation(false, "")
@@ -938,7 +938,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			vrgMissingSCTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
 			vrgMissingSCTemplate.volsyncEnabled = true
 			vrgMissingSCTemplate.scDisabled = true
-			vrgMissingSC = newVRGTestCaseCreateAndStart(1, vrgMissingSCTemplate, true, false)
+			vrgMissingSC = newVRGTestCaseCreateAndStart(1, vrgMissingSCTemplate, true, false, true)
 		})
 		It("waits for VRG status to match", func() {
 			vrgMissingSC.verifyVRGStatusExpectation(false, "")
@@ -976,7 +976,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 				vrgTestTemplate.replicationClassLabels = vrcLabels
 				// Test the scenario where the pvc is not bound yet
 				// and expect no VRs to be created.
-				v := newVRGTestCaseCreateAndStart(c, vrgTestTemplate, false, false)
+				v := newVRGTestCaseCreateAndStart(c, vrgTestTemplate, false, false, true)
 				vrgTests = append(vrgTests, v)
 			}
 		})
@@ -1039,7 +1039,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			storageID := storageIDLabel[vrgController.StorageIDLabel]
 			vrgTestTemplateVSEnabled.storageIDLabels = storageIDLabel
 			vrgTestTemplateVSEnabled.replicationClassLabels = genVRCLabels(replicationIDs[0], storageID, "ramen")
-			v := newVRGTestCaseCreateAndStart(4, vrgTestTemplateVSEnabled, false, false)
+			v := newVRGTestCaseCreateAndStart(4, vrgTestTemplateVSEnabled, false, false, true)
 			vrgStatusTests = append(vrgStatusTests, v)
 		})
 		var v *vrgTest
@@ -1084,7 +1084,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			storageID := storageIDLabel[vrgController.StorageIDLabel]
 			vrgTest2Template.replicationClassLabels = genVRCLabels(replicationIDs[0], storageID, "ramen")
 			vrgTest2Template.storageIDLabels = storageIDLabel
-			v := newVRGTestCaseCreateAndStart(4, vrgTest2Template, true, true)
+			v := newVRGTestCaseCreateAndStart(4, vrgTest2Template, true, true, true)
 			vrgStatus2Tests = append(vrgStatus2Tests, v)
 		})
 		It("waits for VRG to create a VR for each PVC bind and checks status", func() {
@@ -1125,7 +1125,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			storageID := storageIDLabel[vrgController.StorageIDLabel]
 			vrgTest3Template.replicationClassLabels = genVRCLabels(replicationIDs[0], storageID, "ramen")
 			vrgTest3Template.storageIDLabels = storageIDLabel
-			v := newVRGTestCaseCreateAndStart(4, vrgTest3Template, false, true)
+			v := newVRGTestCaseCreateAndStart(4, vrgTest3Template, false, true, true)
 			vrgStatus3Tests = append(vrgStatus3Tests, v)
 		})
 		var v *vrgTest
@@ -1171,7 +1171,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			storageID := storageIDLabel[vrgController.StorageIDLabel]
 			vrgScheduleTestTemplate.replicationClassLabels = genVRCLabels(replicationIDs[0], storageID, "ramen")
 			vrgScheduleTestTemplate.storageIDLabels = storageIDLabel
-			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTestTemplate, true, true)
+			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTestTemplate, true, true, true)
 			vrgScheduleTests = append(vrgScheduleTests, v)
 		})
 		It("expect no VR to be created as PVC not bound and check status", func() {
@@ -1208,7 +1208,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			storageID := storageIDLabel[vrgController.StorageIDLabel]
 			vrgScheduleTest2Template.replicationClassLabels = genVRCLabels(replicationIDs[0], storageID, "ramen")
 			vrgScheduleTest2Template.storageIDLabels = storageIDLabel
-			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest2Template, true, true)
+			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest2Template, true, true, true)
 			vrgSchedule2Tests = append(vrgSchedule2Tests, v)
 		})
 		It("expect no VR to be created as PVC not bound and check status", func() {
@@ -1244,7 +1244,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			vrgScheduleTest3Template.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
 			storageIDLabel := genStorageIDLabel(storageIDs[0])
 			vrgScheduleTest3Template.storageIDLabels = storageIDLabel
-			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest3Template, true, true)
+			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest3Template, true, true, true)
 			vrgSchedule3Tests = append(vrgSchedule3Tests, v)
 		})
 		It("expect no VR to be created as VR not created and check status", func() {
@@ -1290,7 +1290,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			vrgScheduleTest4Template.additionalVRCInfoList[0].replicationClassLabels = genVRCLabels(
 				replicationIDs[0], storageID, "ramen")
 			vrgScheduleTest4Template.storageIDLabels = storageIDLabel
-			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest4Template, true, true)
+			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest4Template, true, true, true)
 			vrgSchedule4Tests = append(vrgSchedule4Tests, v)
 		})
 		It("expect no VR to be created as VR not created and check status", func() {
@@ -1335,7 +1335,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			vrgScheduleTest5Template.additionalVRCInfoList[0].replicationClassLabels = genVRCLabels(
 				replicationIDs[0], storageID, "ramen")
 			vrgScheduleTest5Template.storageIDLabels = storageIDLabel
-			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest5Template, true, true)
+			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest5Template, true, true, true)
 			vrgSchedule5Tests = append(vrgSchedule5Tests, v)
 		})
 		It("expect 4 VRs to be created and check status", func() {
@@ -1392,7 +1392,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			vrgScheduleTest6Template.additionalVRCInfoList[1].replicationClassLabels = genVRCLabels(
 				replicationIDs[0], storageID, "ramen")
 			vrgScheduleTest6Template.storageIDLabels = storageIDLabel
-			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest6Template, true, true)
+			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest6Template, true, true, true)
 			vrgSchedule6Tests = append(vrgSchedule6Tests, v)
 		})
 		It("expect no VR to be created as VR not created and check status", func() {
@@ -1406,6 +1406,80 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		It("cleans up after testing", func() {
 			v := vrgSchedule6Tests[0]
 			v.cleanupStatusAbsent()
+		})
+	})
+
+	// Basic test with no peerClasses
+	var vrgNoPeerClasses []*vrgTest
+	vrgNoPeerClassesTemplate := &template{
+		ClaimBindInfo:        corev1.ClaimBound,
+		VolumeBindInfo:       corev1.VolumeBound,
+		schedulingInterval:   "1h",
+		storageClassName:     "manual",
+		replicationClassName: "test-replicationclass",
+		vrcProvisioner:       "manual.storage.com",
+		scProvisioner:        "manual.storage.com",
+	}
+	Context("Basic test with no peerClassses", func() {
+		It("sets up PVCs, PVs and VRGs", func() {
+			vrgNoPeerClassesTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
+			storageIDLabel := genStorageIDLabel(storageIDs[0])
+			storageID := storageIDLabel[vrgController.StorageIDLabel]
+			vrcLabels := genVRCLabels(replicationIDs[0], storageID, "ramen")
+			vrgNoPeerClassesTemplate.storageIDLabels = storageIDLabel
+			vrgNoPeerClassesTemplate.replicationClassLabels = vrcLabels
+			v := newVRGTestCaseCreateAndStart(2, vrgNoPeerClassesTemplate, true, false, false)
+			vrgNoPeerClasses = append(vrgNoPeerClasses, v)
+		})
+		It("expect VR to be created and check status", func() {
+			v := vrgNoPeerClasses[0]
+			v.waitForVRCountToMatch(v.pvcCount)
+		})
+		It("waits for VRG status to match", func() {
+			v := vrgNoPeerClasses[0]
+			v.promoteVolReps()
+			v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
+		})
+		It("cleans up after testing", func() {
+			v := vrgNoPeerClasses[0]
+			v.cleanupProtected()
+		})
+	})
+
+	// Basic test with no peerClasses with no replicationID in vrc
+	var vrgNoPeerClassesAndReplicationID []*vrgTest
+	vrgNoPeerClassesAndReplicationIDTemplate := &template{
+		ClaimBindInfo:        corev1.ClaimBound,
+		VolumeBindInfo:       corev1.VolumeBound,
+		schedulingInterval:   "1h",
+		storageClassName:     "manual",
+		replicationClassName: "test-replicationclass",
+		vrcProvisioner:       "manual.storage.com",
+		scProvisioner:        "manual.storage.com",
+	}
+	Context("Basic test with no peerClassses with replicationID in vrc", func() {
+		It("sets up PVCs, PVs and VRGs", func() {
+			vrgNoPeerClassesAndReplicationIDTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
+			storageIDLabel := genStorageIDLabel(storageIDs[0])
+			storageID := storageIDLabel[vrgController.StorageIDLabel]
+			vrcLabels := genVRCLabels("", storageID, "ramen")
+			vrgNoPeerClassesAndReplicationIDTemplate.storageIDLabels = storageIDLabel
+			vrgNoPeerClassesAndReplicationIDTemplate.replicationClassLabels = vrcLabels
+			v := newVRGTestCaseCreateAndStart(2, vrgNoPeerClassesAndReplicationIDTemplate, true, false, false)
+			vrgNoPeerClassesAndReplicationID = append(vrgNoPeerClassesAndReplicationID, v)
+		})
+		It("expect VR to be created and check status", func() {
+			v := vrgNoPeerClassesAndReplicationID[0]
+			v.waitForVRCountToMatch(v.pvcCount)
+		})
+		It("waits for VRG status to match", func() {
+			v := vrgNoPeerClassesAndReplicationID[0]
+			v.promoteVolReps()
+			v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
+		})
+		It("cleans up after testing", func() {
+			v := vrgNoPeerClassesAndReplicationID[0]
+			v.cleanupProtected()
 		})
 	})
 
@@ -1532,7 +1606,9 @@ func (v *vrgTest) VRGTestCaseStart() {
 // with Status.Phase set to ClaimPending instead of ClaimBound. Expectation
 // is that, until pvc is not bound, VolRep resources should not be created
 // by VRG.
-func newVRGTestCaseCreateAndStart(pvcCount int, testTemplate *template, checkBind, vrgFirst bool) *vrgTest {
+func newVRGTestCaseCreateAndStart(pvcCount int, testTemplate *template, checkBind,
+	vrgFirst, includePeerClasses bool,
+) *vrgTest {
 	var replicationID string
 
 	v := newVRGTestCaseCreate(pvcCount, testTemplate, checkBind, vrgFirst)
@@ -1544,8 +1620,11 @@ func newVRGTestCaseCreateAndStart(pvcCount int, testTemplate *template, checkBin
 	}
 
 	storageID := testTemplate.storageIDLabels[vrgController.StorageIDLabel]
-	asyncPeerClass := genPeerClass(replicationID, testTemplate.storageClassName, []string{storageID})
-	v.asyncPeerClasses = []ramendrv1alpha1.PeerClass{asyncPeerClass}
+	if includePeerClasses {
+		asyncPeerClass := genPeerClass(replicationID, testTemplate.storageClassName, []string{storageID})
+		v.asyncPeerClasses = []ramendrv1alpha1.PeerClass{asyncPeerClass}
+	}
+
 	v.VRGTestCaseStart()
 
 	return v
@@ -2823,9 +2902,14 @@ func genPeerClass(replicationID, storageClassName string, storageIDs []string) r
 
 //nolint:unparam
 func genVRCLabels(replicationID, storageID, protectionKey string) map[string]string {
-	return map[string]string{
-		vrgController.VolumeReplicationIDLabel: replicationID,
-		vrgController.StorageIDLabel:           storageID,
-		"protection":                           protectionKey,
+	vrcLabel := map[string]string{
+		vrgController.StorageIDLabel: storageID,
+		"protection":                 protectionKey,
 	}
+
+	if replicationID != "" {
+		vrcLabel[vrgController.VolumeReplicationIDLabel] = replicationID
+	}
+
+	return vrcLabel
 }

--- a/internal/controller/vrg_volrep_test.go
+++ b/internal/controller/vrg_volrep_test.go
@@ -40,6 +40,11 @@ const (
 	namespaceLen = 5
 )
 
+var (
+	storageIDs     = []string{"sid-1", "sid-2", "sid-3", "sid-4", "sid-5"}
+	replicationIDs = []string{"repl-1", "repl-2", "repl-3", "repl-4", "repl-5"}
+)
+
 var vrgObjectStorer = &objectStorers[vrgS3ProfileNumber]
 
 func init() {
@@ -73,20 +78,29 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	vrgStatusPvcsGet := func() []ramendrv1alpha1.ProtectedPVC {
 		return vrgGet().Status.ProtectedPVCs
 	}
+	appendSuffix := func(name string) string {
+		return fmt.Sprintf("%s.%s", name, newRandomNamespaceSuffix())
+	}
+	storageIDLabel := genStorageIDLabel(storageIDs[0])
+	storageID := storageIDLabel[vrgController.StorageIDLabel]
+	vrcLabels := genVRCLabels(replicationIDs[0], storageID, "ramen")
+	testcaseTemplate := &template{
+		ClaimBindInfo:          corev1.ClaimBound,
+		VolumeBindInfo:         corev1.VolumeBound,
+		schedulingInterval:     "1h",
+		storageClassName:       appendSuffix("manual-kumbaya"),
+		replicationClassName:   appendSuffix("test-replicationclass"),
+		vrcProvisioner:         "manual.storage.com",
+		scProvisioner:          "manual.storage.com",
+		storageIDLabels:        storageIDLabel,
+		replicationClassLabels: vrcLabels,
+	}
+	syncPeerClass := genPeerClass("", testcaseTemplate.storageClassName, []string{storageID})
 	var dataReadyCondition *metav1.Condition
+	syncPeerClasses := []ramendrv1alpha1.PeerClass{syncPeerClass}
 	Context("Sync Basic Test", func() {
-		syncBasicTestTemplate := &template{
-			ClaimBindInfo:          corev1.ClaimBound,
-			VolumeBindInfo:         corev1.VolumeBound,
-			schedulingInterval:     "1h",
-			storageClassName:       "manual",
-			replicationClassName:   "test-replicationclass",
-			vrcProvisioner:         "manual.storage.com",
-			scProvisioner:          "manual.storage.com",
-			replicationClassLabels: map[string]string{"protection": "ramen"},
-		}
 		It("should initialize test with creating StorageClass and VolumeReplicationClass", func() {
-			createStorageClass(syncBasicTestTemplate)
+			createStorageClass(testcaseTemplate)
 		})
 		When("ReplicationState is invalid", func() {
 			It("should set DataReady status=False reason=Error", func() {
@@ -136,7 +150,9 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		When("ReplicationState is primary and sync is enabled, but s3 profiles are absent", func() {
 			It("should set ClusterDataReady status=False reason=Error", func() {
-				vrg.Spec.Sync = &ramendrv1alpha1.VRGSyncSpec{}
+				vrg.Spec.Sync = &ramendrv1alpha1.VRGSyncSpec{
+					PeerClasses: syncPeerClasses,
+				}
 				updateVRG(vrg)
 				var clusterDataReadyCondition *metav1.Condition
 				Eventually(func() metav1.ConditionStatus {
@@ -165,8 +181,9 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		var pvc0 *corev1.PersistentVolumeClaim
 		When("PV exists, is bound, and its claim's deletion timestamp is non-zero", func() {
 			BeforeEach(func() {
-				pv := pv("pv0", "pvc0", vrg.Namespace, syncBasicTestTemplate.storageClassName)
-				pvc := pvc(pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace, pv.Name, pv.Spec.StorageClassName, nil)
+				pv := pv("pv0", "pvc0", vrg.Namespace, testcaseTemplate.storageClassName)
+				pvc := pvc(pv.Spec.ClaimRef.Name, pv.Spec.ClaimRef.Namespace, pv.Name, pv.Spec.StorageClassName,
+					testcaseTemplate.storageIDLabels)
 				pvc.Finalizers = []string{"ramendr.openshift.io/asdf"}
 				vrgS3KeyPrefix := vrgS3KeyPrefix(vrgNamespacedName)
 				populateS3Store(vrgS3KeyPrefix, []corev1.PersistentVolume{*pv}, []corev1.PersistentVolumeClaim{*pvc})
@@ -182,6 +199,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 				pvc0 = pvc
 			})
 			It("should set ClusterDataReady false", func() {
+				vrg.Spec.Sync.PeerClasses = syncPeerClasses
 				vrg.ResourceVersion = ""
 				vrg.Spec.S3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
 				Expect(k8sClient.Create(context.TODO(), vrg)).To(Succeed())
@@ -225,10 +243,17 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		Specify("VRG delete", func() {
 			Expect(k8sClient.Delete(context.TODO(), vrg)).To(Succeed())
 		})
+		Specify("delete StorageClass and VolumeReplicationClass", func() {
+			cleanupStorageClass(testcaseTemplate)
+			// cleanupVolumeReplicationClass(testcaseTemplate)
+		})
 	})
 
 	// Test first restore
 	Context("restore test case", func() {
+		storageIDLabel := genStorageIDLabel(storageIDs[0])
+		storageID := storageIDLabel[vrgController.StorageIDLabel]
+		vrcLabels := genVRCLabels(replicationIDs[0], storageID, "ramen")
 		restoreTestTemplate := &template{
 			ClaimBindInfo:          corev1.ClaimBound,
 			VolumeBindInfo:         corev1.VolumeBound,
@@ -237,12 +262,16 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			replicationClassName:   "test-replicationclass",
 			vrcProvisioner:         "manual.storage.com",
 			scProvisioner:          "manual.storage.com",
-			replicationClassLabels: map[string]string{"protection": "ramen"},
+			storageIDLabels:        storageIDLabel,
+			replicationClassLabels: vrcLabels,
 		}
 		It("populates the S3 store with PVs/PVCs and start vrg as primary to check that the PVs/PVCs are restored", func() {
 			restoreTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
 			numPVs := 3
 			vtest := newVRGTestCaseCreate(0, restoreTestTemplate, true, false)
+			replicationID := restoreTestTemplate.replicationClassLabels[vrgController.VolumeReplicationIDLabel]
+			asyncPeerClass := genPeerClass(replicationID, restoreTestTemplate.storageClassName, []string{storageID})
+			vtest.asyncPeerClasses = []ramendrv1alpha1.PeerClass{asyncPeerClass}
 			vtest.skipCreationPVandPVC = true
 			pvList := vtest.generateFakePVs("pv", numPVs)
 			pvcList := vtest.generateFakePVCs(pvList)
@@ -256,12 +285,18 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			vtest.promoteVolReps()
 			vtest.waitForVRGStateToTransitionToPrimary()
 			cleanupS3Store()
+			vtest.cleanupNamespace()
+			vtest.cleanupSC()
+			vtest.cleanupVRC()
 		})
 	})
 
 	// Test restore success when bound PV/PVC are present
 	var vrgTestBoundPV *vrgTest
 	Context("restore test case for existing and bound PV/PVC", Ordered, func() {
+		storageIDLabel := genStorageIDLabel(storageIDs[0])
+		storageID := storageIDLabel[vrgController.StorageIDLabel]
+		vrcLabels := genVRCLabels(replicationIDs[0], storageID, "ramen")
 		restoreTestTemplate := &template{
 			ClaimBindInfo:          corev1.ClaimBound,
 			VolumeBindInfo:         corev1.VolumeBound,
@@ -270,13 +305,17 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			replicationClassName:   "test-replicationclass",
 			vrcProvisioner:         "manual.storage.com",
 			scProvisioner:          "manual.storage.com",
-			replicationClassLabels: map[string]string{"protection": "ramen"},
+			storageIDLabels:        storageIDLabel,
+			replicationClassLabels: vrcLabels,
 		}
 		const pvcCount = 3
 		It("populates the S3 store with PVs and starts vrg as primary", func() {
 			restoreTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
 			numPVs := pvcCount
 			vrgTestBoundPV = newVRGTestCaseCreate(numPVs, restoreTestTemplate, true, false)
+			replicationID := restoreTestTemplate.replicationClassLabels[vrgController.VolumeReplicationIDLabel]
+			asyncPeerClass := genPeerClass(replicationID, restoreTestTemplate.storageClassName, []string{storageID})
+			vrgTestBoundPV.asyncPeerClasses = []ramendrv1alpha1.PeerClass{asyncPeerClass}
 			pvList := vrgTestBoundPV.generateFakePVs("pv", numPVs)
 			populateS3Store(vrgTestBoundPV.s3KeyPrefix(), pvList, []corev1.PersistentVolumeClaim{})
 			vrgTestBoundPV.VRGTestCaseStart()
@@ -508,8 +547,11 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 
 	// Test Object store "get" failure for an s3 store, expect ClusterDataReady to remain false
 	var vrgS3StoreGetTestCase *vrgTest
-	Context("in primary state", func() {
-		createTestTemplate := &template{
+	Context("in primary state where ClusterDataReady if object store `get` fails", func() {
+		storageIDLabel := genStorageIDLabel(storageIDs[0])
+		storageID := storageIDLabel[vrgController.StorageIDLabel]
+		vrcLabels := genVRCLabels(replicationIDs[0], storageID, "ramen")
+		vrgS3storeGetTemplate := &template{
 			ClaimBindInfo:          corev1.ClaimBound,
 			VolumeBindInfo:         corev1.VolumeBound,
 			schedulingInterval:     "1h",
@@ -517,11 +559,12 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			replicationClassName:   "test-replicationclass",
 			vrcProvisioner:         "manual.storage.com",
 			scProvisioner:          "manual.storage.com",
-			replicationClassLabels: map[string]string{"protection": "ramen"},
+			storageIDLabels:        storageIDLabel,
+			replicationClassLabels: vrcLabels,
 		}
 		It("sets up PVCs, PVs and VRGs (with s3 stores that fail ObjectStore get)", func() {
-			createTestTemplate.s3Profiles = []string{s3Profiles[bucketInvalidS3ProfileNumber2].S3ProfileName}
-			vrgS3StoreGetTestCase = newVRGTestCaseCreateAndStart(2, createTestTemplate, true, false)
+			vrgS3storeGetTemplate.s3Profiles = []string{s3Profiles[bucketInvalidS3ProfileNumber2].S3ProfileName}
+			vrgS3StoreGetTestCase = newVRGTestCaseCreateAndStart(2, vrgS3storeGetTemplate, true, false)
 		})
 		It("waits for VRG status to match", func() {
 			vrgS3StoreGetTestCase.verifyVRGStatusCondition(vrgController.VRGConditionTypeClusterDataReady, false)
@@ -535,8 +578,11 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	// - Also tests if cached s3 errors are returned rather than invoking the upload for each PV, by having
 	//   more than one PVCs to protect
 	var vrgS3UploadTestCase *vrgTest
-	Context("in primary state", func() {
-		createTestTemplate := &template{
+	Context("in primary state where PV upload fails to an s3 store", func() {
+		storageIDLabel := genStorageIDLabel(storageIDs[0])
+		storageID := storageIDLabel[vrgController.StorageIDLabel]
+		vrcLabels := genVRCLabels(replicationIDs[0], storageID, "ramen")
+		vrgsS3UploadTestTemplate := &template{
 			ClaimBindInfo:          corev1.ClaimBound,
 			VolumeBindInfo:         corev1.VolumeBound,
 			schedulingInterval:     "1h",
@@ -544,11 +590,12 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			replicationClassName:   "test-replicationclass",
 			vrcProvisioner:         "manual.storage.com",
 			scProvisioner:          "manual.storage.com",
-			replicationClassLabels: map[string]string{"protection": "ramen"},
+			storageIDLabels:        storageIDLabel,
+			replicationClassLabels: vrcLabels,
 		}
 		It("sets up PVCs, PVs and VRGs (with s3 stores that fail uploads)", func() {
-			createTestTemplate.s3Profiles = []string{s3Profiles[uploadErrorS3ProfileNumber].S3ProfileName}
-			vrgS3UploadTestCase = newVRGTestCaseCreateAndStart(3, createTestTemplate, true, false)
+			vrgsS3UploadTestTemplate.s3Profiles = []string{s3Profiles[uploadErrorS3ProfileNumber].S3ProfileName}
+			vrgS3UploadTestCase = newVRGTestCaseCreateAndStart(3, vrgsS3UploadTestTemplate, true, false)
 		})
 		It("waits for VRG to create a VR for each PVC", func() {
 			expectedVRCount := len(vrgS3UploadTestCase.pvcNames)
@@ -569,8 +616,11 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 
 	// Test VRG finalizer removal during deletion is deferred till VR is deleted
 	var vrgVRDeleteEnsureTestCase *vrgTest
-	Context("in primary state", func() {
-		createTestTemplate := &template{
+	Context("in primary state where VRG finalizer removal is deferred duing deletion", func() {
+		storageIDLabel := genStorageIDLabel(storageIDs[0])
+		storageID := storageIDLabel[vrgController.StorageIDLabel]
+		vrcLabels := genVRCLabels(replicationIDs[0], storageID, "ramen")
+		vrgVRDeleteEnsureTestTemplate := &template{
 			ClaimBindInfo:          corev1.ClaimBound,
 			VolumeBindInfo:         corev1.VolumeBound,
 			schedulingInterval:     "1h",
@@ -578,11 +628,12 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			replicationClassName:   "test-replicationclass",
 			vrcProvisioner:         "manual.storage.com",
 			scProvisioner:          "manual.storage.com",
-			replicationClassLabels: map[string]string{"protection": "ramen"},
+			storageIDLabels:        storageIDLabel,
+			replicationClassLabels: vrcLabels,
 		}
 		It("sets up PVCs, PVs and VRGs (with s3 stores that fail uploads)", func() {
-			createTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
-			vrgVRDeleteEnsureTestCase = newVRGTestCaseCreateAndStart(1, createTestTemplate, true, false)
+			vrgVRDeleteEnsureTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
+			vrgVRDeleteEnsureTestCase = newVRGTestCaseCreateAndStart(1, vrgVRDeleteEnsureTestTemplate, true, false)
 		})
 		It("waits for VRG to create a VR for each PVC", func() {
 			expectedVRCount := len(vrgVRDeleteEnsureTestCase.pvcNames)
@@ -633,6 +684,9 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	var vrgDeleteFailedVR *vrgTest
 	//nolint:dupl
 	Context("VR failed validation in primary state", func() {
+		storageIDLabel := genStorageIDLabel(storageIDs[0])
+		storageID := storageIDLabel[vrgController.StorageIDLabel]
+		vrcLabels := genVRCLabels(replicationIDs[0], storageID, "ramen")
 		createTestTemplate := &template{
 			ClaimBindInfo:          corev1.ClaimBound,
 			VolumeBindInfo:         corev1.VolumeBound,
@@ -641,11 +695,12 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			replicationClassName:   "test-replicationclass",
 			vrcProvisioner:         "manual.storage.com",
 			scProvisioner:          "manual.storage.com",
-			replicationClassLabels: map[string]string{"protection": "ramen"},
+			storageIDLabels:        storageIDLabel,
+			replicationClassLabels: vrcLabels,
 		}
 		It("sets up PVCs, PVs and VRGs (with s3 stores that fail uploads)", func() {
 			createTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
-			vrgDeleteFailedVR = newVRGTestCaseCreateAndStart(1, createTestTemplate, true, false)
+			vrgDeleteFailedVR = newVRGTestCaseCreateAndStart(1, createTestTemplate, true, false, true)
 		})
 		It("waits for VRG to create a VR for each PVC", func() {
 			expectedVRCount := len(vrgDeleteFailedVR.pvcNames)
@@ -678,6 +733,9 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	var vrgDeleteIncompleteVR *vrgTest
 	//nolint:dupl
 	Context("VR failed validation in primary state and Validated condition is missing", func() {
+		storageIDLabel := genStorageIDLabel(storageIDs[0])
+		storageID := storageIDLabel[vrgController.StorageIDLabel]
+		vrcLabels := genVRCLabels(replicationIDs[0], storageID, "ramen")
 		createTestTemplate := &template{
 			ClaimBindInfo:          corev1.ClaimBound,
 			VolumeBindInfo:         corev1.VolumeBound,
@@ -686,11 +744,12 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			replicationClassName:   "test-replicationclass",
 			vrcProvisioner:         "manual.storage.com",
 			scProvisioner:          "manual.storage.com",
-			replicationClassLabels: map[string]string{"protection": "ramen"},
+			storageIDLabels:        storageIDLabel,
+			replicationClassLabels: vrcLabels,
 		}
 		It("sets up PVCs, PVs and VRGs (with s3 stores that fail uploads)", func() {
 			createTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
-			vrgDeleteIncompleteVR = newVRGTestCaseCreateAndStart(1, createTestTemplate, true, false)
+			vrgDeleteIncompleteVR = newVRGTestCaseCreateAndStart(1, createTestTemplate, true, false, true)
 		})
 		It("waits for VRG to create a VR for each PVC", func() {
 			expectedVRCount := len(vrgDeleteFailedVR.pvcNames)
@@ -732,6 +791,9 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	var vrgDeleteCompletedVR *vrgTest
 	//nolint:dupl
 	Context("VR failed validation in primary state and Validated condition is missing", func() {
+		storageIDLabel := genStorageIDLabel(storageIDs[0])
+		storageID := storageIDLabel[vrgController.StorageIDLabel]
+		vrcLabels := genVRCLabels(replicationIDs[0], storageID, "ramen")
 		createTestTemplate := &template{
 			ClaimBindInfo:          corev1.ClaimBound,
 			VolumeBindInfo:         corev1.VolumeBound,
@@ -740,11 +802,12 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			replicationClassName:   "test-replicationclass",
 			vrcProvisioner:         "manual.storage.com",
 			scProvisioner:          "manual.storage.com",
-			replicationClassLabels: map[string]string{"protection": "ramen"},
+			storageIDLabels:        storageIDLabel,
+			replicationClassLabels: vrcLabels,
 		}
 		It("sets up PVCs, PVs and VRGs (with s3 stores that fail uploads)", func() {
 			createTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
-			vrgDeleteCompletedVR = newVRGTestCaseCreateAndStart(1, createTestTemplate, true, false)
+			vrgDeleteCompletedVR = newVRGTestCaseCreateAndStart(1, createTestTemplate, true, false, true)
 		})
 		It("waits for VRG to create a VR for each PVC", func() {
 			expectedVRCount := len(vrgDeleteFailedVR.pvcNames)
@@ -776,20 +839,24 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	// Try the simple case of creating VRG, PVC, PV and
 	// check whether VolRep resources are created or not
 	var vrgTestCases []*vrgTest
-	Context("in primary state", func() {
+	Context("Create VRG, PVC, PV and check if VolReps are created", func() {
 		createTestTemplate := &template{
-			ClaimBindInfo:          corev1.ClaimBound,
-			VolumeBindInfo:         corev1.VolumeBound,
-			schedulingInterval:     "1h",
-			storageClassName:       "manual",
-			replicationClassName:   "test-replicationclass",
-			vrcProvisioner:         "manual.storage.com",
-			scProvisioner:          "manual.storage.com",
-			replicationClassLabels: map[string]string{"protection": "ramen"},
+			ClaimBindInfo:        corev1.ClaimBound,
+			VolumeBindInfo:       corev1.VolumeBound,
+			schedulingInterval:   "1h",
+			storageClassName:     "manual",
+			replicationClassName: "test-replicationclass",
+			vrcProvisioner:       "manual.storage.com",
+			scProvisioner:        "manual.storage.com",
 		}
 		It("sets up PVCs, PVs and VRGs", func() {
 			createTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
 			for c := 0; c < 5; c++ {
+				storageIDLabel := genStorageIDLabel(storageIDs[c])
+				storageID := storageIDLabel[vrgController.StorageIDLabel]
+				vrcLabels := genVRCLabels(replicationIDs[c], storageID, "ramen")
+				createTestTemplate.storageIDLabels = storageIDLabel
+				createTestTemplate.replicationClassLabels = vrcLabels
 				v := newVRGTestCaseCreateAndStart(c, createTestTemplate, true, false)
 				vrgTestCases = append(vrgTestCases, v)
 			}
@@ -823,20 +890,24 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 
 	// Ensure PVCs with no SCName results in errors
 	var vrgEmptySC *vrgTest
-	Context("in primary state", func() {
-		createTestTemplate := &template{
+	Context("in primary state with no SCName", func() {
+		storageIDLabel := genStorageIDLabel(storageIDs[0])
+		storageID := storageIDLabel[vrgController.StorageIDLabel]
+		vrcLabels := genVRCLabels(replicationIDs[0], storageID, "ramen")
+		vrgEmptySCTemplate := &template{
 			ClaimBindInfo:          corev1.ClaimBound,
 			VolumeBindInfo:         corev1.VolumeBound,
 			schedulingInterval:     "1h",
 			replicationClassName:   "test-replicationclass",
 			vrcProvisioner:         "manual.storage.com",
 			scProvisioner:          "manual.storage.com",
-			replicationClassLabels: map[string]string{"protection": "ramen"},
+			storageIDLabels:        storageIDLabel,
+			replicationClassLabels: vrcLabels,
 		}
 		It("sets up PVCs, PVs and VRGs - with nil/empty StorageClassName", func() {
-			createTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
-			createTestTemplate.volsyncEnabled = true
-			vrgEmptySC = newVRGTestCaseCreateAndStart(1, createTestTemplate, true, false)
+			vrgEmptySCTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
+			vrgEmptySCTemplate.volsyncEnabled = true
+			vrgEmptySC = newVRGTestCaseCreateAndStart(1, vrgEmptySCTemplate, true, false)
 		})
 		It("waits for VRG status to match", func() {
 			vrgEmptySC.verifyVRGStatusExpectation(false, "")
@@ -848,8 +919,11 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 
 	// Ensure PVCs with missing SClass results in errors
 	var vrgMissingSC *vrgTest
-	Context("in primary state", func() {
-		createTestTemplate := &template{
+	Context("in primary state with SClass missing", func() {
+		storageIDLabel := genStorageIDLabel(storageIDs[0])
+		storageID := storageIDLabel[vrgController.StorageIDLabel]
+		vrcLabels := genVRCLabels(replicationIDs[0], storageID, "ramen")
+		vrgMissingSCTemplate := &template{
 			ClaimBindInfo:          corev1.ClaimBound,
 			VolumeBindInfo:         corev1.VolumeBound,
 			schedulingInterval:     "1h",
@@ -857,13 +931,14 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			replicationClassName:   "test-replicationclass",
 			vrcProvisioner:         "manual.storage.com",
 			scProvisioner:          "manual.storage.com",
-			replicationClassLabels: map[string]string{"protection": "ramen"},
+			storageIDLabels:        storageIDLabel,
+			replicationClassLabels: vrcLabels,
 		}
 		It("sets up PVCs, PVs and VRGs - with missing StorageClass", func() {
-			createTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
-			createTestTemplate.volsyncEnabled = true
-			createTestTemplate.scDisabled = true
-			vrgMissingSC = newVRGTestCaseCreateAndStart(1, createTestTemplate, true, false)
+			vrgMissingSCTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
+			vrgMissingSCTemplate.volsyncEnabled = true
+			vrgMissingSCTemplate.scDisabled = true
+			vrgMissingSC = newVRGTestCaseCreateAndStart(1, vrgMissingSCTemplate, true, false)
 		})
 		It("waits for VRG status to match", func() {
 			vrgMissingSC.verifyVRGStatusExpectation(false, "")
@@ -881,20 +956,24 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	// resources have been created or not.
 	var vrgTests []*vrgTest
 	vrgTestTemplate := &template{
-		ClaimBindInfo:          corev1.ClaimPending,
-		VolumeBindInfo:         corev1.VolumePending,
-		schedulingInterval:     "1h",
-		storageClassName:       "manual",
-		replicationClassName:   "test-replicationclass",
-		vrcProvisioner:         "manual.storage.com",
-		scProvisioner:          "manual.storage.com",
-		replicationClassLabels: map[string]string{"protection": "ramen"},
+		ClaimBindInfo:        corev1.ClaimPending,
+		VolumeBindInfo:       corev1.VolumePending,
+		schedulingInterval:   "1h",
+		storageClassName:     "manual",
+		replicationClassName: "test-replicationclass",
+		vrcProvisioner:       "manual.storage.com",
+		scProvisioner:        "manual.storage.com",
 	}
 
 	Context("in primary state", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
 			vrgTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
 			for c := 0; c < 5; c++ {
+				storageIDLabel := genStorageIDLabel(storageIDs[c])
+				storageID := storageIDLabel[vrgController.StorageIDLabel]
+				vrcLabels := genVRCLabels(replicationIDs[c], storageID, "ramen")
+				vrgTestTemplate.storageIDLabels = storageIDLabel
+				vrgTestTemplate.replicationClassLabels = vrcLabels
 				// Test the scenario where the pvc is not bound yet
 				// and expect no VRs to be created.
 				v := newVRGTestCaseCreateAndStart(c, vrgTestTemplate, false, false)
@@ -943,20 +1022,23 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 
 	var vrgStatusTests []*vrgTest
 	vrgTestTemplateVSEnabled := &template{
-		ClaimBindInfo:          corev1.ClaimPending,
-		VolumeBindInfo:         corev1.VolumePending,
-		schedulingInterval:     "1h",
-		storageClassName:       "manual",
-		replicationClassName:   "test-replicationclass",
-		vrcProvisioner:         "manual.storage.com",
-		scProvisioner:          "manual.storage.com",
-		replicationClassLabels: map[string]string{"protection": "ramen"},
-		volsyncEnabled:         true,
+		ClaimBindInfo:        corev1.ClaimPending,
+		VolumeBindInfo:       corev1.VolumePending,
+		schedulingInterval:   "1h",
+		storageClassName:     "manual",
+		replicationClassName: "test-replicationclass",
+		vrcProvisioner:       "manual.storage.com",
+		scProvisioner:        "manual.storage.com",
+		volsyncEnabled:       true,
 	}
 	//nolint:dupl
 	Context("in primary state status check pending to bound", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
 			vrgTestTemplateVSEnabled.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
+			storageIDLabel := genStorageIDLabel(storageIDs[0])
+			storageID := storageIDLabel[vrgController.StorageIDLabel]
+			vrgTestTemplateVSEnabled.storageIDLabels = storageIDLabel
+			vrgTestTemplateVSEnabled.replicationClassLabels = genVRCLabels(replicationIDs[0], storageID, "ramen")
 			v := newVRGTestCaseCreateAndStart(4, vrgTestTemplateVSEnabled, false, false)
 			vrgStatusTests = append(vrgStatusTests, v)
 		})
@@ -983,22 +1065,25 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 	})
 
-	// Changes the order in which VRG and PVC/PV are created.
-
+	// Changes the order in which VRG and PVC/PV are created
+	// here VRG is created first without PV/PVc
 	vrgTest2Template := &template{
-		ClaimBindInfo:          corev1.ClaimBound,
-		VolumeBindInfo:         corev1.VolumeBound,
-		schedulingInterval:     "1h",
-		storageClassName:       "manual",
-		replicationClassName:   "test-replicationclass",
-		vrcProvisioner:         "manual.storage.com",
-		scProvisioner:          "manual.storage.com",
-		replicationClassLabels: map[string]string{"protection": "ramen"},
+		ClaimBindInfo:        corev1.ClaimBound,
+		VolumeBindInfo:       corev1.VolumeBound,
+		schedulingInterval:   "1h",
+		storageClassName:     "manual",
+		replicationClassName: "test-replicationclass",
+		vrcProvisioner:       "manual.storage.com",
+		scProvisioner:        "manual.storage.com",
 	}
 	var vrgStatus2Tests []*vrgTest
 	Context("in primary state status check bound", func() {
 		It("sets up PVCs, PVs", func() {
 			vrgTest2Template.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
+			storageIDLabel := genStorageIDLabel(storageIDs[0])
+			storageID := storageIDLabel[vrgController.StorageIDLabel]
+			vrgTest2Template.replicationClassLabels = genVRCLabels(replicationIDs[0], storageID, "ramen")
+			vrgTest2Template.storageIDLabels = storageIDLabel
 			v := newVRGTestCaseCreateAndStart(4, vrgTest2Template, true, true)
 			vrgStatus2Tests = append(vrgStatus2Tests, v)
 		})
@@ -1023,20 +1108,23 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	// PVC/PV are created (with ClaimPending and VolumePending status respectively). Then
 	// each of them is bound and the result should be same (i.e. VRG being available).
 	vrgTest3Template := &template{
-		ClaimBindInfo:          corev1.ClaimPending,
-		VolumeBindInfo:         corev1.VolumePending,
-		schedulingInterval:     "1h",
-		storageClassName:       "manual",
-		replicationClassName:   "test-replicationclass",
-		vrcProvisioner:         "manual.storage.com",
-		scProvisioner:          "manual.storage.com",
-		replicationClassLabels: map[string]string{"protection": "ramen"},
+		ClaimBindInfo:        corev1.ClaimPending,
+		VolumeBindInfo:       corev1.VolumePending,
+		schedulingInterval:   "1h",
+		storageClassName:     "manual",
+		replicationClassName: "test-replicationclass",
+		vrcProvisioner:       "manual.storage.com",
+		scProvisioner:        "manual.storage.com",
 	}
 	var vrgStatus3Tests []*vrgTest
 	//nolint:dupl
 	Context("in primary state status check create VRG first", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
 			vrgTest3Template.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
+			storageIDLabel := genStorageIDLabel(storageIDs[0])
+			storageID := storageIDLabel[vrgController.StorageIDLabel]
+			vrgTest3Template.replicationClassLabels = genVRCLabels(replicationIDs[0], storageID, "ramen")
+			vrgTest3Template.storageIDLabels = storageIDLabel
 			v := newVRGTestCaseCreateAndStart(4, vrgTest3Template, false, true)
 			vrgStatus3Tests = append(vrgStatus3Tests, v)
 		})
@@ -1068,18 +1156,21 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	// does not match. VolumeReplication resources should not be created.
 	var vrgScheduleTests []*vrgTest
 	vrgScheduleTestTemplate := &template{
-		ClaimBindInfo:          corev1.ClaimBound,
-		VolumeBindInfo:         corev1.VolumeBound,
-		schedulingInterval:     "1h",
-		storageClassName:       "manual",
-		replicationClassName:   "test-replicationclass",
-		vrcProvisioner:         "manual.storage.com",
-		scProvisioner:          "new.storage.com",
-		replicationClassLabels: map[string]string{"protection": "ramen"},
+		ClaimBindInfo:        corev1.ClaimBound,
+		VolumeBindInfo:       corev1.VolumeBound,
+		schedulingInterval:   "1h",
+		storageClassName:     "manual",
+		replicationClassName: "test-replicationclass",
+		vrcProvisioner:       "manual.storage.com",
+		scProvisioner:        "new.storage.com",
 	}
 	Context("schedule test, provisioner does not match", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
 			vrgScheduleTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
+			storageIDLabel := genStorageIDLabel(storageIDs[0])
+			storageID := storageIDLabel[vrgController.StorageIDLabel]
+			vrgScheduleTestTemplate.replicationClassLabels = genVRCLabels(replicationIDs[0], storageID, "ramen")
+			vrgScheduleTestTemplate.storageIDLabels = storageIDLabel
 			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTestTemplate, true, true)
 			vrgScheduleTests = append(vrgScheduleTests, v)
 		})
@@ -1102,18 +1193,21 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	// VolumeReplication resource should not be created.
 	var vrgSchedule2Tests []*vrgTest
 	vrgScheduleTest2Template := &template{
-		ClaimBindInfo:          corev1.ClaimBound,
-		VolumeBindInfo:         corev1.VolumeBound,
-		schedulingInterval:     "22h",
-		storageClassName:       "manual",
-		replicationClassName:   "test-replicationclass",
-		vrcProvisioner:         "manual.storage.com",
-		scProvisioner:          "manual.storage.com",
-		replicationClassLabels: map[string]string{"protection": "ramen"},
+		ClaimBindInfo:        corev1.ClaimBound,
+		VolumeBindInfo:       corev1.VolumeBound,
+		schedulingInterval:   "22h",
+		storageClassName:     "manual",
+		replicationClassName: "test-replicationclass",
+		vrcProvisioner:       "manual.storage.com",
+		scProvisioner:        "manual.storage.com",
 	}
 	Context("schedule tests schedule does not match", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
 			vrgScheduleTest2Template.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
+			storageIDLabel := genStorageIDLabel(storageIDs[0])
+			storageID := storageIDLabel[vrgController.StorageIDLabel]
+			vrgScheduleTest2Template.replicationClassLabels = genVRCLabels(replicationIDs[0], storageID, "ramen")
+			vrgScheduleTest2Template.storageIDLabels = storageIDLabel
 			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest2Template, true, true)
 			vrgSchedule2Tests = append(vrgSchedule2Tests, v)
 		})
@@ -1148,6 +1242,8 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	Context("schedule tests replicationclass does not have labels", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
 			vrgScheduleTest3Template.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
+			storageIDLabel := genStorageIDLabel(storageIDs[0])
+			vrgScheduleTest3Template.storageIDLabels = storageIDLabel
 			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest3Template, true, true)
 			vrgSchedule3Tests = append(vrgSchedule3Tests, v)
 		})
@@ -1188,6 +1284,12 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	Context("two default replicationclass exists", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
 			vrgScheduleTest4Template.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
+			storageIDLabel := genStorageIDLabel(storageIDs[0])
+			storageID := storageIDLabel[vrgController.StorageIDLabel]
+			vrgScheduleTest4Template.replicationClassLabels = genVRCLabels(replicationIDs[0], storageID, "ramen")
+			vrgScheduleTest4Template.additionalVRCInfoList[0].replicationClassLabels = genVRCLabels(
+				replicationIDs[0], storageID, "ramen")
+			vrgScheduleTest4Template.storageIDLabels = storageIDLabel
 			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest4Template, true, true)
 			vrgSchedule4Tests = append(vrgSchedule4Tests, v)
 		})
@@ -1227,6 +1329,12 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	Context("one default & one non-default replicationclass exists", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
 			vrgScheduleTest5Template.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
+			storageIDLabel := genStorageIDLabel(storageIDs[0])
+			storageID := storageIDLabel[vrgController.StorageIDLabel]
+			vrgScheduleTest5Template.replicationClassLabels = genVRCLabels(replicationIDs[0], storageID, "ramen")
+			vrgScheduleTest5Template.additionalVRCInfoList[0].replicationClassLabels = genVRCLabels(
+				replicationIDs[0], storageID, "ramen")
+			vrgScheduleTest5Template.storageIDLabels = storageIDLabel
 			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest5Template, true, true)
 			vrgSchedule5Tests = append(vrgSchedule5Tests, v)
 		})
@@ -1273,6 +1381,17 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	Context("two non-default replicationclass exists", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
 			vrgScheduleTest6Template.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
+			storageIDLabel := genStorageIDLabel(storageIDs[0])
+			storageID := storageIDLabel[vrgController.StorageIDLabel]
+			vrgScheduleTest6Template.replicationClassLabels = map[string]string{
+				vrgController.VolumeReplicationIDLabel: replicationIDs[0],
+				vrgController.StorageIDLabel:           storageID,
+			}
+			vrgScheduleTest6Template.additionalVRCInfoList[0].replicationClassLabels = genVRCLabels(
+				replicationIDs[0], storageID, "ramen")
+			vrgScheduleTest6Template.additionalVRCInfoList[1].replicationClassLabels = genVRCLabels(
+				replicationIDs[0], storageID, "ramen")
+			vrgScheduleTest6Template.storageIDLabels = storageIDLabel
 			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest6Template, true, true)
 			vrgSchedule6Tests = append(vrgSchedule6Tests, v)
 		})
@@ -1308,6 +1427,7 @@ type vrgTest struct {
 	skipCreationPVandPVC bool
 	checkBind            bool
 	vrgFirst             bool
+	asyncPeerClasses     []ramendrv1alpha1.PeerClass
 	template             *template
 }
 
@@ -1324,6 +1444,7 @@ type template struct {
 	vrcProvisioner         string
 	scProvisioner          string
 	storageClassName       string
+	storageIDLabels        map[string]string
 	replicationClassName   string
 	replicationClassLabels map[string]string
 	additionalVRCInfoList  []*additionalVRCInfo
@@ -1347,6 +1468,15 @@ func newRandomNamespaceSuffix() string {
 
 func newVRGTestCaseCreate(pvcCount int, testTemplate *template, checkBind, vrgFirst bool) *vrgTest {
 	objectNameSuffix := newRandomNamespaceSuffix()
+	appendSuffix := func(name string) string {
+		return fmt.Sprintf("%s.%s", name, objectNameSuffix)
+	}
+
+	if testTemplate.storageClassName != "" {
+		testTemplate.storageClassName = appendSuffix(testTemplate.storageClassName)
+	}
+
+	testTemplate.replicationClassName = appendSuffix(testTemplate.replicationClassName)
 
 	v := &vrgTest{
 		uniqueID:         objectNameSuffix,
@@ -1403,8 +1533,19 @@ func (v *vrgTest) VRGTestCaseStart() {
 // is that, until pvc is not bound, VolRep resources should not be created
 // by VRG.
 func newVRGTestCaseCreateAndStart(pvcCount int, testTemplate *template, checkBind, vrgFirst bool) *vrgTest {
+	var replicationID string
+
 	v := newVRGTestCaseCreate(pvcCount, testTemplate, checkBind, vrgFirst)
 
+	if len(testTemplate.replicationClassLabels) == 0 {
+		replicationID = replicationIDs[0]
+	} else {
+		replicationID = testTemplate.replicationClassLabels[vrgController.VolumeReplicationIDLabel]
+	}
+
+	storageID := testTemplate.storageIDLabels[vrgController.StorageIDLabel]
+	asyncPeerClass := genPeerClass(replicationID, testTemplate.storageClassName, []string{storageID})
+	v.asyncPeerClasses = []ramendrv1alpha1.PeerClass{asyncPeerClass}
 	v.VRGTestCaseStart()
 
 	return v
@@ -1678,6 +1819,7 @@ func (v *vrgTest) createVRG() {
 			Async: &ramendrv1alpha1.VRGAsyncSpec{
 				SchedulingInterval:       schedulingInterval,
 				ReplicationClassSelector: metav1.LabelSelector{MatchLabels: replicationClassLabels},
+				PeerClasses:              v.asyncPeerClasses,
 			},
 			VolSync: ramendrv1alpha1.VolSyncSpec{
 				Disabled: !v.template.volsyncEnabled,
@@ -1704,11 +1846,19 @@ func (v *vrgTest) vrgS3ProfilesSet(names []string) {
 	Expect(vrg.Spec.S3Profiles).To(Equal(names), "%#v", vrg.Spec.S3Profiles)
 }
 
+func (v *vrgTest) createSC(testTemplate *template) {
+	createStorageClass(testTemplate)
+}
+
 func (v *vrgTest) createVRC(testTemplate *template) {
+	createVolumeReplicationClass(testTemplate)
+}
+
+func createVolumeReplicationClass(testTemplate *template) {
 	defaultAnnotations := map[string]string{}
 	defaultAnnotations["replication.storage.openshift.io/is-default-class"] = "true"
 
-	By("creating VRC " + v.replicationClass)
+	By("creating VRC " + testTemplate.replicationClassName)
 
 	parameters := make(map[string]string)
 
@@ -1718,7 +1868,7 @@ func (v *vrgTest) createVRC(testTemplate *template) {
 
 	vrc := &volrep.VolumeReplicationClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        v.replicationClass,
+			Name:        testTemplate.replicationClassName,
 			Annotations: defaultAnnotations,
 		},
 		Spec: volrep.VolumeReplicationClassSpec{
@@ -1736,12 +1886,12 @@ func (v *vrgTest) createVRC(testTemplate *template) {
 	err := k8sClient.Create(context.TODO(), vrc)
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
-			err = k8sClient.Get(context.TODO(), types.NamespacedName{Name: v.replicationClass}, vrc)
+			err = k8sClient.Get(context.TODO(), types.NamespacedName{Name: testTemplate.replicationClassName}, vrc)
 		}
 	}
 
 	Expect(err).NotTo(HaveOccurred(),
-		"failed to create/get VolumeReplicationClass %s/%s", v.replicationClass, v.vrgName)
+		"failed to create/get VolumeReplicationClass %s", testTemplate.replicationClassName)
 
 	for _, vrcInfo := range testTemplate.additionalVRCInfoList {
 		vrc := vrcCopy.DeepCopy()
@@ -1755,17 +1905,13 @@ func (v *vrgTest) createVRC(testTemplate *template) {
 		err := k8sClient.Create(context.TODO(), vrc)
 		if err != nil {
 			if errors.IsAlreadyExists(err) {
-				err = k8sClient.Get(context.TODO(), types.NamespacedName{Name: v.replicationClass}, vrc)
+				err = k8sClient.Get(context.TODO(), types.NamespacedName{Name: testTemplate.replicationClassName}, vrc)
 			}
 		}
 
 		Expect(err).NotTo(HaveOccurred(),
-			"failed to create/get VolumeReplicationClass %s/%s", v.replicationClass, v.vrgName)
+			"failed to create/get VolumeReplicationClass %s", testTemplate.replicationClassName)
 	}
-}
-
-func (v *vrgTest) createSC(testTemplate *template) {
-	createStorageClass(testTemplate)
 }
 
 func createStorageClass(testTemplate *template) {
@@ -1777,7 +1923,8 @@ func createStorageClass(testTemplate *template) {
 
 	sc := &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: testTemplate.storageClassName,
+			Name:   testTemplate.storageClassName,
+			Labels: testTemplate.storageIDLabels,
 		},
 		Provisioner: testTemplate.scProvisioner,
 	}
@@ -1790,7 +1937,7 @@ func createStorageClass(testTemplate *template) {
 	}
 
 	Expect(err).NotTo(HaveOccurred(),
-		"failed to create/get StorageClass %s/%s", testTemplate.storageClassName, testTemplate.storageClassName)
+		"failed to create/get StorageClass %s", testTemplate.storageClassName)
 }
 
 func (v *vrgTest) verifyPVCBindingToPV(shouldBeBound bool) {
@@ -2260,12 +2407,20 @@ func (v *vrgTest) cleanupVRG() {
 }
 
 func (v *vrgTest) cleanupSC() {
-	if v.storageClass == "" {
+	cleanupStorageClass(v.template)
+}
+
+func (v *vrgTest) cleanupVRC() {
+	cleanupVolumeReplicationClass(v.template)
+}
+
+func cleanupStorageClass(testTemplate *template) {
+	if testTemplate.storageClassName == "" {
 		return
 	}
 
 	key := types.NamespacedName{
-		Name: v.storageClass,
+		Name: testTemplate.storageClassName,
 	}
 
 	sc := &storagev1.StorageClass{}
@@ -2279,10 +2434,10 @@ func (v *vrgTest) cleanupSC() {
 
 	err = k8sClient.Delete(context.TODO(), sc)
 	Expect(err).To(BeNil(),
-		"failed to delete StorageClass %s", v.storageClass)
+		"failed to delete StorageClass %s", testTemplate.storageClassName)
 }
 
-func (v *vrgTest) cleanupVRC() {
+func cleanupVolumeReplicationClass(testTemplate *template) {
 	vrc := &volrep.VolumeReplicationClass{}
 
 	err := k8sClient.DeleteAllOf(context.TODO(), vrc)
@@ -2291,7 +2446,7 @@ func (v *vrgTest) cleanupVRC() {
 	}
 
 	Expect(err).To(BeNil(),
-		"failed to delete replicationClass %s", v.replicationClass)
+		"failed to delete replicationClass %s", testTemplate.replicationClassName)
 }
 
 func (v *vrgTest) cleanupNamespace() {
@@ -2650,4 +2805,27 @@ func (v *vrgTest) waitForVRGStateToTransitionToPrimary() {
 	Eventually(func() bool {
 		return v.getVRG().Status.State == ramendrv1alpha1.PrimaryState
 	}, timeout, interval).Should(BeTrue())
+}
+
+func genStorageIDLabel(storageID string) map[string]string {
+	return map[string]string{
+		vrgController.StorageIDLabel: storageID,
+	}
+}
+
+func genPeerClass(replicationID, storageClassName string, storageIDs []string) ramendrv1alpha1.PeerClass {
+	return ramendrv1alpha1.PeerClass{
+		ReplicationID:    replicationID,
+		StorageID:        storageIDs,
+		StorageClassName: storageClassName,
+	}
+}
+
+//nolint:unparam
+func genVRCLabels(replicationID, storageID, protectionKey string) map[string]string {
+	return map[string]string{
+		vrgController.VolumeReplicationIDLabel: replicationID,
+		vrgController.StorageIDLabel:           storageID,
+		"protection":                           protectionKey,
+	}
 }


### PR DESCRIPTION
Select select right VRC or VSC from the list of PeerClasses when multiple storageClasses are present. 

Following were tested: 

- Setup: 
  - 4 storageClasses 
      - 2 for RBD 
      - 2 for CephFS
- Tests:
	-  One RBD workload with multiple PVCs with different storageClass for each PVC   
		- Observed:
		   	- ReplicationClasses were created for each PVC matching storageClass
		   	- Failover and relocation were successful

	- One CephFS workload with multiple PVC with different storageClass for each PVC
		- Observed: 
			- VolsnapClasses were created for each PVC matching storageClass
			- Failover and relocation were successful

