### PR TITLE
Updating broken clusteradm link in the doc

### DIFF
--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -135,7 +135,7 @@ enough resources:
    ```
 
 1. Install `clusteradm` tool. See
-   [Install clusteradm CLI tool](https://open-cluster-management.io/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool)
+   [Install clusteradm CLI tool](https://open-cluster-management.io/docs/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool)
    for the details.
    Version v0.8.1 or later is reuired.
 


### PR DESCRIPTION
The current link is not working, gives 404 error.
Maybe they updated it recently!