### PR TITLE
e2e: Fix improper use of formatting

### DIFF
--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -252,7 +252,7 @@ func CreatePlacementDecisionConfigMap(cmName string, cmNamespace string) error {
 	err := util.Ctx.Hub.CtrlClient.Create(context.Background(), configMap)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
-			return fmt.Errorf("could not create configMap " + cmName)
+			return fmt.Errorf("could not create configMap %q", cmName)
 		}
 
 		util.Ctx.Log.Info("configMap " + cmName + " already Exists")
@@ -271,7 +271,7 @@ func DeleteConfigMap(cmName string, cmNamespace string) error {
 	err := util.Ctx.Hub.CtrlClient.Delete(context.Background(), configMap)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			return fmt.Errorf("could not delete configMap " + cmName)
+			return fmt.Errorf("could not delete configMap %q", cmName)
 		}
 
 		util.Ctx.Log.Info("configMap " + cmName + " not found")

--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -30,7 +30,7 @@ func waitSubscriptionPhase(namespace, name string, phase subscriptionv1.Subscrip
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			return fmt.Errorf("subscription %s status is not %s yet before timeout", name, phase)
+			return fmt.Errorf("subscription %q status is not %q yet before timeout", name, phase)
 		}
 
 		time.Sleep(util.RetryInterval)
@@ -51,7 +51,7 @@ func WaitWorkloadHealth(client client.Client, namespace string, w workloads.Work
 		if time.Since(startTime) > util.Timeout {
 			util.Ctx.Log.Info(err.Error())
 
-			return fmt.Errorf("workload %s is not ready yet before timeout of %v",
+			return fmt.Errorf("workload %q is not ready yet before timeout of %v",
 				w.GetName(), util.Timeout)
 		}
 

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -68,7 +68,7 @@ func waitDRPCReady(client client.Client, namespace string, drpcName string) erro
 				util.Ctx.Log.Info("drpc " + drpcName + " LastGroupSyncTime is nil")
 			}
 
-			return fmt.Errorf("drpc " + drpcName + " is not ready yet before timeout, fail")
+			return fmt.Errorf("drpc %q is not ready yet before timeout, fail", drpcName)
 		}
 
 		time.Sleep(util.RetryInterval)
@@ -117,7 +117,7 @@ func waitDRPCPhase(client client.Client, namespace, name string, phase ramen.DRS
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			return fmt.Errorf("drpc %s status is not %s yet before timeout, fail", name, phase)
+			return fmt.Errorf("drpc %q status is not %q yet before timeout, fail", name, phase)
 		}
 
 		time.Sleep(util.RetryInterval)
@@ -184,7 +184,7 @@ func waitDRPCDeleted(client client.Client, namespace string, name string) error 
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			return fmt.Errorf("drpc %s is not deleted yet before timeout, fail", name)
+			return fmt.Errorf("drpc %q is not deleted yet before timeout, fail", name)
 		}
 
 		time.Sleep(util.RetryInterval)
@@ -209,7 +209,7 @@ func waitDRPCProgression(client client.Client, namespace, name string, progressi
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			return fmt.Errorf("drpc %s progression is not %s yet before timeout of %v",
+			return fmt.Errorf("drpc %q progression is not %q yet before timeout of %v",
 				name, progression, util.Timeout)
 		}
 


### PR DESCRIPTION
When using fmt.Errorf(), we don't need to format the message with
fmt.Sprintf().

Fixes #1618
