### PR TITLE
vrg: return on hook errors

### DIFF
--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -643,7 +643,7 @@ func (v *VRGInstance) kubeObjectsRecoveryStartOrResume(
 
 		if rg.IsHook {
 			if err := v.executeHook(rg.Hook, log1); err != nil {
-				break
+				return fmt.Errorf("check hook execution failed during restore %s: %v", rg.Hook.Name, err)
 			}
 		} else {
 			if err := v.executeRecoverGroup(result, s3StoreAccessor, sourceVrgNamespaceName,


### PR DESCRIPTION
Earlier, a failure in hook execution was wrongly exiting out of the for loop and treating the recover process as success. Now we return error instead.