### PR TITLE
e2e: Build and run e2e executable

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,7 +12,7 @@ on:
 env:
   # Limit number of drenv workers.
   MAX_WORKERS: 4
-  GATHER_DIR: gather.${{ github.run_id }}-${{ github.run_attempt }}
+  BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
 
 jobs:
   e2e-rdr:
@@ -81,23 +81,22 @@ jobs:
       working-directory: test
       # Gathering typically takes less than 15 seconds.
       timeout-minutes: 3
-      run: drenv gather --directory ${{ env.GATHER_DIR }} envs/regional-dr.yaml
+      run: drenv gather --directory gather.rdr envs/regional-dr.yaml
 
     # Tar manually to work around github limitations with special chracters (:)
     # in file names, and getting much smaller archives comapred with zip (6m vs
-    # 12m).
+    # 12m). This is also useful to collect all files in one archive.
     # https://github.com/actions/upload-artifact/issues/546
-    - name: Archive gathered data
+    - name: Archive artifacts
       if: failure()
-      working-directory: test
-      run: tar czf ${{ env.GATHER_DIR }}.tar.gz ${{ env.GATHER_DIR }}
+      run: tar czf e2e.${{ env.BUILD_ID }}.tar.gz test/gather.rdr e2e/ramen-e2e.log
 
     - name: Upload artifacts
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ env.GATHER_DIR }}
-        path: test/${{ env.GATHER_DIR }}.tar.gz
+        name: e2e.${{ env.BUILD_ID }}
+        path: e2e.${{ env.BUILD_ID }}.tar.gz
         compression-level: 0
         retention-days: 15
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -77,7 +77,7 @@ jobs:
         make e2e-rdr
 
     - name: Gather environment data
-      if: failure()
+      if: always()
       working-directory: test
       # Gathering typically takes less than 15 seconds.
       timeout-minutes: 3
@@ -88,11 +88,11 @@ jobs:
     # 12m). This is also useful to collect all files in one archive.
     # https://github.com/actions/upload-artifact/issues/546
     - name: Archive artifacts
-      if: failure()
+      if: always()
       run: tar czf e2e.${{ env.BUILD_ID }}.tar.gz test/gather.rdr e2e/ramen-e2e.log
 
     - name: Upload artifacts
-      if: failure()
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: e2e.${{ env.BUILD_ID }}

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-echo "Running tests..."
+# This executable can be used without checking out ramen source.
+go test -c -o ramen-e2e
 
-go test -timeout 0 -v "$@"
+# With an executable -test.timeout is disabled by default.
+./ramen-e2e -test.v "$@"

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -7,4 +7,4 @@
 go test -c -o ramen-e2e
 
 # With an executable -test.timeout is disabled by default.
-./ramen-e2e -test.v "$@"
+./ramen-e2e -test.v "$@" 2>&1 | tee ramen-e2e.log


### PR DESCRIPTION
Change the run.sh script to build the e2e executable and run the tests                                                                                                   
using the executable.

This has several advantages:
- Document how the build an executable
- Test the built executable for every test run 
- When running the executable the default -test.timeout is disable, so
  we don't need to specify it. This makes running the tests directly
  easier.

The new ramen-e2e.log is also collected in the build archive.

Example content of the build archive:

```console
% tree e2e.12932857944-1 -L3
e2e.12932857944-1
├── e2e
│   └── ramen-e2e.log
└── test
    └── gather.rdr
        ├── dr1
        ├── dr2
        ├── gather.log
        └── hub
```

Finally we gather data and upload the archive for all builds, not only for failures.

New artifacts:

<img width="718" alt="Screenshot 2025-01-23 at 18 49 30" src="https://github.com/user-attachments/assets/3f4c5525-79a2-4258-8516-189544c57947" />

Fixes #1743