### PR TITLE
Gather environment on test failures

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -13,6 +13,7 @@ env:
   NAME_PREFIX: "rdr-"
   # Limit number of drenv workers.
   MAX_WORKERS: 4
+  GATHER_DIR: gather.${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
   e2e-rdr:
@@ -67,6 +68,29 @@ jobs:
       run: |
         cat ~/.config/drenv/${{ env.NAME_PREFIX }}rdr/config.yaml >> e2e/config.yaml
         make e2e-rdr
+
+    - name: Gather environment data
+      if: failure()
+      working-directory: test
+      run: drenv gather --directory ${{ env.GATHER_DIR }} --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
+
+    # Tar manually to work around github limitations with special chracters (:)
+    # in file names, and getting much smaller archives comapred with zip (6m vs
+    # 12m).
+    # https://github.com/actions/upload-artifact/issues/546
+    - name: Archive gathered data
+      if: failure()
+      working-directory: test
+      run: tar czf ${{ env.GATHER_DIR }}.tar.gz ${{ env.GATHER_DIR }}
+
+    - name: Upload artifacts
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.GATHER_DIR }}
+        path: test/${{ env.GATHER_DIR }}.tar.gz
+        compression-level: 0
+        retention-days: 15
 
     - name: Delete clusters
       if: always()

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,7 +34,7 @@ jobs:
       run: pip install -e ramenctl
 
     - name: Delete clusters
-      if: ${{ always() }}
+      if: always()
       working-directory: test
       run: drenv delete --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
 
@@ -69,11 +69,11 @@ jobs:
         make e2e-rdr
 
     - name: Delete clusters
-      if: ${{ always() }}
+      if: always()
       working-directory: test
       run: drenv delete --name-prefix ${{ env.NAME_PREFIX }} envs/regional-dr.yaml
 
     - name: Cleanup drenv
-      if: ${{ always() }}
+      if: always()
       working-directory: test
       run: drenv cleanup -v

