### PR TITLE
e2e: Support any storage class name

### DIFF
--- a/e2e/config.yaml
+++ b/e2e/config.yaml
@@ -9,3 +9,5 @@ pvcspecs:
   - name: cephfs
     storageclassname: rook-cephfs
     accessmodes: ReadWriteMany
+    unsupportedDeployers:
+      - disapp

--- a/e2e/config.yaml
+++ b/e2e/config.yaml
@@ -3,7 +3,9 @@ channelname: "ramen-gitops"
 channelnamespace: "ramen-samples"
 giturl: "https://github.com/RamenDR/ocm-ramen-samples.git"
 pvcspecs:
-  - storageclassname: rook-cephfs
-    accessmodes: ReadWriteMany
-  - storageclassname: rook-ceph-block
+  - name: rbd
+    storageclassname: rook-ceph-block
     accessmodes: ReadWriteOnce
+  - name: cephfs
+    storageclassname: rook-cephfs
+    accessmodes: ReadWriteMany

--- a/e2e/deployers/applicationset.go
+++ b/e2e/deployers/applicationset.go
@@ -80,15 +80,11 @@ func (a ApplicationSet) Undeploy(ctx types.Context) error {
 }
 
 func (a ApplicationSet) GetName() string {
-	return "Appset"
+	return "appset"
 }
 
 func (a ApplicationSet) GetNamespace() string {
 	return util.ArgocdNamespace
-}
-
-func (a ApplicationSet) IsWorkloadSupported(w types.Workload) bool {
-	return true
 }
 
 func (a ApplicationSet) IsDiscovered() bool {

--- a/e2e/deployers/discoveredapp.go
+++ b/e2e/deployers/discoveredapp.go
@@ -15,7 +15,7 @@ import (
 type DiscoveredApp struct{}
 
 func (d DiscoveredApp) GetName() string {
-	return "Disapp"
+	return "disapp"
 }
 
 func (d DiscoveredApp) GetNamespace() string {
@@ -112,10 +112,6 @@ func (d DiscoveredApp) Undeploy(ctx types.Context) error {
 	log.Info("Workload undeployed")
 
 	return nil
-}
-
-func (d DiscoveredApp) IsWorkloadSupported(w types.Workload) bool {
-	return w.GetName() != "Deploy-cephfs"
 }
 
 func (d DiscoveredApp) IsDiscovered() bool {

--- a/e2e/deployers/subscription.go
+++ b/e2e/deployers/subscription.go
@@ -15,7 +15,7 @@ const McsbName = ClusterSetName
 type Subscription struct{}
 
 func (s Subscription) GetName() string {
-	return "Subscr"
+	return "subscr"
 }
 
 func (s Subscription) GetNamespace() string {
@@ -84,10 +84,6 @@ func (s Subscription) Undeploy(ctx types.Context) error {
 	}
 
 	return util.DeleteNamespace(util.Ctx.Hub.Client, namespace, log)
-}
-
-func (s Subscription) IsWorkloadSupported(w types.Workload) bool {
-	return true
 }
 
 func (s Subscription) IsDiscovered() bool {

--- a/e2e/exhaustive_suite_test.go
+++ b/e2e/exhaustive_suite_test.go
@@ -5,7 +5,6 @@ package e2e_test
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/ramendr/ramen/e2e/deployers"
@@ -33,30 +32,15 @@ var (
 	Deployers      = []types.Deployer{subscription, appset, discoveredApps}
 )
 
-func generateSuffix(storageClassName string) string {
-	suffix := storageClassName
-
-	if strings.ToLower(storageClassName) == "rook-ceph-block" {
-		suffix = "rbd"
-	}
-
-	if strings.ToLower(storageClassName) == "rook-cephfs" {
-		suffix = "cephfs"
-	}
-
-	return suffix
-}
-
 func generateWorkloads([]types.Workload) {
 	pvcSpecs := util.GetPVCSpecs()
 	for _, pvcSpec := range pvcSpecs {
 		// add storageclass name to deployment name
-		suffix := generateSuffix(pvcSpec.StorageClassName)
 		deployment := &workloads.Deployment{
 			Path:     GITPATH,
 			Revision: GITREVISION,
 			AppName:  APPNAME,
-			Name:     fmt.Sprintf("Deploy-%s", suffix),
+			Name:     fmt.Sprintf("Deploy-%s", pvcSpec.Name),
 			PVCSpec:  pvcSpec,
 		}
 		Workloads = append(Workloads, deployment)

--- a/e2e/test/context.go
+++ b/e2e/test/context.go
@@ -59,8 +59,8 @@ func (c *Context) Logger() *zap.SugaredLogger {
 // Validated return an error if the combination of deployer and workload is not supported.
 // TODO: validate that the workload is compatible with the clusters.
 func (c *Context) Validate() error {
-	if !c.deployer.IsWorkloadSupported(c.workload) {
-		return fmt.Errorf("workload %q not supported by deployer %q", c.workload.GetName(), c.deployer.GetName())
+	if !c.workload.SupportsDeployer(c.deployer) {
+		return fmt.Errorf("workload %q does not support deployer %q", c.workload.GetName(), c.deployer.GetName())
 	}
 
 	return nil

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -15,7 +15,6 @@ type Deployer interface {
 	GetName() string
 	// GetNamespace return the namespace for the ramen resources, or empty string if not using a special namespace.
 	GetNamespace() string
-	IsWorkloadSupported(Workload) bool
 	// Return true for OCM discovered application, false for OCM managed applications.
 	IsDiscovered() bool
 }
@@ -28,6 +27,9 @@ type Workload interface {
 	GetAppName() string
 	GetPath() string
 	GetRevision() string
+
+	// SupportsDeployer returns tue if this workload is compatible with deployer.
+	SupportsDeployer(Deployer) bool
 
 	// TODO: replace client with cluster.
 	Health(ctx Context, client client.Client, namespace string) error

--- a/e2e/util/config.go
+++ b/e2e/util/config.go
@@ -11,9 +11,10 @@ import (
 )
 
 type PVCSpec struct {
-	Name             string
-	StorageClassName string
-	AccessModes      string
+	Name                 string
+	StorageClassName     string
+	AccessModes          string
+	UnsupportedDeployers []string
 }
 type TestConfig struct {
 	ChannelName      string

--- a/e2e/util/config.go
+++ b/e2e/util/config.go
@@ -11,6 +11,7 @@ import (
 )
 
 type PVCSpec struct {
+	Name             string
 	StorageClassName string
 	AccessModes      string
 }

--- a/e2e/workloads/deployment.go
+++ b/e2e/workloads/deployment.go
@@ -5,6 +5,8 @@ package workloads
 
 import (
 	"context"
+	"slices"
+	"strings"
 
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
@@ -35,6 +37,10 @@ func (w Deployment) GetPath() string {
 
 func (w Deployment) GetRevision() string {
 	return w.Revision
+}
+
+func (w Deployment) SupportsDeployer(d types.Deployer) bool {
+	return !slices.Contains(w.PVCSpec.UnsupportedDeployers, strings.ToLower(d.GetName()))
 }
 
 func (w Deployment) Kustomize() string {


### PR DESCRIPTION
Fix the way we configure storage classes so we can create configuration that works with any clsuter.

- Replace coded using hardcoded storage class names with configuration
- Fix the way we filter unsupported workloads and deployers

Fixes #1635