### PR TITLE
vrg: make backupref optional

### DIFF
--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -954,9 +954,10 @@ func convertRecipeHookToCaptureSpec(
 func convertRecipeHookToRecoverSpec(hook Recipe.Hook, suffix string) (*kubeobjects.RecoverSpec, error) {
 	hookSpec := getHookSpecFromHook(hook, suffix)
 
+	// A RecoverSpec with KubeResourcesSpec.IsHook set to true is never sent to
+	// Velero. It will only be used by Ramen to execute the hook.
+	// We don't need a backup name for it.
 	return &kubeobjects.RecoverSpec{
-		// BackupName: arbitrary fixed string to designate that this is will be a Backup, not Restore, object
-		BackupName: ramen.ReservedBackupName,
 		Spec: kubeobjects.Spec{
 			KubeResourcesSpec: kubeobjects.KubeResourcesSpec{
 				IncludedNamespaces: []string{hook.Namespace},
@@ -1036,8 +1037,13 @@ func getOpHookSpec(hook *Recipe.Hook, suffix string) kubeobjects.HookSpec {
 }
 
 func convertRecipeGroupToRecoverSpec(group Recipe.Group) (*kubeobjects.RecoverSpec, error) {
+	backupName := group.Name
+	if group.BackupRef != "" {
+		backupName = group.BackupRef
+	}
+
 	return &kubeobjects.RecoverSpec{
-		BackupName: group.BackupRef,
+		BackupName: backupName,
 		Spec: kubeobjects.Spec{
 			KubeResourcesSpec: kubeobjects.KubeResourcesSpec{
 				IncludedNamespaces: group.IncludedNamespaces,

--- a/internal/controller/vrg_kubeobjects_test.go
+++ b/internal/controller/vrg_kubeobjects_test.go
@@ -12,7 +12,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	Recipe "github.com/ramendr/recipe/api/v1alpha1"
 )
 
@@ -100,7 +99,6 @@ var _ = Describe("VRG_KubeObjectProtection", func() {
 
 		It("Hook to RecoverSpec", func() {
 			targetRecoverSpec := &kubeobjects.RecoverSpec{
-				BackupName: ramen.ReservedBackupName,
 				Spec: kubeobjects.Spec{
 					KubeResourcesSpec: kubeobjects.KubeResourcesSpec{
 						IncludedNamespaces: []string{namespaceName},


### PR DESCRIPTION
When a group is specified in the restore sequence, it uses the name of the group to find the backup to restore the resources. All the resources in the backup will be restored in this step of restore.

However, if one wishes to restore a subset of resources from a backup, then they can create a different group. This group can specify the name of the backup that has the resources by setting the BackupRef field.

This commit makes specifying the BackupRef optional. If a backup is found with the same name as the group in the restore sequence, it will be used. If not, that will be treated as an error.