### PR TITLE
test: Enable PV resizing by setting AllowVolumeExpansion flag in storageClass

### DIFF
--- a/test/addons/rook-pool/storage-class.yaml
+++ b/test/addons/rook-pool/storage-class.yaml
@@ -20,3 +20,4 @@ parameters:
     csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
     csi.storage.k8s.io/fstype: ext4
 reclaimPolicy: Delete
+allowVolumeExpansion: true


### PR DESCRIPTION
Lets PVs to be resized by enabling the 'AllowVolumeExpansion' flag in the StorageClass.
When this flag is set to true, users can dynamically adjust the size of PVCs by specifying the desired
capacity in the PVC specification.

Ref: [Block-Storage-RBD-SC](https://rook.io/docs/rook/latest-release/Storage-Configuration/Block-Storage-RBD/block-storage/#provision-storage)