### PR TITLE
ci: Retry failed jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,11 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Run unit tests
-        run: make test
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: make test
 
   drenv-test:
     name: drenv tests

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -64,10 +64,15 @@ jobs:
         max_attempts: 3
         command: ramenctl config --name-prefix ${{ env.NAME_PREFIX }} test/envs/regional-dr.yaml
 
+    - name: Configure e2e tests
+      run: cat ~/.config/drenv/${{ env.NAME_PREFIX }}rdr/config.yaml >> e2e/config.yaml
+
     - name: Run e2e tests
-      run: |
-        cat ~/.config/drenv/${{ env.NAME_PREFIX }}rdr/config.yaml >> e2e/config.yaml
-        make e2e-rdr
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 20
+        max_attempts: 3
+        command: make e2e-rdr
 
     - name: Gather environment data
       if: failure()


### PR DESCRIPTION
The e2e and unit tests are not stable enough. Save developers time by retrying failed jobs automatically before failing the build.

Example run - unit tests failed in first attempt, succeeded in the second attempt:
https://github.com/RamenDR/ramen/actions/runs/11580608689/job/32239498144