### PR TITLE
test: don't use name-prefix when creating the drenv env

### DIFF
--- a/docs/devel-quick-start.md
+++ b/docs/devel-quick-start.md
@@ -107,20 +107,18 @@ You can either deploy the *Ramen* operator using the make targets or use the
 - Using `ramenctl`
 
     Ensure python virtual environment is active as `ramenctl` is a python tool.
-    The default name-prefix in the make target `create-rdr-env` is `rdr-`, we
-    will use the same in the `ramenctl` commands.
 
     - Deploy the *Ramen* operator in the environment using `ramenctl`.
 
      ```sh
-     ramenctl deploy --name-prefix rdr- test/envs/regional-dr.yaml
+     ramenctl deploy test/envs/regional-dr.yaml
      ```
 
     - Ramen needs to be configured to know about the managed clusters and the s3
    endpoints. Configure the ramen operator for environment.
 
     ```sh
-    ramenctl config --name-prefix rdr- test/envs/regional-dr.yaml
+    ramenctl config test/envs/regional-dr.yaml
     ```
 
 ## Testing Ramen
@@ -133,6 +131,6 @@ If you want to clean up your environment, you can unconfigure *Ramen* and
 undeploy it.
 
 ```sh
-ramenctl unconfig --name-prefix rdr- test/envs/regional-dr.yaml
-ramenctl undeploy --name-prefix rdr- test/envs/regional-dr.yaml
+ramenctl unconfig test/envs/regional-dr.yaml
+ramenctl undeploy test/envs/regional-dr.yaml
 ```

--- a/hack/dev-env.sh
+++ b/hack/dev-env.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-RDR_NAME_PREFIX=${RDR_NAME_PREFIX:-rdr}
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
 if [[ $1 != "create" && $1 != "destroy" ]]; then
@@ -20,9 +19,9 @@ cd "$script_dir"/..
 cd test
 
 if [[ $1 == "create" ]]; then
-    drenv start --name-prefix "${RDR_NAME_PREFIX}"- envs/regional-dr.yaml
+    drenv start envs/regional-dr.yaml
 fi
 
 if [[ $1 == "destroy" ]]; then
-    drenv delete --name-prefix "${RDR_NAME_PREFIX}"- envs/regional-dr.yaml
+    drenv delete envs/regional-dr.yaml
 fi


### PR DESCRIPTION
Our samples repository assume that the clusters are named without a prefix. Using a name-prefix in the devel-quick-start guide and default make targets is making it difficult for the users to get started.

If the users want to create more than one environment they can still use the name-prefix but the defaults should make it easy for them to use the samples as-is.