### PR TITLE
tests: keep all suite cleanup functions in suite_test.go

### DIFF
--- a/internal/controller/ramenconfig_test.go
+++ b/internal/controller/ramenconfig_test.go
@@ -6,11 +6,11 @@ package controllers_test
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	controllers "github.com/ramendr/ramen/internal/controller"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/yaml"
@@ -26,8 +26,28 @@ func configMapCreate(ramenConfig *ramen.RamenConfig) {
 		configMap, err := controllers.ConfigMapNew(ramenNamespace, configMapName, ramenConfig)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(k8sClient.Create(context.TODO(), configMap)).To(Succeed())
-		DeferCleanup(k8sClient.Delete, context.TODO(), configMap)
 	}
+}
+
+func configMapDelete() error {
+	for _, configMapName := range configMapNames {
+		cm := &corev1.ConfigMap{}
+
+		err := k8sClient.Get(context.TODO(), types.NamespacedName{
+			Namespace: ramenNamespace,
+			Name:      configMapName,
+		}, cm)
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+
+		err = k8sClient.Delete(context.TODO(), cm)
+		if err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func configMapUpdate() {

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -242,6 +242,7 @@ var _ = BeforeSuite(func() {
 	ramenConfig.DrClusterOperator.S3SecretDistributionEnabled = true
 	ramenConfig.MultiNamespace.FeatureEnabled = true
 	configMapCreate(ramenConfig)
+	DeferCleanup(configMapDelete)
 
 	s3Secrets[0] = corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Namespace: ramenNamespace, Name: "s3secret0"},


### PR DESCRIPTION
Moving suite cleanup activity to the suite_test.go. This will help us reuse the util functions in other tests.