### PR TITLE
kubeobjects: disable hooks

### DIFF
--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -716,6 +716,10 @@ func getCaptureGroups(recipe Recipe.Recipe) ([]kubeobjects.CaptureSpec, error) {
 		for resourceType := range resource {
 			resourceName := resource[resourceType]
 
+			if resourceType == "hook" {
+				continue
+			}
+
 			captureInstance, err := getResourceAndConvertToCaptureGroup(recipe, resourceType, resourceName)
 			if err != nil {
 				return resources, err
@@ -736,6 +740,10 @@ func getRecoverGroups(recipe Recipe.Recipe) ([]kubeobjects.RecoverSpec, error) {
 		// group: map[string]string, e.g. "group": "groupName", or "hook": "hookName"
 		for resourceType := range resource {
 			resourceName := resource[resourceType]
+
+			if resourceType == "hook" {
+				continue
+			}
 
 			captureInstance, err := getResourceAndConvertToRecoverGroup(recipe, resourceType, resourceName)
 			if err != nil {


### PR DESCRIPTION
So far, we don't have the ability to run hooks specified in a recipe. We
were wrongly passing these hooks to velero in the capture or recover
spec.

This commit disables the hooks completely by skipping them. In a later
PR, we will add the ability to run the hooks in the recipe natively in
Ramen.