### PR TITLE
Fix PlacementDecision Exclusion from Hub Backup Due to Missing Label

### DIFF
--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -2169,6 +2169,13 @@ func (r *DRPlacementControlReconciler) createOrUpdatePlacementDecision(ctx conte
 		if plDecision, err = r.createPlacementDecision(ctx, placement); err != nil {
 			return err
 		}
+	} else if plDecision.GetLabels()[rmnutil.ExcludeFromVeleroBackup] != "true" {
+		err = rmnutil.NewResourceUpdater(plDecision).
+			AddLabel(rmnutil.ExcludeFromVeleroBackup, "true").
+			Update(ctx, r.Client)
+		if err != nil {
+			return err
+		}
 	}
 
 	plDecision.Status = clrapiv1beta1.PlacementDecisionStatus{
@@ -2219,7 +2226,7 @@ func (r *DRPlacementControlReconciler) createPlacementDecision(ctx context.Conte
 
 	plDecision.ObjectMeta.Labels = map[string]string{
 		clrapiv1beta1.PlacementLabel:    placement.GetName(),
-		"velero.io/exclude-from-backup": "true",
+		rmnutil.ExcludeFromVeleroBackup: "true",
 	}
 
 	owner := metav1.NewControllerRef(placement, clrapiv1beta1.GroupVersion.WithKind("Placement"))

--- a/internal/controller/util/labels.go
+++ b/internal/controller/util/labels.go
@@ -12,7 +12,8 @@ const (
 	labelOwnerNamespaceName = "ramendr.openshift.io/owner-namespace-name"
 	labelOwnerName          = "ramendr.openshift.io/owner-name"
 
-	MModesLabel = "ramendr.openshift.io/maintenancemodes"
+	MModesLabel             = "ramendr.openshift.io/maintenancemodes"
+	ExcludeFromVeleroBackup = "velero.io/exclude-from-backup"
 )
 
 type Labels map[string]string

--- a/internal/controller/volsync/secret_propagator.go
+++ b/internal/controller/volsync/secret_propagator.go
@@ -174,7 +174,7 @@ func (sp *secretPropagator) reconcileSecretPropagationPolicy() error {
 			return fmt.Errorf("%w", err)
 		}
 
-		util.AddLabel(policy, "velero.io/exclude-from-backup", "true")
+		util.AddLabel(policy, util.ExcludeFromVeleroBackup, "true")
 
 		policy.Spec = policyv1.PolicySpec{
 			Disabled: false,

--- a/internal/controller/volsync/secret_propagator_test.go
+++ b/internal/controller/volsync/secret_propagator_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Secret_propagator", func() {
 					Expect(plBindingSubject.APIGroup).To(Equal("policy.open-cluster-management.io"))
 					Expect(plBindingSubject.Kind).To(Equal("Policy"))
 					Expect(plBindingSubject.Name).To(Equal(createdPolicy.GetName()))
-					Expect(createdPolicy.GetLabels()["velero.io/exclude-from-backup"]).Should(Equal("true"))
+					Expect(createdPolicy.GetLabels()[util.ExcludeFromVeleroBackup]).Should(Equal("true"))
 				})
 
 				Context("When Policy name combined with namespace is longer than 62 characters", func() {


### PR DESCRIPTION
The issue where the `velero.io/exclude-from-backup` label was not applied originates from our deployment workflow. Initially, we deploy the workload, followed by enabling DR. During the first deployment, the Placement Operator creates the `PlacementDecision` with default labels. However, when `Ramen` tries to add the `velero.io/exclude-from-backup` label during DR setup, it skips because the `PlacementDecision` already exists. Consequently, `Velero` backs up the `PlacementDecision`. And during hub recovery, it is restored without its status, leading to the unintended deletion of the workload. This situation only occurs when the current state wasn't updated before hub recovery was applied.

The fix in this PR does not address the scenario where the workload is deployed, a hub backup is taken, DR is enabled, and then the hub is recovered before another backup is created.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2308801