### PR TITLE
drenv: add missing namespace

### DIFF
--- a/test/addons/ocm-cluster/test
+++ b/test/addons/ocm-cluster/test
@@ -41,6 +41,7 @@ def wait_for_deployment(cluster, hub):
         "deploy/example-deployment",
         "--for=condition=available",
         "--timeout=120s",
+        "--namespace=default",
         context=cluster,
     )
 


### PR DESCRIPTION
In most cases, the context will be pointing to the default namespace and the command will work. However, if someone is using a krew plugin like https://github.com/ahmetb/kubectx, then it is possible that the resources are created in a different namespace and the test fails.