### PR TITLE
Disallow relocation execution when a cluster is unreachable

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -825,6 +825,14 @@ func (d *DRPCInstance) RunRelocate() (bool, error) {
 
 	const done = true
 
+	if d.reconciler.numClustersQueriedSuccessfully != len(d.drPolicy.Spec.DRClusters) {
+		d.log.Info("Can't progress with relocation -- Not all clusters are reachable",
+			"numClustersQueriedSuccessfully", d.reconciler.numClustersQueriedSuccessfully,
+			"NumOfClusters", len(d.drPolicy.Spec.DRClusters))
+
+		return !done, nil
+	}
+
 	preferredCluster := d.instance.Spec.PreferredCluster
 	preferredClusterNamespace := d.instance.Spec.PreferredCluster
 

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -2479,8 +2479,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)
 				clearDRPCStatus()
 				expectedAction := rmn.ActionRelocate
-				expectedPhase := rmn.Relocated
-				exptectedPorgression := rmn.ProgressionCleaningUp
+				expectedPhase := rmn.DRState("")
+				exptectedPorgression := rmn.ProgressionStatus("")
 				verifyDRPCStateAndProgression(expectedAction, expectedPhase, exptectedPorgression)
 
 				// User intervention is required (simulate user intervention)


### PR DESCRIPTION
Added a check to stop relocation reconciliation if one of the clusters is unreachable. This prevents potential misclassification after hub recovery, which could lead to undesired results and inconsistencies.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2304182