--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -199,6 +199,16 @@ enough resources:
 
    For more info see [argocd installation](https://argo-cd.readthedocs.io/en/stable/cli_installation/)
 
+1. Install the `kubectl-gather` plugin
+
+   ```
+   curl -L -o kubectl-gather https://github.com/nirs/kubectl-gather/releases/download/v0.4.1/kubectl-gather-v0.4.1-linux-amd64
+   sudo install kubectl-gather /usr/local/bin
+   rm kubectl-gather
+   ```
+
+   For more info see [kubectl-gather](https://github.com/nirs/kubectl-gather)
+
 1. Install `helm` tool - on Fedora you can use:
 
    ```

--- a/test/README.md
+++ b/test/README.md
@@ -107,6 +107,16 @@ environment.
 
    For more info see [argocd installation](https://argo-cd.readthedocs.io/en/stable/cli_installation/)
 
+1. Install the `kubectl-gather` plugin
+
+   ```
+   curl -L -o kubectl-gather https://github.com/nirs/kubectl-gather/releases/download/v0.4.1/kubectl-gather-v0.4.1-linux-amd64
+   sudo install kubectl-gather /usr/local/bin
+   rm kubectl-gather
+   ```
+
+   For more info see [kubectl-gather](https://github.com/nirs/kubectl-gather)
+
 ### Testing that drenv is healthy
 
 Run this script to make sure `drenv` works:

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -95,6 +95,19 @@ def parse_args():
         help="maximum number of workers per profile",
     )
 
+    p = add_command(sp, "gather", do_gather, help="gather environment data")
+    p.add_argument(
+        "-d",
+        "--directory",
+        help='directory for storing gathered data (default "gather.{timestamp}")',
+    )
+    p.add_argument(
+        "-n",
+        "--namespaces",
+        type=lambda s: s.split(","),
+        help="if specified, comma separated list of namespaces to gather data from",
+    )
+
     add_command(sp, "delete", do_delete, help="delete an environment")
     add_command(sp, "suspend", do_suspend, help="suspend virtual machines")
     add_command(sp, "resume", do_resume, help="resume virtual machines")
@@ -243,6 +256,22 @@ def do_stop(args):
     execute(stop_cluster, env["profiles"], "profiles", hooks=hooks)
     logging.info(
         "[%s] Environment stopped in %.2f seconds",
+        env["name"],
+        time.monotonic() - start,
+    )
+
+
+def do_gather(args):
+    env = load_env(args)
+    start = time.monotonic()
+    logging.info("[%s] Gathering environment", env["name"])
+    kubectl.gather(
+        [p["name"] for p in env["profiles"]],
+        directory=args.directory,
+        namespaces=args.namespaces,
+    )
+    logging.info(
+        "[%s] Environment gathered in %.2f seconds",
         env["name"],
         time.monotonic() - start,
     )

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -59,33 +59,46 @@ def parse_args():
         required=True,
     )
 
-    start_parser = add_command(sp, "start", do_start, help="start an environment")
-    start_parser.add_argument(
+    p = add_command(sp, "start", do_start, help="start an environment")
+    p.add_argument(
         "--skip-tests",
         dest="run_tests",
         action="store_false",
         help="Do not run addons 'test' hooks",
     )
-    start_parser.add_argument(
+    p.add_argument(
         "--skip-addons",
         dest="run_addons",
         action="store_false",
         help="Do not run addons 'start' hooks",
     )
+    p.add_argument(
+        "--max-workers",
+        type=int,
+        metavar="N",
+        help="maximum number of workers per profile",
+    )
 
-    stop_parser = add_command(sp, "stop", do_stop, help="stop an environment")
-    stop_parser.add_argument(
+    p = add_command(sp, "stop", do_stop, help="stop an environment")
+    p.add_argument(
         "--skip-addons",
         dest="run_addons",
         action="store_false",
         help="Do not run addons 'stop' hooks",
     )
 
+    p = add_command(sp, "cache", do_cache, help="cache environment resources")
+    p.add_argument(
+        "--max-workers",
+        type=int,
+        metavar="N",
+        help="maximum number of workers per profile",
+    )
+
     add_command(sp, "delete", do_delete, help="delete an environment")
     add_command(sp, "suspend", do_suspend, help="suspend virtual machines")
     add_command(sp, "resume", do_resume, help="resume virtual machines")
     add_command(sp, "dump", do_dump, help="dump an environment yaml")
-    add_command(sp, "cache", do_cache, help="cache environment resources")
 
     add_command(sp, "clear", do_clear, help="cleared cached resources", envfile=False)
     add_command(sp, "setup", do_setup, help="setup minikube for drenv", envfile=False)
@@ -103,12 +116,6 @@ def add_command(sp, name, func, help=None, envfile=True):
             "--name-prefix",
             metavar="PREFIX",
             help="prefix profile names",
-        )
-        parser.add_argument(
-            "--max-workers",
-            type=int,
-            metavar="N",
-            help="maximum number of workers per profile",
         )
         parser.add_argument("filename", help="path to environment file")
     return parser

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -177,6 +177,18 @@ def watch(
     return commands.watch(*cmd, timeout=timeout)
 
 
+def gather(contexts, namespaces=None, directory=None):
+    """
+    Run kubectl gather plugin.
+    """
+    cmd = ["kubectl", "gather", "--contexts", ",".join(contexts)]
+    if namespaces:
+        cmd.extend(("--namespaces", ",".join(namespaces)))
+    if directory:
+        cmd.extend(("--directory", directory))
+    commands.run(*cmd)
+
+
 def _run(cmd, *args, context=None):
     cmd = ["kubectl", cmd]
     if context:

--- a/test/stress-test/run
+++ b/test/stress-test/run
@@ -121,12 +121,19 @@ def run(name, args):
     log = os.path.join(args.outdir, name + ".log")
 
     start = time.monotonic()
-    cp = drenv("start", args.envfile, log, name_prefix=args.name_prefix)
+    cp = drenv("start", args.envfile, log, name_prefix=args.name_prefix, verbose=True)
     elapsed = time.monotonic() - start
     passed = cp.returncode == 0
 
     if passed or not args.exit_first:
-        drenv("delete", args.envfile, log, name_prefix=args.name_prefix, check=True)
+        drenv(
+            "delete",
+            args.envfile,
+            log,
+            name_prefix=args.name_prefix,
+            verbose=True,
+            check=True,
+        )
 
     return {
         "name": name,
@@ -135,10 +142,19 @@ def run(name, args):
     }
 
 
-def drenv(command, envfile, log, name_prefix=None, check=False):
-    cmd = ["drenv", command, "--verbose"]
+def drenv(
+    command,
+    envfile,
+    log,
+    name_prefix=None,
+    verbose=False,
+    check=False,
+):
+    cmd = ["drenv", command]
     if name_prefix:
         cmd.extend(("--name-prefix", name_prefix))
+    if verbose:
+        cmd.append("--verbose")
     cmd.append(envfile)
     with open(log, "a") as f:
         return subprocess.run(cmd, stderr=f, check=check)

--- a/test/stress-test/run
+++ b/test/stress-test/run
@@ -125,6 +125,15 @@ def run(name, args):
     elapsed = time.monotonic() - start
     passed = cp.returncode == 0
 
+    if not passed:
+        drenv(
+            "gather",
+            args.envfile,
+            log,
+            name_prefix=args.name_prefix,
+            directory=os.path.join(args.outdir, name + ".gather"),
+        )
+
     if passed or not args.exit_first:
         drenv(
             "delete",
@@ -147,12 +156,15 @@ def drenv(
     envfile,
     log,
     name_prefix=None,
+    directory=None,
     verbose=False,
     check=False,
 ):
     cmd = ["drenv", command]
     if name_prefix:
         cmd.extend(("--name-prefix", name_prefix))
+    if directory:
+        cmd.extend(("--directory", directory))
     if verbose:
         cmd.append("--verbose")
     cmd.append(envfile)


### PR DESCRIPTION
Add drenv gather command using the kubectl-gather plugin, and use to gather the entire environment on test failures.

Example (simulated) test failure with gathered data:
https://github.com/RamenDR/ramen/actions/runs/10075519085

Gathered data example:

![Screenshot from 2024-07-24 15-34-05](https://github.com/user-attachments/assets/12e2d478-74b7-4bc6-8386-196329e05a30)
