### PR TITLE
Unify and fix //nolint: comments

### DIFF
--- a/e2e/argocd/appset_hack.go
+++ b/e2e/argocd/appset_hack.go
@@ -37,12 +37,12 @@ type ApplicationSetSpec struct {
 	Template   ApplicationSetTemplate    `json:"template" protobuf:"bytes,3,name=template"`
 }
 
-// nolint: lll
+//nolint:lll
 type ApplicationSetGenerator struct {
 	ClusterDecisionResource *DuckTypeGenerator `json:"clusterDecisionResource,omitempty" protobuf:"bytes,5,name=clusterDecisionResource"`
 }
 
-// nolint: lll
+//nolint:lll
 type DuckTypeGenerator struct {
 	ConfigMapRef        string               `json:"configMapRef" protobuf:"bytes,1,name=configMapRef"`
 	LabelSelector       metav1.LabelSelector `json:"labelSelector,omitempty" protobuf:"bytes,4,name=labelSelector"`
@@ -109,14 +109,14 @@ type KustomizePatch struct {
 	Options map[string]bool    `json:"options,omitempty" yaml:"options,omitempty" protobuf:"bytes,4,opt,name=options"`
 }
 
-// nolint: lll, golint
+//nolint:lll, golint
 type KustomizeSelector struct {
 	KustomizeResId     `json:",inline,omitempty" yaml:",inline,omitempty" protobuf:"bytes,1,opt,name=resId"`
 	AnnotationSelector string `json:"annotationSelector,omitempty" yaml:"annotationSelector,omitempty" protobuf:"bytes,2,opt,name=annotationSelector"`
 	LabelSelector      string `json:"labelSelector,omitempty" yaml:"labelSelector,omitempty" protobuf:"bytes,3,opt,name=labelSelector"`
 }
 
-// nolint: golint, revive, stylecheck
+//nolint:golint, revive, stylecheck
 type KustomizeResId struct {
 	KustomizeGvk `json:",inline,omitempty" yaml:",inline,omitempty" protobuf:"bytes,1,opt,name=gvk"`
 	Name         string `json:"name,omitempty" yaml:"name,omitempty" protobuf:"bytes,2,opt,name=name"`

--- a/e2e/exhaustive_suite_test.go
+++ b/e2e/exhaustive_suite_test.go
@@ -63,7 +63,7 @@ func generateWorkloads([]types.Workload) {
 	}
 }
 
-// nolint: thelper
+//nolint:thelper
 func Exhaustive(dt *testing.T) {
 	t := test.WithLog(dt, util.Ctx.Log)
 	t.Helper()

--- a/e2e/test/context.go
+++ b/e2e/test/context.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: The RamenDR authors
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint: thelper // for using dt *testing.T and keeping test code idiomatic.
+//nolint:thelper // for using dt *testing.T and keeping test code idiomatic.
 package test
 
 import (

--- a/e2e/test/testing.go
+++ b/e2e/test/testing.go
@@ -16,7 +16,8 @@ type T struct {
 }
 
 // WithLog returns a t wrapped with a specified log.
-// nolint: thelper
+//
+//nolint:thelper
 func WithLog(t *testing.T, log *zap.SugaredLogger) *T {
 	return &T{T: t, log: log}
 }

--- a/internal/controller/drclusterconfig_controller.go
+++ b/internal/controller/drclusterconfig_controller.go
@@ -356,7 +356,7 @@ func (r *DRClusterConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	rateLimiter := workqueue.NewTypedMaxOfRateLimiter(
 		workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](1*time.Second, maxReconcileBackoff),
 		// defaults from client-go
-		//nolint: mnd
+		//nolint:mnd
 		&workqueue.TypedBucketRateLimiter[reconcile.Request]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 	)
 

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -972,7 +972,7 @@ func (d *DRPCInstance) ensureCleanupAndSecondaryReplicationSetup(srcCluster stri
 	return nil
 }
 
-// nolint: cyclop
+//nolint:cyclop
 func (d *DRPCInstance) quiesceAndRunFinalSync(homeCluster string) (bool, error) {
 	const done = true
 

--- a/internal/controller/kubeobjects/velero/requests.go
+++ b/internal/controller/kubeobjects/velero/requests.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: The RamenDR authors
 // SPDX-License-Identifier: Apache-2.0
 
-//nolint: lll
+//nolint:lll
 // +kubebuilder:rbac:groups=velero.io,resources=backups,verbs=create;delete;deletecollection;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=velero.io,resources=backups/status,verbs=get
 // +kubebuilder:rbac:groups=velero.io,resources=backupstoragelocations,verbs=create;delete;deletecollection;get;patch;update

--- a/internal/controller/protectedvolumereplicationgrouplist_controller.go
+++ b/internal/controller/protectedvolumereplicationgrouplist_controller.go
@@ -39,7 +39,7 @@ type ProtectedVolumeReplicationGroupListInstance struct {
 	instance   *ramendrv1alpha1.ProtectedVolumeReplicationGroupList
 }
 
-//nolint: lll
+//nolint:lll
 //+kubebuilder:rbac:groups=ramendr.openshift.io,resources=protectedvolumereplicationgrouplists,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=ramendr.openshift.io,resources=protectedvolumereplicationgrouplists/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=ramendr.openshift.io,resources=protectedvolumereplicationgrouplists/finalizers,verbs=update

--- a/internal/controller/replicationgroupsource_controller.go
+++ b/internal/controller/replicationgroupsource_controller.go
@@ -71,7 +71,7 @@ type ReplicationGroupSourceReconciler struct {
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get
 
-// nolint: funlen
+//nolint:funlen
 func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Get ReplicationGroupSource")

--- a/internal/controller/util/mcv_util.go
+++ b/internal/controller/util/mcv_util.go
@@ -26,7 +26,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-// nolint: interfacebloat
+//nolint:interfacebloat
 type ManagedClusterViewGetter interface {
 	GetVRGFromManagedCluster(
 		resourceName, resourceNamespace, managedCluster string,

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -70,7 +70,7 @@ func (r *VolumeReplicationGroupReconciler) SetupWithManager(
 	rateLimiter := workqueue.NewTypedMaxOfRateLimiter(
 		workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](1*time.Second, 1*time.Minute),
 		// defaults from client-go
-		//nolint: mnd
+		//nolint:mnd
 		&workqueue.TypedBucketRateLimiter[reconcile.Request]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 	)
 	if r.RateLimiter != nil {
@@ -359,7 +359,7 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 	return req
 }
 
-//nolint: lll // disabling line length linter
+//nolint:lll // disabling line length linter
 // +kubebuilder:rbac:groups=ramendr.openshift.io,resources=volumereplicationgroups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ramendr.openshift.io,resources=volumereplicationgroups/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=ramendr.openshift.io,resources=volumereplicationgroups/finalizers,verbs=update
@@ -392,7 +392,8 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.7.0/pkg/reconcile
-// nolint: funlen
+//
+//nolint:funlen
 func (r *VolumeReplicationGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("VolumeReplicationGroup", req.NamespacedName, "rid", uuid.New())
 
@@ -527,7 +528,7 @@ func (v *VRGInstance) requeue() {
 	v.result.Requeue = true
 }
 
-// nolint: cyclop
+//nolint:cyclop
 func (v *VRGInstance) processVRG() ctrl.Result {
 	if err := v.validateVRGState(); err != nil {
 		// No requeue, as there is no reconcile till user changes desired spec to a valid value

--- a/internal/controller/vrg_kubeobjects_test.go
+++ b/internal/controller/vrg_kubeobjects_test.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // white box testing desired for Recipe/KubeObject conversions
-package controllers //nolint: testpackage
+package controllers //nolint:testpackage
 
 import (
 	. "github.com/onsi/ginkgo/v2"


### PR DESCRIPTION
We had 3 forms of `nolint:` comments:

| comment            | count |
|--------------------|-------|
| `//nolint:first`   |    99 |
| `//nolint: second` |     5 |
| `// nolint: third` |    12 |

Almost all the comments use the first form, which is also the form of the `//go:build` comments.

The second form does not work with some editors (e.g. Zed). When you save the file to editor convert the comment to the third form[1].

The third form is not correct go machine readable comment, and golangci-lint recommends not to use it[2]. However it does detect these comments and apply them.

Unify all nolint comment to the common and more correct form.

[1] https://github.com/zed-industries/zed/issues/21035
[2] https://golangci-lint.run/usage/false-positives/#nolint-directive