### PR TITLE
ramenctl improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,8 @@ docker-push: ## Push docker image with the manager.
 
 ##@ Deployment
 
+resources: manifests hub-config dr-cluster-config ## Prepare resources for deployment
+
 install: install-hub install-dr-cluster ## Install hub and dr-cluster CRDs into the K8s cluster specified in ~/.kube/config.
 
 uninstall: uninstall-hub uninstall-dr-cluster ## Uninstall hub and dr-cluster CRDs from the K8s cluster specified in ~/.kube/config.
@@ -233,9 +235,11 @@ install-hub: manifests kustomize ## Install hub CRDs into the K8s cluster specif
 uninstall-hub: manifests kustomize ## Uninstall hub CRDs from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/hub/crd | kubectl delete -f -
 
-deploy-hub: manifests kustomize ## Deploy hub controller to the K8s cluster specified in ~/.kube/config.
+hub-config: kustomize
 	cd config/hub/default/$(PLATFORM) && $(KUSTOMIZE) edit set image kube-rbac-proxy=$(RBAC_PROXY_IMG)
 	cd config/hub/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+
+deploy-hub: manifests kustomize hub-config ## Deploy hub controller to the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/hub/default/$(PLATFORM) | kubectl apply -f -
 
 undeploy-hub: kustomize ## Undeploy hub controller from the K8s cluster specified in ~/.kube/config.

--- a/ramenctl/ramenctl/config.py
+++ b/ramenctl/ramenctl/config.py
@@ -26,8 +26,6 @@ def run(args):
     if env["hub"]:
         hub_cm = generate_config_map("hub", env, args)
 
-        wait_for_ramen_hub_operator(env["hub"], args)
-
         create_ramen_s3_secrets(env["hub"], s3_secrets)
 
         create_ramen_config_map(env["hub"], hub_cm)
@@ -42,18 +40,6 @@ def run(args):
         for cluster in env["clusters"]:
             create_ramen_s3_secrets(cluster, s3_secrets)
             create_ramen_config_map(cluster, dr_cluster_cm)
-
-
-def wait_for_ramen_hub_operator(hub, args):
-    command.info("Waiting until ramen-hub-operator is rolled out")
-    kubectl.rollout(
-        "status",
-        "deploy/ramen-hub-operator",
-        f"--namespace={args.ramen_namespace}",
-        "--timeout=180s",
-        context=hub,
-        log=command.debug,
-    )
 
 
 def generate_ramen_s3_secrets(clusters, args):

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -43,6 +43,17 @@ def get(*args, context=None):
     return _run("get", *args, context=context)
 
 
+def kustomize(src, load_restrictor=None):
+    """
+    Run kubectl kustomize ... and return the output.
+    """
+    args = []
+    if load_restrictor:
+        args.append(f"--load-restrictor={load_restrictor}")
+    args.append(src)
+    return _run("kustomize", *args)
+
+
 def describe(*args, context=None):
     return _run("describe", *args, context=context)
 


### PR DESCRIPTION
Make ramenctl more reliable, faster, and simpler:

- Wait until ramen deployments are rolled
- Deploy clusters in parallel
