### PR TITLE
e2e: replace kubernetes.Clientset with client.Client

### DIFF
--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -49,7 +49,7 @@ func CreateManagedClusterSetBinding(name, namespace string) error {
 		},
 	}
 
-	err := util.Ctx.Hub.CtrlClient.Create(context.Background(), mcsb)
+	err := util.Ctx.Hub.Client.Create(context.Background(), mcsb)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return err
@@ -68,7 +68,7 @@ func DeleteManagedClusterSetBinding(ctx types.Context, name, namespace string) e
 		},
 	}
 
-	err := util.Ctx.Hub.CtrlClient.Delete(context.Background(), mcsb)
+	err := util.Ctx.Hub.Client.Delete(context.Background(), mcsb)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return err
@@ -99,7 +99,7 @@ func CreatePlacement(ctx types.Context, name, namespace string) error {
 		},
 	}
 
-	err := util.Ctx.Hub.CtrlClient.Create(context.Background(), placement)
+	err := util.Ctx.Hub.Client.Create(context.Background(), placement)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return err
@@ -120,7 +120,7 @@ func DeletePlacement(ctx types.Context, name, namespace string) error {
 		},
 	}
 
-	err := util.Ctx.Hub.CtrlClient.Delete(context.Background(), placement)
+	err := util.Ctx.Hub.Client.Delete(context.Background(), placement)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return err
@@ -176,7 +176,7 @@ func CreateSubscription(ctx types.Context, s Subscription) error {
 		})
 	}
 
-	err := util.Ctx.Hub.CtrlClient.Create(context.Background(), subscription)
+	err := util.Ctx.Hub.Client.Create(context.Background(), subscription)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return err
@@ -200,7 +200,7 @@ func DeleteSubscription(ctx types.Context, s Subscription) error {
 		},
 	}
 
-	err := util.Ctx.Hub.CtrlClient.Delete(context.Background(), subscription)
+	err := util.Ctx.Hub.Client.Delete(context.Background(), subscription)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return err
@@ -237,7 +237,7 @@ func CreatePlacementDecisionConfigMap(ctx types.Context, cmName string, cmNamesp
 
 	configMap := &corev1.ConfigMap{ObjectMeta: object, Data: data}
 
-	err := util.Ctx.Hub.CtrlClient.Create(context.Background(), configMap)
+	err := util.Ctx.Hub.Client.Create(context.Background(), configMap)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return fmt.Errorf("could not create configMap %q", cmName)
@@ -257,7 +257,7 @@ func DeleteConfigMap(ctx types.Context, cmName string, cmNamespace string) error
 		ObjectMeta: object,
 	}
 
-	err := util.Ctx.Hub.CtrlClient.Delete(context.Background(), configMap)
+	err := util.Ctx.Hub.Client.Delete(context.Background(), configMap)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("could not delete configMap %q", cmName)
@@ -338,7 +338,7 @@ func CreateApplicationSet(ctx types.Context, a ApplicationSet) error {
 		appset.Spec.Template.Spec.Source.Kustomize = patches
 	}
 
-	err := util.Ctx.Hub.CtrlClient.Create(context.Background(), appset)
+	err := util.Ctx.Hub.Client.Create(context.Background(), appset)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return err
@@ -362,7 +362,7 @@ func DeleteApplicationSet(ctx types.Context, a ApplicationSet) error {
 		},
 	}
 
