### PR TITLE
Fix rdspec and protectedpvcs condition

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -1530,7 +1530,7 @@ func (d *DRPCInstance) createVRGManifestWork(homeCluster string, repState rmn.Re
 	annotations[DRPCNameAnnotation] = d.instance.Name
 	annotations[DRPCNamespaceAnnotation] = d.instance.Namespace
 
-	if err := d.mwu.CreateOrUpdateVRGManifestWork(
+	if _, err := d.mwu.CreateOrUpdateVRGManifestWork(
 		d.instance.Name, d.vrgNamespace,
 		homeCluster, vrg, annotations); err != nil {
 		d.log.Error(err, "failed to create or update VolumeReplicationGroup manifest")

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -1405,6 +1405,8 @@ func (d *DRPCInstance) moveVRGToSecondaryEverywhere() bool {
 }
 
 func (d *DRPCInstance) cleanupSecondaries(skipCluster string) (bool, error) {
+	d.log.Info("Cleaning up secondaries.")
+
 	for _, clusterName := range rmnutil.DRPolicyClusterNames(d.drPolicy) {
 		if skipCluster == clusterName {
 			continue
@@ -1759,7 +1761,7 @@ func (d *DRPCInstance) EnsureCleanup(clusterToSkip string) error {
 	}
 
 	if !clean {
-		msg := "cleaning secondaries"
+		msg := "cleaning up secondaries"
 		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
 			metav1.ConditionFalse, rmn.ReasonCleaning, msg)
 
@@ -1774,8 +1776,7 @@ func (d *DRPCInstance) EnsureCleanup(clusterToSkip string) error {
 
 //nolint:gocognit
 func (d *DRPCInstance) cleanupForVolSync(clusterToSkip string) error {
-	d.log.Info("VolSync needs both VRGs. No need to clean up secondary")
-	d.log.Info("Ensure secondary on peer")
+	d.log.Info("VolSync needs both VRGs. Ensure secondary setup on peer")
 
 	peersReady := true
 

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -874,7 +874,7 @@ func (d *DRPCInstance) RunRelocate() (bool, error) {
 		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), errMsg)
 
-		return !done, fmt.Errorf(errMsg)
+		return !done, fmt.Errorf("%s", errMsg)
 	}
 
 	if d.getLastDRState() != rmn.Relocating && !d.validatePeerReady() {
@@ -935,7 +935,7 @@ func (d *DRPCInstance) ensureCleanupAndVolSyncReplicationSetup(srcCluster string
 	// in the MW, but the VRGs in the vrgs slice are fetched using MCV.
 	vrg, ok := d.vrgs[srcCluster]
 	if !ok || len(vrg.Spec.VolSync.RDSpec) != 0 {
-		return fmt.Errorf(fmt.Sprintf("Waiting for RDSpec count on cluster %s to go to zero. VRG OK? %v", srcCluster, ok))
+		return fmt.Errorf("waiting for RDSpec count on cluster %s to go to zero. VRG OK? %v", srcCluster, ok)
 	}
 
 	err = d.EnsureCleanup(srcCluster)
@@ -1521,10 +1521,10 @@ func (d *DRPCInstance) createVRGManifestWork(homeCluster string, repState rmn.Re
 	}
 
 	// create VRG ManifestWork
-	d.log.Info("Creating VRG ManifestWork",
+	d.log.Info("Creating VRG ManifestWork", "ReplicationState", repState,
 		"Last State:", d.getLastDRState(), "cluster", homeCluster)
 
-	vrg := d.generateVRG(homeCluster, repState)
+	vrg := d.newVRG(homeCluster, repState)
 	vrg.Spec.VolSync.Disabled = d.volSyncDisabled
 
 	annotations := make(map[string]string)
@@ -1589,7 +1589,7 @@ func (d *DRPCInstance) setVRGAction(vrg *rmn.VolumeReplicationGroup) {
 	vrg.Spec.Action = action
 }
 
-func (d *DRPCInstance) generateVRG(dstCluster string, repState rmn.ReplicationState) rmn.VolumeReplicationGroup {
+func (d *DRPCInstance) newVRG(dstCluster string, repState rmn.ReplicationState) rmn.VolumeReplicationGroup {
 	vrg := rmn.VolumeReplicationGroup{
 		TypeMeta: metav1.TypeMeta{Kind: "VolumeReplicationGroup", APIVersion: "ramendr.openshift.io/v1alpha1"},
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -935,8 +935,7 @@ func (d *DRPCInstance) ensureCleanupAndVolSyncReplicationSetup(srcCluster string
 	// in the MW, but the VRGs in the vrgs slice are fetched using MCV.
 	vrg, ok := d.vrgs[srcCluster]
 	if !ok || len(vrg.Spec.VolSync.RDSpec) != 0 {
-		return fmt.Errorf(fmt.Sprintf("Waiting for RDSpec count on cluster %s to go to zero. VRG OK? %v",
-			srcCluster, ok))
+		return fmt.Errorf(fmt.Sprintf("Waiting for RDSpec count on cluster %s to go to zero. VRG OK? %v", srcCluster, ok))
 	}
 
 	err = d.EnsureCleanup(srcCluster)
@@ -1793,7 +1792,7 @@ func (d *DRPCInstance) cleanupForVolSync(clusterToSkip string) error {
 
 			// Recreate the VRG ManifestWork for the secondary. This typically happens during Hub Recovery.
 			if errors.IsNotFound(err) {
-				err := d.createVolSyncDestManifestWork(clusterToSkip)
+				err := d.ensureVolSyncSetup(clusterToSkip)
 				if err != nil {
 					return err
 				}

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -1134,7 +1134,7 @@ func getVRGsFromManagedClusters(
 
 		vrgs[drCluster.Name] = vrg
 
-		log.Info("VRG location", "VRG on", drCluster.Name)
+		log.Info("VRG location", "VRG on", drCluster.Name, "replicationState", vrg.Spec.ReplicationState)
 	}
 
 	// We are done if we successfully queried all drClusters

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -2244,7 +2244,7 @@ func adoptExistingVRGManifestWork(
 	annotations[DRPCNameAnnotation] = drpc.Name
 	annotations[DRPCNamespaceAnnotation] = drpc.Namespace
 
-	err := mwu.CreateOrUpdateVRGManifestWork(drpc.Name, vrgNamespace, cluster, *vrg, annotations)
+	_, err := mwu.CreateOrUpdateVRGManifestWork(drpc.Name, vrgNamespace, cluster, *vrg, annotations)
 	if err != nil {
 		log.Info("error updating VRG via ManifestWork during adoption", "error", err, "cluster", cluster)
 	}
@@ -2281,7 +2281,7 @@ func adoptOrphanVRG(
 
 	vrg.Annotations[DRPCUIDAnnotation] = string(drpc.UID)
 
-	if err := mwu.CreateOrUpdateVRGManifestWork(
+	if _, err := mwu.CreateOrUpdateVRGManifestWork(
 		drpc.Name, vrgNamespace,
 		cluster, *vrg, annotations); err != nil {
 		log.Info("error creating VRG via ManifestWork during adoption", "error", err, "cluster", cluster)

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -1004,7 +1004,8 @@ func createVRGMW(name, namespace, homeCluster string) {
 		TargetNamespace: namespace,
 	}
 
-	Expect(mwu.CreateOrUpdateVRGManifestWork(name, namespace, homeCluster, *vrg, nil)).To(Succeed())
+	_, err := mwu.CreateOrUpdateVRGManifestWork(name, namespace, homeCluster, *vrg, nil)
+	Expect(err).To(Succeed())
 }
 
 func updateManifestWorkStatus(clusterNamespace, vrgNamespace, mwType, workType string) {

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -56,14 +56,12 @@ const (
 	SyncDRPolicyName      = "my-sync-dr-peers"
 	MModeReplicationID    = "storage-replication-id-1"
 	MModeCSIProvisioner   = "test.csi.com"
-
-	pvcCount = 2 // Count of fake PVCs reported in the VRG status
 )
 
 var (
-	NumberOfVrgsToReturnWhenRebuildingState = 0
-
-	UseApplicationSet = false
+	ProtectedPVCCount   = 2 // Count of fake PVCs reported in the VRG status
+	RunningVolSyncTests = false
+	UseApplicationSet   = false
 
 	west1Cluster = &spokeClusterV1.ManagedCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -425,7 +423,7 @@ func (f FakeMCVGetter) GetVRGFromManagedCluster(resourceName, resourceNamespace,
 		return nil, fmt.Errorf("%s: Faking cluster down %s", getFunctionNameAtIndex(2), managedCluster)
 	}
 
-	vrg, err := getVRGFromManifestWork(managedCluster, resourceNamespace)
+	vrg, err := GetFakeVRGFromMCVUsingMW(managedCluster, resourceNamespace)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return fakeVRGConditionally(resourceNamespace, managedCluster, err)
@@ -506,7 +504,8 @@ func getVRGNamespace(defaultNamespace string) string {
 }
 
 //nolint:funlen
-func getVRGFromManifestWork(managedCluster, resourceNamespace string) (*rmn.VolumeReplicationGroup, error) {
+func GetFakeVRGFromMCVUsingMW(managedCluster, resourceNamespace string,
+) (*rmn.VolumeReplicationGroup, error) {
 	manifestLookupKey := types.NamespacedName{
 		Name:      rmnutil.ManifestWorkName(DRPCCommonName, getVRGNamespace(resourceNamespace), "vrg"),
 		Namespace: managedCluster,
@@ -540,14 +539,10 @@ func getVRGFromManifestWork(managedCluster, resourceNamespace string) (*rmn.Volu
 	vrg.Status.FinalSyncComplete = true
 	vrg.Status.ProtectedPVCs = []rmn.ProtectedPVC{}
 
-	for i := 0; i < pvcCount; i++ {
-		protectedPVC := rmn.ProtectedPVC{}
-		protectedPVC.Name = fmt.Sprintf("fakePVC%d", i)
-		protectedPVC.StorageIdentifiers.ReplicationID.ID = MModeReplicationID
-		protectedPVC.StorageIdentifiers.StorageProvisioner = MModeCSIProvisioner
-		protectedPVC.StorageIdentifiers.ReplicationID.Modes = []rmn.MMode{rmn.MModeFailover}
-
-		vrg.Status.ProtectedPVCs = append(vrg.Status.ProtectedPVCs, protectedPVC)
+	if RunningVolSyncTests {
+		createFakeProtectedPVCsForVolSync(vrg)
+	} else {
+		createFakeProtectedPVCsForVolRep(vrg)
 	}
 
 	// Always report conditions as a success?
@@ -596,6 +591,28 @@ func getVRGFromManifestWork(managedCluster, resourceNamespace string) (*rmn.Volu
 	})
 
 	return vrg, nil
+}
+
+func createFakeProtectedPVCsForVolRep(vrg *rmn.VolumeReplicationGroup) {
+	for i := 0; i < ProtectedPVCCount; i++ {
+		protectedPVC := rmn.ProtectedPVC{}
+		protectedPVC.Name = fmt.Sprintf("fakePVC%d", i)
+		protectedPVC.StorageIdentifiers.ReplicationID.ID = MModeReplicationID
+		protectedPVC.StorageIdentifiers.StorageProvisioner = MModeCSIProvisioner
+		protectedPVC.StorageIdentifiers.ReplicationID.Modes = []rmn.MMode{rmn.MModeFailover}
+
+		vrg.Status.ProtectedPVCs = append(vrg.Status.ProtectedPVCs, protectedPVC)
+	}
+}
+
+func createFakeProtectedPVCsForVolSync(vrg *rmn.VolumeReplicationGroup) {
+	for i := 0; i < ProtectedPVCCount; i++ {
+		protectedPVC := rmn.ProtectedPVC{}
+		protectedPVC.Name = fmt.Sprintf("fakePVC-%d-for-volsync", i)
+		protectedPVC.ProtectedByVolSync = true
+
+		vrg.Status.ProtectedPVCs = append(vrg.Status.ProtectedPVCs, protectedPVC)
+	}
 }
 
 func fakeVRGWithMModesProtectedPVC(vrgNamespace string) *rmn.VolumeReplicationGroup {
@@ -1384,7 +1401,7 @@ func verifyDRPCStatusPreferredClusterExpectation(namespace string, drState rmn.D
 			return d.ClusterName == East1ManagedCluster &&
 				idx != -1 &&
 				condition.Reason == string(drState) &&
-				len(updatedDRPC.Status.ResourceConditions.ResourceMeta.ProtectedPVCs) == pvcCount
+				len(updatedDRPC.Status.ResourceConditions.ResourceMeta.ProtectedPVCs) == ProtectedPVCCount
 		}
 
 		return false
@@ -1495,7 +1512,7 @@ func runFailoverAction(placementObj client.Object, fromCluster, toCluster string
 		fenceCluster(fromCluster, manualFence)
 	}
 
-	recoverToFailoverCluster(placementObj, fromCluster, toCluster)
+	recoverToFailoverCluster(placementObj, fromCluster, toCluster, false)
 	// TODO: DRCluster as part of Unfence operation, first unfences
 	//       the NetworkFence CR and then deletes it. Hence, by the
 	//       time this test is made, depending upon whether NetworkFence
@@ -1548,7 +1565,7 @@ func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR 
 		resetdrCluster(toCluster1)
 	}
 
-	relocateToPreferredCluster(placementObj, fromCluster)
+	relocateToPreferredCluster(placementObj, fromCluster, false)
 	// TODO: DRCluster as part of Unfence operation, first unfences
 	//       the NetworkFence CR and then deletes it. Hence, by the
 	//       time this test is made, depending upon whether NetworkFence
@@ -1598,7 +1615,7 @@ func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferre
 	Expect(decision.ClusterName).To(Equal(preferredCluster))
 }
 
-func relocateToPreferredCluster(placementObj client.Object, fromCluster string) {
+func relocateToPreferredCluster(placementObj client.Object, fromCluster string, skipWaitForWMDeletion bool) {
 	toCluster1 := "east1-cluster"
 
 	setDRPCSpecExpectationTo(placementObj.GetNamespace(), toCluster1, fromCluster, rmn.ActionRelocate)
@@ -1609,12 +1626,14 @@ func relocateToPreferredCluster(placementObj client.Object, fromCluster string) 
 	verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.Relocated)
 	verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster1)
 
-	waitForVRGMWDeletion(West1ManagedCluster, placementObj.GetNamespace())
+	if !skipWaitForWMDeletion {
+		waitForVRGMWDeletion(West1ManagedCluster, placementObj.GetNamespace())
+	}
 
 	waitForCompletion(string(rmn.Relocated))
 }
 
-func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster string) {
+func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster string, skipWaitForWMDeletion bool) {
 	setDRPCSpecExpectationTo(placementObj.GetNamespace(), fromCluster, toCluster, rmn.ActionFailover)
 
 	updateManifestWorkStatus(toCluster, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)
@@ -1623,7 +1642,9 @@ func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster
 	verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.FailedOver)
 	verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster)
 
-	waitForVRGMWDeletion(fromCluster, placementObj.GetNamespace())
+	if !skipWaitForWMDeletion {
+		waitForVRGMWDeletion(fromCluster, placementObj.GetNamespace())
+	}
 
 	waitForCompletion(string(rmn.FailedOver))
 }
@@ -1753,7 +1774,7 @@ func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster s
 func verifyFailoverToSecondary(placementObj client.Object, toCluster string,
 	isSyncDR bool,
 ) {
-	recoverToFailoverCluster(placementObj, East1ManagedCluster, toCluster)
+	recoverToFailoverCluster(placementObj, East1ManagedCluster, toCluster, false)
 
 	// TODO: DRCluster as part of Unfence operation, first unfences
 	//       the NetworkFence CR and then deletes it. Hence, by the
@@ -1787,7 +1808,7 @@ func verifyActionResultForPlacement(placement *clrapiv1beta1.Placement, homeClus
 	Expect(placementDecision).ShouldNot(BeNil())
 	Expect(placementDecision.GetLabels()[rmnutil.ExcludeFromVeleroBackup]).Should(Equal("true"))
 	Expect(placementDecision.Status.Decisions[0].ClusterName).Should(Equal(homeCluster))
-	vrg, err := getVRGFromManifestWork(homeCluster, placement.GetNamespace())
+	vrg, err := GetFakeVRGFromMCVUsingMW(homeCluster, placement.GetNamespace())
 	Expect(err).NotTo(HaveOccurred())
 
 	switch plType {
@@ -2653,7 +2674,145 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(0))
 		})
 	})
+
+	Context("Test DRPlacementControl With VolSync Setup", func() {
+		var userPlacementRule *plrv1.PlacementRule
+		var drpc *rmn.DRPlacementControl
+
+		Specify("DRClusters", func() {
+			RunningVolSyncTests = true
+			populateDRClusters()
+		})
+		When("The Application is deployed for VolSync", func() {
+			It("Should deploy to East1ManagedCluster", func() {
+				var placementObj client.Object
+				placementObj, drpc = InitialDeploymentAsync(
+					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
+				userPlacementRule = placementObj.(*plrv1.PlacementRule)
+				Expect(userPlacementRule).NotTo(BeNil())
+				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
+				verifyDRPCOwnedByPlacement(userPlacementRule, getLatestDRPC(DefaultDRPCNamespace))
+			})
+		})
+		When("DRAction is changed to Failover", func() {
+			It("Should failover to Secondary (West1ManagedCluster)", func() {
+				recoverToFailoverCluster(userPlacementRule, East1ManagedCluster, West1ManagedCluster, true)
+				Expect(getVRGManifestWorkCount()).Should(Equal(2))
+				verifyRDSpecAfterActionSwitch(West1ManagedCluster, East1ManagedCluster, 2)
+			})
+		})
+		When("DRAction is set to Relocate", func() {
+			It("Should relocate to Primary (East1ManagedCluster)", func() {
+				relocateToPreferredCluster(userPlacementRule, West1ManagedCluster, true)
+				Expect(getVRGManifestWorkCount()).Should(Equal(2))
+				verifyRDSpecAfterActionSwitch(East1ManagedCluster, West1ManagedCluster, 2)
+			})
+		})
+		When("DRAction is changed back to Failover using only 1 protectedPVC", func() {
+			It("Should failover to secondary (West1ManagedCluster)", func() {
+				ProtectedPVCCount = 1
+				recoverToFailoverCluster(userPlacementRule, East1ManagedCluster, West1ManagedCluster, true)
+				Expect(getVRGManifestWorkCount()).Should(Equal(2))
+				verifyRDSpecAfterActionSwitch(West1ManagedCluster, East1ManagedCluster, 1)
+				ProtectedPVCCount = 2
+			})
+		})
+		When("DRAction is set back to Relocate using only 1 protectedPVC", func() {
+			It("Should relocate to Primary (East1ManagedCluster)", func() {
+				ProtectedPVCCount = 1
+				relocateToPreferredCluster(userPlacementRule, West1ManagedCluster, true)
+				Expect(getVRGManifestWorkCount()).Should(Equal(2))
+				verifyRDSpecAfterActionSwitch(East1ManagedCluster, West1ManagedCluster, 1)
+				ProtectedPVCCount = 2
+			})
+		})
+		When("DRAction is changed back to Failover using only 10 protectedPVC", func() {
+			It("Should failover to secondary (West1ManagedCluster)", func() {
+				ProtectedPVCCount = 10
+				recoverToFailoverCluster(userPlacementRule, East1ManagedCluster, West1ManagedCluster, true)
+				Expect(getVRGManifestWorkCount()).Should(Equal(2))
+				verifyRDSpecAfterActionSwitch(West1ManagedCluster, East1ManagedCluster, 10)
+				ProtectedPVCCount = 2
+			})
+		})
+		When("DRAction is set back to Relocate using only 10 protectedPVC", func() {
+			It("Should relocate to Primary (East1ManagedCluster)", func() {
+				ProtectedPVCCount = 10
+				relocateToPreferredCluster(userPlacementRule, West1ManagedCluster, true)
+				Expect(getVRGManifestWorkCount()).Should(Equal(2))
+				verifyRDSpecAfterActionSwitch(East1ManagedCluster, West1ManagedCluster, 10)
+				ProtectedPVCCount = 2
+			})
+		})
+		When("Deleting DRPolicy with DRPC references", func() {
+			It("Should retain the deleted DRPolicy in the API server", func() {
+				deleteDRPolicyAsync()
+				ensureDRPolicyIsNotDeleted(drpc)
+			})
+		})
+		When("Deleting user PlacementRule", func() {
+			It("Should cleanup DRPC", func() {
+				deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+			})
+		})
+
+		When("Deleting DRPC", func() {
+			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
+				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG MW
+				deleteDRPC()
+				waitForCompletion("deleted")
+				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
+				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
+				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
+			})
+			It("should delete the DRPC causing its referenced drpolicy to be deleted"+
+				" by drpolicy controller since no DRPCs reference it anymore", func() {
+				ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)
+			})
+		})
+		Specify("delete drclusters", func() {
+			RunningVolSyncTests = false
+			deleteDRClustersAsync()
+		})
+	})
 })
+
+func getVRGManifestWorkCount() int {
+	count := 0
+
+	for _, drCluster := range drClusters {
+		mwName := rmnutil.ManifestWorkName(DRPCCommonName, DefaultDRPCNamespace, rmnutil.MWTypeVRG)
+		mw := &ocmworkv1.ManifestWork{}
+
+		err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: mwName, Namespace: drCluster.Name}, mw)
+		if err == nil {
+			count++
+		}
+	}
+
+	return count
+}
+
+func getVRGFromManifestWork(clusterNamespace string) (*rmn.VolumeReplicationGroup, error) {
+	mwName := rmnutil.ManifestWorkName(DRPCCommonName, DefaultDRPCNamespace, rmnutil.MWTypeVRG)
+	mw := &ocmworkv1.ManifestWork{}
+
+	err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: mwName, Namespace: clusterNamespace}, mw)
+	Expect(err).NotTo(HaveOccurred())
+
+	return rmnutil.ExtractVRGFromManifestWork(mw)
+}
+
+func verifyRDSpecAfterActionSwitch(primaryCluster, secondaryCluster string, numOfRDSpecs int) {
+	// For Primary Cluster
+	vrg, err := getVRGFromManifestWork(primaryCluster)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(vrg.Spec.VolSync.RDSpec)).Should(Equal(0))
+	// For Secondary Cluster
+	vrg, err = getVRGFromManifestWork(secondaryCluster)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(len(vrg.Spec.VolSync.RDSpec)).Should(Equal(numOfRDSpecs))
+}
 
 func verifyDRPCStateAndProgression(expectedAction rmn.DRAction, expectedPhase rmn.DRState,
 	exptectedPorgression rmn.ProgressionStatus,

--- a/internal/controller/drplacementcontrolvolsync.go
+++ b/internal/controller/drplacementcontrolvolsync.go
@@ -183,7 +183,7 @@ func (d *DRPCInstance) refreshRDSpec(srcCluster, dstCluster string) (*rmn.Volume
 		return nil, WaitForSourceCluster
 	}
 
-	dstVRG := d.generateVRG(dstCluster, rmn.Secondary)
+	dstVRG := d.newVRG(dstCluster, rmn.Secondary)
 	d.resetRDSpec(srcVRG, &dstVRG)
 
 	return &dstVRG, nil
@@ -237,7 +237,7 @@ func (d *DRPCInstance) ResetVolSyncRDOnPrimary(clusterName string) error {
 	if vrg.Spec.ReplicationState != rmn.Primary {
 		d.log.Info(fmt.Sprintf("VRG %s not primary on this cluster %s", vrg.Name, mw.Namespace))
 
-		return fmt.Errorf(fmt.Sprintf("VRG %s not primary on this cluster %s", vrg.Name, mw.Namespace))
+		return fmt.Errorf("vrg %s is not set as primary on this cluster, %s", vrg.Name, mw.Namespace)
 	}
 
 	if len(vrg.Spec.VolSync.RDSpec) == 0 {

--- a/internal/controller/drplacementcontrolvolsync.go
+++ b/internal/controller/drplacementcontrolvolsync.go
@@ -32,20 +32,14 @@ func (d *DRPCInstance) EnsureVolSyncReplicationSetup(homeCluster string) error {
 		return nil
 	}
 
-	err = d.ensureVolSyncReplicationCommon(homeCluster)
-	if err != nil {
-		return err
-	}
-
-	return d.ensureVolSyncReplicationDestination(homeCluster)
+	return d.ensureVolSyncSetup(homeCluster)
 }
 
-func (d *DRPCInstance) ensureVolSyncReplicationCommon(srcCluster string) error {
-	// Make sure we have Source and Destination VRGs - Source should already have been created at this point
+func (d *DRPCInstance) ensureVolSyncSetup(srcCluster string) error {
 	d.setProgression(rmn.ProgressionEnsuringVolSyncSetup)
 
 	// Create or update the destination VRG
-	err := d.createVolSyncDestManifestWork(srcCluster)
+	err := d.createOrUpdateVolSyncDestManifestWork(srcCluster)
 	if err != nil {
 		return err
 	}
@@ -94,93 +88,6 @@ func (d *DRPCInstance) ensureVolSyncReplicationCommon(srcCluster string) error {
 	return nil
 }
 
-func (d *DRPCInstance) ensureVolSyncReplicationDestination(srcCluster string) error {
-	d.setProgression(rmn.ProgressionSettingupVolsyncDest)
-
-	srcVRG, found := d.vrgs[srcCluster]
-	if !found {
-		return fmt.Errorf("failed to find source VolSync VRG in cluster %s. VRGs %v", srcCluster, d.vrgs)
-	}
-
-	d.log.Info("Ensuring VolSync replication destination")
-
-	if len(srcVRG.Status.ProtectedPVCs) == 0 {
-		d.log.Info("ProtectedPVCs on pirmary cluster is empty")
-
-		return WaitForSourceCluster
-	}
-
-	for dstCluster, dstVRG := range d.vrgs {
-		if dstCluster == srcCluster {
-			continue
-		}
-
-		if dstVRG == nil {
-			return fmt.Errorf("invalid VolSync VRG entry")
-		}
-
-		volSyncPVCCount := d.getVolSyncPVCCount(srcCluster)
-		if len(dstVRG.Spec.VolSync.RDSpec) != volSyncPVCCount || d.containsMismatchVolSyncPVCs(srcVRG, dstVRG) {
-			err := d.updateDestinationVRG(dstCluster, srcVRG, dstVRG)
-			if err != nil {
-				return fmt.Errorf("failed to update dst VRG on cluster %s - %w", dstCluster, err)
-			}
-		}
-
-		d.log.Info(fmt.Sprintf("Ensured VolSync replication destination for cluster %s", dstCluster))
-		// TODO: Should we handle more than one dstVRG? For now, just settle for one.
-		break
-	}
-
-	return nil
-}
-
-// containsMismatchVolSyncPVCs returns true if a VolSync protected pvc in the source VRG is not
-// found in the destination VRG RDSpecs.  Since we never delete protected PVCS from the source VRG,
-// we don't check for other case - a protected PVC in destination not found in the source.
-func (d *DRPCInstance) containsMismatchVolSyncPVCs(srcVRG *rmn.VolumeReplicationGroup,
-	dstVRG *rmn.VolumeReplicationGroup,
-) bool {
-	for _, protectedPVC := range srcVRG.Status.ProtectedPVCs {
-		if !protectedPVC.ProtectedByVolSync {
-			continue
-		}
-
-		for _, rdSpec := range dstVRG.Spec.VolSync.RDSpec {
-			if protectedPVC.Name == rdSpec.ProtectedPVC.Name &&
-				protectedPVC.Namespace == rdSpec.ProtectedPVC.Namespace {
-				return false
-			}
-		}
-
-		// VolSync PVC not found in destination.
-		return true
-	}
-
-	return false
-}
-
-func (d *DRPCInstance) updateDestinationVRG(clusterName string, srcVRG *rmn.VolumeReplicationGroup,
-	dstVRG *rmn.VolumeReplicationGroup,
-) error {
-	// clear RDSpec
-	dstVRG.Spec.VolSync.RDSpec = nil
-
-	for _, protectedPVC := range srcVRG.Status.ProtectedPVCs {
-		if !protectedPVC.ProtectedByVolSync {
-			continue
-		}
-
-		rdSpec := rmn.VolSyncReplicationDestinationSpec{
-			ProtectedPVC: protectedPVC,
-		}
-
-		dstVRG.Spec.VolSync.RDSpec = append(dstVRG.Spec.VolSync.RDSpec, rdSpec)
-	}
-
-	return d.updateVRGSpec(clusterName, dstVRG)
-}
-
 func (d *DRPCInstance) IsVolSyncReplicationRequired(homeCluster string) (bool, error) {
 	if d.volSyncDisabled {
 		d.log.Info("VolSync is disabled")
@@ -214,85 +121,16 @@ func (d *DRPCInstance) IsVolSyncReplicationRequired(homeCluster string) (bool, e
 	return !required, nil
 }
 
-func (d *DRPCInstance) getVolSyncPVCCount(homeCluster string) int {
-	pvcCount := 0
-	vrg := d.vrgs[homeCluster]
-
-	if vrg == nil {
-		d.log.Info(fmt.Sprintf("getVolSyncPVCCount: VRG not available on cluster %s", homeCluster))
-
-		return pvcCount
-	}
-
-	for _, protectedPVC := range vrg.Status.ProtectedPVCs {
-		if protectedPVC.ProtectedByVolSync {
-			pvcCount++
-		}
-	}
-
-	return pvcCount
-}
-
-func (d *DRPCInstance) updateVRGSpec(clusterName string, tgtVRG *rmn.VolumeReplicationGroup) error {
-	mw, err := d.mwu.FindManifestWorkByType(rmnutil.MWTypeVRG, clusterName)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-
-		d.log.Error(err, "failed to update VRG")
-
-		return fmt.Errorf("failed to update VRG MW, in namespace %s (%w)",
-			clusterName, err)
-	}
-
-	d.log.Info(fmt.Sprintf("Updating VRG ownedby MW %s for cluster %s", mw.Name, clusterName))
-
-	vrg, err := rmnutil.ExtractVRGFromManifestWork(mw)
-	if err != nil {
-		d.log.Error(err, "failed to update VRG state")
-
-		return err
-	}
-
-	if vrg.Spec.ReplicationState != rmn.Secondary {
-		d.log.Info(fmt.Sprintf("VRG %s is not secondary on this cluster %s", vrg.Name, mw.Namespace))
-
-		return fmt.Errorf("failed to update MW due to wrong VRG state (%v) for the request",
-			vrg.Spec.ReplicationState)
-	}
-
-	vrg.Spec.VolSync.RDSpec = tgtVRG.Spec.VolSync.RDSpec
-
-	vrgClientManifest, err := d.mwu.GenerateManifest(vrg)
-	if err != nil {
-		d.log.Error(err, "failed to generate manifest")
-
-		return fmt.Errorf("failed to generate VRG manifest (%w)", err)
-	}
-
-	mw.Spec.Workload.Manifests[0] = *vrgClientManifest
-
-	err = d.reconciler.Update(d.ctx, mw)
-	if err != nil {
-		return fmt.Errorf("failed to update MW (%w)", err)
-	}
-
-	d.log.Info(fmt.Sprintf("Updated VRG running in cluster %s. VRG (%s)", clusterName, vrg.Name))
-
-	return nil
-}
-
-// createVolSyncDestManifestWork creates volsync Secondaries skipping the cluster referenced in clusterToSkip.
-// Typically, clusterToSkip is passed in as the cluster where volsync is the Primary.
-func (d *DRPCInstance) createVolSyncDestManifestWork(clusterToSkip string) error {
+// createOrUpdateVolSyncDestManifestWork creates or updates volsync Secondaries skipping the cluster srcCluster.
+// The srcCluster is primary cluster.
+func (d *DRPCInstance) createOrUpdateVolSyncDestManifestWork(srcCluster string) error {
 	// create VRG ManifestWork
-	d.log.Info("Creating VRG ManifestWork for destination clusters",
-		"Last State:", d.getLastDRState(), "homeCluster", clusterToSkip)
+	d.log.Info("Creating or updating VRG ManifestWork for destination clusters",
+		"Last State:", d.getLastDRState(), "homeCluster", srcCluster)
 
 	// Create or update ManifestWork for all the peers
 	for _, dstCluster := range rmnutil.DRPolicyClusterNames(d.drPolicy) {
-		if dstCluster == clusterToSkip {
+		if dstCluster == srcCluster {
 			// skip source cluster
 			continue
 		}
@@ -308,10 +146,14 @@ func (d *DRPCInstance) createVolSyncDestManifestWork(clusterToSkip string) error
 		annotations[DRPCNameAnnotation] = d.instance.Name
 		annotations[DRPCNamespaceAnnotation] = d.instance.Namespace
 
-		vrg := d.generateVRG(dstCluster, rmn.Secondary)
+		vrg, err := d.refreshRDSpec(srcCluster, dstCluster)
+		if err != nil {
+			return err
+		}
+
 		if err := d.mwu.CreateOrUpdateVRGManifestWork(
 			d.instance.Name, d.vrgNamespace,
-			dstCluster, vrg, annotations); err != nil {
+			dstCluster, *vrg, annotations); err != nil {
 			d.log.Error(err, "failed to create or update VolumeReplicationGroup manifest")
 
 			return fmt.Errorf("failed to create or update VolumeReplicationGroup manifest in namespace %s (%w)", dstCluster, err)
@@ -321,7 +163,46 @@ func (d *DRPCInstance) createVolSyncDestManifestWork(clusterToSkip string) error
 		break
 	}
 
+	d.log.Info("Ensured VolSync replication for destination clusters")
+
 	return nil
+}
+
+func (d *DRPCInstance) refreshRDSpec(srcCluster, dstCluster string) (*rmn.VolumeReplicationGroup, error) {
+	d.setProgression(rmn.ProgressionSettingupVolsyncDest)
+
+	srcVRG, found := d.vrgs[srcCluster]
+	if !found {
+		return nil, fmt.Errorf("failed to find source VolSync VRG in cluster %s. VRGs %v", srcCluster, d.vrgs)
+	}
+
+	if len(srcVRG.Status.ProtectedPVCs) == 0 {
+		d.log.Info("ProtectedPVCs on pirmary cluster is empty")
+
+		return nil, WaitForSourceCluster
+	}
+
+	dstVRG := d.generateVRG(dstCluster, rmn.Secondary)
+	d.resetRDSpec(srcVRG, &dstVRG)
+
+	return &dstVRG, nil
+}
+
+func (d *DRPCInstance) resetRDSpec(srcVRG, dstVRG *rmn.VolumeReplicationGroup,
+) {
+	dstVRG.Spec.VolSync.RDSpec = nil
+
+	for _, protectedPVC := range srcVRG.Status.ProtectedPVCs {
+		if !protectedPVC.ProtectedByVolSync {
+			continue
+		}
+
+		rdSpec := rmn.VolSyncReplicationDestinationSpec{
+			ProtectedPVC: protectedPVC,
+		}
+
+		dstVRG.Spec.VolSync.RDSpec = append(dstVRG.Spec.VolSync.RDSpec, rdSpec)
+	}
 }
 
 func (d *DRPCInstance) ResetVolSyncRDOnPrimary(clusterName string) error {

--- a/internal/controller/drplacementcontrolvolsync.go
+++ b/internal/controller/drplacementcontrolvolsync.go
@@ -248,21 +248,5 @@ func (d *DRPCInstance) ResetVolSyncRDOnPrimary(clusterName string) error {
 
 	vrg.Spec.VolSync.RDSpec = nil
 
-	vrgClientManifest, err := d.mwu.GenerateManifest(vrg)
-	if err != nil {
-		d.log.Error(err, "failed to generate manifest")
-
-		return fmt.Errorf("failed to generate VRG manifest (%w)", err)
-	}
-
-	mw.Spec.Workload.Manifests[0] = *vrgClientManifest
-
-	err = d.reconciler.Update(d.ctx, mw)
-	if err != nil {
-		return fmt.Errorf("failed to update MW (%w)", err)
-	}
-
-	d.log.Info(fmt.Sprintf("Updated VRG running in cluster %s to secondary. VRG (%v)", clusterName, vrg))
-
-	return nil
+	return d.mwu.UpdateVRGManifestWork(vrg, mw)
 }

--- a/internal/controller/util/mw_util.go
+++ b/internal/controller/util/mw_util.go
@@ -642,21 +642,6 @@ func (mwu *MWUtil) createOrUpdateManifestWork(
 	return ctrlutil.OperationResultNone, nil
 }
 
-func (mwu *MWUtil) GetVRGManifestWorkCount(drClusters []string) int {
-	count := 0
-
-	for _, clusterName := range drClusters {
-		_, err := mwu.FindManifestWorkByType(MWTypeVRG, clusterName)
-		if err != nil {
-			continue
-		}
-
-		count++
-	}
-
-	return count
-}
-
 func (mwu *MWUtil) DeleteNamespaceManifestWork(clusterName string, annotations map[string]string) error {
 	mwName := mwu.BuildManifestWorkName(MWTypeNS)
 	mw := &ocmworkv1.ManifestWork{}

--- a/internal/controller/util/mw_util.go
+++ b/internal/controller/util/mw_util.go
@@ -26,6 +26,7 @@ import (
 
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -121,10 +122,10 @@ func IsManifestInAppliedState(mw *ocmworkv1.ManifestWork) bool {
 func (mwu *MWUtil) CreateOrUpdateVRGManifestWork(
 	name, namespace, homeCluster string,
 	vrg rmn.VolumeReplicationGroup, annotations map[string]string,
-) error {
+) (ctrlutil.OperationResult, error) {
 	manifestWork, err := mwu.generateVRGManifestWork(name, namespace, homeCluster, vrg, annotations)
 	if err != nil {
-		return err
+		return ctrlutil.OperationResultNone, err
 	}
 
 	return mwu.createOrUpdateManifestWork(manifestWork, homeCluster)
@@ -163,7 +164,9 @@ func (mwu *MWUtil) CreateOrUpdateMModeManifestWork(
 		return err
 	}
 
-	return mwu.createOrUpdateManifestWork(manifestWork, cluster)
+	_, err = mwu.createOrUpdateManifestWork(manifestWork, cluster)
+
+	return err
 }
 
 func (mwu *MWUtil) generateMModeManifestWork(name, cluster string,
@@ -242,7 +245,9 @@ func (mwu *MWUtil) CreateOrUpdateNFManifestWork(
 		return err
 	}
 
-	return mwu.createOrUpdateManifestWork(manifestWork, homeCluster)
+	_, err = mwu.createOrUpdateManifestWork(manifestWork, homeCluster)
+
+	return err
 }
 
 func (mwu *MWUtil) generateNFManifestWork(name, homeCluster string,
@@ -280,7 +285,9 @@ func (mwu *MWUtil) CreateOrUpdateDRCConfigManifestWork(cluster string, cConfig r
 		return err
 	}
 
-	return mwu.createOrUpdateManifestWork(manifestWork, cluster)
+	_, err = mwu.createOrUpdateManifestWork(manifestWork, cluster)
+
+	return err
 }
 
 func (mwu *MWUtil) generateDRCConfigManifestWork(
@@ -358,7 +365,9 @@ func (mwu *MWUtil) CreateOrUpdateNamespaceManifest(
 		PropagationPolicy: ocmworkv1.DeletePropagationPolicyTypeOrphan,
 	}
 
-	return mwu.createOrUpdateManifestWork(manifestWork, managedClusterNamespace)
+	_, err = mwu.createOrUpdateManifestWork(manifestWork, managedClusterNamespace)
+
+	return err
 }
 
 func Namespace(name string) *corev1.Namespace {
@@ -453,7 +462,7 @@ func (mwu *MWUtil) CreateOrUpdateDrClusterManifestWork(
 		manifests[i] = *manifest
 	}
 
-	return mwu.createOrUpdateManifestWork(
+	_, err := mwu.createOrUpdateManifestWork(
 		mwu.newManifestWork(
 			DrClusterManifestWorkName,
 			clusterName,
@@ -462,6 +471,8 @@ func (mwu *MWUtil) CreateOrUpdateDrClusterManifestWork(
 		),
 		clusterName,
 	)
+
+	return err
 }
 
 var (
@@ -591,25 +602,29 @@ func (mwu *MWUtil) newManifestWork(name string, mcNamespace string,
 func (mwu *MWUtil) createOrUpdateManifestWork(
 	mw *ocmworkv1.ManifestWork,
 	managedClusternamespace string,
-) error {
+) (ctrlutil.OperationResult, error) {
 	key := types.NamespacedName{Name: mw.Name, Namespace: managedClusternamespace}
 	foundMW := &ocmworkv1.ManifestWork{}
 
 	err := mwu.Client.Get(mwu.Ctx, key, foundMW)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			return errorswrapper.Wrap(err, fmt.Sprintf("failed to fetch ManifestWork %s", key))
+			return ctrlutil.OperationResultNone, errorswrapper.Wrap(err, fmt.Sprintf("failed to fetch ManifestWork %s", key))
 		}
 
 		mwu.Log.Info("Creating ManifestWork", "cluster", managedClusternamespace, "MW", mw)
 
-		return mwu.Client.Create(mwu.Ctx, mw)
+		if err := mwu.Create(mwu.Ctx, mw); err != nil {
+			return ctrlutil.OperationResultNone, err
+		}
+
+		return ctrlutil.OperationResultCreated, nil
 	}
 
 	if !reflect.DeepEqual(foundMW.Spec, mw.Spec) {
 		mwu.Log.Info("Updating ManifestWork", "name", mw.Name, "namespace", foundMW.Namespace)
 
-		return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 			if err := mwu.Client.Get(mwu.Ctx, key, foundMW); err != nil {
 				return err
 			}
@@ -618,9 +633,13 @@ func (mwu *MWUtil) createOrUpdateManifestWork(
 
 			return mwu.Client.Update(mwu.Ctx, foundMW)
 		})
+
+		if err == nil {
+			return ctrlutil.OperationResultUpdated, nil
+		}
 	}
 
-	return nil
+	return ctrlutil.OperationResultNone, nil
 }
 
 func (mwu *MWUtil) GetVRGManifestWorkCount(drClusters []string) int {

--- a/internal/controller/util/mw_util.go
+++ b/internal/controller/util/mw_util.go
@@ -704,6 +704,26 @@ func (mwu *MWUtil) DeleteManifestWork(mwName, mwNamespace string) error {
 	return nil
 }
 
+func (mwu *MWUtil) UpdateVRGManifestWork(vrg *rmn.VolumeReplicationGroup, mw *ocmworkv1.ManifestWork) error {
+	vrgClientManifest, err := mwu.GenerateManifest(vrg)
+	if err != nil {
+		mwu.Log.Error(err, "failed to generate manifest")
+
+		return fmt.Errorf("failed to generate VRG manifest (%w)", err)
+	}
+
+	mw.Spec.Workload.Manifests[0] = *vrgClientManifest
+
+	err = mwu.Client.Update(mwu.Ctx, mw)
+	if err != nil {
+		return fmt.Errorf("failed to update MW (%w)", err)
+	}
+
+	mwu.Log.Info(fmt.Sprintf("Added VRG %s to MW %s for cluster %s", vrg.GetName(), mw.GetName(), mw.GetNamespace()))
+
+	return nil
+}
+
 func ExtractVRGFromManifestWork(mw *ocmworkv1.ManifestWork) (*rmn.VolumeReplicationGroup, error) {
 	if len(mw.Spec.Workload.Manifests) == 0 {
 		return nil, fmt.Errorf("invalid VRG ManifestWork for type: %s", mw.Name)

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -33,6 +33,9 @@ func (v *VRGInstance) restorePVsAndPVCsForVolSync() (int, error) {
 		failoverAction := v.instance.Spec.Action == ramendrv1alpha1.VRGActionFailover
 
 		var err error
+		// Source conditions are not needed and should not be added to vrg.status.ProtectedPVCs,
+		// as this would result in incorrect information.
+		rdSpec.ProtectedPVC.Conditions = nil
 
 		cg, ok := rdSpec.ProtectedPVC.Labels[ConsistencyGroupLabel]
 		if ok && util.IsCGEnabled(v.instance.Annotations) {
@@ -75,7 +78,8 @@ func (v *VRGInstance) restorePVsAndPVCsForVolSync() (int, error) {
 	}
 
 	if numPVsRestored != len(v.instance.Spec.VolSync.RDSpec) {
-		return numPVsRestored, fmt.Errorf("failed to restore all PVCs using RDSpec (%v)", v.instance.Spec.VolSync.RDSpec)
+		return numPVsRestored, fmt.Errorf("failed to restore all PVCs. Restored %d PVCs out of %d RDSpecs",
+			numPVsRestored, len(v.instance.Spec.VolSync.RDSpec))
 	}
 
 	v.log.Info("Success restoring VolSync PVs", "Total", numPVsRestored)
@@ -142,8 +146,8 @@ func (v *VRGInstance) reconcilePVCAsVolSyncPrimary(pvc corev1.PersistentVolumeCl
 
 	protectedPVC := v.findProtectedPVC(pvc.Namespace, pvc.Name)
 	if protectedPVC == nil {
-		protectedPVC = newProtectedPVC
-		v.instance.Status.ProtectedPVCs = append(v.instance.Status.ProtectedPVCs, *protectedPVC)
+		v.instance.Status.ProtectedPVCs = append(v.instance.Status.ProtectedPVCs, *newProtectedPVC)
+		protectedPVC = &v.instance.Status.ProtectedPVCs[len(v.instance.Status.ProtectedPVCs)-1]
 	} else if !reflect.DeepEqual(protectedPVC, newProtectedPVC) {
 		newProtectedPVC.Conditions = protectedPVC.Conditions
 		newProtectedPVC.DeepCopyInto(protectedPVC)


### PR DESCRIPTION
This PR includes critical fixes for Cephfs workloads that occasionally caused the relocation to stall forever in the WaitForReadiness progression.

**Key Changes**:
1. Fix for RDSpec List Alternation
Addressed an issue where frequent VRG resource updates caused the RDSpec list to alternate between empty and non-empty list. This inconsistency was leading to incomplete PVC restores during failover or relocation, halting the recovery process.

2. Fix for ProtectedPVC `PVsRestored` Condition
In certain edge cases, ProtectedPVCs were failing to add the PVsRestored condition permanently, which caused the relocate process to get stuck in the WaitForReadiness progression. This fix ensures the condition is consistently applied, preventing the relocation from stalling.

3. Refactor of ManifestWork Creation Function
The utility function that creates ManifestWork has been refactored to return the last operation result (created, updated, or none) alongside any errors. This change allows tracking of whether a ManifestWork resource was newly created, updated, or left unchanged.

Fixes Bug: [2319334](https://bugzilla.redhat.com/show_bug.cgi?id=2319334)