### PR TITLE
Introduce drenv providers

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Setup drenv
       working-directory: test
-      run: drenv setup -v
+      run: drenv setup -v envs/regional-dr.yaml
 
     - name: Install ramenctl
       run: pip install -e ramenctl
@@ -100,4 +100,4 @@ jobs:
     - name: Cleanup drenv
       if: always()
       working-directory: test
-      run: drenv cleanup -v
+      run: drenv cleanup -v envs/regional-dr.yaml

--- a/hack/make-venv
+++ b/hack/make-venv
@@ -27,9 +27,6 @@ cp coverage.pth $venv/lib/python*/site-packages
 echo "Adding venv symlink..."
 ln -sf $venv/bin/activate venv
 
-echo "Setting up minikube for drenv"
-$venv/bin/drenv setup -v
-
 echo
 echo "To activate the environment run:"
 echo

--- a/test/Makefile
+++ b/test/Makefile
@@ -50,7 +50,7 @@ coverage-html:
 	xdg-open htmlcov/index.html
 
 cluster:
-	drenv start --name-prefix $(prefix) $(env)
+	drenv start --name-prefix $(prefix) $(env) -v
 
 clean:
 	drenv delete --name-prefix $(prefix) $(env)

--- a/test/README.md
+++ b/test/README.md
@@ -539,9 +539,11 @@ $ drenv delete envs/example.yaml
 
 - `templates`: templates for creating new profiles.
     - `name`: profile name.
-    - `external`: true if this is existing external cluster. In this
-      case the tool will not start a minikube cluster and all other
-      options are ignored.
+    - `provider`: cluster provider. The default provider is "minikube",
+      creating cluster using VM or containers.  Use "external" to use
+      exsiting clusters not managed by `drenv`. Use the special value
+      "$provider" to select the best provider for the host. (default
+      "$provider")
     - `driver`: The minikube driver. On Linux, the default drivers are kvm2 and
       docker for VMs and containers. On MacOS, the defaults are hyperkit and
       podman. Use "$vm" and "$container" values to use the recommended VM and

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -187,7 +187,7 @@ def do_setup(args):
     for name in set(p["provider"] for p in env["profiles"]):
         logging.info("[main] Setting up '%s' for drenv", name)
         provider = providers.get(name)
-        provider.setup_files()
+        provider.setup()
 
 
 def do_cleanup(args):
@@ -195,7 +195,7 @@ def do_cleanup(args):
     for name in set(p["provider"] for p in env["profiles"]):
         logging.info("[main] Cleaning up '%s' for drenv", name)
         provider = providers.get(name)
-        provider.cleanup_files()
+        provider.cleanup()
 
 
 def do_clear(args):
@@ -363,7 +363,7 @@ def start_cluster(profile, hooks=(), args=None, **options):
     if profile["external"]:
         logging.debug("[%s] Skipping external cluster", profile["name"])
     else:
-        is_restart = provider.exists(profile["name"])
+        is_restart = provider.exists(profile)
         provider.start(profile, verbose=args.verbose)
         if profile["containerd"]:
             logging.info("[%s] Configuring containerd", profile["name"])
@@ -371,7 +371,7 @@ def start_cluster(profile, hooks=(), args=None, **options):
         if is_restart:
             restart_failed_deployments(profile)
         else:
