### PR TITLE
e2e: log to a file instead of stdout

### DIFF
--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -23,12 +23,18 @@ func TestMain(m *testing.M) {
 
 	flag.Parse()
 
+	logFile, err := os.Create("ramentest.log")
+	if err != nil {
+		panic(err)
+	}
+
 	log := zap.New(zap.UseFlagOptions(&zap.Options{
 		Development: true,
 		ZapOpts: []uberzap.Option{
 			uberzap.AddCaller(),
 		},
 		TimeEncoder: zapcore.ISO8601TimeEncoder,
+		DestWriter:  logFile,
 	}))
 
 	util.Ctx, err = util.NewContext(&log, util.ConfigFile)


### PR DESCRIPTION
This makes the test result output easier to read.