### PR TITLE
Cleanups in e2e retries

### DIFF
--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -13,12 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const FiveSecondsDuration = 5 * time.Second
-
 func waitSubscriptionPhase(namespace, name string, phase subscriptionv1.SubscriptionPhase) error {
-	// sleep to wait for subscription is processed
-	time.Sleep(FiveSecondsDuration)
-
 	startTime := time.Now()
 
 	for {
@@ -43,8 +38,6 @@ func waitSubscriptionPhase(namespace, name string, phase subscriptionv1.Subscrip
 }
 
 func WaitWorkloadHealth(client client.Client, namespace string, w workloads.Workload) error {
-	time.Sleep(FiveSecondsDuration)
-
 	startTime := time.Now()
 
 	for {

--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -34,11 +34,11 @@ func waitSubscriptionPhase(namespace, name string, phase subscriptionv1.Subscrip
 			return nil
 		}
 
-		if time.Since(startTime) > time.Second*time.Duration(util.Timeout) {
+		if time.Since(startTime) > util.Timeout {
 			return fmt.Errorf(fmt.Sprintf("subscription %s status is not %s yet before timeout", name, phase))
 		}
 
-		time.Sleep(time.Second * time.Duration(util.TimeInterval))
+		time.Sleep(util.TimeInterval)
 	}
 }
 
@@ -55,13 +55,13 @@ func WaitWorkloadHealth(client client.Client, namespace string, w workloads.Work
 			return nil
 		}
 
-		if time.Since(startTime) > time.Second*time.Duration(util.Timeout) {
+		if time.Since(startTime) > util.Timeout {
 			util.Ctx.Log.Info(err.Error())
 
 			return fmt.Errorf(fmt.Sprintf("workload %s is not ready yet before timeout of %v",
 				w.GetName(), util.Timeout))
 		}
 
-		time.Sleep(time.Second * time.Duration(util.TimeInterval))
+		time.Sleep(util.TimeInterval)
 	}
 }

--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -30,7 +30,7 @@ func waitSubscriptionPhase(namespace, name string, phase subscriptionv1.Subscrip
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			return fmt.Errorf(fmt.Sprintf("subscription %s status is not %s yet before timeout", name, phase))
+			return fmt.Errorf("subscription %s status is not %s yet before timeout", name, phase)
 		}
 
 		time.Sleep(util.RetryInterval)
@@ -51,8 +51,8 @@ func WaitWorkloadHealth(client client.Client, namespace string, w workloads.Work
 		if time.Since(startTime) > util.Timeout {
 			util.Ctx.Log.Info(err.Error())
 
-			return fmt.Errorf(fmt.Sprintf("workload %s is not ready yet before timeout of %v",
-				w.GetName(), util.Timeout))
+			return fmt.Errorf("workload %s is not ready yet before timeout of %v",
+				w.GetName(), util.Timeout)
 		}
 
 		time.Sleep(util.RetryInterval)

--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -38,7 +38,7 @@ func waitSubscriptionPhase(namespace, name string, phase subscriptionv1.Subscrip
 			return fmt.Errorf(fmt.Sprintf("subscription %s status is not %s yet before timeout", name, phase))
 		}
 
-		time.Sleep(util.TimeInterval)
+		time.Sleep(util.RetryInterval)
 	}
 }
 
@@ -62,6 +62,6 @@ func WaitWorkloadHealth(client client.Client, namespace string, w workloads.Work
 				w.GetName(), util.Timeout))
 		}
 
-		time.Sleep(util.TimeInterval)
+		time.Sleep(util.RetryInterval)
 	}
 }

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -44,12 +44,12 @@ func waitPlacementDecision(client client.Client, namespace string, placementName
 			return placementDecision.Name, nil
 		}
 
-		if time.Since(startTime) > time.Second*time.Duration(util.Timeout) {
+		if time.Since(startTime) > util.Timeout {
 			return "", fmt.Errorf(
 				"could not get placement decision for " + placementName + " before timeout, fail")
 		}
 
-		time.Sleep(time.Second * time.Duration(util.TimeInterval))
+		time.Sleep(util.TimeInterval)
 	}
 }
 
