### PR TITLE
Fix drenv delete when kubeconfig is empty

### DIFF
--- a/test/drenv/kubeconfig.py
+++ b/test/drenv/kubeconfig.py
@@ -51,7 +51,7 @@ def remove(profile, target=DEFAULT_CONFIG):
             return
 
         for k in ("contexts", "clusters", "users"):
-            old = config.get(k, [])
+            old = config.get(k) or []
             new = [v for v in old if v["name"] != profile["name"]]
             if len(new) < len(old):
                 config[k] = new


### PR DESCRIPTION
If start failed before any kubeconfig was would get None instead of an empty list, and fail with:

    % drenv delete envs/regional-dr.yaml
    2024-10-09 19:05:17,766 INFO    [rdr] Deleting environment
    2024-10-09 19:05:17,769 INFO    [dr1] Deleting lima cluster
    2024-10-09 19:05:17,769 INFO    [dr2] Deleting lima cluster
    2024-10-09 19:05:17,769 INFO    [hub] Deleting lima cluster
    2024-10-09 19:05:17,795 INFO    [dr1] Deleting disk dr1-disk0
    2024-10-09 19:05:17,827 ERROR   Command failed
    Traceback (most recent call last):
        ...
      File "/Users/nsoffer/src/ramen/test/drenv/kubeconfig.py", line 55, in remove
        new = [v for v in old if v["name"] != profile["name"]]
                          ^^^
    TypeError: 'NoneType' object is not iterable