-            provider.load_files(profile["name"])
+            provider.configure(profile)
 
     if hooks:
         execute(
@@ -400,7 +400,7 @@ def stop_cluster(profile, hooks=(), **options):
     if profile["external"]:
         logging.debug("[%s] Skipping external cluster", profile["name"])
     elif cluster_status != cluster.UNKNOWN:
-        provider.stop(profile["name"])
+        provider.stop(profile)
 
 
 def delete_cluster(profile, **options):
@@ -408,7 +408,7 @@ def delete_cluster(profile, **options):
     if profile["external"]:
         logging.debug("[%s] Skipping external cluster", profile["name"])
     else:
-        provider.delete(profile["name"])
+        provider.delete(profile)
 
     profile_config = drenv.config_dir(profile["name"])
     if os.path.exists(profile_config):

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -411,18 +411,12 @@ def delete_cluster(profile, **options):
         shutil.rmtree(profile_config)
 
 
-def restart_failed_deployments(profile, initial_wait=30):
+def restart_failed_deployments(profile):
     """
-    When restarting, kubectl can report stale status for a while, before it
-    starts to report real status. Then it takes a while until all deployments
-    become available.
-
-    We first wait for initial_wait seconds to give Kubernetes chance to fail
-    liveness and readiness checks. Then we restart for failed deployments.
+    When restarting after failure, some deployment may enter failing state.
+    This is not handled by the addons. Restarting the deployment solves this
+    issue. This may also be solved at the addon level.
     """
-    logging.info("[%s] Waiting for fresh status", profile["name"])
-    time.sleep(initial_wait)
-
     logging.info("[%s] Looking up failed deployments", profile["name"])
     debug = partial(logging.debug, f"[{profile['name']}] %s")
 

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -305,14 +305,16 @@ def do_suspend(args):
     env = load_env(args)
     logging.info("[%s] Suspending environment", env["name"])
     for profile in env["profiles"]:
-        run("virsh", "-c", "qemu:///system", "suspend", profile["name"])
+        provider = providers.get(profile["provider"])
+        provider.suspend(profile)
 
 
 def do_resume(args):
     env = load_env(args)
     logging.info("[%s] Resuming environment", env["name"])
     for profile in env["profiles"]:
-        run("virsh", "-c", "qemu:///system", "resume", profile["name"])
+        provider = providers.get(profile["provider"])
+        provider.resume(profile)
 
 
 def do_dump(args):

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -19,7 +19,6 @@ import drenv
 from . import cache
 from . import cluster
 from . import commands
-from . import containerd
 from . import envfile
 from . import kubectl
 from . import providers
@@ -363,15 +362,11 @@ def start_cluster(profile, hooks=(), args=None, **options):
     if profile["external"]:
         logging.debug("[%s] Skipping external cluster", profile["name"])
     else:
-        is_restart = provider.exists(profile)
+        existing = provider.exists(profile)
         provider.start(profile, verbose=args.verbose)
-        if profile["containerd"]:
-            logging.info("[%s] Configuring containerd", profile["name"])
-            containerd.configure(provider, profile)
-        if is_restart:
+        provider.configure(profile, existing=existing)
+        if existing:
             restart_failed_deployments(profile)
-        else:
-            provider.configure(profile)
 
     if hooks:
         execute(

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -359,14 +359,13 @@ def collect_addons(env):
 
 def start_cluster(profile, hooks=(), args=None, **options):
     provider = providers.get(profile["provider"])
-    if profile["external"]:
-        logging.debug("[%s] Skipping external cluster", profile["name"])
-    else:
-        existing = provider.exists(profile)
-        provider.start(profile, verbose=args.verbose)
-        provider.configure(profile, existing=existing)
-        if existing:
-            restart_failed_deployments(profile)
+    existing = provider.exists(profile)
+
+    provider.start(profile, verbose=args.verbose)
+    provider.configure(profile, existing=existing)
+
+    if existing:
+        restart_failed_deployments(profile)
 
     if hooks:
         execute(
@@ -391,19 +390,14 @@ def stop_cluster(profile, hooks=(), **options):
             allow_failure=True,
         )
 
-    provider = providers.get(profile["provider"])
-    if profile["external"]:
-        logging.debug("[%s] Skipping external cluster", profile["name"])
-    elif cluster_status != cluster.UNKNOWN:
+    if cluster_status != cluster.UNKNOWN:
+        provider = providers.get(profile["provider"])
         provider.stop(profile)
 
 
 def delete_cluster(profile, **options):
     provider = providers.get(profile["provider"])
-    if profile["external"]:
-        logging.debug("[%s] Skipping external cluster", profile["name"])
-    else:
-        provider.delete(profile)
+    provider.delete(profile)
 
     profile_config = drenv.config_dir(profile["name"])
     if os.path.exists(profile_config):

--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -108,9 +108,22 @@ def run(*args, input=None, decode=True, env=None):
     return output.decode() if decode else output
 
 
-def watch(*args, input=None, keepends=False, decode=True, timeout=None, env=None):
+def watch(
+    *args,
+    input=None,
+    keepends=False,
+    decode=True,
+    timeout=None,
+    env=None,
+    stderr=subprocess.PIPE,
+):
     """
     Run command args, iterating over lines read from the child process stdout.
+
+    Some commands have no output and log everyting to stderr (like drenv). To
+    watch the output call with stderr=subprocess.STDOUT. When such command
+    fails, we have always have empty error, since the content was already
+    yielded to the caller.
 
     Assumes that the child process output UTF-8. Will raise if the command
     outputs binary data. This is not a problem in this projects since all our
@@ -144,7 +157,7 @@ def watch(*args, input=None, keepends=False, decode=True, timeout=None, env=None
                 # Avoid blocking foerver if there is no input.
                 stdin=subprocess.PIPE if input else subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stderr=stderr,
                 env=env,
             )
         except OSError as e:

--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -170,6 +170,35 @@ for i in range(10):
     assert output == ["line %d" % i for i in range(10)]
 
 
+def test_watch_stderr_success():
+    # Watching command like drenv, logging only to stderr without any output.
+    script = r"""
+import sys
+for i in range(10):
+    sys.stderr.write(f"line {i}\n")
+"""
+    cmd = ["python3", "-c", script]
+    output = list(commands.watch(*cmd, stderr=subprocess.STDOUT))
+    assert output == [f"line {i}" for i in range(10)]
+
+
+def test_watch_stderr_error():
+    # When stderr is redirected to stdout the error is empty.
+    script = r"""
+import sys
+sys.stderr.write("before error\n")
+sys.exit("error")
+"""
+    cmd = ["python3", "-c", script]
+    output = []
+    with pytest.raises(commands.Error) as e:
+        for line in commands.watch(*cmd, stderr=subprocess.STDOUT):
+            output.append(line)
+
+    assert output == ["before error", "error"]
+    assert e.value.error == ""
+
+
 def test_watch_partial_lines():
     script = """
 import time

--- a/test/drenv/containerd.py
+++ b/test/drenv/containerd.py
@@ -6,17 +6,16 @@ import tempfile
 
 import toml
 
-from . import minikube
 from . import patch
 
 
-def configure(profile):
+def configure(provider, profile):
     config = f"{profile['name']}:/etc/containerd/config.toml"
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = os.path.join(tmpdir, "config.toml")
 
-        minikube.cp(profile["name"], config, tmp)
+        provider.cp(profile["name"], config, tmp)
         with open(tmp) as f:
             old_config = toml.load(f)
 
@@ -24,6 +23,6 @@ def configure(profile):
 
         with open(tmp, "w") as f:
             toml.dump(new_config, f)
-        minikube.cp(profile["name"], tmp, config)
+        provider.cp(profile["name"], tmp, config)
 
-    minikube.ssh(profile["name"], "sudo systemctl restart containerd")
+    provider.ssh(profile["name"], "sudo systemctl restart containerd")

--- a/test/drenv/drenv_test.py
+++ b/test/drenv/drenv_test.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import logging
 import os
+import subprocess
 
 import yaml
 import pytest
@@ -19,23 +21,23 @@ EXTERNAL_ENV = os.path.join("envs", "external.yaml")
 def test_start_unknown():
     # Cluster does not exists, so it should fail.
     with pytest.raises(commands.Error):
-        commands.run("drenv", "start", "--name-prefix", "unknown-", EXTERNAL_ENV)
+        watch("drenv", "start", "--name-prefix", "unknown-", EXTERNAL_ENV, "--verbose")
 
 
 def test_start(tmpenv):
-    commands.run("drenv", "start", "--name-prefix", tmpenv.prefix, EXTERNAL_ENV)
+    watch("drenv", "start", "--name-prefix", tmpenv.prefix, EXTERNAL_ENV, "--verbose")
     assert cluster.status(tmpenv.prefix + "cluster") == cluster.READY
 
 
 def test_dump_without_prefix():
-    out = commands.run("drenv", "dump", EXAMPLE_ENV)
+    out = run("drenv", "dump", EXAMPLE_ENV)
     dump = yaml.safe_load(out)
     assert dump["profiles"][0]["name"] == "ex1"
     assert dump["profiles"][1]["name"] == "ex2"
 
 
 def test_dump_with_prefix():
-    out = commands.run("drenv", "dump", "--name-prefix", "test-", EXAMPLE_ENV)
+    out = run("drenv", "dump", "--name-prefix", "test-", EXAMPLE_ENV)
     dump = yaml.safe_load(out)
     assert dump["profiles"][0]["name"] == "test-ex1"
     assert dump["profiles"][1]["name"] == "test-ex2"
@@ -43,23 +45,23 @@ def test_dump_with_prefix():
 
 def test_stop_unknown():
     # Does nothing, so should succeed.
-    commands.run("drenv", "stop", "--name-prefix", "unknown-", EXTERNAL_ENV)
+    run("drenv", "stop", "--name-prefix", "unknown-", EXTERNAL_ENV)
 
 
 def test_stop(tmpenv):
     # Stop does nothing, so cluster must be ready.
-    commands.run("drenv", "stop", "--name-prefix", tmpenv.prefix, EXTERNAL_ENV)
+    run("drenv", "stop", "--name-prefix", tmpenv.prefix, EXTERNAL_ENV)
     assert cluster.status(tmpenv.prefix + "cluster") == cluster.READY
 
 
 def test_delete_unknown():
     # Does nothing, so should succeed.
-    commands.run("drenv", "delete", "--name-prefix", "unknown-", EXTERNAL_ENV)
+    run("drenv", "delete", "--name-prefix", "unknown-", EXTERNAL_ENV)
 
 
 def test_delete(tmpenv):
     # Delete does nothing, so cluster must be ready.
-    commands.run("drenv", "delete", "--name-prefix", tmpenv.prefix, EXTERNAL_ENV)
+    run("drenv", "delete", "--name-prefix", tmpenv.prefix, EXTERNAL_ENV)
     assert cluster.status(tmpenv.prefix + "cluster") == cluster.READY
 
 
@@ -76,7 +78,7 @@ profiles:
     path = tmpdir.join("missing-addon.yaml")
     path.write(content)
     with pytest.raises(commands.Error):
-        commands.run("drenv", "start", str(path))
+        run("drenv", "start", str(path))
 
 
 def test_kustomization(tmpdir):
@@ -153,3 +155,12 @@ def get_config(context=None, kubeconfig=None):
         args.append(f"--kubeconfig={kubeconfig}")
     out = kubectl.config(*args, context=context)
     return json.loads(out)
+
+
+def run(*args):
+    return commands.run(*args)
+
+
+def watch(*args):
+    for line in commands.watch(*args, stderr=subprocess.STDOUT):
+        logging.debug("%s", line)

--- a/test/drenv/envfile.py
+++ b/test/drenv/envfile.py
@@ -1,8 +1,9 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import copy
+import logging
+import os
 import platform
 
 import yaml
@@ -52,6 +53,7 @@ def platform_defaults():
     # By default, use minikube defaults.
 
     operating_system = platform.system().lower()
+    logging.debug("[envfile] Detected os: '%s'", operating_system)
     return _PLATFORM_DEFAULTS.get(operating_system, _PLATFORM_DEFAULTS["__default__"])
 
 
@@ -149,6 +151,7 @@ def _validate_profile(profile, addons_root):
 def _validate_platform_defaults(profile):
     platform = platform_defaults()
     machine = os.uname().machine
+    logging.debug("[envfile] Detected machine: '%s'", machine)
 
     if profile["driver"] == VM:
         profile["driver"] = platform[VM][machine]
@@ -157,6 +160,10 @@ def _validate_platform_defaults(profile):
 
     if profile["network"] == SHARED_NETWORK:
         profile["network"] = platform[SHARED_NETWORK][machine]
+
+    logging.debug("[envfile] Using provider: '%s'", profile["provider"])
+    logging.debug("[envfile] Using driver: '%s'", profile["driver"])
+    logging.debug("[envfile] Using network: '%s'", profile["network"])
 
 
 def _validate_worker(worker, env, addons_root, index):

--- a/test/drenv/envfile.py
+++ b/test/drenv/envfile.py
@@ -8,12 +8,17 @@ import platform
 
 import yaml
 
+PROVIDER = "$provider"
 VM = "$vm"
 CONTAINER = "$container"
 SHARED_NETWORK = "$network"
 
 _PLATFORM_DEFAULTS = {
     "__default__": {
+        PROVIDER: {
+            "x86_64": "",
+            "arm64": "",
+        },
         VM: {
             "x86_64": "",
             "arm64": "",
@@ -25,6 +30,10 @@ _PLATFORM_DEFAULTS = {
         },
     },
     "linux": {
+        PROVIDER: {
+            "x86_64": "minikube",
+            "arm64": "",
+        },
         VM: {
             "x86_64": "kvm2",
             "arm64": "",
@@ -36,6 +45,10 @@ _PLATFORM_DEFAULTS = {
         },
     },
     "darwin": {
+        PROVIDER: {
+            "x86_64": "minikube",
+            "arm64": "minikube",
+        },
         VM: {
             "x86_64": "hyperkit",
             "arm64": "qemu",
@@ -50,8 +63,7 @@ _PLATFORM_DEFAULTS = {
 
 
 def platform_defaults():
-    # By default, use minikube defaults.
-
+    # By default, use provider defaults.
     operating_system = platform.system().lower()
     logging.debug("[envfile] Detected os: '%s'", operating_system)
     return _PLATFORM_DEFAULTS.get(operating_system, _PLATFORM_DEFAULTS["__default__"])
@@ -124,7 +136,8 @@ def _validate_profile(profile, addons_root):
     # If True, this is an external cluster and we don't have to start it.
     profile.setdefault("external", False)
 
-    # Properties for minikube created cluster.
+    # Properties for drenv managed cluster.
+    profile.setdefault("provider", PROVIDER)
     profile.setdefault("driver", VM)
     profile.setdefault("container_runtime", "")
     profile.setdefault("extra_disks", 0)
@@ -152,6 +165,9 @@ def _validate_platform_defaults(profile):
     platform = platform_defaults()
     machine = os.uname().machine
     logging.debug("[envfile] Detected machine: '%s'", machine)
+
+    if profile["provider"] == PROVIDER:
+        profile["provider"] = platform[PROVIDER][machine]
 
     if profile["driver"] == VM:
         profile["driver"] = platform[VM][machine]

--- a/test/drenv/minikube.py
+++ b/test/drenv/minikube.py
@@ -29,12 +29,12 @@ def profile(command, output=None):
     return _run("profile", command, output=output)
 
 
-def status(profile, output=None):
-    return _run("status", profile=profile, output=output)
+def status(name, output=None):
+    return _run("status", profile=name, output=output)
 
 
 def start(
-    profile,
+    name,
     driver=None,
     container_runtime=None,
     extra_disks=None,
@@ -94,23 +94,23 @@ def start(
     # TODO: Use --interactive=false when the bug is fixed.
     # https://github.com/kubernetes/minikube/issues/19518
 
-    _watch("start", *args, profile=profile)
+    _watch("start", *args, profile=name)
 
 
-def stop(profile):
-    _watch("stop", profile=profile)
+def stop(name):
+    _watch("stop", profile=name)
 
 
-def delete(profile):
-    _watch("delete", profile=profile)
+def delete(name):
+    _watch("delete", profile=name)
 
 
-def cp(profile, src, dst):
-    _watch("cp", src, dst, profile=profile)
+def cp(name, src, dst):
+    _watch("cp", src, dst, profile=name)
 
 
-def ssh(profile, command):
-    _watch("ssh", command, profile=profile)
+def ssh(name, command):
+    _watch("ssh", command, profile=name)
 
 
 def setup_files():
@@ -127,7 +127,7 @@ def setup_files():
     _setup_systemd_resolved(version)
 
 
-def load_files(profile):
+def load_files(name):
     """
     Load configuration done in setup_files() before the minikube cluster was
     started.
@@ -135,8 +135,8 @@ def load_files(profile):
     Must be called after the cluster is started, before running any addon. Not
     need when starting a stopped cluster.
     """
-    _load_sysctl(profile)
-    _load_systemd_resolved(profile)
+    _load_sysctl(name)
+    _load_systemd_resolved(name)
 
 
 def cleanup_files():
@@ -178,11 +178,11 @@ fs.inotify.max_user_watches = 65536
     _write_file(path, data)
 
 
-def _load_sysctl(profile):
+def _load_sysctl(name):
     if not os.path.exists(_sysctl_drenv_conf()):
         return
-    logging.debug("[%s] Loading drenv sysctl configuration", profile)
-    ssh(profile, "sudo sysctl -p /etc/sysctl.d/99-drenv.conf")
+    logging.debug("[%s] Loading drenv sysctl configuration", name)
+    ssh(name, "sudo sysctl -p /etc/sysctl.d/99-drenv.conf")
 
 
 def _sysctl_drenv_conf():
@@ -211,11 +211,11 @@ DNSSEC=no
     _write_file(path, data)
 
 
-def _load_systemd_resolved(profile):
+def _load_systemd_resolved(name):
     if not os.path.exists(_systemd_resolved_drenv_conf()):
         return
-    logging.debug("[%s] Loading drenv systemd-resolved configuration", profile)
-    ssh(profile, "sudo systemctl restart systemd-resolved.service")
+    logging.debug("[%s] Loading drenv systemd-resolved configuration", name)
+    ssh(name, "sudo systemctl restart systemd-resolved.service")
 
 
 def _systemd_resolved_drenv_conf():

--- a/test/drenv/providers/__init__.py
+++ b/test/drenv/providers/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+
+
+def get(name):
+    return importlib.import_module("drenv.providers." + name)

--- a/test/drenv/providers/external.py
+++ b/test/drenv/providers/external.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import time
+from functools import partial
+
+from drenv import cluster
+
+# Provider scope
+
+
+def setup():
+    logging.info("[external] Skipping setup for external provider")
+
+
+def cleanup():
+    logging.info("[external] Skipping cleanup for external provider")
+
+
+# Cluster scope
+
+
+def exists(profile):
+    return True
+
+
+def start(profile, verbose=False):
+    start = time.monotonic()
+    logging.info("[%s] Checking external cluster status", profile["name"])
+
+    # Fail fast if cluster is not configured, we cannot recover from this.
+    status = cluster.status(profile["name"])
+    if status == cluster.UNKNOWN:
+        raise RuntimeError(f"Cluster '{profile['name']}' does not exist")
+
+    # Otherwise handle temporary outage gracefuly.
+    debug = partial(logging.debug, f"[{profile['name']}] %s")
+    cluster.wait_until_ready(profile["name"], timeout=60, log=debug)
+
+    logging.info(
+        "[%s] Cluster ready in %.2f seconds",
+        profile["name"],
+        time.monotonic() - start,
+    )
+
+
+def configure(profile, existing=False):
+    logging.info("[%s] Skipping configure for external cluster", profile["name"])
+
+
+def stop(profile):
+    logging.info("[%s] Skipping stop for external cluster", profile["name"])
+
+
+def delete(profile):
+    logging.info("[%s] Skipping delete for external cluster", profile["name"])
+
+
+def suspend(profile):
+    logging.info("[%s] Skipping suspend for external cluster", profile["name"])
+
+
+def resume(profile):
+    logging.info("[%s] Skipping resume for external cluster", profile["name"])
+
+
+def cp(name, src, dst):
+    logging.warning("[%s] cp not implemented yet for external cluster", name)
+
+
+def ssh(name, command):
+    logging.warning("[%s] ssh not implemented yet for external cluster", name)

--- a/test/drenv/providers/minikube.py
+++ b/test/drenv/providers/minikube.py
@@ -142,6 +142,9 @@ def configure(profile, existing=False):
         _configure_sysctl(profile["name"])
         _configure_systemd_resolved(profile["name"])
 
+    if existing:
+        _wait_for_fresh_status(profile)
+
 
 def stop(profile):
     start = time.monotonic()
@@ -194,6 +197,19 @@ def ssh(name, command):
 
 
 # Private helpers
+
+
+def _wait_for_fresh_status(profile):
+    """
+    When starting an existing cluster, kubectl can report stale status for a
+    while, before it starts to report real status. Then it takes a while until
+    all deployments become available.
+
+    We wait 30 seconds to give Kubernetes chance to fail liveness and readiness
+    checks and start reporting real cluster status.
+    """
+    logging.info("[%s] Waiting for fresh status", profile["name"])
+    time.sleep(30)
 
 
 def _profile(command, output=None):

--- a/test/drenv/providers/minikube.py
+++ b/test/drenv/providers/minikube.py
@@ -22,18 +22,6 @@ EXTRA_CONFIG = [
 ]
 
 
-def profile(command, output=None):
-    # Workaround for https://github.com/kubernetes/minikube/pull/16900
-    # TODO: remove when issue is fixed.
-    _create_profiles_dir()
-
-    return _run("profile", command, output=output)
-
-
-def status(name, output=None):
-    return _run("status", profile=name, output=output)
-
-
 def start(profile, verbose=False):
     start = time.monotonic()
     logging.info("[%s] Starting minikube cluster", profile["name"])
@@ -124,7 +112,7 @@ def ssh(name, command):
 
 
 def exists(name):
-    out = profile("list", output="json")
+    out = _profile("list", output="json")
     profiles = json.loads(out)
     for p in profiles["valid"]:
         if p["Name"] == name:
@@ -164,6 +152,18 @@ def cleanup_files():
     """
     _cleanup_file(_systemd_resolved_drenv_conf())
     _cleanup_file(_sysctl_drenv_conf())
+
+
+def _profile(command, output=None):
+    # Workaround for https://github.com/kubernetes/minikube/pull/16900
+    # TODO: remove when issue is fixed.
+    _create_profiles_dir()
+
+    return _run("profile", command, output=output)
+
+
+def _status(name, output=None):
+    return _run("status", profile=name, output=output)
 
 
 def _version():

--- a/test/drenv/providers/minikube.py
+++ b/test/drenv/providers/minikube.py
@@ -5,11 +5,13 @@ import errno
 import json
 import logging
 import os
+import sys
 import time
 
 from packaging.version import Version
 
 from drenv import commands
+from drenv import containerd
 
 EXTRA_CONFIG = [
     # When enabled, tells the Kubelet to pull images one at a time. This slows
@@ -126,16 +128,19 @@ def start(profile, verbose=False):
     )
 
 
-def configure(profile):
+def configure(profile, existing=False):
     """
     Load configuration done in setup() before the minikube cluster was
     started.
 
-    Must be called after the cluster is started, before running any addon. Not
-    needed when starting a stopped cluster.
+    Must be called after the cluster is started, before running any addon.
     """
-    _configure_sysctl(profile["name"])
-    _configure_systemd_resolved(profile["name"])
+    if not existing:
+        if profile["containerd"]:
+            logging.info("[%s] Configuring containerd", profile["name"])
+            containerd.configure(sys.modules[__name__], profile)
+        _configure_sysctl(profile["name"])
+        _configure_systemd_resolved(profile["name"])
 
 
 def stop(profile):

--- a/test/drenv/providers/minikube.py
+++ b/test/drenv/providers/minikube.py
@@ -9,7 +9,7 @@ import time
 
 from packaging.version import Version
 
-from . import commands
+from drenv import commands
 
 EXTRA_CONFIG = [
     # When enabled, tells the Kubelet to pull images one at a time. This slows

--- a/test/drenv/providers/minikube.py
+++ b/test/drenv/providers/minikube.py
@@ -103,6 +103,26 @@ def delete(name):
     logging.info("[%s] Cluster deleted in %.2f seconds", name, time.monotonic() - start)
 
 
+def suspend(profile):
+    if profile["driver"] != "kvm2":
+        logging.warning("[%s] suspend supported only for kvm2 driver", profile["name"])
+        return
+    logging.info("[%s] Suspending cluster", profile["name"])
+    cmd = ["virsh", "-c", "qemu:///system", "suspend", profile["name"]]
+    for line in commands.watch(*cmd):
+        logging.debug("[%s] %s", profile["name"], line)
+
+
+def resume(profile):
+    if profile["driver"] != "kvm2":
+        logging.warning("[%s] resume supported only for kvm2 driver", profile["name"])
+        return
+    logging.info("[%s] Resuming cluster", profile["name"])
+    cmd = ["virsh", "-c", "qemu:///system", "resume", profile["name"]]
+    for line in commands.watch(*cmd):
+        logging.debug("[%s] %s", profile["name"], line)
+
+
 def cp(name, src, dst):
     _watch("cp", src, dst, profile=name)
 

--- a/test/envs/external.yaml
+++ b/test/envs/external.yaml
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-# Example environment using external clusters. The cluster `test` must exist
-# when this environment is started.
+# Example environment using external clusters. The cluster must exist when this
+# environment is started.
 #
 # To try this example, create the cluster with:
 #
-#     drenv start envs/test.yaml
+#     drenv start envs/vm.yaml
 #
 # Now you can start this environment with:
 #
@@ -20,7 +20,7 @@
 name: external
 profiles:
   - name: cluster
-    external: true
+    provider: external
     workers:
       - addons:
           - name: example

--- a/test/setup.py
+++ b/test/setup.py
@@ -17,7 +17,10 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/RamenDR/ramen",
-    packages=["drenv"],
+    packages=[
+        "drenv",
+        "drenv.providers",
+    ],
     install_requires=[
         "PyYAML",
         "toml",


### PR DESCRIPTION
Preparing for running drenv on Apple silicon via [lima](https://github.com/lima-vm/lima), introduce the providers package. The first provider is minikube.

This is change mostly internal refactoring without changing the behavior, making it easy to add a lima provider in a clean and safe way.

Behavior changes:
- drenv setup and cleanup commands requires an env file, since the provider is a profile property. This allows mixing different types of clusters in the same environment which may be useful.
- Minor logging changes

Testing:
- [x] macOS vm.yaml, example.yaml, external.yaml: tested locally
  - we cannot run much more with minikube qemu driver
- [x] Linux regional-dr.yaml
  - https://github.com/RamenDR/ramen/actions/runs/10586666591/job/29335908730 (cephfs test failed but it is common)
  - https://github.com/RamenDR/ramen/actions/runs/10586666591/job/29338290912
- [x] Linux regional-dr-kubevirt.yaml 

Part of #1513