### PR TITLE
util: fix extra linter errors

### DIFF
--- a/internal/controller/util/json_util.go
+++ b/internal/controller/util/json_util.go
@@ -202,15 +202,18 @@ func getObjectsBasedOnType(objList client.ObjectList) []client.Object {
 	switch v := objList.(type) {
 	case *corev1.PodList:
 		for _, pod := range v.Items {
-			objs = append(objs, &pod)
+			podCopy := pod
+			objs = append(objs, &podCopy)
 		}
 	case *appsv1.DeploymentList:
 		for _, dep := range v.Items {
-			objs = append(objs, &dep)
+			depCopy := dep
+			objs = append(objs, &depCopy)
 		}
 	case *appsv1.StatefulSetList:
 		for _, ss := range v.Items {
-			objs = append(objs, &ss)
+			ssCopy := ss
+			objs = append(objs, &ssCopy)
 		}
 	}
 

--- a/internal/controller/util/json_util_test.go
+++ b/internal/controller/util/json_util_test.go
@@ -108,7 +108,7 @@ func TestEvaluateCheckHookExp(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			var jsonData map[string]interface{}
 
-			err := json.Unmarshal(tt.jsonText, &jsonData)
+			err := json.Unmarshal(test.jsonText, &jsonData)
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
These errors were discovered when running some extra linters which are not part of the default suite. I will enable the extra linters in a different PR.