### PR TITLE
yamllint: ignore keys for truthy evaluation

### DIFF
--- a/.github/workflows/e2e-daily.yaml
+++ b/.github/workflows/e2e-daily.yaml
@@ -5,7 +5,7 @@
 # yamllint disable rule:line-length
 name: E2E Daily
 
-on:  # yamllint disable-line rule:truthy
+on:
   # Run every day on 03:00.
   schedule:
     - cron: '0 3 * * *'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5,7 +5,7 @@
 # yamllint disable rule:line-length
 name: E2E
 
-on:  # yamllint disable-line rule:truthy
+on:
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/ramen.yaml
+++ b/.github/workflows/ramen.yaml
@@ -10,7 +10,7 @@ name: ramen
 # fork in github, minimizing noise for maintainers. This
 # workflow also runs on nightly basis at 12:00 AM (00:00 UTC)
 
-on:  # yamllint disable-line rule:truthy
+on:
   push:
   pull_request:
   schedule:

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -10,7 +10,7 @@ name: tools
 # fork in github, minimizing noise for maintainers. This
 # workflow also runs on nightly basis at 12:00 AM (00:00 UTC)
 
-on:  # yamllint disable-line rule:truthy
+on:
   push:
   pull_request:
   schedule:

--- a/hack/yamlconfig.yaml
+++ b/hack/yamlconfig.yaml
@@ -13,3 +13,5 @@ rules:
     indent-sequences: consistent
   line-length:
     allow-non-breakable-inline-mappings: true
+  truthy:
+    check-keys: false


### PR DESCRIPTION
We don't use a bool in the key for any yamls and it is unlikely we will. Add the yamllint configuration for ignoring keys for truthy evaluation.