### PR TITLE
Wait when deleting a namespace                                                                                                                                  

### DIFF
--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -83,8 +83,8 @@ func EnableProtection(w workloads.Workload, d deployers.Deployer) error {
 	}
 
 	// this is the application namespace in drclusters to add the annotation
-	nsToAnnonate := name
-	if err := util.CreateNamespaceAndAddAnnotation(nsToAnnonate); err != nil {
+	nsToAnnotate := name
+	if err := util.CreateNamespaceAndAddAnnotation(nsToAnnotate); err != nil {
 		return err
 	}
 

--- a/e2e/util/crud.go
+++ b/e2e/util/crud.go
@@ -5,6 +5,7 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -55,11 +56,11 @@ func DeleteNamespace(client client.Client, namespace string) error {
 	}
 
 	Ctx.Log.Info("waiting until namespace " + namespace + " is deleted")
+
+	startTime := time.Now()
 	key := types.NamespacedName{Name: namespace}
 
 	for {
-		time.Sleep(time.Second)
-
 		if err := client.Get(context.Background(), key, ns); err != nil {
 			if !errors.IsNotFound(err) {
 				return err
@@ -69,6 +70,12 @@ func DeleteNamespace(client client.Client, namespace string) error {
 
 			return nil
 		}
+
+		if time.Since(startTime) > 60*time.Second {
+			return fmt.Errorf("timeout deleting namespace %q", namespace)
+		}
+
+		time.Sleep(time.Second)
 	}
 }
 

--- a/e2e/util/crud.go
+++ b/e2e/util/crud.go
@@ -5,6 +5,7 @@ package util
 
 import (
 	"context"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -49,9 +50,26 @@ func DeleteNamespace(client client.Client, namespace string) error {
 		}
 
 		Ctx.Log.Info("namespace " + namespace + " not found")
+
+		return nil
 	}
 
-	return nil
+	Ctx.Log.Info("waiting until namespace " + namespace + " is deleted")
+	key := types.NamespacedName{Name: namespace}
+
+	for {
+		time.Sleep(time.Second)
+
+		if err := client.Get(context.Background(), key, ns); err != nil {
+			if !errors.IsNotFound(err) {
+				return err
+			}
+
+			Ctx.Log.Info("namespace " + namespace + " deleted")
+
+			return nil
+		}
+	}
 }
 
 func createChannel() error {


### PR DESCRIPTION
If we don't wait we will fail when trying to run a test again when using
-count=N or when running the test suit in a loop.

Example error:

    main_test.go:64: failed to ensure channel:
    channels.apps.open-cluster-management.io "ramen-gitops" is
    forbidden: unable to create new content in namespace ramen-samples
    because it is being terminated

Fixes #1620