### PR TITLE
DFBUGS-1026: Provision to disable DRPC reconsile temporarily - WA of CG

### DIFF
--- a/api/v1alpha1/ramenconfig_types.go
+++ b/api/v1alpha1/ramenconfig_types.go
@@ -191,6 +191,10 @@ type RamenConfig struct {
 
 	// RamenOpsNamespace is the namespace where resources for unmanaged apps are created
 	RamenOpsNamespace string `json:"ramenOpsNamespace,omitempty"`
+
+	// StartDRPCReconciliationPaused is a flag to pause all the DRPC reconcile temporarily.
+	// This flag can be overridden by the annotation drplacementcontrol.ramendr.openshift.io/reconciliationUnpaused
+	StartDRPCReconciliationPaused bool `json:"startDRPCReconciliationPaused,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/DFBUGS-1026

**Description**
The issue is the user has to choose a multivolume consistency group way of replication via DRPC(DRPlacementContorl CR) by adding an annotation. The limitation is, that the user has to add this annotation while creating DRPC. They can't do it after creating DRPC.  But the problem is UI. Users can't test this techpreview feature via UI because UI is creating a DRPC for them. The user can't add annotation after UI creates it. KCS: https://access.redhat.com/articles/7091592

**The proposed solution is:**
To temporarily halt the DRPC reconcile, a new ramen configuration specification is being introduced. Thus, it won't be reconciled when a DRPC is created through the user interface. The user can add annotations `drplacementcontrol.ramendr.openshift.io/is-cg-enabled`, `drplacementcontrol.ramendr.openshift.io/reconciliationUnpaused` to resume the reconcile and enable consistency group for a specific DRPC. This is a short-term fix for the devpreview function. 