### PR TITLE
Add drenv configuration flag for enabling/disabling consistency groups

### DIFF
--- a/test/drenv/test.py
+++ b/test/drenv/test.py
@@ -144,6 +144,8 @@ def enable_dr():
 
     cluster = lookup_cluster()
     placement_name = placement.split("/")[1]
+    consistency_groups = env["features"].get("consistency_groups", False)
+    cg_enabled = "true" if consistency_groups else "false"
 
     drpc = f"""
 apiVersion: ramendr.openshift.io/v1alpha1
@@ -151,6 +153,8 @@ kind: DRPlacementControl
 metadata:
   name: {config['name']}-drpc
   namespace: {config['namespace']}
+  annotations:
+    drplacementcontrol.ramendr.openshift.io/is-cg-enabled: '{cg_enabled}'
   labels:
     app: {config['name']}
 spec:


### PR DESCRIPTION
We want to be disable or enable consistency groups support for testing with drenv.
The enabling/disabling flag can be added in envs files:

ramen:
  hub: hub
  clusters: [dr1, dr2]
  topology: regional-dr
  features:
    volsync: true
   consistency_groups: true

When flag is not present, consistency groups are disabled by default
