### PR TITLE
Fix waiting until placement decision is available

### DIFF
--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -43,18 +43,13 @@ func EnableProtection(w workloads.Workload, d deployers.Deployer) error {
 	placementName := name
 	drpcName := name
 
-	placementDecisionName, err := waitPlacementDecision(util.Ctx.Hub.CtrlClient, namespace, placementName)
-	if err != nil {
-		return err
-	}
-
-	placementDecision, err := getPlacementDecision(util.Ctx.Hub.CtrlClient, namespace, placementDecisionName)
+	placementDecision, err := waitPlacementDecision(util.Ctx.Hub.CtrlClient, namespace, placementName)
 	if err != nil {
 		return err
 	}
 
 	clusterName := placementDecision.Status.Decisions[0].ClusterName
-	util.Ctx.Log.Info("got clusterName " + clusterName + " from " + placementDecisionName)
+	util.Ctx.Log.Info("got clusterName " + clusterName + " from " + placementDecision.Name)
 
 	util.Ctx.Log.Info("update placement " + placementName + " annotation")
 

--- a/e2e/dractions/crud.go
+++ b/e2e/dractions/crud.go
@@ -33,18 +33,6 @@ func updatePlacement(client client.Client, placement *clusterv1beta1.Placement) 
 	return client.Update(context.Background(), placement)
 }
 
-func getPlacementDecision(client client.Client, namespace, name string) (*clusterv1beta1.PlacementDecision, error) {
-	placementDecision := &clusterv1beta1.PlacementDecision{}
-	key := types.NamespacedName{Namespace: namespace, Name: name}
-
-	err := client.Get(context.Background(), key, placementDecision)
-	if err != nil {
-		return nil, err
-	}
-
-	return placementDecision, nil
-}
-
 func getDRPC(client client.Client, namespace, name string) (*ramen.DRPlacementControl, error) {
 	drpc := &ramen.DRPlacementControl{}
 	key := types.NamespacedName{Namespace: namespace, Name: name}


### PR DESCRIPTION
We cannot use the method we used in [drenv/test.lookup_cluster](https://github.com/RamenDR/ramen/blob/2886c647e9c465f5fe7a8665e53c37de002b6326/test/drenv/test.py#L204) since placement Satisfied condition is not set in discovered apps flows.

Simplify the code to wait until we have placement decisions status
contains non empty decisions list. 

Fixes: https://github.com/RamenDR/ramen/issues/1562