### PR TITLE
e2e: Improve waiting for drpc readiness

### DIFF
--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -5,7 +5,6 @@ package dractions
 
 import (
 	"strings"
-	"time"
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/e2e/deployers"
@@ -17,8 +16,6 @@ import (
 
 const (
 	OcmSchedulingDisable = "cluster.open-cluster-management.io/experimental-scheduling-disable"
-
-	FiveSecondsDuration = 5 * time.Second
 )
 
 // If AppSet/Subscription, find Placement

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -123,7 +123,7 @@ func Failover(ctx types.Context) error {
 
 	log.Info("Failing over workload")
 
-	return failoverRelocate(ctx, ramen.ActionFailover)
+	return failoverRelocate(ctx, ramen.ActionFailover, ramen.FailedOver)
 }
 
 // Determine DRPC
@@ -140,24 +140,19 @@ func Relocate(ctx types.Context) error {
 
 	log.Info("Relocating workload")
 
-	return failoverRelocate(ctx, ramen.ActionRelocate)
+	return failoverRelocate(ctx, ramen.ActionRelocate, ramen.Relocated)
 }
 
-func failoverRelocate(ctx types.Context, action ramen.DRAction) error {
-	name := ctx.Name()
+func failoverRelocate(ctx types.Context, action ramen.DRAction, state ramen.DRState) error {
+	drpcName := ctx.Name()
 	namespace := ctx.Namespace()
-	drpcName := name
 	client := util.Ctx.Hub.Client
 
 	if err := waitAndUpdateDRPC(ctx, client, namespace, drpcName, action); err != nil {
 		return err
 	}
 
-	if action == ramen.ActionFailover {
-		return waitDRPC(ctx, client, namespace, name, ramen.FailedOver)
-	}
-
-	return waitDRPC(ctx, client, namespace, name, ramen.Relocated)
+	return waitDRPC(ctx, client, namespace, drpcName, state)
 }
 
 func waitAndUpdateDRPC(

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -152,7 +152,11 @@ func failoverRelocate(ctx types.Context, action ramen.DRAction, state ramen.DRSt
 		return err
 	}
 
-	return waitDRPC(ctx, client, namespace, drpcName, state)
+	if err := waitDRPCPhase(ctx, client, namespace, drpcName, state); err != nil {
+		return err
+	}
+
+	return waitDRPCReady(ctx, client, namespace, drpcName)
 }
 
 func waitAndUpdateDRPC(

--- a/e2e/dractions/actionsdiscoveredapps.go
+++ b/e2e/dractions/actionsdiscoveredapps.go
@@ -90,18 +90,18 @@ func FailoverDiscoveredApps(ctx types.Context) error {
 	log := ctx.Logger()
 	log.Info("Failing over workload")
 
-	return failoverRelocateDiscoveredApps(ctx, ramen.ActionFailover)
+	return failoverRelocateDiscoveredApps(ctx, ramen.ActionFailover, ramen.FailedOver)
 }
 
 func RelocateDiscoveredApps(ctx types.Context) error {
 	log := ctx.Logger()
 	log.Info("Relocating workload")
 
-	return failoverRelocateDiscoveredApps(ctx, ramen.ActionRelocate)
+	return failoverRelocateDiscoveredApps(ctx, ramen.ActionRelocate, ramen.Relocated)
 }
 
 // nolint:funlen,cyclop
-func failoverRelocateDiscoveredApps(ctx types.Context, action ramen.DRAction) error {
+func failoverRelocateDiscoveredApps(ctx types.Context, action ramen.DRAction, state ramen.DRState) error {
 	name := ctx.Name()
 	log := ctx.Logger()
 	namespace := ctx.Namespace() // this namespace is in hub
@@ -142,11 +142,7 @@ func failoverRelocateDiscoveredApps(ctx types.Context, action ramen.DRAction) er
 		return err
 	}
 
-	if err = waitDRPCProgression(ctx, client, namespace, name, ramen.ProgressionCompleted); err != nil {
-		return err
-	}
-
-	if err = waitDRPCReady(ctx, client, namespace, name); err != nil {
+	if err = waitDRPC(ctx, client, namespace, name, state); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/actionsdiscoveredapps.go
+++ b/e2e/dractions/actionsdiscoveredapps.go
@@ -142,7 +142,11 @@ func failoverRelocateDiscoveredApps(ctx types.Context, action ramen.DRAction, st
 		return err
 	}
 
-	if err = waitDRPC(ctx, client, namespace, name, state); err != nil {
+	if err := waitDRPCPhase(ctx, client, namespace, name, state); err != nil {
+		return err
+	}
+
+	if err := waitDRPCReady(ctx, client, namespace, name); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"open-cluster-management.io/api/cluster/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -48,58 +50,36 @@ func waitDRPCReady(ctx types.Context, client client.Client, namespace string, dr
 	log := ctx.Logger()
 	startTime := time.Now()
 
+	log.Info("Waiting until drpc is ready")
+
 	for {
 		drpc, err := getDRPC(client, namespace, drpcName)
 		if err != nil {
 			return err
 		}
 
-		conditionReady := checkDRPCConditions(drpc)
-		if conditionReady && drpc.Status.LastGroupSyncTime != nil {
+		available := conditionMet(drpc.Status.Conditions, ramen.ConditionAvailable)
+		peerReady := conditionMet(drpc.Status.Conditions, ramen.ConditionPeerReady)
+
+		if available && peerReady && drpc.Status.LastGroupSyncTime != nil {
 			log.Info("drpc is ready")
 
 			return nil
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			if !conditionReady {
-				log.Info("drpc condition 'Available' or 'PeerReady' is not True")
-			}
-
-			if conditionReady && drpc.Status.LastGroupSyncTime == nil {
-				log.Info("drpc LastGroupSyncTime is nil")
-			}
-
-			return fmt.Errorf("drpc %q is not ready yet before timeout, fail", drpcName)
+			return fmt.Errorf("timeout waiting for drpc to become ready (Available: %v, PeerReady: %v, lastGroupSyncTime: %v)",
+				available, peerReady, drpc.Status.LastGroupSyncTime)
 		}
 
 		time.Sleep(util.RetryInterval)
 	}
 }
 
-func checkDRPCConditions(drpc *ramen.DRPlacementControl) bool {
-	available := false
-	peerReady := false
+func conditionMet(conditions []metav1.Condition, conditionType string) bool {
+	condition := meta.FindStatusCondition(conditions, conditionType)
 
-	for _, cond := range drpc.Status.Conditions {
-		if cond.Type == "Available" {
-			if cond.Status != "True" {
-				return false
-			}
-
-			available = true
-		}
-
-		if cond.Type == "PeerReady" {
-			if cond.Status != "True" {
-				return false
-			}
-
-			peerReady = true
-		}
-	}
-
-	return available && peerReady
+	return condition != nil && condition.Status == "True"
 }
 
 func waitDRPCPhase(ctx types.Context, client client.Client, namespace, name string, phase ramen.DRState) error {

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -141,16 +141,6 @@ func getTargetCluster(client client.Client, namespace, placementName string, drp
 	return targetCluster, nil
 }
 
-// first wait DRPC to have the expected phase, then check DRPC conditions
-func waitDRPC(ctx types.Context, client client.Client, namespace, name string, expectedPhase ramen.DRState) error {
-	// check Phase
-	if err := waitDRPCPhase(ctx, client, namespace, name, expectedPhase); err != nil {
-		return err
-	}
-	// then check Conditions
-	return waitDRPCReady(ctx, client, namespace, name)
-}
-
 func waitDRPCDeleted(ctx types.Context, client client.Client, namespace string, name string) error {
 	log := ctx.Logger()
 	startTime := time.Now()


### PR DESCRIPTION
Improve the implementation and logging when waiting until drpc is ready.

- Improve waitDRPCReady logging and error handling
- Unify waiting for failover or relocate

Part of #1686