### PR TITLE
Log error if GetVRGFromManagedCluster failed

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -398,6 +398,9 @@ func (d *DRPCInstance) isValidFailoverTarget(cluster string) bool {
 
 	vrg, err := d.reconciler.MCVGetter.GetVRGFromManagedCluster(d.instance.Name, d.vrgNamespace, cluster, annotations)
 	if err != nil {
+		d.log.Info("Failed to get VRG from managed cluster", "name", d.instance.Name, "namespace", d.vrgNamespace,
+			"cluster", cluster, "annotations", annotations, "error", err)
+
 		return false
 	}
 


### PR DESCRIPTION
We returned false, swallowing the error silently.

The drpc remained in this state:

    - lastTransitionTime: "2024-12-10T12:45:26Z" message: unable to start failover, spec.FailoverCluster (dr2) is not a valid Secondary target

With no clue why dr2 is not a valid Secondary cluster. The new log may explain the reason.