### PR TITLE
Ignore not found namespace in argocd test

### DIFF
--- a/test/addons/argocd/test
+++ b/test/addons/argocd/test
@@ -83,7 +83,13 @@ def undeploy_guestbook(hub, cluster):
             print(line)
 
     print(f"Deleting namespace argocd-test in cluster {cluster}")
-    kubectl.delete("namespace", "argocd-test", "--wait=false", context=cluster)
+    kubectl.delete(
+        "namespace",
+        "argocd-test",
+        "--wait=false",
+        "--ignore-not-found",
+        context=cluster,
+    )
 
 
 def wait_until_guestbook_is_deleted(hub, cluster):


### PR DESCRIPTION
Fixing this error seen in the CI:

    drenv.commands.Error: Command failed:
       command: ('addons/argocd/test', 'rdr-hub', 'rdr-dr1', 'rdr-dr2')
       exitcode: 1
       error:
          Traceback (most recent call last):
            ...
          drenv.commands.Error: Command failed:
             command: ('kubectl', 'delete', '--context', 'rdr-dr2', 'namespace', 'argocd-test', '--wait=false')
             exitcode: 1
             error:
                Error from server (NotFound): namespaces "argocd-test" not found