### PR TITLE
Unify go version requirement

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/ramendr/ramen/api
 
-go 1.22.0
+go 1.22.5
 
 toolchain go1.22.7
 

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/ramendr/ramen/e2e
 
-go 1.22.0
+go 1.22.5
 
 toolchain go1.22.7
 


### PR DESCRIPTION
For unknown reason, we require go 1.22.0 for api and e2e, but 1.22.5 for ramen itself. Use 1.22.5 for all.