### PR TITLE
e2e: Eliminate unneeded nesting

### DIFF
--- a/e2e/exhaustive_suite_test.go
+++ b/e2e/exhaustive_suite_test.go
@@ -78,21 +78,18 @@ func Exhaustive(t *testing.T) {
 
 	generateWorkloads(Workloads)
 
-	for _, workload := range Workloads {
-		for _, deployer := range Deployers {
+	for _, deployer := range Deployers {
+		for _, workload := range Workloads {
 			// assign workload and deployer to a local variable to avoid parallel test issue
 			// see https://go.dev/wiki/CommonMistakes
-			w := workload
 			d := deployer
+			w := workload
 
-			t.Run(w.GetName(), func(t *testing.T) {
+			t.Run(deployers.GetCombinedName(d, w), func(t *testing.T) {
 				t.Parallel()
-				t.Run(d.GetName(), func(t *testing.T) {
-					t.Parallel()
-					testcontext.AddTestContext(t.Name(), w, d)
-					runTestFlow(t)
-					testcontext.DeleteTestContext(t.Name())
-				})
+				testcontext.AddTestContext(t.Name(), w, d)
+				runTestFlow(t)
+				testcontext.DeleteTestContext(t.Name())
 			})
 		}
 	}


### PR DESCRIPTION
We had nested loops, creating a sub test for the workload, and then nesting more sub tests for every deployer. This causes the go test framework to add "#N" suffix to the sub test name, which make the name unpredictable and harder to use for running specific tests using the -run option.

Simplify the way we generated sub tests, so we generate one sub test for every deployer-workload combination. The sub test name is is the same name we used for the test namespace and all resources, making it easier to follow and more consistent.

Because we use deployer-workload format, and not workload-deployer, switch the loops to match the name format.

Example run showing the new structure:

    --- PASS: TestSuites (0.06s)
        --- PASS: TestSuites/Validate (0.06s)
            --- PASS: TestSuites/Validate/CheckRamenHubOperatorStatus (0.03s)
            --- PASS: TestSuites/Validate/CheckRamenSpokeOperatorStatus (0.03s)
        --- PASS: TestSuites/Exhaustive (6.04s)
            --- SKIP: TestSuites/Exhaustive/disapp-deploy-cephfs-busybox (0.00s)
            --- PASS: TestSuites/Exhaustive/subscr-deploy-cephfs-busybox (431.67s)
                --- PASS: TestSuites/Exhaustive/subscr-deploy-cephfs-busybox/Deploy (5.16s)
                --- PASS: TestSuites/Exhaustive/subscr-deploy-cephfs-busybox/Enable (155.16s)
                --- PASS: TestSuites/Exhaustive/subscr-deploy-cephfs-busybox/Failover (85.08s)
                --- PASS: TestSuites/Exhaustive/subscr-deploy-cephfs-busybox/Relocate (150.14s)
                --- PASS: TestSuites/Exhaustive/subscr-deploy-cephfs-busybox/Disable (30.03s)
                --- PASS: TestSuites/Exhaustive/subscr-deploy-cephfs-busybox/Undeploy (6.10s)
            --- PASS: TestSuites/Exhaustive/subscr-deploy-rbd-busybox (461.77s)
                --- PASS: TestSuites/Exhaustive/subscr-deploy-rbd-busybox/Deploy (5.17s)
                --- PASS: TestSuites/Exhaustive/subscr-deploy-rbd-busybox/Enable (90.24s)
                --- PASS: TestSuites/Exhaustive/subscr-deploy-rbd-busybox/Failover (180.15s)
                --- PASS: TestSuites/Exhaustive/subscr-deploy-rbd-busybox/Relocate (150.14s)
                --- PASS: TestSuites/Exhaustive/subscr-deploy-rbd-busybox/Disable (30.03s)
                --- PASS: TestSuites/Exhaustive/subscr-deploy-rbd-busybox/Undeploy (6.05s)
            --- PASS: TestSuites/Exhaustive/disapp-deploy-rbd-busybox (496.64s)
                --- PASS: TestSuites/Exhaustive/disapp-deploy-rbd-busybox/Deploy (1.39s)
                --- PASS: TestSuites/Exhaustive/disapp-deploy-rbd-busybox/Enable (90.11s)
                --- PASS: TestSuites/Exhaustive/disapp-deploy-rbd-busybox/Failover (179.97s)
                --- PASS: TestSuites/Exhaustive/disapp-deploy-rbd-busybox/Relocate (179.87s)
                --- PASS: TestSuites/Exhaustive/disapp-deploy-rbd-busybox/Disable (30.05s)
                --- PASS: TestSuites/Exhaustive/disapp-deploy-rbd-busybox/Undeploy (15.24s)
            --- PASS: TestSuites/Exhaustive/appset-deploy-cephfs-busybox (600.76s)
                --- PASS: TestSuites/Exhaustive/appset-deploy-cephfs-busybox/Deploy (0.16s)
                --- PASS: TestSuites/Exhaustive/appset-deploy-cephfs-busybox/Enable (150.18s)
                --- PASS: TestSuites/Exhaustive/appset-deploy-cephfs-busybox/Failover (180.16s)
                --- PASS: TestSuites/Exhaustive/appset-deploy-cephfs-busybox/Relocate (240.21s)
                --- PASS: TestSuites/Exhaustive/appset-deploy-cephfs-busybox/Disable (30.03s)
                --- PASS: TestSuites/Exhaustive/appset-deploy-cephfs-busybox/Undeploy (0.02s)
            --- PASS: TestSuites/Exhaustive/appset-deploy-rbd-busybox (696.19s)
                --- PASS: TestSuites/Exhaustive/appset-deploy-rbd-busybox/Deploy (0.16s)
                --- PASS: TestSuites/Exhaustive/appset-deploy-rbd-busybox/Enable (95.34s)
                --- PASS: TestSuites/Exhaustive/appset-deploy-rbd-busybox/Failover (300.39s)
                --- PASS: TestSuites/Exhaustive/appset-deploy-rbd-busybox/Relocate (270.26s)
                --- PASS: TestSuites/Exhaustive/appset-deploy-rbd-busybox/Disable (30.03s)
                --- PASS: TestSuites/Exhaustive/appset-deploy-rbd-busybox/Undeploy (0.02s)

With this change we can run any single test using:

    ./run.sh -run TestSuites/Exhaustive/appset-deploy-cephfs-busybox

We can also run multiple tests, for example all tests using applicationsets:

    ./run.sh -run TestSuites/Exhaustive/appset

Or all tests using rbd storage:

    ./run.sh -run TestSuites/Exhaustive/rbd

Based on Talur's PR #1606, which has also other unrelated changes.

Fixes: #1614