### PR TITLE
Update tiniest VM creation config on minikube : fix for error RSRC_INSUFFICIENT_CORES

### DIFF
--- a/test/envs/vm.yaml
+++ b/test/envs/vm.yaml
@@ -8,7 +8,7 @@ profiles:
   - name: cluster
     driver: $vm
     container_runtime: containerd
-    cpus: 1
+    cpus: 2
     memory: "2g"
     rosetta: false
     workers:


### PR DESCRIPTION
Update test/envs/vm.yaml with 2 cpu count to resolve the following error:

	$ drenv start envs/vm.yaml
	2024-11-11 01:35:05,809 INFO    [vm] Starting environment
	2024-11-11 01:35:05,943 INFO    [cluster] Starting minikube cluster
	2024-11-11 01:35:06,330 ERROR   Command failed
	:
	  File "/home/ramenuser/ramen/test/drenv/commands.py", line 207, in watch
	    raise Error(args, error, exitcode=p.returncode)
	drenv.commands.Error: Command failed:
	   command: ('minikube', 'start', '--profile', 'cluster', '--driver', 'kvm2', '--container-runtime', 'containerd', '--disk-size', '20g', '--nodes', '1', '--cni', 'auto', '--cpus', '1', '--memory', '2g', '--extra-config', 'kubelet.serialize-image-pulls=false', '--insecure-registry=host.minikube.internal:5000')
	   exitcode: 29
	   error:
	      X Exiting due to RSRC_INSUFFICIENT_CORES: Requested cpu count 1 is less than the minimum allowed of 2