### PR TITLE
Support drenv on Apple silicon with the new vfkit driver

### DIFF
--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -47,6 +47,7 @@ def main():
         sys.exit(1)
     finally:
         shutdown_executors()
+        # XXX Does not work for vfkit driver
         terminate_process_group()
 
 

--- a/test/drenv/envfile.py
+++ b/test/drenv/envfile.py
@@ -12,9 +12,39 @@ CONTAINER = "$container"
 SHARED_NETWORK = "$network"
 
 _PLATFORM_DEFAULTS = {
-    "__default__": {VM: "", CONTAINER: "", SHARED_NETWORK: ""},
-    "linux": {VM: "kvm2", CONTAINER: "docker", SHARED_NETWORK: "default"},
-    "darwin": {VM: "hyperkit", CONTAINER: "podman", SHARED_NETWORK: ""},
+    "__default__": {
+        VM: {
+            "x86_64": "",
+            "arm64": "",
+        },
+        CONTAINER: "",
+        SHARED_NETWORK: {
+            "x86_64": "",
+            "arm64": "",
+        },
+    },
+    "linux": {
+        VM: {
+            "x86_64": "kvm2",
+            "arm64": "",
+        },
+        CONTAINER: "docker",
+        SHARED_NETWORK: {
+            "x86_64": "default",
+            "arm64": "",
+        },
+    },
+    "darwin": {
+        VM: {
+            "x86_64": "hyperkit",
+            "arm64": "",
+        },
+        CONTAINER: "podman",
+        SHARED_NETWORK: {
+            "x86_64": "",
+            "arm64": "",
+        },
+    },
 }
 
 
@@ -118,14 +148,15 @@ def _validate_profile(profile, addons_root):
 
 def _validate_platform_defaults(profile):
     platform = platform_defaults()
+    machine = os.uname().machine
 
     if profile["driver"] == VM:
-        profile["driver"] = platform[VM]
+        profile["driver"] = platform[VM][machine]
     elif profile["driver"] == CONTAINER:
         profile["driver"] = platform[CONTAINER]
 
     if profile["network"] == SHARED_NETWORK:
-        profile["network"] = platform[SHARED_NETWORK]
+        profile["network"] = platform[SHARED_NETWORK][machine]
 
 
 def _validate_worker(worker, env, addons_root, index):

--- a/test/drenv/envfile.py
+++ b/test/drenv/envfile.py
@@ -37,7 +37,7 @@ _PLATFORM_DEFAULTS = {
     "darwin": {
         VM: {
             "x86_64": "hyperkit",
-            "arm64": "",
+            "arm64": "vfkit",
         },
         CONTAINER: "podman",
         SHARED_NETWORK: {

--- a/test/drenv/envfile_test.py
+++ b/test/drenv/envfile_test.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import io
+import os
+
 import pytest
 from collections import namedtuple
 
@@ -86,10 +88,11 @@ workers:
 def test_driver(valid_env):
     env = envfile.load(valid_env.file, addons_root=valid_env.addons_root)
     platform_defaults = envfile.platform_defaults()
+    machine = os.uname().machine
 
     # no driver
     profile = env["profiles"][0]
-    assert profile["driver"] == platform_defaults[envfile.VM]
+    assert profile["driver"] == platform_defaults[envfile.VM][machine]
 
     # concrete driver
     profile = env["profiles"][1]
@@ -101,12 +104,13 @@ def test_driver(valid_env):
 
     # platform vm driver
     profile = env["profiles"][3]
-    assert profile["driver"] == platform_defaults[envfile.VM]
+    assert profile["driver"] == platform_defaults[envfile.VM][machine]
 
 
 def test_network(valid_env):
     env = envfile.load(valid_env.file, addons_root=valid_env.addons_root)
     platform_defaults = envfile.platform_defaults()
+    machine = os.uname().machine
 
     # no network
     profile = env["profiles"][0]
@@ -118,7 +122,7 @@ def test_network(valid_env):
 
     # platform drenv-shared network
     profile = env["profiles"][2]
-    assert profile["network"] == platform_defaults[envfile.SHARED_NETWORK]
+    assert profile["network"] == platform_defaults[envfile.SHARED_NETWORK][machine]
 
 
 def test_valid(valid_env):


### PR DESCRIPTION
Change drenv to support the new experimental vfkit driver on Apple silicon.

Issues:
- Missing rosetta support
- We don't have a way to create shared network allowing access between vms
- Nested virtualization is not supported yet, and it may work only on M3+ cpus