### PR TITLE
More typos fixes

### DIFF
--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -102,7 +102,7 @@ const (
 	ProgressionWaitForReadiness                    = ProgressionStatus("WaitForReadiness")
 	ProgressionCleaningUp                          = ProgressionStatus("Cleaning Up")
 	ProgressionWaitOnUserToCleanUp                 = ProgressionStatus("WaitOnUserToCleanUp")
-	ProgressionCheckingFailoverPrequisites         = ProgressionStatus("CheckingFailoverPrequisites")
+	ProgressionCheckingFailoverPrerequisites       = ProgressionStatus("CheckingFailoverPrerequisites")
 	ProgressionFailingOverToCluster                = ProgressionStatus("FailingOverToCluster")
 	ProgressionWaitForFencing                      = ProgressionStatus("WaitForFencing")
 	ProgressionWaitForStorageMaintenanceActivation = ProgressionStatus("WaitForStorageMaintenanceActivation")

--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -38,7 +38,7 @@ const (
 
 	// Deploying, state recorded in the DRPC status to indicate that the
 	// initial deployment is in progress. Deploying means selecting the
-	// preffered cluster and creating a VRG MW for it and waiting for MW
+	// preferred cluster and creating a VRG MW for it and waiting for MW
 	// to be applied in the managed cluster
 	Deploying = DRState("Deploying")
 
@@ -144,7 +144,7 @@ type DRPlacementControlSpec struct {
 	PreferredCluster string `json:"preferredCluster,omitempty"`
 
 	// FailoverCluster is the cluster name that the user wants to failover the application to.
-	// If not sepcified, then the DRPC will select the surviving cluster from the DRPolicy
+	// If not specified, then the DRPC will select the surviving cluster from the DRPolicy
 	FailoverCluster string `json:"failoverCluster,omitempty"`
 
 	// Label selector to identify all the PVCs that need DR protection.
@@ -194,7 +194,7 @@ type VRGResourceMeta struct {
 // VRGConditions represents the conditions of the resources deployed on a
 // managed cluster.
 type VRGConditions struct {
-	// ResourceMeta represents the VRG resoure.
+	// ResourceMeta represents the VRG resource.
 	ResourceMeta VRGResourceMeta `json:"resourceMeta,omitempty"`
 
 	// Conditions represents the conditions of this resource on a managed cluster.

--- a/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
@@ -130,7 +130,7 @@ spec:
               failoverCluster:
                 description: |-
                   FailoverCluster is the cluster name that the user wants to failover the application to.
-                  If not sepcified, then the DRPC will select the surviving cluster from the DRPolicy
+                  If not specified, then the DRPC will select the surviving cluster from the DRPolicy
                 type: string
               kubeObjectProtection:
                 properties:
@@ -493,7 +493,7 @@ spec:
                       type: object
                     type: array
                   resourceMeta:
-                    description: ResourceMeta represents the VRG resoure.
+                    description: ResourceMeta represents the VRG resource.
                     properties:
                       generation:
                         description: A sequence number representing a specific generation

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -44,7 +44,7 @@ var (
 	WaitForVolSyncDestRepToComplete     error = errorswrapper.New("Waiting for VolSync RD to complete...")
 	WaitForSourceCluster                error = errorswrapper.New("Waiting for primary to provide Protected PVCs...")
 	WaitForVolSyncManifestWorkCreation  error = errorswrapper.New("Waiting for VolSync ManifestWork to be created...")
-	WaitForVolSyncRDInfoAvailibility    error = errorswrapper.New("Waiting for VolSync RDInfo...")
+	WaitForVolSyncRDInfoAvailability    error = errorswrapper.New("Waiting for VolSync RDInfo...")
 )
 
 type DRType string
@@ -245,7 +245,7 @@ func (d *DRPCInstance) isUserPlRuleUpdated(homeCluster string) bool {
 			plRule.Status.Decisions[0].ClusterName == homeCluster
 	}
 
-	// Othewise, it is a Placement object
+	// Otherwise, it is a Placement object
 	plcmt := ConvertToPlacement(d.userPlacement)
 	if plcmt != nil {
 		clusterDecision := d.reconciler.getClusterDecision(d.userPlacement)
@@ -518,7 +518,7 @@ func (d *DRPCInstance) getCurrentHomeClusterName(toCluster string, drClusters []
 	return ""
 }
 
-// checkFailoverPrerequisites checks for any failover prerequsites that need to be met on the
+// checkFailoverPrerequisites checks for any failover prerequisites that need to be met on the
 // failoverCluster before initiating a failover.
 // Returns:
 //   - bool: Indicating if prerequisites are met
@@ -539,7 +539,7 @@ func (d *DRPCInstance) checkFailoverPrerequisites(curHomeCluster string) (bool, 
 		return true, nil
 	}
 
-	msg := "Waiting for spec.failoverCluster to meet failover prerequsites"
+	msg := "Waiting for spec.failoverCluster to meet failover prerequisites"
 
 	if err != nil {
 		msg = err.Error()
@@ -554,7 +554,7 @@ func (d *DRPCInstance) checkFailoverPrerequisites(curHomeCluster string) (bool, 
 	return met, err
 }
 
-// checkMetroFailoverPrerequisites checks for any MetroDR failover prerequsites that need to be met on the
+// checkMetroFailoverPrerequisites checks for any MetroDR failover prerequisites that need to be met on the
 // failoverCluster before initiating a failover from the curHomeCluster.
 // Returns:
 //   - bool: Indicating if prerequisites are met
@@ -576,7 +576,7 @@ func (d *DRPCInstance) checkMetroFailoverPrerequisites(curHomeCluster string) (b
 	return met, nil
 }
 
-// checkRegionalFailoverPrerequisites checks for any RegionalDR failover prerequsites that need to be met on the
+// checkRegionalFailoverPrerequisites checks for any RegionalDR failover prerequisites that need to be met on the
 // failoverCluster before initiating a failover.
 // Returns:
 //   - bool: Indicating if prerequisites are met
@@ -2011,7 +2011,7 @@ func (d *DRPCInstance) ensureVRGIsSecondaryOnCluster(clusterName string) bool {
 // preferredCluster where the app is being relocated to.
 // This is because, preferredCluster wont have a VRG in a secondary state when
 // relocate is started at first. preferredCluster will get VRG as primary when DRPC is
-// about to move the workload to the preferredCluser. And before doing that, DataProtected
+// about to move the workload to the preferredCluster. And before doing that, DataProtected
 // has to be ensured. This can only be done at the other cluster which has been moved to
 // secondary by now.
 func (d *DRPCInstance) ensureDataProtected(targetCluster string) bool {

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -452,7 +452,7 @@ func (d *DRPCInstance) switchToFailoverCluster() (bool, error) {
 	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
 		metav1.ConditionFalse, rmn.ReasonNotStarted,
 		fmt.Sprintf("Started failover to cluster %q", d.instance.Spec.FailoverCluster))
-	d.setProgression(rmn.ProgressionCheckingFailoverPrequisites)
+	d.setProgression(rmn.ProgressionCheckingFailoverPrerequisites)
 
 	curHomeCluster := d.getCurrentHomeClusterName(d.instance.Spec.FailoverCluster, d.drClusters)
 	if curHomeCluster == "" {
@@ -2240,7 +2240,7 @@ failoverProgressions are used to indicate progression during failover action pro
 - postFailoverProgressions indicates Progressions that are noted post creating VRG on the failoverCluster
 
 	preFailoverProgressions := {
-		ProgressionCheckingFailoverPrequisites,
+		ProgressionCheckingFailoverPrerequisites,
 		ProgressionWaitForFencing,
 		ProgressionWaitForStorageMaintenanceActivation,
 	}

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -1323,7 +1323,7 @@ func (r *DRPlacementControlReconciler) updateResourceCondition(
 
 		if vrg.ResourceVersion < drpc.Status.ResourceConditions.ResourceMeta.ResourceVersion {
 			r.Log.Info("VRG resourceVersion is lower than the previously recorded VRG's resourceVersion in DRPC")
-			// if the VRG resourceVersion is less, then leave the DRPC ResourceCondtions.ResourceMeta.ResourceVersion as is.
+			// if the VRG resourceVersion is less, then leave the DRPC ResourceConditions.ResourceMeta.ResourceVersion as is.
 			return
 		}
 	}
@@ -2060,7 +2060,7 @@ func (r *DRPlacementControlReconciler) determineDRPCState(
 
 	// IF 2 clusters queried, 1 failed and 1 VRG found on the failover cluster, then check the action, if they don't
 	// match, stop until corrected by the user. If they do match, then also stop but allow failover if the VRG in-hand
-	// is a secondary. Othewise, continue...
+	// is a secondary. Otherwise, continue...
 	if successfullyQueriedClusterCount == 1 && len(vrgs) == 1 {
 		var clusterName string
 
@@ -2139,7 +2139,7 @@ func (r *DRPlacementControlReconciler) determineDRPCState(
 
 // ensureVRGsManagedByDRPC ensures that VRGs reported by ManagedClusterView are managed by the current instance of
 // DRPC. This is done using the DRPC UID annotation on the viewed VRG matching the current DRPC UID and if not
-// creating or updating the exisiting ManifestWork for the VRG.
+// creating or updating the existing ManifestWork for the VRG.
 // Returns a bool indicating true if VRGs are managed by the current DRPC resource
 func ensureVRGsManagedByDRPC(
 	log logr.Logger,

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -1712,8 +1712,8 @@ func getApplicationDestinationNamespace(
 		appSet := &appSetList.Items[i]
 		if len(appSet.Spec.Generators) > 0 &&
 			appSet.Spec.Generators[0].ClusterDecisionResource != nil {
-			pn := appSet.Spec.Generators[0].ClusterDecisionResource.LabelSelector.MatchLabels[clrapiv1beta1.PlacementLabel]
-			if pn == placement.GetName() {
+			name := appSet.Spec.Generators[0].ClusterDecisionResource.LabelSelector.MatchLabels[clrapiv1beta1.PlacementLabel]
+			if name == placement.GetName() {
 				log.Info("Found ApplicationSet for Placement", "name", appSet.Name, "placement", placement.GetName())
 				// Retrieving the Destination.Namespace from Application.Spec requires iterating through all Applications
 				// and checking their ownerReferences, which can be time-consuming. Alternatively, we can get the same


### PR DESCRIPTION
Most of the fixes are in comments, error messages, constants, and variable names.

One fix in progression name and text, which may affects users that hard coded the old progression value.