### PR TITLE
Disable rbd debug logs by default

### DIFF
--- a/test/addons/rbd-mirror/README.md
+++ b/test/addons/rbd-mirror/README.md
@@ -1,0 +1,16 @@
+# rbd-mirror addon
+
+## Enabling debug logs
+
+If Ceph developers require debug logs you can enable them by starting
+the environment with RBD_MIRROR_DEBUG=1:
+
+```
+RBD_MIRROR_DEBUG=1 drenv start envs/regional-dr.yaml
+```
+
+If the environment is already running you can enable the logs using:
+
+```
+RBD_MIRROR_DEBUG=1 addons/rbd-mirror/start dr1 dr2
+```

--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -239,13 +239,13 @@ os.chdir(os.path.dirname(__file__))
 cluster1 = sys.argv[1]
 cluster2 = sys.argv[2]
 
-# Run with RBD_MIRROR_DEBUG=0 to disable debug logs.
-if os.environ.get("RBD_MIRROR_DEBUG") == "0":
-    disable_rbd_mirror_debug_logs(cluster1)
-    disable_rbd_mirror_debug_logs(cluster2)
-else:
+# Run with RBD_MIRROR_DEBUG=1 to enable debug logs.
+if os.environ.get("RBD_MIRROR_DEBUG") == "1":
     enable_rbd_mirror_debug_logs(cluster1)
     enable_rbd_mirror_debug_logs(cluster2)
+else:
+    disable_rbd_mirror_debug_logs(cluster1)
+    disable_rbd_mirror_debug_logs(cluster2)
 
 cluster1_info = fetch_secret_info(cluster1)
 cluster2_info = fetch_secret_info(cluster2)


### PR DESCRIPTION
The debug logs generate gigabytes of logs when running an environment for long time, finally filling the minikube disk and causing the VM to pause. So far we need the logs once and paying for the logs without any benefit does not make sense.