### PR TITLE
Use --force-update to ensure old repos are updated

### DIFF
--- a/test/addons/volsync/start
+++ b/test/addons/volsync/start
@@ -19,6 +19,8 @@ def add_helm_repo():
         "helm",
         "repo",
         "add",
+        # replace (overwrite) the repo if it already exists.
+        "--force-update",
         "backube",
         "https://backube.github.io/helm-charts/",
     ]


### PR DESCRIPTION
Without this you can get old volsync version (e.g. 0.7.0) silently instead of the latest release (e.g. 0.10.0). With an old version the volsync block self test will time out.