### PR TITLE
config: enable volsync for multinamespace feature by default

### DIFF
--- a/config/dr-cluster/manager/ramen_manager_config.yaml
+++ b/config/dr-cluster/manager/ramen_manager_config.yaml
@@ -16,5 +16,6 @@ volSync:
 ramenOpsNamespace: ramen-ops
 multiNamespace:
   FeatureEnabled: true
+  volsyncSupported: true
 kubeObjectProtection:
   veleroNamespaceName: velero

--- a/config/hub/manager/ramen_manager_config.yaml
+++ b/config/hub/manager/ramen_manager_config.yaml
@@ -16,5 +16,6 @@ volSync:
 ramenOpsNamespace: ramen-ops
 multiNamespace:
   FeatureEnabled: true
+  volsyncSupported: true
 kubeObjectProtection:
   veleroNamespaceName: velero


### PR DESCRIPTION
This PR enables the volsync feature for discovered apps.

For volsync PVCs, we don't clean up the VRG and therefore the progression never enters the `ProgressionWaitOnUserToCleanUp` state. This is by design for now.

Future work: We need to address the use-case where both VolumeReplication and Volsync PVCs can coexist.