### PR TITLE
Upgrading capabilities in the Operator CSVs

### DIFF
--- a/config/dr-cluster/manifests/bases/ramen_dr_cluster.clusterserviceversion.yaml
+++ b/config/dr-cluster/manifests/bases/ramen_dr_cluster.clusterserviceversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[]'
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
     operators.openshift.io/infrastructure-features: '["disconnected"]'
   name: ramen-dr-cluster-operator.v0.0.0
   namespace: placeholder

--- a/config/hub/manifests/bases/ramen_hub.clusterserviceversion.yaml
+++ b/config/hub/manifests/bases/ramen_hub.clusterserviceversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[]'
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
     operators.openshift.io/infrastructure-features: '["disconnected"]'
   name: ramen-hub-operator.v0.0.0
   namespace: placeholder


### PR DESCRIPTION
For ramen, the capabilities for the hub and cluster bundles currently states "Basic Install"

Updating it to "Seamless Upgrades" as it is verified.

Fixes: [Bug-2303823](https://bugzilla.redhat.com/show_bug.cgi?id=2303823)