### PR TITLE
Initial blueprint changes for preserving VRG as Secondary always

### DIFF
--- a/internal/controller/drplacementcontrolvolsync.go
+++ b/internal/controller/drplacementcontrolvolsync.go
@@ -13,34 +13,11 @@ import (
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func (d *DRPCInstance) EnsureVolSyncReplicationSetup(homeCluster string) error {
-	d.log.Info(fmt.Sprintf("Ensure VolSync replication has been setup for cluster %s", homeCluster))
-
-	if d.volSyncDisabled {
-		d.log.Info("VolSync is disabled")
-
-		return nil
-	}
-
-	vsRepNeeded, err := d.IsVolSyncReplicationRequired(homeCluster)
-	if err != nil {
-		return err
-	}
-
-	if !vsRepNeeded {
-		d.log.Info("No PVCs found that require VolSync replication")
-
-		return nil
-	}
-
-	return d.ensureVolSyncSetup(homeCluster)
-}
-
-func (d *DRPCInstance) ensureVolSyncSetup(srcCluster string) error {
-	d.setProgression(rmn.ProgressionEnsuringVolSyncSetup)
+func (d *DRPCInstance) EnsureSecondaryReplicationSetup(srcCluster string) error {
+	d.setProgression(rmn.ProgressionEnsuringVolSyncSetup) // TODO: Update progression string
 
 	// Create or update the destination VRG
-	opResult, err := d.createOrUpdateVolSyncDestManifestWork(srcCluster)
+	opResult, err := d.createOrUpdateSecondaryManifestWork(srcCluster)
 	if err != nil {
 		return err
 	}
@@ -50,7 +27,18 @@ func (d *DRPCInstance) ensureVolSyncSetup(srcCluster string) error {
 	}
 
 	if _, found := d.vrgs[srcCluster]; !found {
-		return fmt.Errorf("failed to find source VolSync VRG in cluster %s. VRGs %v", srcCluster, d.vrgs)
+		return fmt.Errorf("failed to find source VRG in cluster %s. VRGs %v", srcCluster, d.vrgs)
+	}
+
+	vsRepNeeded, err := d.IsVolSyncReplicationRequired(srcCluster)
+	if err != nil {
+		return err
+	}
+
+	if !vsRepNeeded {
+		d.log.Info("No PVCs found that require VolSync replication")
+
+		return nil
 	}
 
 	// Now we should have a source and destination VRG created
@@ -119,9 +107,9 @@ func (d *DRPCInstance) IsVolSyncReplicationRequired(homeCluster string) (bool, e
 	return !required, nil
 }
 
-// createOrUpdateVolSyncDestManifestWork creates or updates volsync Secondaries skipping the cluster srcCluster.
+// createOrUpdateSecondaryManifestWork creates or updates volsync Secondaries skipping the cluster srcCluster.
 // The srcCluster is primary cluster.
-func (d *DRPCInstance) createOrUpdateVolSyncDestManifestWork(srcCluster string) (ctrlutil.OperationResult, error) {
+func (d *DRPCInstance) createOrUpdateSecondaryManifestWork(srcCluster string) (ctrlutil.OperationResult, error) {
 	// create VRG ManifestWork
 	d.log.Info("Creating or updating VRG ManifestWork for destination clusters",
 		"Last State:", d.getLastDRState(), "homeCluster", srcCluster)
@@ -184,13 +172,17 @@ func (d *DRPCInstance) refreshVRGSecondarySpec(srcCluster, dstCluster string) (*
 
 	dstVRG := d.newVRG(dstCluster, rmn.Secondary, nil)
 
-	if len(srcVRGView.Status.ProtectedPVCs) != 0 {
-		d.resetRDSpec(srcVRGView, &dstVRG)
-	}
+	if d.drType == DRTypeAsync {
+		if len(srcVRGView.Status.ProtectedPVCs) != 0 {
+			d.resetRDSpec(srcVRGView, &dstVRG)
+		}
 
-	// Update destination VRG peerClasses with the source classes, such that when secondary is promoted to primary
-	// on actions, it uses the same peerClasses as the primary
-	dstVRG.Spec.Async.PeerClasses = srcVRG.Spec.Async.PeerClasses
+		// Update destination VRG peerClasses with the source classes, such that when secondary is promoted to primary
+		// on actions, it uses the same peerClasses as the primary
+		dstVRG.Spec.Async.PeerClasses = srcVRG.Spec.Async.PeerClasses
+	} else {
+		dstVRG.Spec.Sync.PeerClasses = srcVRG.Spec.Sync.PeerClasses
+	}
 
 	return &dstVRG, nil
 }

--- a/internal/controller/drplacementcontrolvolsync.go
+++ b/internal/controller/drplacementcontrolvolsync.go
@@ -30,6 +30,10 @@ func (d *DRPCInstance) EnsureSecondaryReplicationSetup(srcCluster string) error 
 		return fmt.Errorf("failed to find source VRG in cluster %s. VRGs %v", srcCluster, d.vrgs)
 	}
 
+	return d.EnsureVolSyncReplicationSetup(srcCluster)
+}
+
+func (d *DRPCInstance) EnsureVolSyncReplicationSetup(srcCluster string) error {
 	vsRepNeeded, err := d.IsVolSyncReplicationRequired(srcCluster)
 	if err != nil {
 		return err

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1541,15 +1541,13 @@ func (v *VRGInstance) updateVRGConditions() {
 func (v *VRGInstance) vrgReadyStatus(reason string) *metav1.Condition {
 	v.log.Info("Marking VRG ready with replicating reason", "reason", reason)
 
-	unusedMsg := "No PVCs are protected using VolumeReplication scheme"
-	if v.instance.Spec.Sync != nil {
-		unusedMsg = "No PVCs are protected, no PVCs found matching the selector"
-	}
-
 	if v.instance.Spec.ReplicationState == ramendrv1alpha1.Secondary {
 		msg := "PVCs in the VolumeReplicationGroup group are replicating"
 		if reason == VRGConditionReasonUnused {
-			msg = unusedMsg
+			msg = "PVC protection as secondary is complete, or no PVCs needed protection using VolumeReplication scheme"
+			if v.instance.Spec.Sync != nil {
+				msg = "PVC protection as secondary is complete, or no PVCs needed protection"
+			}
 		} else {
 			reason = VRGConditionReasonReplicating
 		}
@@ -1560,7 +1558,10 @@ func (v *VRGInstance) vrgReadyStatus(reason string) *metav1.Condition {
 	// VRG as primary
 	msg := "PVCs in the VolumeReplicationGroup are ready for use"
 	if reason == VRGConditionReasonUnused {
-		msg = unusedMsg
+		msg = "No PVCs are protected using VolumeReplication scheme"
+		if v.instance.Spec.Sync != nil {
+			msg = "No PVCs are protected, no PVCs found matching the selector"
+		}
 	}
 
 	return newVRGAsPrimaryReadyCondition(v.instance.Generation, reason, msg)

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1380,6 +1380,8 @@ func (v *VRGInstance) errorConditionLogAndSet(err error, msg string,
 }
 
 func (v *VRGInstance) updateVRGConditionsAndStatus(result ctrl.Result) ctrl.Result {
+	// Check if as Secondary things would be updated accordingly, should protectedPVC be cleared?
+	// cleanupProtectedPVCs
 	v.updateVRGConditions()
 
 	return v.updateVRGStatus(result)


### PR DESCRIPTION
- Start by not needing to delete VRG as secondary from DRPC reconciler
- For VR based VRG reconciliation ensure PVC is released when requested state is Secondary
- Some trivial rename of functions to handle as secondary than as secondary for volsync
- Adjust test cases to expect a secondary manifest work to be always present

There is more work to do in terms of cleanup and refactoring, but the bulk of changes to address the need should be present with this commit.

NOTE: Posted for reviews, refactor of the commit into more logical units is possible as work progresses