-	err := util.Ctx.Hub.CtrlClient.Delete(context.Background(), appset)
+	err := util.Ctx.Hub.Client.Delete(context.Background(), appset)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return err
@@ -378,7 +378,7 @@ func DeleteApplicationSet(ctx types.Context, a ApplicationSet) error {
 func isLastAppsetInArgocdNs(namespace string) (bool, error) {
 	appsetList := &argocdv1alpha1hack.ApplicationSetList{}
 
-	err := util.Ctx.Hub.CtrlClient.List(
+	err := util.Ctx.Hub.Client.List(
 		context.Background(), appsetList, client.InNamespace(namespace))
 	if err != nil {
 		return false, fmt.Errorf("failed to list applicationsets: %w", err)

--- a/e2e/deployers/discoveredapps.go
+++ b/e2e/deployers/discoveredapps.go
@@ -46,7 +46,7 @@ func (d DiscoveredApps) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub.CtrlClient, util.DefaultDRPolicyName)
+	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub.Client, util.DefaultDRPolicyName)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (d DiscoveredApps) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	if err = WaitWorkloadHealth(ctx, util.Ctx.C1.CtrlClient, namespace); err != nil {
+	if err = WaitWorkloadHealth(ctx, util.Ctx.C1.Client, namespace); err != nil {
 		return err
 	}
 
@@ -78,7 +78,7 @@ func (d DiscoveredApps) Undeploy(ctx types.Context) error {
 
 	log.Info("Undeploying workload")
 
-	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub.CtrlClient, util.DefaultDRPolicyName)
+	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub.Client, util.DefaultDRPolicyName)
 	if err != nil {
 		return err
 	}
@@ -99,13 +99,13 @@ func (d DiscoveredApps) Undeploy(ctx types.Context) error {
 	log.Infof("Deleting namespace %q on cluster %q", namespace, drpolicy.Spec.DRClusters[0])
 
 	// delete namespace on both clusters
-	if err := util.DeleteNamespace(util.Ctx.C1.CtrlClient, namespace, log); err != nil {
+	if err := util.DeleteNamespace(util.Ctx.C1.Client, namespace, log); err != nil {
 		return err
 	}
 
 	log.Infof("Deleting namespace %q on cluster %q", namespace, drpolicy.Spec.DRClusters[1])
 
-	if err := util.DeleteNamespace(util.Ctx.C2.CtrlClient, namespace, log); err != nil {
+	if err := util.DeleteNamespace(util.Ctx.C2.Client, namespace, log); err != nil {
 		return err
 	}
 

--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -18,7 +18,7 @@ func waitSubscriptionPhase(ctx types.Context, namespace, name string, phase subs
 	startTime := time.Now()
 
 	for {
-		sub, err := getSubscription(util.Ctx.Hub.CtrlClient, namespace, name)
+		sub, err := getSubscription(util.Ctx.Hub.Client, namespace, name)
 		if err != nil {
 			return err
 		}

--- a/e2e/deployers/subscription.go
+++ b/e2e/deployers/subscription.go
@@ -37,7 +37,7 @@ func (s Subscription) Deploy(ctx types.Context) error {
 	log.Info("Deploying workload")
 
 	// create subscription namespace
-	err := util.CreateNamespace(util.Ctx.Hub.CtrlClient, namespace)
+	err := util.CreateNamespace(util.Ctx.Hub.Client, namespace)
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func (s Subscription) Undeploy(ctx types.Context) error {
 		return err
 	}
 
-	return util.DeleteNamespace(util.Ctx.Hub.CtrlClient, namespace, log)
+	return util.DeleteNamespace(util.Ctx.Hub.Client, namespace, log)
 }
 
 func (s Subscription) IsWorkloadSupported(w types.Workload) bool {

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -46,7 +46,7 @@ func EnableProtection(ctx types.Context) error {
 	placementName := name
 	drpcName := name
 
-	placementDecision, err := waitPlacementDecision(util.Ctx.Hub.CtrlClient, namespace, placementName)
+	placementDecision, err := waitPlacementDecision(util.Ctx.Hub.Client, namespace, placementName)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func EnableProtection(ctx types.Context) error {
 	log.Info("Annotating placement")
 
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		placement, err := getPlacement(util.Ctx.Hub.CtrlClient, namespace, placementName)
+		placement, err := getPlacement(util.Ctx.Hub.Client, namespace, placementName)
 		if err != nil {
 			return err
 		}
@@ -68,7 +68,7 @@ func EnableProtection(ctx types.Context) error {
 
 		placement.Annotations[OcmSchedulingDisable] = "true"
 
-		return updatePlacement(util.Ctx.Hub.CtrlClient, placement)
+		return updatePlacement(util.Ctx.Hub.Client, placement)
 	})
 	if err != nil {
 		return err
@@ -77,7 +77,7 @@ func EnableProtection(ctx types.Context) error {
 	log.Info("Creating drpc")
 
 	drpc := generateDRPC(name, namespace, clusterName, drPolicyName, placementName, appname)
-	if err = createDRPC(util.Ctx.Hub.CtrlClient, drpc); err != nil {
+	if err = createDRPC(util.Ctx.Hub.Client, drpc); err != nil {
 		return err
 	}
 
@@ -87,7 +87,7 @@ func EnableProtection(ctx types.Context) error {
 		return err
 	}
 
-	return waitDRPCReady(ctx, util.Ctx.Hub.CtrlClient, namespace, drpcName)
+	return waitDRPCReady(ctx, util.Ctx.Hub.Client, namespace, drpcName)
 }
 
 // remove DRPC
@@ -105,7 +105,7 @@ func DisableProtection(ctx types.Context) error {
 	name := ctx.Name()
 	namespace := ctx.Namespace()
 	drpcName := name
-	client := util.Ctx.Hub.CtrlClient
+	client := util.Ctx.Hub.Client
 
 	log.Info("Deleting drpc")
 
@@ -150,7 +150,7 @@ func failoverRelocate(ctx types.Context, action ramen.DRAction) error {
 	name := ctx.Name()
 	namespace := ctx.Namespace()
 	drpcName := name
-	client := util.Ctx.Hub.CtrlClient
+	client := util.Ctx.Hub.Client
 
 	if err := waitAndUpdateDRPC(ctx, client, namespace, drpcName, action); err != nil {
 		return err

--- a/e2e/dractions/actionsdiscoveredapps.go
+++ b/e2e/dractions/actionsdiscoveredapps.go
@@ -35,7 +35,7 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 	}
 
 	// create drpc
-	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub.CtrlClient, drPolicyName)
+	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub.Client, drPolicyName)
 	if err != nil {
 		return err
 	}
@@ -46,12 +46,12 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 
 	drpc := generateDRPCDiscoveredApps(
 		name, namespace, clusterName, drPolicyName, placementName, appname, namespaceInDrCluster)
-	if err = createDRPC(util.Ctx.Hub.CtrlClient, drpc); err != nil {
+	if err = createDRPC(util.Ctx.Hub.Client, drpc); err != nil {
 		return err
 	}
 
 	// wait for drpc ready
-	return waitDRPCReady(ctx, util.Ctx.Hub.CtrlClient, namespace, drpcName)
+	return waitDRPCReady(ctx, util.Ctx.Hub.Client, namespace, drpcName)
 }
 
 // remove DRPC
@@ -66,7 +66,7 @@ func DisableProtectionDiscoveredApps(ctx types.Context) error {
 	placementName := name
 	drpcName := name
 
-	client := util.Ctx.Hub.CtrlClient
+	client := util.Ctx.Hub.Client
 
 	log.Info("Deleting drpc")
 
@@ -108,7 +108,7 @@ func failoverRelocateDiscoveredApps(ctx types.Context, action ramen.DRAction) er
 	namespaceInDrCluster := name // this namespace is in dr clusters
 
 	drpcName := name
-	client := util.Ctx.Hub.CtrlClient
+	client := util.Ctx.Hub.Client
 
 	currentCluster, err := getCurrentCluster(client, namespace, name)
 	if err != nil {

--- a/e2e/dractions/crud.go
+++ b/e2e/dractions/crud.go
@@ -129,7 +129,7 @@ func createPlacementManagedByRamen(ctx types.Context, name, namespace string) er
 		},
 	}
 
-	err := util.Ctx.Hub.CtrlClient.Create(context.Background(), placement)
+	err := util.Ctx.Hub.Client.Create(context.Background(), placement)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return err

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -139,10 +139,10 @@ func getCurrentCluster(client client.Client, namespace string, placementName str
 // return dr cluster client
 func getDRClusterClient(clusterName string, drpolicy *ramen.DRPolicy) client.Client {
 	if clusterName == drpolicy.Spec.DRClusters[0] {
-		return util.Ctx.C1.CtrlClient
+		return util.Ctx.C1.Client
 	}
 
-	return util.Ctx.C2.CtrlClient
+	return util.Ctx.C2.Client
 }
 
 func getTargetCluster(client client.Client, namespace, placementName string, drpolicy *ramen.DRPolicy) (string, error) {

--- a/e2e/util/crud.go
+++ b/e2e/util/crud.go
@@ -92,7 +92,7 @@ func createChannel() error {
 		},
 	}
 
-	err := Ctx.Hub.CtrlClient.Create(context.Background(), objChannel)
+	err := Ctx.Hub.Client.Create(context.Background(), objChannel)
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return err
@@ -114,7 +114,7 @@ func deleteChannel() error {
 		},
 	}
 
-	err := Ctx.Hub.CtrlClient.Delete(context.Background(), channel)
+	err := Ctx.Hub.Client.Delete(context.Background(), channel)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			return err
@@ -130,7 +130,7 @@ func deleteChannel() error {
 
 func EnsureChannel() error {
 	// create channel namespace
-	err := CreateNamespace(Ctx.Hub.CtrlClient, GetChannelNamespace())
+	err := CreateNamespace(Ctx.Hub.Client, GetChannelNamespace())
 	if err != nil {
 		return err
 	}
@@ -143,26 +143,26 @@ func EnsureChannelDeleted() error {
 		return err
 	}
 
-	return DeleteNamespace(Ctx.Hub.CtrlClient, GetChannelNamespace(), Ctx.Log)
+	return DeleteNamespace(Ctx.Hub.Client, GetChannelNamespace(), Ctx.Log)
 }
 
 // Problem: currently we must manually add an annotation to application’s namespace to make volsync work.
 // See this link https://volsync.readthedocs.io/en/stable/usage/permissionmodel.html#controlling-mover-permissions
 // Workaround: create ns in both drclusters and add annotation
 func CreateNamespaceAndAddAnnotation(namespace string) error {
-	if err := CreateNamespace(Ctx.C1.CtrlClient, namespace); err != nil {
+	if err := CreateNamespace(Ctx.C1.Client, namespace); err != nil {
 		return err
 	}
 
-	if err := AddNamespaceAnnotationForVolSync(Ctx.C1.CtrlClient, namespace); err != nil {
+	if err := AddNamespaceAnnotationForVolSync(Ctx.C1.Client, namespace); err != nil {
 		return err
 	}
 
-	if err := CreateNamespace(Ctx.C2.CtrlClient, namespace); err != nil {
+	if err := CreateNamespace(Ctx.C2.Client, namespace); err != nil {
 		return err
 	}
 
-	return AddNamespaceAnnotationForVolSync(Ctx.C2.CtrlClient, namespace)
+	return AddNamespaceAnnotationForVolSync(Ctx.C2.Client, namespace)
 }
 
 func AddNamespaceAnnotationForVolSync(client client.Client, namespace string) error {

--- a/e2e/validation_suite_test.go
+++ b/e2e/validation_suite_test.go
@@ -16,7 +16,7 @@ func Validate(dt *testing.T) {
 	t.Run("hub", func(dt *testing.T) {
 		t := test.WithLog(dt, util.Ctx.Log)
 
-		err := util.ValidateRamenHubOperator(util.Ctx.Hub.K8sClientSet)
+		err := util.ValidateRamenHubOperator(util.Ctx.Hub.CtrlClient)
 		if err != nil {
 			t.Fatalf("Failed to validated hub cluster: %s", err)
 		}
@@ -24,7 +24,7 @@ func Validate(dt *testing.T) {
 	t.Run("c1", func(dt *testing.T) {
 		t := test.WithLog(dt, util.Ctx.Log)
 
-		err := util.ValidateRamenDRClusterOperator(util.Ctx.C1.K8sClientSet, "c1")
+		err := util.ValidateRamenDRClusterOperator(util.Ctx.C1.CtrlClient, "c1")
 		if err != nil {
 			t.Fatalf("Failed to validated dr cluster c1: %s", err)
 		}
@@ -32,7 +32,7 @@ func Validate(dt *testing.T) {
 	t.Run("c2", func(dt *testing.T) {
 		t := test.WithLog(dt, util.Ctx.Log)
 
-		err := util.ValidateRamenDRClusterOperator(util.Ctx.C2.K8sClientSet, "c2")
+		err := util.ValidateRamenDRClusterOperator(util.Ctx.C2.CtrlClient, "c2")
 		if err != nil {
 			t.Fatalf("Failed to validated dr cluster c2: %s", err)
 		}

--- a/e2e/validation_suite_test.go
+++ b/e2e/validation_suite_test.go
@@ -16,7 +16,7 @@ func Validate(dt *testing.T) {
 	t.Run("hub", func(dt *testing.T) {
 		t := test.WithLog(dt, util.Ctx.Log)
 
-		err := util.ValidateRamenHubOperator(util.Ctx.Hub.CtrlClient)
+		err := util.ValidateRamenHubOperator(util.Ctx.Hub.Client)
 		if err != nil {
 			t.Fatalf("Failed to validated hub cluster: %s", err)
 		}
@@ -24,7 +24,7 @@ func Validate(dt *testing.T) {
 	t.Run("c1", func(dt *testing.T) {
 		t := test.WithLog(dt, util.Ctx.Log)
 
-		err := util.ValidateRamenDRClusterOperator(util.Ctx.C1.CtrlClient, "c1")
+		err := util.ValidateRamenDRClusterOperator(util.Ctx.C1.Client, "c1")
 		if err != nil {
 			t.Fatalf("Failed to validated dr cluster c1: %s", err)
 		}
@@ -32,7 +32,7 @@ func Validate(dt *testing.T) {
 	t.Run("c2", func(dt *testing.T) {
 		t := test.WithLog(dt, util.Ctx.Log)
 
-		err := util.ValidateRamenDRClusterOperator(util.Ctx.C2.CtrlClient, "c2")
+		err := util.ValidateRamenDRClusterOperator(util.Ctx.C2.Client, "c2")
 		if err != nil {
 			t.Fatalf("Failed to validated dr cluster c2: %s", err)
 		}


### PR DESCRIPTION
Just simplifying the code a bit more. We were using kubernetes.Clientset for things where we couldn't figure out how to use client.Client.