### PR TITLE
Add storageid and replicationid labels to volumegroupreplication

### DIFF
--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -111,6 +111,10 @@ def configure_rbd_mirroring(cluster, peer_info):
     yaml = template.substitute(cluster=cluster)
     kubectl.apply("--filename=-", input=yaml, context=cluster)
 
+    template = drenv.template("start-data/vgrc-sample.yaml")
+    yaml = template.substitute(cluster=cluster, pool=POOL_NAME)
+    kubectl.apply("--filename=-", input=yaml, context=cluster)
+
     print(f"Apply rbd mirror to cluster '{cluster}'")
     kubectl.apply("--kustomize=start-data", context=cluster)
 

--- a/test/addons/rbd-mirror/start-data/kustomization.yaml
+++ b/test/addons/rbd-mirror/start-data/kustomization.yaml
@@ -3,7 +3,6 @@
 
 ---
 resources:
-- vgrc-sample.yaml
 - rbd-mirror.yaml
 
 namespace: rook-ceph

--- a/test/addons/rbd-mirror/start-data/vgrc-sample.yaml
+++ b/test/addons/rbd-mirror/start-data/vgrc-sample.yaml
@@ -6,9 +6,14 @@ apiVersion: replication.storage.openshift.io/v1alpha1
 kind: VolumeGroupReplicationClass
 metadata:
   name: vgrc-sample
+  labels:
+    ramendr.openshift.io/storageid: rook-ceph-$cluster-1
+    ramendr.openshift.io/replicationid: rook-ceph-replication-1
 spec:
   provisioner: rook-ceph.rbd.csi.ceph.com
   parameters:
-    replication.storage.openshift.io/replication-secret-name: rook-csi-rbd-provisioner
-    replication.storage.openshift.io/replication-secret-namespace: rook-ceph
+    clusterID: rook-ceph
+    pool: $pool
+    replication.storage.openshift.io/group-replication-secret-name: rook-csi-rbd-provisioner
+    replication.storage.openshift.io/group-replication-secret-namespace: rook-ceph
     schedulingInterval: 1m


### PR DESCRIPTION
As part of peer classes update, I added two mandatory labels to volume group replication:

    ramendr.openshift.io/storageid: rook-ceph-$cluster-1
    ramendr.openshift.io/replicationid: rook-ceph-replication-1

Also 
    clusterID: rook-ceph
    pool: $pool

During the integration process, we found out, that these parameters have to be added to volume group replication. This adjustment is necessary to meet CSI requirements