### PR TITLE
Fix kubeobjects RequestProcessingError comparison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,9 @@ test-util: generate manifests envtest ## Run util tests.
 test-util-pvc: generate manifests envtest ## Run util-pvc tests.
 	 go test ./internal/controller/util -coverprofile cover.out  -ginkgo.focus PVCS_Util
 
+test-kubeobjects: ## Run kubeobjects tests.
+	 go test ./internal/controller/kubeobjects -coverprofile cover.out  -ginkgo.focus Kubeobjects
+
 test-drenv: ## Run drenv tests.
 	$(MAKE) -C test
 

--- a/internal/controller/kubeobjects/kubeobjects_suite_test.go
+++ b/internal/controller/kubeobjects/kubeobjects_suite_test.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kubeobjects_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestKubeobjects(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kubeobjects Suite")
+}

--- a/internal/controller/kubeobjects/requests.go
+++ b/internal/controller/kubeobjects/requests.go
@@ -107,7 +107,13 @@ type HookSpec struct {
 
 func RequestProcessingErrorCreate(s string) RequestProcessingError { return RequestProcessingError{s} }
 func (e RequestProcessingError) Error() string                     { return e.string }
-func (RequestProcessingError) Is(err error) bool                   { return true }
+
+// Called by errors.Is() to match target.
+func (RequestProcessingError) Is(target error) bool {
+	_, ok := target.(RequestProcessingError)
+
+	return ok
+}
 
 type RequestsManager interface {
 	ProtectsPath() string

--- a/internal/controller/kubeobjects/requests_test.go
+++ b/internal/controller/kubeobjects/requests_test.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kubeobjects_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/ramendr/ramen/internal/controller/kubeobjects"
+)
+
+var _ = Describe("kubeobjects", func() {
+	Context("comparing errors", func() {
+		err := kubeobjects.RequestProcessingErrorCreate("error")
+		other := kubeobjects.RequestProcessingErrorCreate("other")
+
+		It("is not equal", func() {
+			Expect(other == err).To(Equal(false))
+		})
+		It("is same error", func() {
+			Expect(errors.Is(other, err)).To(Equal(true))
+		})
+		It("is not same error", func() {
+			Expect(errors.Is(err, errors.New("error"))).To(Equal(false))
+		})
+	})
+})


### PR DESCRIPTION
RequestProcessingError.Is() was broken, matching any error. Fix it to match only another instance of RequestProcessingError.