### PR TITLE
Support testing bigger vms

### DIFF
--- a/test/drenv/minikube.py
+++ b/test/drenv/minikube.py
@@ -89,6 +89,8 @@ def start(
     if alsologtostderr:
         args.append("--alsologtostderr")
 
+    args.append("--insecure-registry=host.minikube.internal:5000")
+
     # TODO: Use --interactive=false when the bug is fixed.
     # https://github.com/kubernetes/minikube/issues/19518
 

--- a/test/envs/kubevirt.yaml
+++ b/test/envs/kubevirt.yaml
@@ -13,10 +13,10 @@ profiles:
         io.containerd.grpc.v1.cri:
           device_ownership_from_security_context: true
     network: $network
-    cpus: 4
-    memory: "8g"
+    cpus: 8
+    memory: "16g"
     extra_disks: 1
-    disk_size: "50g"
+    disk_size: "100g"
     workers:
       - addons:
           - name: rook-operator

--- a/test/registry/README.md
+++ b/test/registry/README.md
@@ -16,7 +16,7 @@
        --volume registry:/var/lib/registry:Z \
        --detach \
        --replace \
-       docker.io/library/registry:latest
+       docker.io/library/registry:2
    ```
 
    Use `--replace` to replace an existing container, typically left

--- a/test/registry/README.md
+++ b/test/registry/README.md
@@ -16,7 +16,7 @@
        --volume registry:/var/lib/registry:Z \
        --detach \
        --replace \
-       docker.io/library/registry:2
+       quay.io/libpod/registry:2
    ```
 
    Use `--replace` to replace an existing container, typically left

--- a/test/registry/systemd/registry.container
+++ b/test/registry/systemd/registry.container
@@ -4,7 +4,7 @@ Description=Registry container
 [Container]
 Label=app=registry
 ContainerName=registry
-Image=docker.io/library/registry:2
+Image=quay.io/libpod/registry:2
 PublishPort=5000:5000
 Volume=registry.volume:/var/lib/registry
 

--- a/test/registry/systemd/registry.container
+++ b/test/registry/systemd/registry.container
@@ -4,7 +4,7 @@ Description=Registry container
 [Container]
 Label=app=registry
 ContainerName=registry
-Image=docker.io/library/registry:latest
+Image=docker.io/library/registry:2
 PublishPort=5000:5000
 Volume=registry.volume:/var/lib/registry
 

--- a/test/scripts/watch-replication
+++ b/test/scripts/watch-replication
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+When we demonstrate DR flows, we want to make changes in the application
+data before failover or relocate, and then wait at least one replication
+interval, ensuring that replication started after our changes were made.
+
+Example usage with 1m replication interval:
+
+    $ scripts/watch-replication fedora-drpc-1
+    2024-08-07T22:12:01Z Replication updated
+    2024-08-07T22:13:00Z Replication updated
+
+Flow:
+
+1. Start watching the app
+2. When you see the first message, write data in the app
+3. When you see the second message, start failover or relocate
+
+The total wait time is less than 2 replication intervals.
+"""
+
+import argparse
+import time
+
+from drenv import kubectl
+
+
+def main():
+    args = parse_args()
+    last = last_group_sync_time(args)
+
+    try:
+        while True:
+            time.sleep(10)
+            current = last_group_sync_time(args)
+            if current != last:
+                print(f"{current} Replication updated")
+                last = current
+    except KeyboardInterrupt:
+        print()
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("-d", "--drpc", required=True, help="drpc name")
+    p.add_argument("-n", "--namespace", required=True, help="application namespace")
+    p.add_argument("--context", help="hub cluster context")
+    args = p.parse_args()
+    return args
+
+
+def last_group_sync_time(args):
+    return kubectl.get(
+        f"drpc/{args.drpc}",
+        "--output=jsonpath={.status.lastGroupSyncTime}",
+        f"--namespace={args.namespace}",
+        context=args.context,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Various tweaks to support testing bigger vms with more cpus, memory, and large disks.

- Add script for watching replication changes
- Allow pulling from insecure local registry
- Use registry:v2 instead of latest
- Use registry image from quay.io
- Enlarge kubevirt environment