@@ -69,7 +69,7 @@ func waitDRPCReady(client client.Client, namespace string, drpcName string) erro
 			return nil
 		}
 
-		if time.Since(startTime) > time.Second*time.Duration(util.Timeout) {
+		if time.Since(startTime) > util.Timeout {
 			if !conditionReady {
 				util.Ctx.Log.Info("drpc " + drpcName + " condition 'Available' or 'PeerReady' is not True")
 			}
@@ -81,7 +81,7 @@ func waitDRPCReady(client client.Client, namespace string, drpcName string) erro
 			return fmt.Errorf("drpc " + drpcName + " is not ready yet before timeout, fail")
 		}
 
-		time.Sleep(time.Second * time.Duration(util.TimeInterval))
+		time.Sleep(util.TimeInterval)
 	}
 }
 
@@ -126,12 +126,12 @@ func waitDRPCPhase(client client.Client, namespace, name string, phase ramen.DRS
 			return nil
 		}
 
-		if time.Since(startTime) > time.Second*time.Duration(util.Timeout) {
+		if time.Since(startTime) > util.Timeout {
 			return fmt.Errorf(fmt.Sprintf(
 				"drpc %s status is not %s yet before timeout, fail", name, phase))
 		}
 
-		time.Sleep(time.Second * time.Duration(util.TimeInterval))
+		time.Sleep(util.TimeInterval)
 	}
 }
 
@@ -205,11 +205,11 @@ func waitDRPCDeleted(client client.Client, namespace string, name string) error 
 			util.Ctx.Log.Info(fmt.Sprintf("error to get drpc %s: %v", name, err))
 		}
 
-		if time.Since(startTime) > time.Second*time.Duration(util.Timeout) {
+		if time.Since(startTime) > util.Timeout {
 			return fmt.Errorf(fmt.Sprintf("drpc %s is not deleted yet before timeout, fail", name))
 		}
 
-		time.Sleep(time.Second * time.Duration(util.TimeInterval))
+		time.Sleep(util.TimeInterval)
 	}
 }
 
@@ -230,12 +230,12 @@ func waitDRPCProgression(client client.Client, namespace, name string, progressi
 			return nil
 		}
 
-		if time.Since(startTime) > time.Second*time.Duration(util.Timeout) {
+		if time.Since(startTime) > util.Timeout {
 			return fmt.Errorf(fmt.Sprintf("drpc %s progression is not %s yet before timeout of %v",
 				name, progression, util.Timeout))
 		}
 
-		time.Sleep(time.Second * time.Duration(util.TimeInterval))
+		time.Sleep(util.TimeInterval)
 	}
 }
 

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -127,8 +127,7 @@ func waitDRPCPhase(client client.Client, namespace, name string, phase ramen.DRS
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			return fmt.Errorf(fmt.Sprintf(
-				"drpc %s status is not %s yet before timeout, fail", name, phase))
+			return fmt.Errorf("drpc %s status is not %s yet before timeout, fail", name, phase)
 		}
 
 		time.Sleep(util.RetryInterval)
@@ -202,7 +201,7 @@ func waitDRPCDeleted(client client.Client, namespace string, name string) error 
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			return fmt.Errorf(fmt.Sprintf("drpc %s is not deleted yet before timeout, fail", name))
+			return fmt.Errorf("drpc %s is not deleted yet before timeout, fail", name)
 		}
 
 		time.Sleep(util.RetryInterval)
@@ -227,8 +226,8 @@ func waitDRPCProgression(client client.Client, namespace, name string, progressi
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			return fmt.Errorf(fmt.Sprintf("drpc %s progression is not %s yet before timeout of %v",
-				name, progression, util.Timeout))
+			return fmt.Errorf("drpc %s progression is not %s yet before timeout of %v",
+				name, progression, util.Timeout)
 		}
 
 		time.Sleep(util.RetryInterval)

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -49,7 +49,7 @@ func waitPlacementDecision(client client.Client, namespace string, placementName
 				"could not get placement decision for " + placementName + " before timeout, fail")
 		}
 
-		time.Sleep(util.TimeInterval)
+		time.Sleep(util.RetryInterval)
 	}
 }
 
