### PR TITLE
github: change the ubuntu versions to 24.04

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4

--- a/.github/workflows/ramen.yaml
+++ b/.github/workflows/ramen.yaml
@@ -32,7 +32,7 @@ defaults:
 jobs:
   lint:
     name: Linters
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
 
   golangci:
     name: Golangci Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         directory: [., api, e2e]
@@ -98,7 +98,7 @@ jobs:
 
   unit-test:
     name: Unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
 
   build-image:
     name: Build image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -139,7 +139,7 @@ jobs:
   deploy-check:
     name: Check artifacts and operator deployment
     needs: [build-image]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -216,7 +216,7 @@ jobs:
       (github.ref == 'refs/heads/main' ||
        startsWith(github.ref, 'refs/heads/release-') ||
        startsWith(github.ref, 'refs/tags/v'))
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Download image artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
         python-version:
           - "3.10"
           - "3.11"
@@ -150,7 +150,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-24.04
         python-version:
           - "3.10"
           - "3.11"


### PR DESCRIPTION
We have different versions of ubuntu being used across the github workflows. Change to 24.04 version throughout. Github workflows is changing the `latest` tag to 24.04 by 2025-01-17.

https://github.com/actions/runner-images/issues/10636