### PR TITLE
e2e: Easier to follow log

### DIFF
--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -208,7 +208,7 @@ func DeleteSubscription(s Subscription, w workloads.Workload) error {
 }
 
 func GetCombinedName(d Deployer, w workloads.Workload) string {
-	return strings.ToLower(d.GetName() + "-" + w.GetName() + "-" + w.GetAppName())
+	return strings.ToLower(d.GetName() + "-" + w.GetName())
 }
 
 func GetNamespace(d Deployer, w workloads.Workload) string {

--- a/e2e/deployers/discoveredapps.go
+++ b/e2e/deployers/discoveredapps.go
@@ -107,5 +107,6 @@ func (d DiscoveredApps) Undeploy(w workloads.Workload) error {
 }
 
 func (d DiscoveredApps) IsWorkloadSupported(w workloads.Workload) bool {
-	return w.GetName() != "Deploy-cephfs"
+	// TODO: This works only for the default configuration. Replace with a more robust way.
+	return w.GetName() != "cephfs"
 }

--- a/e2e/exhaustive_suite_test.go
+++ b/e2e/exhaustive_suite_test.go
@@ -4,7 +4,6 @@
 package e2e_test
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -32,30 +31,29 @@ var (
 	Deployers      = []deployers.Deployer{subscription, appset, discoveredApps}
 )
 
-func generateSuffix(storageClassName string) string {
-	suffix := storageClassName
+func storageName(storageClassName string) string {
+	name := storageClassName
 
 	if strings.ToLower(storageClassName) == "rook-ceph-block" {
-		suffix = "rbd"
+		name = "rbd"
 	}
 
 	if strings.ToLower(storageClassName) == "rook-cephfs" {
-		suffix = "cephfs"
+		name = "cephfs"
 	}
 
-	return suffix
+	return name
 }
 
 func generateWorkloads([]workloads.Workload) {
 	pvcSpecs := util.GetPVCSpecs()
 	for _, pvcSpec := range pvcSpecs {
 		// add storageclass name to deployment name
-		suffix := generateSuffix(pvcSpec.StorageClassName)
 		deployment := &workloads.Deployment{
 			Path:     GITPATH,
 			Revision: GITREVISION,
 			AppName:  APPNAME,
-			Name:     fmt.Sprintf("Deploy-%s", suffix),
+			Name:     storageName(pvcSpec.StorageClassName),
 			PVCSpec:  pvcSpec,
 		}
 		Workloads = append(Workloads, deployment)

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/ramendr/ramen/e2e/util"
-	uberzap "go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -25,9 +24,6 @@ func TestMain(m *testing.M) {
 
 	log := zap.New(zap.UseFlagOptions(&zap.Options{
 		Development: true,
-		ZapOpts: []uberzap.Option{
-			uberzap.AddCaller(),
-		},
 		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}))
 


### PR DESCRIPTION
Additional log cleanups split from #1628:
- remove the file:line since it make it harder to follow the log and does not add much value.
  - it could be nice to have it we could move it to the end of the log https://github.com/uber-go/zap/discussions/1471
  - I checked zap code, the location of the caller is hard-coded. The only way is to use our own encoder that will convert file/line info to field, which logged at the end.
  - We can remove the caller in the console logs when we have a log file (#1722)
- Remove unhelpful noise from test name "Deploy", "busybox"
  - deploy will be useful when we add other workloads (statefulset, daemonset, vm)
  - busybox can be removed - the name will be in the specific workload debug logs