### PR TITLE
drenv: Fix submariner for MacOS

### DIFF
--- a/test/addons/submariner/start
+++ b/test/addons/submariner/start
@@ -60,6 +60,7 @@ def join_cluster(cluster, broker_info):
         clusterid=cluster,
         cable_driver="vxlan",
         version=VERSION,
+        check_broker_certificate=False,
     )
 
 

--- a/test/drenv/subctl.py
+++ b/test/drenv/subctl.py
@@ -27,11 +27,20 @@ def deploy_broker(context, globalnet=False, broker_info=None, version=None, log=
         shutil.move(BROKER_INFO, broker_info)
 
 
-def join(broker_info, context, clusterid, cable_driver=None, version=None, log=print):
+def join(
+    broker_info,
+    context,
+    clusterid,
+    cable_driver=None,
+    version=None,
+    check_broker_certificate=True,
+    log=print,
+):
     """
     Run subctl join ... logging progress messages.
     """
     args = ["join", broker_info, "--context", context, "--clusterid", clusterid]
+    args.append(f"--check-broker-certificate={check_broker_certificate}")
     if cable_driver:
         args.extend(("--cable-driver", cable_driver))
     if version:


### PR DESCRIPTION
On Mac, the check for certs is more strict and it fails for submariner
service. Turning off the check for certs.

More info: golang/go#51991

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>