### PR TITLE
Enable DRPC Consistency Groups Using an Annotation

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -1590,6 +1590,7 @@ func (d *DRPCInstance) generateVRG(dstCluster string, repState rmn.ReplicationSt
 				DestinationClusterAnnotationKey: dstCluster,
 				DoNotDeletePVCAnnotation:        d.instance.GetAnnotations()[DoNotDeletePVCAnnotation],
 				DRPCUIDAnnotation:               string(d.instance.UID),
+				rmnutil.IsCGEnabledAnnotation:   d.instance.GetAnnotations()[rmnutil.IsCGEnabledAnnotation],
 			},
 		},
 		Spec: rmn.VolumeReplicationGroupSpec{

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -2839,6 +2839,8 @@ func constructVRGFromView(viewVRG *rmn.VolumeReplicationGroup) *rmn.VolumeReplic
 			fallthrough
 		case DoNotDeletePVCAnnotation:
 			fallthrough
+		case rmnutil.IsCGEnabledAnnotation:
+			fallthrough
 		case DRPCUIDAnnotation:
 			rmnutil.AddAnnotation(vrg, k, v)
 		default:

--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -20,6 +20,8 @@ import (
 const (
 	OCMBackupLabelKey   string = "cluster.open-cluster-management.io/backup"
 	OCMBackupLabelValue string = "ramen"
+
+	IsCGEnabledAnnotation = "drplacementcontrol.ramendr.openshift.io/is-cg-enabled"
 )
 
 type ResourceUpdater struct {
@@ -211,4 +213,12 @@ func CreateNamespaceIfNotExists(ctx context.Context, k8sClient client.Client, na
 	}
 
 	return nil
+}
+
+func IsCGEnabled(annotations map[string]string) bool {
+	if annotations == nil {
+		return false
+	}
+
+	return annotations[IsCGEnabledAnnotation] == "true"
 }

--- a/internal/controller/util/misc_test.go
+++ b/internal/controller/util/misc_test.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package util_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/ramendr/ramen/internal/controller/util"
+)
+
+var _ = Describe("misc", func() {
+	Expect(util.IsCGEnabled(nil)).Should(Equal(false))
+	Expect(util.IsCGEnabled(map[string]string{})).Should(Equal(false))
+	Expect(util.IsCGEnabled(map[string]string{util.IsCGEnabledAnnotation: "true"})).Should(Equal(true))
+})


### PR DESCRIPTION
Both annotations and the DRPC spec allow us to enable consistency groups (CG) per-DRPC basis, providing more granular control than a global configuration. However, we chose to use annotations instead of modifying the DRPC spec to prepare for the future full use of CG. As CG usage matures, we will gradually phase out non-CG snapshotting and replication. Using an annotation also makes it easier to remove for backward compatibility.