### PR TITLE
Exclude PV and PVC in velero backups

### DIFF
--- a/docs/krp.md
+++ b/docs/krp.md
@@ -96,7 +96,8 @@ The VRG enables Kubernetes resources to be captured(backed up) and recovered as
 part of disaster protection.  This is accomplished through the
 kubeObjectProtection section of the VRG spec.  If kubeObjectProtection is not
 included in a VRG, then Kubernetes resources are not protected as part of the
-VRG disaster protection.
+VRG disaster protection. PVCs and PVs are protected by Ramen and all resources
+are protected and backed by kubeObjectProtection.
 
 The kubeObjectProtection section contains two sub-sections, captureOrder and
 recoverOrder.  This captureOrder section provides instructions on how to backup

--- a/internal/controller/kubeobjects/velero/requests.go
+++ b/internal/controller/kubeobjects/velero/requests.go
@@ -371,7 +371,8 @@ func getBackupSpecFromObjectsSpec(objectsSpec kubeobjects.Spec) velero.BackupSpe
 		IncludedResources:  objectsSpec.IncludedResources,
 		// exclude VRs from Backup so VRG can create them: see https://github.com/RamenDR/ramen/issues/884
 		ExcludedResources: append(objectsSpec.ExcludedResources, "volumereplications.replication.storage.openshift.io",
-			"replicationsources.volsync.backube", "replicationdestinations.volsync.backube"),
+			"replicationsources.volsync.backube", "replicationdestinations.volsync.backube",
+			"PersistentVolumeClaims", "PersistentVolumes"),
 		LabelSelector:           objectsSpec.LabelSelector,
 		OrLabelSelectors:        objectsSpec.OrLabelSelectors,
 		TTL:                     metav1.Duration{}, // TODO: set default here


### PR DESCRIPTION
fixes https://github.com/RamenDR/ramen/issues/1540 - used `Option 2` from the issue description to disable PV and PVC backup.   
