### PR TITLE
e2e: Easier to manage namespaces

### DIFF
--- a/e2e/deployers/applicationset.go
+++ b/e2e/deployers/applicationset.go
@@ -10,24 +10,25 @@ import (
 
 type ApplicationSet struct{}
 
+// Deploy creates an ApplicationSet on the hub cluster, creating the workload on one of the managed clusters.
 func (a ApplicationSet) Deploy(ctx types.Context) error {
 	name := ctx.Name()
 	log := ctx.Logger()
-	namespace := util.ArgocdNamespace
+	managementNamespace := ctx.ManagementNamespace()
 
 	log.Info("Deploying workload")
 
-	err := CreateManagedClusterSetBinding(McsbName, namespace)
+	err := CreateManagedClusterSetBinding(McsbName, managementNamespace)
 	if err != nil {
 		return err
 	}
 
-	err = CreatePlacement(ctx, name, namespace)
+	err = CreatePlacement(ctx, name, managementNamespace)
 	if err != nil {
 		return err
 	}
 
-	err = CreatePlacementDecisionConfigMap(ctx, name, namespace)
+	err = CreatePlacementDecisionConfigMap(ctx, name, managementNamespace)
 	if err != nil {
 		return err
 	}
@@ -40,10 +41,11 @@ func (a ApplicationSet) Deploy(ctx types.Context) error {
 	return err
 }
 
+// Undeploy deletes an ApplicationSet from the hub cluster, deleting the workload from the managed clusters.
 func (a ApplicationSet) Undeploy(ctx types.Context) error {
 	name := ctx.Name()
 	log := ctx.Logger()
-	namespace := util.ArgocdNamespace
+	managementNamespace := ctx.ManagementNamespace()
 
 	log.Info("Undeploying workload")
 
@@ -52,25 +54,25 @@ func (a ApplicationSet) Undeploy(ctx types.Context) error {
 		return err
 	}
 
-	err = DeleteConfigMap(ctx, name, namespace)
+	err = DeleteConfigMap(ctx, name, managementNamespace)
 	if err != nil {
 		return err
 	}
 
-	err = DeletePlacement(ctx, name, namespace)
+	err = DeletePlacement(ctx, name, managementNamespace)
 	if err != nil {
 		return err
 	}
 
 	// multiple appsets could use the same mcsb in argocd ns.
 	// so delete mcsb if only 1 appset is in argocd ns
-	lastAppset, err := isLastAppsetInArgocdNs(namespace)
+	lastAppset, err := isLastAppsetInArgocdNs(managementNamespace)
 	if err != nil {
 		return err
 	}
 
 	if lastAppset {
-		err = DeleteManagedClusterSetBinding(ctx, McsbName, namespace)
+		err = DeleteManagedClusterSetBinding(ctx, McsbName, managementNamespace)
 		if err != nil {
 			return err
 		}

--- a/e2e/deployers/applicationset.go
+++ b/e2e/deployers/applicationset.go
@@ -16,7 +16,7 @@ func (a ApplicationSet) Deploy(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	log.Info("Deploying workload")
+	log.Infof("Deploying applicationset in namespace %q", managementNamespace)
 
 	err := CreateManagedClusterSetBinding(McsbName, managementNamespace)
 	if err != nil {
@@ -47,7 +47,7 @@ func (a ApplicationSet) Undeploy(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	log.Info("Undeploying workload")
+	log.Infof("Undeploying applicationset in namespace %q", managementNamespace)
 
 	err := DeleteApplicationSet(ctx, a)
 	if err != nil {

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -136,7 +136,7 @@ func CreateSubscription(ctx types.Context, s Subscription) error {
 	name := ctx.Name()
 	log := ctx.Logger()
 	w := ctx.Workload()
-	namespace := name
+	managementNamespace := ctx.ManagementNamespace()
 
 	labels := make(map[string]string)
 	labels[AppLabelKey] = name
@@ -156,7 +156,7 @@ func CreateSubscription(ctx types.Context, s Subscription) error {
 	subscription := &subscriptionv1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   namespace,
+			Namespace:   managementNamespace,
 			Labels:      labels,
 			Annotations: annotations,
 		},
@@ -191,12 +191,12 @@ func CreateSubscription(ctx types.Context, s Subscription) error {
 func DeleteSubscription(ctx types.Context, s Subscription) error {
 	name := ctx.Name()
 	log := ctx.Logger()
-	namespace := name
+	managementNamespace := ctx.ManagementNamespace()
 
 	subscription := &subscriptionv1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: managementNamespace,
 		},
 	}
 
@@ -276,12 +276,13 @@ func CreateApplicationSet(ctx types.Context, a ApplicationSet) error {
 	name := ctx.Name()
 	log := ctx.Logger()
 	w := ctx.Workload()
-	namespace := util.ArgocdNamespace
+	managementNamespace := ctx.ManagementNamespace()
+	appNamespace := ctx.AppNamespace()
 
 	appset := &argocdv1alpha1hack.ApplicationSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: managementNamespace,
 		},
 		Spec: argocdv1alpha1hack.ApplicationSetSpec{
 			Generators: []argocdv1alpha1hack.ApplicationSetGenerator{
@@ -309,7 +310,7 @@ func CreateApplicationSet(ctx types.Context, a ApplicationSet) error {
 					},
 					Destination: argocdv1alpha1hack.ApplicationDestination{
 						Server:    "{{server}}",
-						Namespace: name,
+						Namespace: appNamespace,
 					},
 					Project: "default",
 					SyncPolicy: &argocdv1alpha1hack.SyncPolicy{
@@ -353,12 +354,12 @@ func CreateApplicationSet(ctx types.Context, a ApplicationSet) error {
 func DeleteApplicationSet(ctx types.Context, a ApplicationSet) error {
 	name := ctx.Name()
 	log := ctx.Logger()
-	namespace := util.ArgocdNamespace
+	managementNamespace := ctx.ManagementNamespace()
 
 	appset := &argocdv1alpha1hack.ApplicationSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
+			Namespace: managementNamespace,
 		},
 	}
 

--- a/e2e/deployers/discoveredapp.go
+++ b/e2e/deployers/discoveredapp.go
@@ -27,7 +27,7 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 	log := ctx.Logger()
 	appNamespace := ctx.AppNamespace()
 
-	log.Info("Deploying workload")
+	log.Infof("Deploying workload in namespace %q", appNamespace)
 
 	// create namespace in both dr clusters
 	if err := util.CreateNamespaceAndAddAnnotation(appNamespace); err != nil {
@@ -76,7 +76,7 @@ func (d DiscoveredApp) Undeploy(ctx types.Context) error {
 	log := ctx.Logger()
 	appNamespace := ctx.AppNamespace()
 
-	log.Info("Undeploying workload")
+	log.Infof("Undeploying workload in namespace %q", appNamespace)
 
 	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub.Client, util.DefaultDRPolicyName)
 	if err != nil {

--- a/e2e/deployers/subscription.go
+++ b/e2e/deployers/subscription.go
@@ -35,7 +35,7 @@ func (s Subscription) Deploy(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	log.Info("Deploying workload")
+	log.Infof("Deploying subscription in namespace %q", managementNamespace)
 
 	// create subscription namespace
 	err := util.CreateNamespace(util.Ctx.Hub.Client, managementNamespace)
@@ -67,7 +67,7 @@ func (s Subscription) Undeploy(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	log.Info("Undeploying workload")
+	log.Infof("Undeploying subscription in namespace %q", managementNamespace)
 
 	err := DeleteSubscription(ctx, s)
 	if err != nil {

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -35,7 +35,7 @@ func EnableProtection(ctx types.Context) error {
 	managementNamespace := ctx.ManagementNamespace()
 	log := ctx.Logger()
 
-	log.Info("Protecting workload")
+	log.Infof("Protecting workload in namespace %q", managementNamespace)
 
 	drPolicyName := util.DefaultDRPolicyName
 	appname := w.GetAppName()
@@ -93,11 +93,12 @@ func DisableProtection(ctx types.Context) error {
 		return DisableProtectionDiscoveredApps(ctx)
 	}
 
-	log := ctx.Logger()
-	log.Info("Unprotecting workload")
-
 	name := ctx.Name()
 	managementNamespace := ctx.ManagementNamespace()
+	log := ctx.Logger()
+
+	log.Infof("Unprotecting workload in namespace %q", managementNamespace)
+
 	drpcName := name
 	client := util.Ctx.Hub.Client
 
@@ -116,8 +117,10 @@ func Failover(ctx types.Context) error {
 		return FailoverDiscoveredApps(ctx)
 	}
 
+	managementNamespace := ctx.ManagementNamespace()
 	log := ctx.Logger()
-	log.Info("Failing over workload")
+
+	log.Infof("Failing over workload in namespace %q", managementNamespace)
 
 	return failoverRelocate(ctx, ramen.ActionFailover, ramen.FailedOver)
 }
@@ -132,8 +135,10 @@ func Relocate(ctx types.Context) error {
 		return RelocateDiscoveredApps(ctx)
 	}
 
+	managementNamespace := ctx.ManagementNamespace()
 	log := ctx.Logger()
-	log.Info("Relocating workload")
+
+	log.Infof("Relocating workload in namespace %q", managementNamespace)
 
 	return failoverRelocate(ctx, ramen.ActionRelocate, ramen.Relocated)
 }

--- a/e2e/dractions/discovered.go
+++ b/e2e/dractions/discovered.go
@@ -17,7 +17,8 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 	managementNamespace := ctx.ManagementNamespace()
 	appNamespace := ctx.AppNamespace()
 
-	log.Info("Protecting workload")
+	// TODO: log cluster namespace for completeness?
+	log.Infof("Protecting workload in namespace %q", managementNamespace)
 
 	drPolicyName := util.DefaultDRPolicyName
 	appname := w.GetAppName()
@@ -61,7 +62,8 @@ func DisableProtectionDiscoveredApps(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	log.Info("Unprotecting workload")
+	// TODO: log cluster namespace for completeness?
+	log.Infof("Unprotecting workload in namespace %q", managementNamespace)
 
 	placementName := name
 	drpcName := name
@@ -88,14 +90,18 @@ func DisableProtectionDiscoveredApps(ctx types.Context) error {
 
 func FailoverDiscoveredApps(ctx types.Context) error {
 	log := ctx.Logger()
-	log.Info("Failing over workload")
+	managementNamespace := ctx.ManagementNamespace()
+
+	log.Infof("Failing over workload in namespace %q", managementNamespace)
 
 	return failoverRelocateDiscoveredApps(ctx, ramen.ActionFailover, ramen.FailedOver)
 }
 
 func RelocateDiscoveredApps(ctx types.Context) error {
 	log := ctx.Logger()
-	log.Info("Relocating workload")
+	managementNamespace := ctx.ManagementNamespace()
+
+	log.Infof("Relocating workload in namespace %q", managementNamespace)
 
 	return failoverRelocateDiscoveredApps(ctx, ramen.ActionRelocate, ramen.Relocated)
 }

--- a/e2e/test/context.go
+++ b/e2e/test/context.go
@@ -44,11 +44,15 @@ func (c *Context) Name() string {
 	return c.name
 }
 
-func (c *Context) Namespace() string {
+func (c *Context) ManagementNamespace() string {
 	if ns := c.deployer.GetNamespace(); ns != "" {
 		return ns
 	}
 
+	return c.AppNamespace()
+}
+
+func (c *Context) AppNamespace() string {
 	return c.name
 }
 

--- a/e2e/test/context.go
+++ b/e2e/test/context.go
@@ -14,6 +14,9 @@ import (
 	"go.uber.org/zap"
 )
 
+// Make it easier to manage namespaces created by the tests.
+const appNamespacePrefix = "e2e-"
+
 type Context struct {
 	workload types.Workload
 	deployer types.Deployer
@@ -53,7 +56,7 @@ func (c *Context) ManagementNamespace() string {
 }
 
 func (c *Context) AppNamespace() string {
-	return c.name
+	return appNamespacePrefix + c.name
 }
 
 func (c *Context) Logger() *zap.SugaredLogger {

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -39,6 +39,13 @@ type Context interface {
 	Deployer() Deployer
 	Workload() Workload
 	Name() string
-	Namespace() string
+
+	// Namespace for OCM and Ramen resources (Subscription, ApplicationSet, DRPC, VRG) on the hub and managed clusters.
+	// Depending on the deployer, it may be the same as AppNamespace().
+	ManagementNamespace() string
+
+	// Namespace for application resources on the managed clusters.
+	AppNamespace() string
+
 	Logger() *zap.SugaredLogger
 }


### PR DESCRIPTION
Clarify the way we use namespaces, and add a "e2e-" prefix for test namespaces.

Context includes now:
- ManagementNamespace()
- AppNamespace()

When using temporary variables, use either hubNamespace or clusterNamespace.

The application namespace has a "e2e-" prefix now.

Example namespaces during test:

```console
% kubectl get ns --context dr1 | grep e2e-
e2e-appset-deploy-cephfs-busybox      Active   16m
e2e-appset-deploy-rbd-busybox         Active   16m
e2e-disapp-deploy-rbd-busybox         Active   14s
e2e-subscr-deploy-cephfs-busybox      Active   16m
e2e-subscr-deploy-rbd-busybox         Active   16m
```

Fixes #1611