### PR TITLE
e2e: Easier to follow log

### DIFF
--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -7,13 +7,14 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/ramendr/ramen/e2e/util"
 	"github.com/ramendr/ramen/e2e/workloads"
 	subscriptionv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func waitSubscriptionPhase(namespace, name string, phase subscriptionv1.SubscriptionPhase) error {
+func waitSubscriptionPhase(namespace, name string, phase subscriptionv1.SubscriptionPhase, log logr.Logger) error {
 	startTime := time.Now()
 
 	for {
@@ -24,7 +25,7 @@ func waitSubscriptionPhase(namespace, name string, phase subscriptionv1.Subscrip
 
 		currentPhase := sub.Status.Phase
 		if currentPhase == phase {
-			util.Ctx.Log.Info(fmt.Sprintf("subscription %s phase is %s", name, phase))
+			log.Info(fmt.Sprintf("Subscription phase is %s", phase))
 
 			return nil
 		}
@@ -37,19 +38,19 @@ func waitSubscriptionPhase(namespace, name string, phase subscriptionv1.Subscrip
 	}
 }
 
-func WaitWorkloadHealth(client client.Client, namespace string, w workloads.Workload) error {
+func WaitWorkloadHealth(client client.Client, namespace string, w workloads.Workload, log logr.Logger) error {
 	startTime := time.Now()
 
 	for {
-		err := w.Health(client, namespace)
+		err := w.Health(client, namespace, log)
 		if err == nil {
-			util.Ctx.Log.Info(fmt.Sprintf("workload %s is ready", w.GetName()))
+			log.Info("Workload is ready")
 
 			return nil
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			util.Ctx.Log.Info(err.Error())
+			log.Info(err.Error())
 
 			return fmt.Errorf("workload %q is not ready yet before timeout of %v",
 				w.GetName(), util.Timeout)

--- a/e2e/deployers/subscription.go
+++ b/e2e/deployers/subscription.go
@@ -27,8 +27,9 @@ func (s Subscription) Deploy(w workloads.Workload) error {
 	// Address namespace/label/suffix as needed for various resources
 	name := GetCombinedName(s, w)
 	namespace := name
+	log := util.Ctx.Log.WithName(name)
 
-	util.Ctx.Log.Info("enter Deploy " + name)
+	log.Info("Deploying workload")
 
 	// create subscription namespace
 	err := util.CreateNamespace(util.Ctx.Hub.CtrlClient, namespace)
@@ -41,42 +42,43 @@ func (s Subscription) Deploy(w workloads.Workload) error {
 		return err
 	}
 
-	err = CreatePlacement(name, namespace)
+	err = CreatePlacement(name, namespace, log)
 	if err != nil {
 		return err
 	}
 
-	err = CreateSubscription(s, w)
+	err = CreateSubscription(s, w, log)
 	if err != nil {
 		return err
 	}
 
-	return waitSubscriptionPhase(namespace, name, subscriptionv1.SubscriptionPropagated)
+	return waitSubscriptionPhase(namespace, name, subscriptionv1.SubscriptionPropagated, log)
 }
 
 // Delete Subscription, Placement, Binding
 func (s Subscription) Undeploy(w workloads.Workload) error {
 	name := GetCombinedName(s, w)
 	namespace := name
+	log := util.Ctx.Log.WithName(name)
 
-	util.Ctx.Log.Info("enter Undeploy " + name)
+	log.Info("Undeploying workload")
 
-	err := DeleteSubscription(s, w)
+	err := DeleteSubscription(s, w, log)
 	if err != nil {
 		return err
 	}
 
-	err = DeletePlacement(name, namespace)
+	err = DeletePlacement(name, namespace, log)
 	if err != nil {
 		return err
 	}
 
-	err = DeleteManagedClusterSetBinding(McsbName, namespace)
+	err = DeleteManagedClusterSetBinding(McsbName, namespace, log)
 	if err != nil {
 		return err
 	}
 
-	return util.DeleteNamespace(util.Ctx.Hub.CtrlClient, namespace)
+	return util.DeleteNamespace(util.Ctx.Hub.CtrlClient, namespace, log)
 }
 
 func (s Subscription) IsWorkloadSupported(w workloads.Workload) bool {

--- a/e2e/dractions/crud.go
+++ b/e2e/dractions/crud.go
@@ -6,6 +6,7 @@ package dractions
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/e2e/deployers"
 	"github.com/ramendr/ramen/e2e/util"
@@ -106,7 +107,7 @@ func generateDRPC(name, namespace, clusterName, drPolicyName, placementName, app
 	return drpc
 }
 
-func createPlacementManagedByRamen(name, namespace string) error {
+func createPlacementManagedByRamen(name, namespace string, log logr.Logger) error {
 	labels := make(map[string]string)
 	labels[deployers.AppLabelKey] = name
 	clusterSet := []string{"default"}
@@ -133,7 +134,7 @@ func createPlacementManagedByRamen(name, namespace string) error {
 			return err
 		}
 
-		util.Ctx.Log.Info("placement " + placement.Name + " already Exists")
+		log.Info("Placement already Exists")
 	}
 
 	return nil

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/e2e/util"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -43,7 +44,7 @@ func waitPlacementDecision(client client.Client, namespace string, placementName
 	}
 }
 
-func waitDRPCReady(client client.Client, namespace string, drpcName string) error {
+func waitDRPCReady(client client.Client, namespace string, drpcName string, log logr.Logger) error {
 	startTime := time.Now()
 
 	for {
@@ -54,18 +55,18 @@ func waitDRPCReady(client client.Client, namespace string, drpcName string) erro
 
 		conditionReady := checkDRPCConditions(drpc)
 		if conditionReady && drpc.Status.LastGroupSyncTime != nil {
-			util.Ctx.Log.Info("drpc " + drpcName + " is ready")
+			log.Info("drpc is ready")
 
 			return nil
 		}
 
 		if time.Since(startTime) > util.Timeout {
 			if !conditionReady {
-				util.Ctx.Log.Info("drpc " + drpcName + " condition 'Available' or 'PeerReady' is not True")
+				log.Info("drpc condition 'Available' or 'PeerReady' is not True")
 			}
 
 			if conditionReady && drpc.Status.LastGroupSyncTime == nil {
-				util.Ctx.Log.Info("drpc " + drpcName + " LastGroupSyncTime is nil")
+				log.Info("drpc LastGroupSyncTime is nil")
 			}
 
 			return fmt.Errorf("drpc %q is not ready yet before timeout, fail", drpcName)
@@ -100,7 +101,7 @@ func checkDRPCConditions(drpc *ramen.DRPlacementControl) bool {
 	return available && peerReady
 }
 
-func waitDRPCPhase(client client.Client, namespace, name string, phase ramen.DRState) error {
+func waitDRPCPhase(client client.Client, namespace, name string, phase ramen.DRState, log logr.Logger) error {
 	startTime := time.Now()
 
 	for {
@@ -111,7 +112,7 @@ func waitDRPCPhase(client client.Client, namespace, name string, phase ramen.DRS
 
 		currentPhase := drpc.Status.Phase
 		if currentPhase == phase {
-			util.Ctx.Log.Info(fmt.Sprintf("drpc %s phase is %s", name, phase))
+			log.Info(fmt.Sprintf("drpc phase is %s", phase))
 
 			return nil
 		}
@@ -159,28 +160,28 @@ func getTargetCluster(client client.Client, namespace, placementName string, drp
 }
 
 // first wait DRPC to have the expected phase, then check DRPC conditions
-func waitDRPC(client client.Client, namespace, name string, expectedPhase ramen.DRState) error {
+func waitDRPC(client client.Client, namespace, name string, expectedPhase ramen.DRState, log logr.Logger) error {
 	// check Phase
-	if err := waitDRPCPhase(client, namespace, name, expectedPhase); err != nil {
+	if err := waitDRPCPhase(client, namespace, name, expectedPhase, log); err != nil {
 		return err
 	}
 	// then check Conditions
-	return waitDRPCReady(client, namespace, name)
+	return waitDRPCReady(client, namespace, name, log)
 }
 
-func waitDRPCDeleted(client client.Client, namespace string, name string) error {
+func waitDRPCDeleted(client client.Client, namespace string, name string, log logr.Logger) error {
 	startTime := time.Now()
 
 	for {
 		_, err := getDRPC(client, namespace, name)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				util.Ctx.Log.Info("drpc " + name + " is deleted")
+				log.Info("drpc is deleted")
 
 				return nil
 			}
 
-			util.Ctx.Log.Info(fmt.Sprintf("error to get drpc %s: %v", name, err))
+			log.Info(fmt.Sprintf("failed to get drpc: %v", err))
 		}
 
 		if time.Since(startTime) > util.Timeout {
@@ -192,7 +193,9 @@ func waitDRPCDeleted(client client.Client, namespace string, name string) error 
 }
 
 // nolint:unparam
-func waitDRPCProgression(client client.Client, namespace, name string, progression ramen.ProgressionStatus) error {
+func waitDRPCProgression(client client.Client, namespace, name string, progression ramen.ProgressionStatus,
+	log logr.Logger,
+) error {
 	startTime := time.Now()
 
 	for {
@@ -203,7 +206,7 @@ func waitDRPCProgression(client client.Client, namespace, name string, progressi
 
 		currentProgression := drpc.Status.Progression
 		if currentProgression == progression {
-			util.Ctx.Log.Info(fmt.Sprintf("drpc %s progression is %s", name, progression))
+			log.Info(fmt.Sprintf("drpc progression is %s", progression))
 
 			return nil
 		}

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}))
 
-	util.Ctx, err = util.NewContext(&log, util.ConfigFile)
+	util.Ctx, err = util.NewContext(log, util.ConfigFile)
 	if err != nil {
 		log.Error(err, "unable to create new testing context")
 

--- a/e2e/util/config.go
+++ b/e2e/util/config.go
@@ -27,7 +27,7 @@ type TestConfig struct {
 var config = &TestConfig{}
 
 //nolint:cyclop
-func ReadConfig(log *logr.Logger, configFile string) error {
+func ReadConfig(log logr.Logger, configFile string) error {
 	viper.SetDefault("ChannelName", defaultChannelName)
 	viper.SetDefault("ChannelNamespace", defaultChannelNamespace)
 	viper.SetDefault("GitURL", defaultGitURL)

--- a/e2e/util/context.go
+++ b/e2e/util/context.go
@@ -33,7 +33,7 @@ type Cluster struct {
 }
 
 type Context struct {
-	Log *logr.Logger
+	Log logr.Logger
 	Hub Cluster
 	C1  Cluster
 	C2  Cluster
@@ -99,7 +99,7 @@ func setupClient(kubeconfigPath string) (*kubernetes.Clientset, client.Client, e
 	return k8sClientSet, ctrlClient, nil
 }
 
-func NewContext(log *logr.Logger, configFile string) (*Context, error) {
+func NewContext(log logr.Logger, configFile string) (*Context, error) {
 	var err error
 
 	ctx := new(Context)

--- a/e2e/util/crud.go
+++ b/e2e/util/crud.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/go-logr/logr"
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,7 +38,7 @@ func CreateNamespace(client client.Client, namespace string) error {
 	return nil
 }
 
-func DeleteNamespace(client client.Client, namespace string) error {
+func DeleteNamespace(client client.Client, namespace string, log logr.Logger) error {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
@@ -50,12 +51,12 @@ func DeleteNamespace(client client.Client, namespace string) error {
 			return err
 		}
 
-		Ctx.Log.Info("namespace " + namespace + " not found")
+		log.Info("Namespace " + namespace + " not found")
 
 		return nil
 	}
 
-	Ctx.Log.Info("waiting until namespace " + namespace + " is deleted")
+	log.Info("Waiting until namespace " + namespace + " is deleted")
 
 	startTime := time.Now()
 	key := types.NamespacedName{Name: namespace}
@@ -66,7 +67,7 @@ func DeleteNamespace(client client.Client, namespace string) error {
 				return err
 			}
 
-			Ctx.Log.Info("namespace " + namespace + " deleted")
+			log.Info("Namespace " + namespace + " deleted")
 
 			return nil
 		}
@@ -97,9 +98,9 @@ func createChannel() error {
 			return err
 		}
 
-		Ctx.Log.Info("channel " + GetChannelName() + " already exists")
+		Ctx.Log.Info("Channel " + GetChannelName() + " already exists")
 	} else {
-		Ctx.Log.Info("channel " + GetChannelName() + " is created")
+		Ctx.Log.Info("Created channel " + GetChannelName())
 	}
 
 	return nil
@@ -119,9 +120,9 @@ func deleteChannel() error {
 			return err
 		}
 
-		Ctx.Log.Info("channel " + GetChannelName() + " not found")
+		Ctx.Log.Info("Channel " + GetChannelName() + " not found")
 	} else {
-		Ctx.Log.Info("channel " + GetChannelName() + " is deleted")
+		Ctx.Log.Info("Channel " + GetChannelName() + " is deleted")
 	}
 
 	return nil
@@ -142,7 +143,7 @@ func EnsureChannelDeleted() error {
 		return err
 	}
 
-	return DeleteNamespace(Ctx.Hub.CtrlClient, GetChannelNamespace())
+	return DeleteNamespace(Ctx.Hub.CtrlClient, GetChannelNamespace(), Ctx.Log)
 }
 
 // Problem: currently we must manually add an annotation to application’s namespace to make volsync work.

--- a/e2e/workloads/deployment.go
+++ b/e2e/workloads/deployment.go
@@ -5,8 +5,8 @@ package workloads
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/ramendr/ramen/e2e/util"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -72,14 +72,14 @@ func (w Deployment) GetResources() error {
 }
 
 // Check the workload health deployed in a cluster namespace
-func (w Deployment) Health(client client.Client, namespace string) error {
+func (w Deployment) Health(client client.Client, namespace string, log logr.Logger) error {
 	deploy, err := getDeployment(client, namespace, w.GetAppName())
 	if err != nil {
 		return err
 	}
 
 	if deploy.Status.Replicas == deploy.Status.ReadyReplicas {
-		util.Ctx.Log.Info(fmt.Sprintf("deployment %s is ready", w.GetAppName()))
+		log.Info("Deployment is ready")
 
 		return nil
 	}

--- a/e2e/workloads/workload.go
+++ b/e2e/workloads/workload.go
@@ -3,7 +3,10 @@
 
 package workloads
 
-import "sigs.k8s.io/controller-runtime/pkg/client"
+import (
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 type Workload interface {
 	Kustomize() string // Can differ based on the workload, hence part of the Workload interface
@@ -16,5 +19,5 @@ type Workload interface {
 	GetPath() string
 	GetRevision() string
 
-	Health(client client.Client, namespace string) error
+	Health(client client.Client, namespace string, log logr.Logger) error
 }


### PR DESCRIPTION
Add the name of the test (workload-deployer-appname) to the logger and clean up the logging message to make it easier to follow single test.

Part-of #1597