### PR TITLE
Replace github.com/pkg/errors with standard library errors package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
 	github.com/operator-framework/api v0.17.6
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.20.4
 	github.com/ramendr/ramen/api v0.0.0-20240924121439-b7cba82de417
 	github.com/ramendr/recipe v0.0.0-20240918115450-667b9d79599f
@@ -76,6 +75,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.59.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/internal/controller/cel/cel_drclusters_test.go
+++ b/internal/controller/cel/cel_drclusters_test.go
@@ -14,7 +14,7 @@ import (
 	// corev1 "k8s.io/api/core/v1"
 	// validationErrors "k8s.io/kube-openapi/pkg/validation/errors"
 	// "sigs.k8s.io/controller-runtime/pkg/client"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -64,7 +64,7 @@ var _ = Describe("DRCluster-CEL", func() {
 	drclusterDelete := func(drcluster *ramen.DRCluster) {
 		Expect(k8sClient.Delete(context.TODO(), drcluster)).To(Succeed())
 		Eventually(func() bool {
-			return errors.IsNotFound(k8sClient.Get(context.TODO(), types.NamespacedName{
+			return k8serrors.IsNotFound(k8sClient.Get(context.TODO(), types.NamespacedName{
 				Name: drcluster.Name,
 			}, drcluster))
 		}, timeout, interval).Should(BeTrue())

--- a/internal/controller/cel/cel_drplacementcontrol_test.go
+++ b/internal/controller/cel/cel_drplacementcontrol_test.go
@@ -12,7 +12,7 @@ import (
 	// gomegaTypes "github.com/onsi/gomega/types"
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	// validationErrors "k8s.io/kube-openapi/pkg/validation/errors"
@@ -92,7 +92,7 @@ var _ = Describe("DRPC-CEL", func() {
 	deleteDRPC := func(drpc *ramen.DRPlacementControl) {
 		Expect(k8sClient.Delete(context.TODO(), drpc)).To(Succeed())
 		Eventually(func() bool {
-			return errors.IsNotFound(k8sClient.Get(context.TODO(), types.NamespacedName{
+			return k8serrors.IsNotFound(k8sClient.Get(context.TODO(), types.NamespacedName{
 				Name: drpc.Name, Namespace: drpc.Namespace,
 			}, drpc))
 		}, timeout, interval).Should(BeTrue())

--- a/internal/controller/cel/cel_drpolicy_test.go
+++ b/internal/controller/cel/cel_drpolicy_test.go
@@ -12,7 +12,7 @@ import (
 	// gomegaTypes "github.com/onsi/gomega/types"
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	// corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,7 +56,7 @@ var _ = Describe("DRPolicy-CEL", func() {
 	drpolicyDeleteAndConfirm := func(drpolicy *ramen.DRPolicy) {
 		Expect(k8sClient.Delete(context.TODO(), drpolicy)).To(Succeed())
 		Eventually(func() bool {
-			return errors.IsNotFound(k8sClient.Get(context.TODO(), types.NamespacedName{Name: drpolicy.Name}, drpolicy))
+			return k8serrors.IsNotFound(k8sClient.Get(context.TODO(), types.NamespacedName{Name: drpolicy.Name}, drpolicy))
 		}, timeout, interval).Should(BeTrue())
 	}
 	drpolicyDelete := func(drpolicy *ramen.DRPolicy) {
@@ -76,10 +76,10 @@ var _ = Describe("DRPolicy-CEL", func() {
 		It("should fail to create drpolicy", func() {
 			drp := drpolicies[0].DeepCopy()
 			drp.Spec.DRClusters = nil
-			err := func() *errors.StatusError {
+			err := func() *k8serrors.StatusError {
 				path := field.NewPath("spec", "drClusters")
 
-				return errors.NewInvalid(
+				return k8serrors.NewInvalid(
 					schema.GroupKind{
 						Group: ramen.GroupVersion.Group,
 						Kind:  "DRPolicy",

--- a/internal/controller/cephfscg/cghandler.go
+++ b/internal/controller/cephfscg/cghandler.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ramendr/ramen/internal/controller/util"
 	"github.com/ramendr/ramen/internal/controller/volsync"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -349,7 +349,7 @@ func (c *cgHandler) DeleteLocalRDAndRS(rd *volsyncv1alpha1.ReplicationDestinatio
 		Namespace: lrs.GetNamespace(),
 	}, lrs)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return c.VSHandler.DeleteLocalRD(
 				getLocalReplicationName(rd.Name),
 				rd.Namespace,

--- a/internal/controller/cephfscg/volumegroupsourcehandler.go
+++ b/internal/controller/cephfscg/volumegroupsourcehandler.go
@@ -17,7 +17,7 @@ import (
 	"github.com/ramendr/ramen/internal/controller/volsync"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -159,7 +159,7 @@ func (h *volumeGroupSourceHandler) CleanVolumeGroupSnapshot(
 	if err := h.Client.Get(ctx, types.NamespacedName{
 		Name: h.VolumeGroupSnapshotName, Namespace: h.VolumeGroupSnapshotNamespace,
 	}, volumeGroupSnapshot); err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			logger.Info("Volume group snapshot was already deleted")
 
 			return nil
@@ -194,7 +194,7 @@ func (h *volumeGroupSourceHandler) CleanVolumeGroupSnapshot(
 					Name:      restoredPVCName,
 					Namespace: restoredPVCNamespace,
 				},
-			}); err != nil && !errors.IsNotFound(err) {
+			}); err != nil && !k8serrors.IsNotFound(err) {
 				logger.Error(err, "Failed to delete restored PVC ",
 					"PVCName", restoredPVCName, "PVCNamespace", restoredPVCNamespace)
 
@@ -203,7 +203,7 @@ func (h *volumeGroupSourceHandler) CleanVolumeGroupSnapshot(
 		}
 	}
 
-	if err := h.Client.Delete(ctx, volumeGroupSnapshot); err != nil && !errors.IsNotFound(err) {
+	if err := h.Client.Delete(ctx, volumeGroupSnapshot); err != nil && !k8serrors.IsNotFound(err) {
 		logger.Error(err, "Failed to delete volume group snapshot")
 
 		return err
@@ -335,7 +335,7 @@ func (h *volumeGroupSourceHandler) RestoreVolumesFromSnapshot(
 			)
 			// If this pvc already exists and not pointing to our desired snapshot, we will need to
 			// delete it and re-create as we cannot update the datah.VolumeGroupSnapshotSource
-			if err := h.Client.Delete(ctx, restoredPVC); err != nil && !errors.IsNotFound(err) {
+			if err := h.Client.Delete(ctx, restoredPVC); err != nil && !k8serrors.IsNotFound(err) {
 				return fmt.Errorf("failed to delete PVC: %w", err)
 			}
 

--- a/internal/controller/cephfscg/volumegroupsourcehandler_test.go
+++ b/internal/controller/cephfscg/volumegroupsourcehandler_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -105,7 +105,7 @@ var _ = Describe("Volumegroupsourcehandler", func() {
 						Namespace: "default",
 					}, pvc)
 					if err != nil {
-						return !errors.IsNotFound(err)
+						return !k8serrors.IsNotFound(err)
 					}
 
 					return pvc.DeletionTimestamp.IsZero()

--- a/internal/controller/controllers_utils_test.go
+++ b/internal/controller/controllers_utils_test.go
@@ -18,7 +18,7 @@ import (
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	controllers "github.com/ramendr/ramen/internal/controller"
 	"github.com/ramendr/ramen/internal/controller/util"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -378,7 +378,7 @@ func ensureDRClusterConfigMWNotFound(k8sClient client.Client, managedCluster str
 			mw,
 		)
 
-		return errors.IsNotFound(err)
+		return k8serrors.IsNotFound(err)
 	}
 
 	if always {

--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	viewv1beta1 "github.com/stolostron/multicloud-operators-foundation/pkg/apis/view/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -948,7 +948,7 @@ func (u *drclusterInstance) unfenceClusterOnCluster(peerCluster *ramen.DRCluster
 	nf, err := u.reconciler.MCVGetter.GetNFFromManagedCluster(u.object.Name,
 		u.object.Namespace, peerCluster.Name, annotations)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return u.requeueIfNFMWExists(peerCluster)
 		}
 
@@ -979,7 +979,7 @@ func (u *drclusterInstance) unfenceClusterOnCluster(peerCluster *ramen.DRCluster
 func (u *drclusterInstance) requeueIfNFMWExists(peerCluster *ramen.DRCluster) (bool, error) {
 	_, mwErr := u.mwUtil.FindManifestWorkByType(util.MWTypeNF, peerCluster.Name)
 	if mwErr != nil {
-		if errors.IsNotFound(mwErr) {
+		if k8serrors.IsNotFound(mwErr) {
 			u.log.Info("NetworkFence and MW for it not found. Cleaned")
 
 			return false, nil

--- a/internal/controller/drcluster_controller_test.go
+++ b/internal/controller/drcluster_controller_test.go
@@ -14,7 +14,7 @@ import (
 	controllers "github.com/ramendr/ramen/internal/controller"
 	"github.com/ramendr/ramen/internal/controller/util"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -88,13 +88,13 @@ var _ = Describe("DRClusterController", func() {
 		clusterName := drcluster.Name
 		Expect(k8sClient.Delete(context.TODO(), drcluster)).To(Succeed())
 		Eventually(func() bool {
-			return errors.IsNotFound(apiReader.Get(context.TODO(), types.NamespacedName{
+			return k8serrors.IsNotFound(apiReader.Get(context.TODO(), types.NamespacedName{
 				Namespace: drcluster.Namespace,
 				Name:      drcluster.Name,
 			}, drcluster))
 		}, timeout, interval).Should(BeTrue())
 		manifestWork := &workv1.ManifestWork{}
-		Expect(errors.IsNotFound(apiReader.Get(
+		Expect(k8serrors.IsNotFound(apiReader.Get(
 			context.TODO(),
 			types.NamespacedName{
 				Name:      util.DrClusterManifestWorkName,
@@ -180,7 +180,7 @@ var _ = Describe("DRClusterController", func() {
 		Eventually(func() error {
 			return k8sClient.Get(context.TODO(), types.NamespacedName{Name: namespace.Name}, namespace)
 		}, timeout, interval).Should(
-			MatchError(errors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, namespace.Name)),
+			MatchError(k8serrors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, namespace.Name)),
 			"%v", namespace,
 		)
 	}
@@ -226,7 +226,7 @@ var _ = Describe("DRClusterController", func() {
 		policy := drpolicy.DeepCopy()
 		Expect(k8sClient.Delete(context.TODO(), policy)).To(Succeed())
 		Eventually(func() bool {
-			return errors.IsNotFound(apiReader.Get(context.TODO(), types.NamespacedName{Name: policy.Name}, policy))
+			return k8serrors.IsNotFound(apiReader.Get(context.TODO(), types.NamespacedName{Name: policy.Name}, policy))
 		}, timeout, interval).Should(BeTrue())
 	}
 

--- a/internal/controller/drcluster_mmode.go
+++ b/internal/controller/drcluster_mmode.go
@@ -6,7 +6,7 @@ package controllers
 import (
 	"github.com/go-logr/logr"
 	viewv1beta1 "github.com/stolostron/multicloud-operators-foundation/pkg/apis/view/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ocmworkv1 "open-cluster-management.io/api/work/v1"
 
@@ -341,7 +341,7 @@ func (u *drclusterInstance) pruneMModeMCV(
 	}
 
 	// Other errors require us to try later
-	if !errors.IsNotFound(err) {
+	if !k8serrors.IsNotFound(err) {
 		u.log.Error(err, "Error fetching viewed resource")
 
 		u.requeue = true

--- a/internal/controller/drclusterconfig_controller_test.go
+++ b/internal/controller/drclusterconfig_controller_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -207,7 +207,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 				Name: "local",
 			}, drCConfig)
 
-			return errors.IsNotFound(err)
+			return k8serrors.IsNotFound(err)
 		}, timeout, interval).Should(BeTrue())
 
 		By("ensuring claim count is 0 post deletion")

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -13,7 +13,7 @@ import (
 	errorswrapper "github.com/pkg/errors"
 	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clrapiv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
@@ -298,7 +298,7 @@ func (d *DRPCInstance) startDeploying(homeCluster, homeClusterNamespace string) 
 	d.setProgression(rmn.ProgressionCreatingMW)
 	// Create VRG first, to leverage user PlacementRule decision to skip placement and move to cleanup
 	err := d.createVRGManifestWork(homeCluster, rmn.Primary)
-	if err != nil && !errors.IsAlreadyExists(err) {
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		return false, err
 	}
 
@@ -1339,7 +1339,7 @@ func (d *DRPCInstance) createVRGManifestWorkAsPrimary(targetCluster string) (boo
 
 	vrg, err := d.getVRGFromManifestWork(targetCluster)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return false, err
 		}
 	}
@@ -1401,7 +1401,7 @@ func (d *DRPCInstance) vrgExistsAndPrimary(targetCluster string) bool {
 func (d *DRPCInstance) mwExistsAndPlacementUpdated(targetCluster string) (bool, error) {
 	_, err := d.mwu.FindManifestWorkByType(rmnutil.MWTypeVRG, targetCluster)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return false, nil
 		}
 
@@ -1425,7 +1425,7 @@ func (d *DRPCInstance) moveVRGToSecondaryEverywhere() bool {
 	for _, clusterName := range rmnutil.DRPolicyClusterNames(d.drPolicy) {
 		_, err := d.updateVRGState(clusterName, rmn.Secondary)
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if k8serrors.IsNotFound(err) {
 				continue
 			}
 
@@ -1490,7 +1490,7 @@ func (d *DRPCInstance) createVRGManifestWork(homeCluster string, repState rmn.Re
 
 	// Safety latch to ensure VRG MW is not present
 	vrg, err := d.getVRGFromManifestWork(homeCluster)
-	if (err != nil && !errors.IsNotFound(err)) || vrg != nil {
+	if (err != nil && !k8serrors.IsNotFound(err)) || vrg != nil {
 		if err != nil {
 			return fmt.Errorf("error (%w) determining ManifestWork for VolumeReplicationGroup resource "+
 				"exists on cluster %s", err, homeCluster)
@@ -1503,7 +1503,7 @@ func (d *DRPCInstance) createVRGManifestWork(homeCluster string, repState rmn.Re
 		}
 
 		return fmt.Errorf("VolumeReplicationGroup ManifestWork for cluster %s in state %s exists (%w)",
-			homeCluster, string(vrg.Spec.ReplicationState), errors.NewAlreadyExists(
+			homeCluster, string(vrg.Spec.ReplicationState), k8serrors.NewAlreadyExists(
 				schema.GroupResource{
 					Group:    rmn.GroupVersion.Group,
 					Resource: "VolumeReplicationGroup",
@@ -1538,7 +1538,7 @@ func (d *DRPCInstance) ensureVRGManifestWork(homeCluster string) error {
 
 	mw, mwErr := d.mwu.FindManifestWorkByType(rmnutil.MWTypeVRG, homeCluster)
 	if mwErr != nil {
-		if errors.IsNotFound(mwErr) {
+		if k8serrors.IsNotFound(mwErr) {
 			return fmt.Errorf("failed to find ManifestWork for VolumeReplicationGroup from cluster %s", homeCluster)
 		}
 
@@ -1830,7 +1830,7 @@ func (d *DRPCInstance) ensureNamespaceManifestWork(homeCluster string) error {
 	// Ensure the MW for the namespace exists
 	mw, err := d.mwu.FindManifestWorkByType(rmnutil.MWTypeNS, homeCluster)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return fmt.Errorf("failed to get NS MW (%w)", err)
 		}
 
@@ -1922,7 +1922,7 @@ func (d *DRPCInstance) cleanupSecondaries(clusterToSkip string) error {
 			// Ideally this will never be called due to adoption of VRG in place, in the case of upgrades from older
 			// scheme were VRG was not preserved for VR workloads, this can be hit IFF the upgrade happened when some
 			// workload was not in peerReady state.
-			if errors.IsNotFound(err) {
+			if k8serrors.IsNotFound(err) {
 				err := d.EnsureSecondaryReplicationSetup(clusterToSkip)
 				if err != nil {
 					return err
@@ -1986,7 +1986,7 @@ func (d *DRPCInstance) ensureVRGIsSecondaryOnCluster(clusterName string) bool {
 	vrg, err := d.reconciler.MCVGetter.GetVRGFromManagedCluster(d.instance.Name,
 		d.vrgNamespace, clusterName, annotations)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return true // ensured
 		}
 
@@ -2048,7 +2048,7 @@ func (d *DRPCInstance) ensureDataProtectedOnCluster(clusterName string) bool {
 	vrg, err := d.reconciler.MCVGetter.GetVRGFromManagedCluster(d.instance.Name,
 		d.vrgNamespace, clusterName, annotations)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// expectation is that VRG should be present. Otherwise, this function
 			// would not have been called. Return false
 			d.log.Info("VRG not found", "errorValue", err)

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -5,12 +5,12 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
 
 	"github.com/go-logr/logr"
-	errorswrapper "github.com/pkg/errors"
 	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -40,11 +40,11 @@ const (
 )
 
 var (
-	WaitForAppResourceRestoreToComplete error = errorswrapper.New("Waiting for App resources to be restored...")
-	WaitForVolSyncDestRepToComplete     error = errorswrapper.New("Waiting for VolSync RD to complete...")
-	WaitForSourceCluster                error = errorswrapper.New("Waiting for primary to provide Protected PVCs...")
-	WaitForVolSyncManifestWorkCreation  error = errorswrapper.New("Waiting for VolSync ManifestWork to be created...")
-	WaitForVolSyncRDInfoAvailability    error = errorswrapper.New("Waiting for VolSync RDInfo...")
+	WaitForAppResourceRestoreToComplete error = errors.New("Waiting for App resources to be restored...")
+	WaitForVolSyncDestRepToComplete     error = errors.New("Waiting for VolSync RD to complete...")
+	WaitForSourceCluster                error = errors.New("Waiting for primary to provide Protected PVCs...")
+	WaitForVolSyncManifestWorkCreation  error = errors.New("Waiting for VolSync ManifestWork to be created...")
+	WaitForVolSyncRDInfoAvailability    error = errors.New("Waiting for VolSync RDInfo...")
 )
 
 type DRType string

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -40,11 +40,11 @@ const (
 )
 
 var (
-	WaitForAppResourceRestoreToComplete error = errors.New("Waiting for App resources to be restored...")
-	WaitForVolSyncDestRepToComplete     error = errors.New("Waiting for VolSync RD to complete...")
-	WaitForSourceCluster                error = errors.New("Waiting for primary to provide Protected PVCs...")
-	WaitForVolSyncManifestWorkCreation  error = errors.New("Waiting for VolSync ManifestWork to be created...")
-	WaitForVolSyncRDInfoAvailability    error = errors.New("Waiting for VolSync RDInfo...")
+	ErrWaitForAppResourceRestoreToComplete = errors.New("waiting for App resources to be restored")
+	ErrWaitForVolSyncDestRepToComplete     = errors.New("waiting for VolSync RD to complete")
+	ErrWaitForSourceCluster                = errors.New("waiting for primary to provide Protected PVCs")
+	ErrWaitForVolSyncManifestWorkCreation  = errors.New("waiting for VolSync ManifestWork to be created")
+	ErrWaitForVolSyncRDInfoAvailability    = errors.New("waiting for VolSync RDInfo")
 )
 
 type DRType string
@@ -1315,13 +1315,13 @@ func (d *DRPCInstance) switchToCluster(targetCluster, targetClusterNamespace str
 		d.setProgression(rmn.ProgressionWaitingForResourceRestore)
 
 		// We just created MWs. Give it time until the App resources have been restored
-		return fmt.Errorf("%w)", WaitForAppResourceRestoreToComplete)
+		return fmt.Errorf("%w)", ErrWaitForAppResourceRestoreToComplete)
 	}
 
 	if !d.checkReadiness(targetCluster) {
 		d.setProgression(rmn.ProgressionWaitingForResourceRestore)
 
-		return fmt.Errorf("%w)", WaitForAppResourceRestoreToComplete)
+		return fmt.Errorf("%w)", ErrWaitForAppResourceRestoreToComplete)
 	}
 
 	err = d.updateUserPlacementRule(targetCluster, targetClusterNamespace)

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -60,7 +60,7 @@ const (
 	DoNotDeletePVCAnnotationVal = "true"
 )
 
-var InitialWaitTimeForDRPCPlacementRule = errors.New("Waiting for DRPC Placement to produces placement decision")
+var ErrInitialWaitTimeForDRPCPlacementRule = errors.New("waiting for DRPC Placement to produces placement decision")
 
 // ProgressCallback of function type
 type ProgressCallback func(string, string)
@@ -222,17 +222,17 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	d, err := r.createDRPCInstance(ctx, drPolicy, drpc, placementObj, ramenConfig, logger)
-	if err != nil && !errors.Is(err, InitialWaitTimeForDRPCPlacementRule) {
+	if err != nil && !errors.Is(err, ErrInitialWaitTimeForDRPCPlacementRule) {
 		err2 := r.updateDRPCStatus(ctx, drpc, placementObj, logger)
 
 		return ctrl.Result{}, fmt.Errorf("failed to create DRPC instance (%w) and (%v)", err, err2)
 	}
 
-	if errors.Is(err, InitialWaitTimeForDRPCPlacementRule) {
+	if errors.Is(err, ErrInitialWaitTimeForDRPCPlacementRule) {
 		const initialWaitTime = 5
 
 		r.recordFailure(ctx, drpc, placementObj, "Waiting",
-			fmt.Sprintf("%v - wait time: %v", InitialWaitTimeForDRPCPlacementRule, initialWaitTime), logger)
+			fmt.Sprintf("%v - wait time: %v", ErrInitialWaitTimeForDRPCPlacementRule, initialWaitTime), logger)
 
 		return ctrl.Result{RequeueAfter: time.Second * initialWaitTime}, nil
 	}
@@ -791,7 +791,7 @@ func (r *DRPlacementControlReconciler) getDRPCPlacementRule(ctx context.Context,
 
 		// Make sure that we give time to the DRPC PlacementRule to run and produces decisions
 		if drpcPlRule != nil && len(drpcPlRule.Status.Decisions) == 0 {
-			return fmt.Errorf("%w", InitialWaitTimeForDRPCPlacementRule)
+			return ErrInitialWaitTimeForDRPCPlacementRule
 		}
 	} else {
 		log.Info("Preferred cluster is configured. Dynamic selection is disabled",

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -5,6 +5,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
@@ -13,9 +14,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
-	errorswrapper "github.com/pkg/errors"
 	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,7 +60,7 @@ const (
 	DoNotDeletePVCAnnotationVal = "true"
 )
 
-var InitialWaitTimeForDRPCPlacementRule = errorswrapper.New("Waiting for DRPC Placement to produces placement decision")
+var InitialWaitTimeForDRPCPlacementRule = errors.New("Waiting for DRPC Placement to produces placement decision")
 
 // ProgressCallback of function type
 type ProgressCallback func(string, string)
@@ -130,13 +130,13 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	err := r.APIReader.Get(ctx, req.NamespacedName, drpc)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			logger.Info(fmt.Sprintf("DRPC object not found %v", req.NamespacedName))
 			// Request object not found, could have been deleted after reconcile request.
 			return ctrl.Result{}, nil
 		}
 
-		return ctrl.Result{}, errorswrapper.Wrap(err, "failed to get DRPC object")
+		return ctrl.Result{}, fmt.Errorf("failed to get DRPC object: %w", err)
 	}
 
 	// Save a copy of the instance status to be used for the VRG status update comparison
@@ -155,7 +155,7 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 	var placementObj client.Object
 
 	placementObj, err = getPlacementOrPlacementRule(ctx, r.Client, drpc, logger)
-	if err != nil && !(errors.IsNotFound(err) && rmnutil.ResourceIsDeleted(drpc)) {
+	if err != nil && !(k8serrors.IsNotFound(err) && rmnutil.ResourceIsDeleted(drpc)) {
 		r.recordFailure(ctx, drpc, placementObj, "Error", err.Error(), logger)
 
 		return ctrl.Result{}, err
@@ -222,13 +222,13 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 	}
 
 	d, err := r.createDRPCInstance(ctx, drPolicy, drpc, placementObj, ramenConfig, logger)
-	if err != nil && !errorswrapper.Is(err, InitialWaitTimeForDRPCPlacementRule) {
+	if err != nil && !errors.Is(err, InitialWaitTimeForDRPCPlacementRule) {
 		err2 := r.updateDRPCStatus(ctx, drpc, placementObj, logger)
 
 		return ctrl.Result{}, fmt.Errorf("failed to create DRPC instance (%w) and (%v)", err, err2)
 	}
 
-	if errorswrapper.Is(err, InitialWaitTimeForDRPCPlacementRule) {
+	if errors.Is(err, InitialWaitTimeForDRPCPlacementRule) {
 		const initialWaitTime = 5
 
 		r.recordFailure(ctx, drpc, placementObj, "Waiting",
@@ -846,7 +846,7 @@ func getPlacementOrPlacementRule(
 
 	usrPlacement, err = getPlacementRule(ctx, k8sclient, drpc, log)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			// PacementRule not found. Check Placement instead
 			usrPlacement, err = getPlacement(ctx, k8sclient, drpc, log)
 		}
@@ -1026,7 +1026,7 @@ func (r *DRPlacementControlReconciler) getOrClonePlacementRule(ctx context.Conte
 
 	clonedPlRule, err := r.getClonedPlacementRule(ctx, clonedPlRuleName, drpc.Namespace, log)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			clonedPlRule, err = r.clonePlacementRule(ctx, drPolicy, userPlRule, clonedPlRuleName, log)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create cloned placementrule error: %w", err)
@@ -1081,7 +1081,7 @@ func (r *DRPlacementControlReconciler) clonePlacementRule(ctx context.Context,
 	if err != nil {
 		log.Error(err, "failed to clone placement rule", "name", clonedPlRule.Name)
 
-		return nil, errorswrapper.Wrap(err, "failed to create PlacementRule")
+		return nil, fmt.Errorf("failed to create PlacementRule: %w", err)
 	}
 
 	return clonedPlRule, nil
@@ -1110,7 +1110,7 @@ func getVRGsFromManagedClusters(
 		vrg, err := mcvGetter.GetVRGFromManagedCluster(drpc.Name, vrgNamespace, drCluster.Name, annotations)
 		if err != nil {
 			// Only NotFound error is accepted
-			if errors.IsNotFound(err) {
+			if k8serrors.IsNotFound(err) {
 				log.Info(fmt.Sprintf("VRG not found on %q", drCluster.Name))
 
 				numClustersQueriedSuccessfully++
@@ -1155,7 +1155,7 @@ func (r *DRPlacementControlReconciler) deleteClonedPlacementRule(ctx context.Con
 ) error {
 	plRule, err := r.getClonedPlacementRule(ctx, name, namespace, log)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 
@@ -1267,7 +1267,7 @@ func (r *DRPlacementControlReconciler) updateDRPCStatus(
 	drpc.Status.LastUpdateTime = &now
 
 	if err := r.Status().Update(ctx, drpc); err != nil {
-		return errorswrapper.Wrap(err, "failed to update DRPC status")
+		return fmt.Errorf("failed to update DRPC status: %w", err)
 	}
 
 	log.Info("Updated DRPC Status")
@@ -1675,7 +1675,7 @@ func (r *DRPlacementControlReconciler) createPlacementDecision(ctx context.Conte
 			return plDecision, nil
 		}
 
-		if !errors.IsAlreadyExists(err) {
+		if !k8serrors.IsAlreadyExists(err) {
 			return nil, err
 		}
 
@@ -2186,7 +2186,7 @@ func adoptVRG(
 
 	mw, err := mwu.FindManifestWorkByType(rmnutil.MWTypeVRG, cluster)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			log.Info("error fetching VRG ManifestWork during adoption", "error", err, "cluster", cluster)
 
 			return !adopted

--- a/internal/controller/drplacementcontrolvolsync.go
+++ b/internal/controller/drplacementcontrolvolsync.go
@@ -23,7 +23,7 @@ func (d *DRPCInstance) EnsureSecondaryReplicationSetup(srcCluster string) error 
 	}
 
 	if opResult == ctrlutil.OperationResultCreated {
-		return WaitForVolSyncManifestWorkCreation
+		return ErrWaitForVolSyncManifestWorkCreation
 	}
 
 	if _, found := d.vrgs[srcCluster]; !found {
@@ -99,7 +99,7 @@ func (d *DRPCInstance) IsVolSyncReplicationRequired(homeCluster string) (bool, e
 	}
 
 	if len(vrg.Status.ProtectedPVCs) == 0 {
-		return false, WaitForSourceCluster
+		return false, ErrWaitForSourceCluster
 	}
 
 	for _, protectedPVC := range vrg.Status.ProtectedPVCs {

--- a/internal/controller/drplacementcontrolvolsync.go
+++ b/internal/controller/drplacementcontrolvolsync.go
@@ -9,7 +9,7 @@ import (
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
 	rmnutil "github.com/ramendr/ramen/internal/controller/util"
 	"github.com/ramendr/ramen/internal/controller/volsync"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -217,7 +217,7 @@ func (d *DRPCInstance) ResetVolSyncRDOnPrimary(clusterName string) error {
 
 	mw, err := d.mwu.FindManifestWorkByType(rmnutil.MWTypeVRG, clusterName)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 

--- a/internal/controller/drpolicy_controller_test.go
+++ b/internal/controller/drpolicy_controller_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ramendr/ramen/internal/controller/util"
 	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -66,7 +66,7 @@ var _ = Describe("DRPolicyController", func() {
 	drpolicyDeleteAndConfirm := func(drpolicy *ramen.DRPolicy) {
 		Expect(k8sClient.Delete(context.TODO(), drpolicy)).To(Succeed())
 		Eventually(func() bool {
-			return errors.IsNotFound(apiReader.Get(context.TODO(), types.NamespacedName{Name: drpolicy.Name}, drpolicy))
+			return k8serrors.IsNotFound(apiReader.Get(context.TODO(), types.NamespacedName{Name: drpolicy.Name}, drpolicy))
 		}, timeout, interval).Should(BeTrue())
 	}
 	drpolicyDelete := func(drpolicy *ramen.DRPolicy) {
@@ -286,10 +286,10 @@ var _ = Describe("DRPolicyController", func() {
 	})
 	When(`a drpolicy creation request contains an invalid scheduling interval`, func() {
 		It(`should fail`, func() {
-			err := func(value string) *errors.StatusError {
+			err := func(value string) *k8serrors.StatusError {
 				path := field.NewPath(`spec`, `schedulingInterval`)
 
-				return errors.NewInvalid(
+				return k8serrors.NewInvalid(
 					schema.GroupKind{
 						Group: ramen.GroupVersion.Group,
 						Kind:  `DRPolicy`,

--- a/internal/controller/kubeobjects/velero/requests.go
+++ b/internal/controller/kubeobjects/velero/requests.go
@@ -13,9 +13,9 @@ package velero
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/go-logr/logr"
-	pkgerrors "github.com/pkg/errors"
 	"github.com/ramendr/ramen/internal/controller/kubeobjects"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -109,7 +109,7 @@ func (RequestsManager) ProtectRequestsDelete(
 	}
 
 	if err := writer.DeleteAllOf(ctx, &velero.Backup{}, options...); err != nil {
-		return pkgerrors.Wrap(err, "backup requests delete")
+		return fmt.Errorf("backup requests delete: %w", err)
 	}
 
 	return writer.DeleteAllOf(ctx, &velero.BackupStorageLocation{}, options...)
@@ -125,7 +125,7 @@ func (r RequestsManager) RecoverRequestsDelete(
 		client.InNamespace(requestNamespaceName),
 		client.MatchingLabels(labels),
 	); err != nil {
-		return pkgerrors.Wrap(err, "restore requests delete")
+		return fmt.Errorf("restore requests delete: %w", err)
 	}
 
 	return r.ProtectRequestsDelete(ctx, writer, requestNamespaceName, labels)
@@ -210,7 +210,7 @@ func restoreRealCreate(
 			annotations,
 		)
 		if err != nil {
-			return nil, pkgerrors.Wrap(err, "backup dummy request create")
+			return nil, fmt.Errorf("backup dummy request create: %w", err)
 		}
 
 		return nil, err
@@ -496,7 +496,7 @@ func (w objectWriter) restoreObjectsDelete(
 func (w objectWriter) objectCreate(o client.Object) error {
 	if err := w.Create(w.ctx, o); err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
-			return pkgerrors.Wrap(err, "object create")
+			return fmt.Errorf("object create: %w", err)
 		}
 
 		w.log.Info("Object created previously", "type", o.GetObjectKind(), "name", o.GetName())
@@ -510,7 +510,7 @@ func (w objectWriter) objectCreate(o client.Object) error {
 func (w objectWriter) objectDelete(o client.Object) error {
 	if err := w.Delete(w.ctx, o); err != nil {
 		if !k8serrors.IsNotFound(err) {
-			return pkgerrors.Wrap(err, "object delete")
+			return fmt.Errorf("object delete: %w", err)
 		}
 
 		w.log.Info("Object deleted previously", "type", o.GetObjectKind(), "name", o.GetName())

--- a/internal/controller/objects_test.go
+++ b/internal/controller/objects_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
 	gomegatypes "github.com/onsi/gomega/types"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -33,7 +33,7 @@ func objectDeletionTimestampRecentVerify(namespacedName types.NamespacedName, ob
 }
 
 func objectNotFoundErrorMatch(groupResource schema.GroupResource, objectName string) gomegatypes.GomegaMatcher {
-	return MatchError(errors.NewNotFound(groupResource, objectName))
+	return MatchError(k8serrors.NewNotFound(groupResource, objectName))
 }
 
 func objectAbsentVerify(namespacedName types.NamespacedName, object client.Object, groupResource schema.GroupResource) {

--- a/internal/controller/protectedvolumereplicationgrouplist_controller_test.go
+++ b/internal/controller/protectedvolumereplicationgrouplist_controller_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	controllers "github.com/ramendr/ramen/internal/controller"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -72,7 +72,7 @@ func protectedVrgListDeleteAndNotFoundWait(protectedVrgList *ramen.ProtectedVolu
 		return protectedVrgListGet(protectedVrgList)
 	}, timeout, interval).Should(
 		MatchError(
-			errors.NewNotFound(
+			k8serrors.NewNotFound(
 				schema.GroupResource{
 					Group:    ramen.GroupVersion.Group,
 					Resource: "protectedvolumereplicationgrouplists",

--- a/internal/controller/ramenconfig_test.go
+++ b/internal/controller/ramenconfig_test.go
@@ -10,7 +10,7 @@ import (
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	controllers "github.com/ramendr/ramen/internal/controller"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/yaml"
@@ -37,12 +37,12 @@ func configMapDelete() error {
 			Namespace: ramenNamespace,
 			Name:      configMapName,
 		}, cm)
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !k8serrors.IsNotFound(err) {
 			return err
 		}
 
 		err = k8sClient.Delete(context.TODO(), cm)
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil && !k8serrors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/internal/controller/replicationgroupdestination_controller.go
+++ b/internal/controller/replicationgroupdestination_controller.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ramendr/ramen/internal/controller/cephfscg"
 	"github.com/ramendr/ramen/internal/controller/util"
 	"github.com/ramendr/ramen/internal/controller/volsync"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -44,7 +44,7 @@ func (r *ReplicationGroupDestinationReconciler) Reconcile(ctx context.Context, r
 
 	rgd := &ramendrv1alpha1.ReplicationGroupDestination{}
 	if err := r.Client.Get(ctx, req.NamespacedName, rgd); err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			logger.Error(err, "Failed to get ReplicationGroupDestination")
 		}
 

--- a/internal/controller/replicationgroupsource_controller.go
+++ b/internal/controller/replicationgroupsource_controller.go
@@ -10,7 +10,7 @@ import (
 	vgsv1alphfa1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -84,7 +84,7 @@ func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ct
 
 	rgs := &ramendrv1alpha1.ReplicationGroupSource{}
 	if err := r.Client.Get(ctx, req.NamespacedName, rgs); err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			logger.Error(err, "Failed to get ReplicationGroupSource")
 		}
 

--- a/internal/controller/s3utils.go
+++ b/internal/controller/s3utils.go
@@ -21,7 +21,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/go-logr/logr"
-	errorswrapper "github.com/pkg/errors"
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -233,7 +232,7 @@ func (s *s3ObjectStore) CreateBucket(bucket string) (err error) {
 	_, err = s.client.CreateBucket(cbInput)
 	if err != nil {
 		var aerr awserr.Error
-		if errorswrapper.As(err, &aerr) {
+		if errors.As(err, &aerr) {
 			switch aerr.Code() {
 			case s3.ErrCodeBucketAlreadyExists:
 			case s3.ErrCodeBucketAlreadyOwnedByYou:
@@ -575,7 +574,7 @@ func (s *s3ObjectStore) DownloadObject(key string,
 	}
 
 	gzReader, err := gzip.NewReader(bytes.NewReader(writerAt.Bytes()))
-	if err != nil && !errorswrapper.Is(err, io.EOF) {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return fmt.Errorf("failed to unzip data of %s:%s, %w",
 			bucket, key, err)
 	}
@@ -665,7 +664,7 @@ func (s *s3ObjectStore) DeleteObjects(keys ...string) error {
 // the awserr.ErrCodeNoSuchBucket anywhere in its chain of errors.
 func isAwsErrCodeNoSuchBucket(err error) bool {
 	var aerr awserr.Error
-	if errorswrapper.As(err, &aerr) {
+	if errors.As(err, &aerr) {
 		if aerr.Code() == s3.ErrCodeNoSuchBucket {
 			return true
 		}

--- a/internal/controller/util/cephfs_cg.go
+++ b/internal/controller/util/cephfs_cg.go
@@ -15,7 +15,7 @@ import (
 	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -71,7 +71,7 @@ func DeleteReplicationGroupSource(
 
 	err := k8sClient.Delete(ctx, rgs)
 
-	if errors.IsNotFound(err) {
+	if k8serrors.IsNotFound(err) {
 		return nil
 	}
 
@@ -91,7 +91,7 @@ func DeleteReplicationGroupDestination(
 
 	err := k8sClient.Delete(ctx, rgd)
 
-	if errors.IsNotFound(err) {
+	if k8serrors.IsNotFound(err) {
 		return nil
 	}
 

--- a/internal/controller/util/cephfs_cg_test.go
+++ b/internal/controller/util/cephfs_cg_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ramendr/ramen/internal/controller/util"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -88,7 +88,7 @@ var _ = Describe("CephfsCg", func() {
 						},
 					})
 				Expect(err).NotTo(BeNil())
-				Expect(errors.IsNotFound(err)).To(BeTrue())
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
 			})
 		})
 		Describe("the numb of RD in status == the numb of RDSpecs in Spec, but RDs is not ready", func() {

--- a/internal/controller/util/mcv_util.go
+++ b/internal/controller/util/mcv_util.go
@@ -14,7 +14,7 @@ import (
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	errorswrapper "github.com/pkg/errors"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -335,7 +335,7 @@ func parseErrorMessage(message string) error {
 	}
 
 	if checkNotFound(message) {
-		return errors.NewNotFound(schema.GroupResource{}, "requested resource not found in ManagedCluster")
+		return k8serrors.NewNotFound(schema.GroupResource{}, "requested resource not found in ManagedCluster")
 	}
 
 	return fmt.Errorf("err: %s", extractLastError(message))
@@ -396,7 +396,7 @@ func (m ManagedClusterViewGetterImpl) getOrCreateManagedClusterView(
 
 	err := m.Get(context.TODO(), key, mcv)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return nil, errorswrapper.Wrap(err, "failed to get ManagedClusterView")
 		}
 
@@ -456,7 +456,7 @@ func (m ManagedClusterViewGetterImpl) DeleteManagedClusterView(clusterName, mcvN
 
 	err := m.Get(context.TODO(), types.NamespacedName{Name: mcvName, Namespace: clusterName}, mcv)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 

--- a/internal/controller/util/mcv_util.go
+++ b/internal/controller/util/mcv_util.go
@@ -12,7 +12,6 @@ import (
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
 	"github.com/go-logr/logr"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
-	errorswrapper "github.com/pkg/errors"
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -303,7 +302,7 @@ func (m ManagedClusterViewGetterImpl) getManagedClusterResource(
 	// create MCV first
 	mcv, err := m.getOrCreateManagedClusterView(meta, viewscope, logger)
 	if err != nil {
-		return errorswrapper.Wrap(err, "getManagedClusterResource failed")
+		return fmt.Errorf("getManagedClusterResource failed: %w", err)
 	}
 
 	logger.Info(fmt.Sprintf("Get managedClusterResource Returned the following MCV Conditions: %v",
@@ -362,13 +361,13 @@ func (m ManagedClusterViewGetterImpl) GetResource(mcv *viewv1beta1.ManagedCluste
 	}
 
 	if err != nil {
-		return errorswrapper.Wrap(err, "getManagedClusterResource results")
+		return fmt.Errorf("getManagedClusterResource results: %w", err)
 	}
 
 	// good path: convert raw data to usable object
 	err = json.Unmarshal(mcv.Status.Result.Raw, resource)
 	if err != nil {
-		return errorswrapper.Wrap(err, "failed to Unmarshal data from ManagedClusterView to resource")
+		return fmt.Errorf("failed to Unmarshal data from ManagedClusterView to resource: %w", err)
 	}
 
 	return nil // success
@@ -397,14 +396,14 @@ func (m ManagedClusterViewGetterImpl) getOrCreateManagedClusterView(
 	err := m.Get(context.TODO(), key, mcv)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
-			return nil, errorswrapper.Wrap(err, "failed to get ManagedClusterView")
+			return nil, fmt.Errorf("failed to get ManagedClusterView: %w", err)
 		}
 
 		logger.Info(fmt.Sprintf("Creating ManagedClusterView %s with scope %s",
 			key, viewscope.Name))
 
 		if err := m.Create(context.TODO(), mcv); err != nil {
-			return nil, errorswrapper.Wrap(err, "failed to create ManagedClusterView")
+			return nil, fmt.Errorf("failed to create ManagedClusterView: %w", err)
 		}
 	}
 
@@ -415,7 +414,7 @@ func (m ManagedClusterViewGetterImpl) getOrCreateManagedClusterView(
 
 		mcv.Spec.Scope = viewscope
 		if err := m.Update(context.TODO(), mcv); err != nil {
-			return nil, errorswrapper.Wrap(err, "failed to update ManagedClusterView")
+			return nil, fmt.Errorf("failed to update ManagedClusterView: %w", err)
 		}
 	}
 

--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -9,7 +9,7 @@ import (
 
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -223,7 +223,7 @@ func CreateNamespaceIfNotExists(ctx context.Context, k8sClient client.Client, na
 
 	err := k8sClient.Get(ctx, types.NamespacedName{Name: namespace}, ns)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			ns.Name = namespace
 
 			err = k8sClient.Create(ctx, ns)

--- a/internal/controller/util/mw_util.go
+++ b/internal/controller/util/mw_util.go
@@ -13,7 +13,7 @@ import (
 	errorswrapper "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -88,7 +88,7 @@ func (mwu *MWUtil) FindManifestWork(mwName, managedCluster string) (*ocmworkv1.M
 
 	err := mwu.Client.Get(mwu.Ctx, types.NamespacedName{Name: mwName, Namespace: managedCluster}, mw)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return nil, fmt.Errorf("%w", err)
 		}
 
@@ -426,7 +426,7 @@ func GetRawExtension(
 func (mwu *MWUtil) GetDrClusterManifestWork(clusterName string) (*ocmworkv1.ManifestWork, error) {
 	mw, err := mwu.FindManifestWork(DrClusterManifestWorkName, clusterName)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return nil, nil
 		}
 
@@ -611,7 +611,7 @@ func (mwu *MWUtil) createOrUpdateManifestWork(
 
 	err := mwu.Client.Get(mwu.Ctx, key, foundMW)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return ctrlutil.OperationResultNone, errorswrapper.Wrap(err, fmt.Sprintf("failed to fetch ManifestWork %s", key))
 		}
 
@@ -651,7 +651,7 @@ func (mwu *MWUtil) DeleteNamespaceManifestWork(clusterName string, annotations m
 
 	err := mwu.Client.Get(mwu.Ctx, types.NamespacedName{Name: mwName, Namespace: clusterName}, mw)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 
@@ -690,7 +690,7 @@ func (mwu *MWUtil) DeleteManifestWork(mwName, mwNamespace string) error {
 
 	err := mwu.Client.Get(mwu.Ctx, types.NamespacedName{Name: mwName, Namespace: mwNamespace}, mw)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return nil
 		}
 
@@ -700,7 +700,7 @@ func (mwu *MWUtil) DeleteManifestWork(mwName, mwNamespace string) error {
 	mwu.Log.Info("Deleting ManifestWork", "name", mw.Name, "namespace", mwNamespace)
 
 	err = mwu.Client.Delete(mwu.Ctx, mw)
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete MW. Error %w", err)
 	}
 

--- a/internal/controller/util/mw_util.go
+++ b/internal/controller/util/mw_util.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
-	errorswrapper "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -612,7 +611,7 @@ func (mwu *MWUtil) createOrUpdateManifestWork(
 	err := mwu.Client.Get(mwu.Ctx, key, foundMW)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
-			return ctrlutil.OperationResultNone, errorswrapper.Wrap(err, fmt.Sprintf("failed to fetch ManifestWork %s", key))
+			return ctrlutil.OperationResultNone, fmt.Errorf("failed to fetch ManifestWork %s: %w", key, err)
 		}
 
 		mwu.Log.Info("Creating ManifestWork", "cluster", managedClusternamespace, "MW", mw)

--- a/internal/controller/util/secrets_util.go
+++ b/internal/controller/util/secrets_util.go
@@ -16,7 +16,7 @@ import (
 	errorswrapper "github.com/pkg/errors"
 	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -403,7 +403,7 @@ func (sutil *SecretsUtil) createPolicyResources(
 	}
 
 	plRuleBindingObject := newPlacementRuleBinding(plBindingName, namespace, plRuleName, subjects)
-	if err := sutil.Client.Create(sutil.Ctx, plRuleBindingObject); err != nil && !errors.IsAlreadyExists(err) {
+	if err := sutil.Client.Create(sutil.Ctx, plRuleBindingObject); err != nil && !k8serrors.IsAlreadyExists(err) {
 		sutil.Log.Error(err, "unable to create placement binding", "secret", secret.Name, "cluster", cluster)
 
 		return errorswrapper.Wrap(err, fmt.Sprintf("unable to create placement binding (secret: %s, cluster: %s)",
@@ -418,7 +418,7 @@ func (sutil *SecretsUtil) createPolicyResources(
 
 	policyObject := newPolicy(policyName, namespace,
 		secret.ResourceVersion, runtime.RawExtension{Object: configObject})
-	if err := sutil.Client.Create(sutil.Ctx, policyObject); err != nil && !errors.IsAlreadyExists(err) {
+	if err := sutil.Client.Create(sutil.Ctx, policyObject); err != nil && !k8serrors.IsAlreadyExists(err) {
 		sutil.Log.Error(err, "unable to create policy", "secret", secret.Name, "cluster", cluster)
 
 		return errorswrapper.Wrap(err, fmt.Sprintf("unable to create policy (secret: %s, cluster: %s)",
@@ -427,7 +427,7 @@ func (sutil *SecretsUtil) createPolicyResources(
 
 	// Create a PlacementRule, including cluster
 	plRuleObject := newPlacementRule(plRuleName, namespace, []string{cluster})
-	if err := sutil.Client.Create(sutil.Ctx, plRuleObject); err != nil && !errors.IsAlreadyExists(err) {
+	if err := sutil.Client.Create(sutil.Ctx, plRuleObject); err != nil && !k8serrors.IsAlreadyExists(err) {
 		sutil.Log.Error(err, "unable to create placement rule", "secret", secret.Name, "cluster", cluster)
 
 		return errorswrapper.Wrap(err, fmt.Sprintf("unable to create placement rule (secret: %s, cluster: %s)",
@@ -475,7 +475,7 @@ func (sutil *SecretsUtil) deletePolicyResources(
 			Namespace: namespace,
 		},
 	}
-	if err := sutil.Client.Delete(sutil.Ctx, plRuleBindingObject); err != nil && !errors.IsNotFound(err) {
+	if err := sutil.Client.Delete(sutil.Ctx, plRuleBindingObject); err != nil && !k8serrors.IsNotFound(err) {
 		sutil.Log.Error(err, "unable to delete placement binding", "secret", secret.Name)
 
 		return errorswrapper.Wrap(err, fmt.Sprintf("unable to delete placement binding (secret: %s)", secret.Name))
@@ -487,7 +487,7 @@ func (sutil *SecretsUtil) deletePolicyResources(
 			Namespace: namespace,
 		},
 	}
-	if err := sutil.Client.Delete(sutil.Ctx, policyObject); err != nil && !errors.IsNotFound(err) {
+	if err := sutil.Client.Delete(sutil.Ctx, policyObject); err != nil && !k8serrors.IsNotFound(err) {
 		sutil.Log.Error(err, "unable to delete policy", "secret", secret.Name)
 
 		return errorswrapper.Wrap(err, fmt.Sprintf("unable to delete policy (secret: %s)", secret.Name))
@@ -499,7 +499,7 @@ func (sutil *SecretsUtil) deletePolicyResources(
 			Namespace: namespace,
 		},
 	}
-	if err := sutil.Client.Delete(sutil.Ctx, plRuleObject); err != nil && !errors.IsNotFound(err) {
+	if err := sutil.Client.Delete(sutil.Ctx, plRuleObject); err != nil && !k8serrors.IsNotFound(err) {
 		sutil.Log.Error(err, "unable to delete placement rule", "secret", secret.Name)
 
 		return errorswrapper.Wrap(err, fmt.Sprintf("unable to delete placement rule (secret: %s)",
@@ -654,7 +654,7 @@ func (sutil *SecretsUtil) ensureS3SecretResources(
 	if err := sutil.Client.Get(sutil.Ctx,
 		types.NamespacedName{Namespace: namespace, Name: secretName},
 		&secret); err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return nil, errorswrapper.Wrap(err, "failed to get secret object")
 		}
 
@@ -716,7 +716,7 @@ func (sutil *SecretsUtil) AddSecretToCluster(
 	// Fetch secret placement rule, create secret resources if not found
 	err = sutil.APIReader.Get(sutil.Ctx, plRuleName, plRule)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return errorswrapper.Wrap(err, "failed to get placementRule object")
 		}
 
@@ -753,7 +753,7 @@ func (sutil *SecretsUtil) RemoveSecretFromCluster(
 	// Fetch secret placement rule, success if not found
 	err = sutil.APIReader.Get(sutil.Ctx, plRuleName, plRule)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return errorswrapper.Wrap(err, "failed to get placementRule object")
 		}
 

--- a/internal/controller/util/secrets_util_test.go
+++ b/internal/controller/util/secrets_util_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ramendr/ramen/internal/controller/util"
 	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gppv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -61,7 +61,7 @@ var _ = Describe("Secrets_Util", func() {
 	plRuleAbsent := func(plRuleName, namespace string) bool {
 		plRule := &plrv1.PlacementRule{}
 
-		return errors.IsNotFound(k8sClient.Get(context.TODO(),
+		return k8serrors.IsNotFound(k8sClient.Get(context.TODO(),
 			types.NamespacedName{Name: plRuleName, Namespace: namespace},
 			plRule))
 	}
@@ -178,7 +178,7 @@ var _ = Describe("Secrets_Util", func() {
 	secretAbsent := func(secretName string) bool {
 		secret := &corev1.Secret{}
 
-		return errors.IsNotFound(k8sClient.Get(
+		return k8serrors.IsNotFound(k8sClient.Get(
 			context.TODO(),
 			types.NamespacedName{
 				Name:      secretName,

--- a/internal/controller/vrg_recipe_test.go
+++ b/internal/controller/vrg_recipe_test.go
@@ -16,7 +16,7 @@ import (
 	recipe "github.com/ramendr/recipe/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -247,7 +247,7 @@ var _ = Describe("VolumeReplicationGroupRecipe", func() {
 	}
 	vrgDelete := func() {
 		Expect(k8sClient.Delete(ctx, vrg)).To(Succeed())
-		Eventually(vrgGet).Should(MatchError(errors.NewNotFound(
+		Eventually(vrgGet).Should(MatchError(k8serrors.NewNotFound(
 			schema.GroupResource{
 				Group:    ramen.GroupVersion.Group,
 				Resource: "volumereplicationgroups",

--- a/internal/controller/vrg_volrep_test.go
+++ b/internal/controller/vrg_volrep_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/ramendr/ramen/internal/controller/util"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -171,7 +171,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			It("should allow the VRG to be deleted", func() {
 				Eventually(func() error {
 					return apiReader.Get(context.TODO(), vrgNamespacedName, vrg)
-				}).Should(MatchError(errors.NewNotFound(schema.GroupResource{
+				}).Should(MatchError(k8serrors.NewNotFound(schema.GroupResource{
 					Group:    ramendrv1alpha1.GroupVersion.Group,
 					Resource: "volumereplicationgroups",
 				}, vrg.Name)))
@@ -668,7 +668,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 
 				return apiReader.Get(context.TODO(), vrgVRDeleteEnsureTestCase.vrgNamespacedName(), vrg)
 			}, vrgtimeout*2, vrginterval).
-				Should(MatchError(errors.NewNotFound(schema.GroupResource{
+				Should(MatchError(k8serrors.NewNotFound(schema.GroupResource{
 					Group:    ramendrv1alpha1.GroupVersion.Group,
 					Resource: "volumereplicationgroups",
 				}, vrgVRDeleteEnsureTestCase.vrgName)),
@@ -731,7 +731,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			Eventually(func() error {
 				return apiReader.Get(context.TODO(), vrgDeleteFailedVR.vrgNamespacedName(), vrg)
 			}, vrgtimeout, vrginterval).
-				Should(MatchError(errors.NewNotFound(schema.GroupResource{
+				Should(MatchError(k8serrors.NewNotFound(schema.GroupResource{
 					Group:    ramendrv1alpha1.GroupVersion.Group,
 					Resource: "volumereplicationgroups",
 				}, vrgDeleteFailedVR.vrgName)))
@@ -789,7 +789,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			Eventually(func() error {
 				return apiReader.Get(context.TODO(), vrgDeleteFailedVR.vrgNamespacedName(), vrg)
 			}, vrgtimeout, vrginterval).
-				Should(MatchError(errors.NewNotFound(schema.GroupResource{
+				Should(MatchError(k8serrors.NewNotFound(schema.GroupResource{
 					Group:    ramendrv1alpha1.GroupVersion.Group,
 					Resource: "volumereplicationgroups",
 				}, vrgDeleteFailedVR.vrgName)))
@@ -838,7 +838,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			Eventually(func() error {
 				return apiReader.Get(context.TODO(), vrgDeleteFailedVR.vrgNamespacedName(), vrg)
 			}, vrgtimeout, vrginterval).
-				Should(MatchError(errors.NewNotFound(schema.GroupResource{
+				Should(MatchError(k8serrors.NewNotFound(schema.GroupResource{
 					Group:    ramendrv1alpha1.GroupVersion.Group,
 					Resource: "volumereplicationgroups",
 				}, vrgDeleteFailedVR.vrgName)))
@@ -1739,7 +1739,7 @@ func (v *vrgTest) createNamespace() {
 
 	appNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: v.namespace}}
 	err := k8sClient.Create(context.TODO(), appNamespace)
-	expectedErr := errors.NewAlreadyExists(
+	expectedErr := k8serrors.NewAlreadyExists(
 		schema.GroupResource{Resource: "namespaces"}, v.namespace)
 	Expect(err).To(SatisfyAny(BeNil(), MatchError(expectedErr)),
 		"failed to create namespace %s", v.namespace)
@@ -1751,7 +1751,7 @@ func (v *vrgTest) createPV(pvName, claimName string, bindInfo corev1.PersistentV
 	pv := v.generatePV(pvName, claimName)
 
 	err := k8sClient.Create(context.TODO(), pv)
-	expectedErr := errors.NewAlreadyExists(
+	expectedErr := k8serrors.NewAlreadyExists(
 		schema.GroupResource{Resource: "persistentvolumes"}, pvName)
 	Expect(err).To(SatisfyAny(BeNil(), MatchError(expectedErr)),
 		"failed to create PV %s", pvName)
@@ -1821,7 +1821,7 @@ func (v *vrgTest) createPVC(pvcName, namespace, volumeName string, labels map[st
 	pvc := v.generatePVC(pvcName, namespace, volumeName, labels)
 
 	err := k8sClient.Create(context.TODO(), pvc)
-	expectedErr := errors.NewAlreadyExists(
+	expectedErr := k8serrors.NewAlreadyExists(
 		schema.GroupResource{Resource: "persistentvolumeclaims"}, pvcName)
 	Expect(err).To(SatisfyAny(BeNil(), MatchError(expectedErr)),
 		"failed to create PVC %s", pvcName)
@@ -1920,7 +1920,7 @@ func (v *vrgTest) createVRG() {
 		},
 	}
 	err := k8sClient.Create(context.TODO(), vrg)
-	expectedErr := errors.NewAlreadyExists(
+	expectedErr := k8serrors.NewAlreadyExists(
 		schema.GroupResource{
 			Group:    "ramendr.openshift.io",
 			Resource: "volumereplicationgroups",
@@ -1977,7 +1977,7 @@ func createVolumeReplicationClass(testTemplate *template) {
 
 	err := k8sClient.Create(context.TODO(), vrc)
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
+		if k8serrors.IsAlreadyExists(err) {
 			err = k8sClient.Get(context.TODO(), types.NamespacedName{Name: testTemplate.replicationClassName}, vrc)
 		}
 	}
@@ -1996,7 +1996,7 @@ func createVolumeReplicationClass(testTemplate *template) {
 
 		err := k8sClient.Create(context.TODO(), vrc)
 		if err != nil {
-			if errors.IsAlreadyExists(err) {
+			if k8serrors.IsAlreadyExists(err) {
 				err = k8sClient.Get(context.TODO(), types.NamespacedName{Name: testTemplate.replicationClassName}, vrc)
 			}
 		}
@@ -2023,7 +2023,7 @@ func createStorageClass(testTemplate *template) {
 
 	err := k8sClient.Create(context.TODO(), sc)
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
+		if k8serrors.IsAlreadyExists(err) {
 			err = k8sClient.Get(context.TODO(), types.NamespacedName{Name: testTemplate.storageClassName}, sc)
 		}
 	}
@@ -2519,7 +2519,7 @@ func cleanupStorageClass(testTemplate *template) {
 
 	err := k8sClient.Get(context.TODO(), key, sc)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if k8serrors.IsNotFound(err) {
 			return
 		}
 	}
@@ -2533,7 +2533,7 @@ func cleanupVolumeReplicationClass(testTemplate *template) {
 	vrc := &volrep.VolumeReplicationClass{}
 
 	err := k8sClient.DeleteAllOf(context.TODO(), vrc)
-	if errors.IsNotFound(err) {
+	if k8serrors.IsNotFound(err) {
 		return
 	}
 

--- a/internal/controller/vrg_volsync_test.go
+++ b/internal/controller/vrg_volsync_test.go
@@ -22,7 +22,7 @@ import (
 	controller "github.com/ramendr/ramen/internal/controller"
 	"github.com/ramendr/ramen/internal/controller/volsync"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 const (
@@ -497,7 +497,7 @@ func createSC() {
 
 	err := k8sClient.Create(context.TODO(), sc)
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
+		if k8serrors.IsAlreadyExists(err) {
 			err = k8sClient.Get(context.TODO(), types.NamespacedName{Name: sc.Name}, sc)
 		}
 	}
@@ -518,7 +518,7 @@ func createVSC() {
 
 	err := k8sClient.Create(context.TODO(), vsc)
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
+		if k8serrors.IsAlreadyExists(err) {
 			err = k8sClient.Get(context.TODO(), types.NamespacedName{Name: vsc.Name}, vsc)
 		}
 	}


### PR DESCRIPTION
- Import apimachinery api errors as k8serrors
- Replace github.com/pkg/errors with standard errors
- Fix errors to make revive happy

Fixes #1678 