@@ -81,7 +81,7 @@ func waitDRPCReady(client client.Client, namespace string, drpcName string) erro
 			return fmt.Errorf("drpc " + drpcName + " is not ready yet before timeout, fail")
 		}
 
-		time.Sleep(util.TimeInterval)
+		time.Sleep(util.RetryInterval)
 	}
 }
 
@@ -131,7 +131,7 @@ func waitDRPCPhase(client client.Client, namespace, name string, phase ramen.DRS
 				"drpc %s status is not %s yet before timeout, fail", name, phase))
 		}
 
-		time.Sleep(util.TimeInterval)
+		time.Sleep(util.RetryInterval)
 	}
 }
 
@@ -209,7 +209,7 @@ func waitDRPCDeleted(client client.Client, namespace string, name string) error 
 			return fmt.Errorf(fmt.Sprintf("drpc %s is not deleted yet before timeout, fail", name))
 		}
 
-		time.Sleep(util.TimeInterval)
+		time.Sleep(util.RetryInterval)
 	}
 }
 
@@ -235,7 +235,7 @@ func waitDRPCProgression(client client.Client, namespace, name string, progressi
 				name, progression, util.Timeout))
 		}
 
-		time.Sleep(util.TimeInterval)
+		time.Sleep(util.RetryInterval)
 	}
 }
 

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -178,8 +178,6 @@ func getTargetCluster(client client.Client, namespace, placementName string, drp
 
 // first wait DRPC to have the expected phase, then check DRPC conditions
 func waitDRPC(client client.Client, namespace, name string, expectedPhase ramen.DRState) error {
-	// sleep to wait for DRPC is processed
-	time.Sleep(FiveSecondsDuration)
 	// check Phase
 	if err := waitDRPCPhase(client, namespace, name, expectedPhase); err != nil {
 		return err
@@ -190,8 +188,6 @@ func waitDRPC(client client.Client, namespace, name string, expectedPhase ramen.
 
 func waitDRPCDeleted(client client.Client, namespace string, name string) error {
 	startTime := time.Now()
-	// sleep to wait for DRPC is deleted
-	time.Sleep(FiveSecondsDuration)
 
 	for {
 		_, err := getDRPC(client, namespace, name)

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 	}
 
 	log.Info("Global setting", "Timeout", util.Timeout)
-	log.Info("Global setting", "Retry Interval", util.TimeInterval)
+	log.Info("Global setting", "Retry Interval", util.RetryInterval)
 
 	os.Exit(m.Run())
 }

--- a/e2e/util/const.go
+++ b/e2e/util/const.go
@@ -3,11 +3,13 @@
 
 package util
 
+import "time"
+
 const (
 	RamenSystemNamespace = "ramen-system"
 
-	Timeout      = 600 // seconds
-	TimeInterval = 30  // seconds
+	Timeout      = 600 * time.Second
+	TimeInterval = 30 * time.Second
 
 	defaultChannelName      = "ramen-gitops"
 	defaultChannelNamespace = "ramen-samples"

--- a/e2e/util/const.go
+++ b/e2e/util/const.go
@@ -9,7 +9,7 @@ const (
 	RamenSystemNamespace = "ramen-system"
 
 	Timeout       = 600 * time.Second
-	RetryInterval = 30 * time.Second
+	RetryInterval = 5 * time.Second
 
 	defaultChannelName      = "ramen-gitops"
 	defaultChannelNamespace = "ramen-samples"

--- a/e2e/util/const.go
+++ b/e2e/util/const.go
@@ -8,8 +8,8 @@ import "time"
 const (
 	RamenSystemNamespace = "ramen-system"
 
-	Timeout      = 600 * time.Second
-	TimeInterval = 30 * time.Second
+	Timeout       = 600 * time.Second
+	RetryInterval = 30 * time.Second
 
 	defaultChannelName      = "ramen-gitops"
 	defaultChannelNamespace = "ramen-samples"


### PR DESCRIPTION
- Use time.Duration for timeouts
- Rename TimeoutInterval to RetryInterval
- Shorten retry internal to 5 seconds
- Remove unneeded use of fmt.Sprintf