### PR TITLE
Add missing license headers to source files

### DIFF
--- a/internal/controller/cel/cel_drclusters_test.go
+++ b/internal/controller/cel/cel_drclusters_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package cel_test
 
 import (

--- a/internal/controller/cel/cel_drplacementcontrol_test.go
+++ b/internal/controller/cel/cel_drplacementcontrol_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package cel_test
 
 import (

--- a/internal/controller/cel/cel_drpolicy_test.go
+++ b/internal/controller/cel/cel_drpolicy_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package cel_test
 
 import (

--- a/internal/controller/cephfscg/cephfscg_suite_test.go
+++ b/internal/controller/cephfscg/cephfscg_suite_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package cephfscg_test
 
 import (

--- a/internal/controller/cephfscg/cghandler.go
+++ b/internal/controller/cephfscg/cghandler.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package cephfscg
 
 import (

--- a/internal/controller/cephfscg/cghandler_test.go
+++ b/internal/controller/cephfscg/cghandler_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package cephfscg_test
 
 import (

--- a/internal/controller/cephfscg/replicationgroupdestination.go
+++ b/internal/controller/cephfscg/replicationgroupdestination.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package cephfscg
 
 import (

--- a/internal/controller/cephfscg/replicationgroupdestination_test.go
+++ b/internal/controller/cephfscg/replicationgroupdestination_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package cephfscg_test
 
 import (

--- a/internal/controller/cephfscg/replicationgroupsource.go
+++ b/internal/controller/cephfscg/replicationgroupsource.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package cephfscg
 
 import (

--- a/internal/controller/cephfscg/replicationgroupsource_test.go
+++ b/internal/controller/cephfscg/replicationgroupsource_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package cephfscg_test
 
 import (

--- a/internal/controller/cephfscg/utils.go
+++ b/internal/controller/cephfscg/utils.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package cephfscg
 
 import (

--- a/internal/controller/cephfscg/volumegroupsourcehandler.go
+++ b/internal/controller/cephfscg/volumegroupsourcehandler.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package cephfscg
 
 import (

--- a/internal/controller/cephfscg/volumegroupsourcehandler_test.go
+++ b/internal/controller/cephfscg/volumegroupsourcehandler_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package cephfscg_test
 
 import (

--- a/internal/controller/util/cephfs_cg.go
+++ b/internal/controller/util/cephfs_cg.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package util
 
 import (

--- a/internal/controller/util/cephfs_cg_test.go
+++ b/internal/controller/util/cephfs_cg_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package util_test
 
 import (

--- a/internal/controller/util/json_util.go
+++ b/internal/controller/util/json_util.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package util
 
 import (

--- a/internal/controller/util/json_util_test.go
+++ b/internal/controller/util/json_util_test.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package util_test
 
 import (


### PR DESCRIPTION
Discovered while attempting to revive goheader linter.

The linter itself seems to have some issues, but as that is being worked on, adding the license to the flagged off files by the linter.