### PR TITLE
Enable RBD PVC VolSync support and ensure tmp source PVCs accessModes

### DIFF
--- a/internal/controller/cephfscg/replicationgroupsource.go
+++ b/internal/controller/cephfscg/replicationgroupsource.go
@@ -140,7 +140,7 @@ func (m *replicationGroupSourceMachine) Synchronize(ctx context.Context) (mover.
 
 		return mover.InProgress(), err
 	}
-	
+
 	replicationSources, err := m.VolumeGroupHandler.CreateOrUpdateReplicationSourceForRestoredPVCs(
 		ctx, m.ReplicationGroupSource.Status.LastSyncStartTime.String(), restoredPVCs, m.ReplicationGroupSource)
 	if err != nil {

--- a/internal/controller/cephfscg/replicationgroupsource.go
+++ b/internal/controller/cephfscg/replicationgroupsource.go
@@ -113,15 +113,6 @@ func (m *replicationGroupSourceMachine) Synchronize(ctx context.Context) (mover.
 		return mover.InProgress(), err
 	}
 
-	m.Logger.Info("Restore PVCs from volume group snapshot")
-
-	restoredPVCs, err := m.VolumeGroupHandler.RestoreVolumesFromVolumeGroupSnapshot(ctx, m.ReplicationGroupSource)
-	if err != nil {
-		m.Logger.Error(err, "Failed to restore volume group snapshot")
-
-		return mover.InProgress(), err
-	}
-
 	m.Logger.Info("Create ReplicationSource for each Restored PVC")
 	vrgName := m.ReplicationGroupSource.GetLabels()[volsync.VRGOwnerNameLabel]
 	// Pre-allocated shared secret - DRPC will generate and propagate this secret from hub to clusters
@@ -141,6 +132,15 @@ func (m *replicationGroupSourceMachine) Synchronize(ctx context.Context) (mover.
 		return mover.InProgress(), nil
 	}
 
+	m.Logger.Info("Restore PVCs from volume group snapshot")
+
+	restoredPVCs, err := m.VolumeGroupHandler.RestoreVolumesFromVolumeGroupSnapshot(ctx, m.ReplicationGroupSource)
+	if err != nil {
+		m.Logger.Error(err, "Failed to restore volume group snapshot")
+
+		return mover.InProgress(), err
+	}
+	
 	replicationSources, err := m.VolumeGroupHandler.CreateOrUpdateReplicationSourceForRestoredPVCs(
 		ctx, m.ReplicationGroupSource.Status.LastSyncStartTime.String(), restoredPVCs, m.ReplicationGroupSource)
 	if err != nil {

--- a/internal/controller/cephfscg/utils.go
+++ b/internal/controller/cephfscg/utils.go
@@ -11,10 +11,8 @@ import (
 	"github.com/ramendr/ramen/internal/controller/volsync"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // ------------- [Begin] Copied from existing code in Ramen ----
@@ -52,55 +50,6 @@ func getLocalServiceNameForRDFromPVCName(pvcName string) string {
 func getLocalServiceNameForRD(rdName string) string {
 	// This is the name VolSync will use for the service
 	return fmt.Sprintf("volsync-rsync-tls-dst-%s", rdName)
-}
-
-// ------------- [End] Copied from existing code in Ramen ----
-
-// ------------- [Begin] Edited from existing code in Ramen ----
-
-// Copied from func (v *VSHandler) ModifyRSSpecForCephFS
-func GetRestoreStorageClass(
-	ctx context.Context, k8sClient client.Client, storageClassName string,
-	defaultCephFSCSIDriverName string,
-) (*storagev1.StorageClass, error) {
-	storageClass, err := GetStorageClass(ctx, k8sClient, &storageClassName)
-	if err != nil {
-		return nil, err
-	}
-
-	if storageClass.Provisioner != defaultCephFSCSIDriverName {
-		return storageClass, nil // No workaround required
-	}
-
-	// Create/update readOnlyPVCStorageClass
-	readOnlyPVCStorageClass := &storagev1.StorageClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: storageClass.GetName() + "-vrg",
-		},
-	}
-
-	_, err = ctrlutil.CreateOrUpdate(ctx, k8sClient, readOnlyPVCStorageClass, func() error {
-		// Do not update the storageclass if it already exists - Provisioner and Parameters are immutable anyway
-		if readOnlyPVCStorageClass.CreationTimestamp.IsZero() {
-			readOnlyPVCStorageClass.Provisioner = storageClass.Provisioner
-
-			// Copy other parameters from the original storage class
-			readOnlyPVCStorageClass.Parameters = map[string]string{}
-			for k, v := range storageClass.Parameters {
-				readOnlyPVCStorageClass.Parameters[k] = v
-			}
-
-			// Set backingSnapshot parameter to true
-			readOnlyPVCStorageClass.Parameters["backingSnapshot"] = "true"
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("%w", err)
-	}
-
-	return readOnlyPVCStorageClass, nil
 }
 
 // Copied from func (v *VSHandler) getStorageClass(

--- a/internal/controller/cephfscg/volumegroupsourcehandler.go
+++ b/internal/controller/cephfscg/volumegroupsourcehandler.go
@@ -26,8 +26,8 @@ import (
 )
 
 var (
-	VolumeGroupSnapshotNameFormat = "cephfscg-%s"
-	RestorePVCinCGNameFormat      = "cephfscg-%s"
+	VolumeGroupSnapshotNameFormat = "vs-cg-%s"
+	RestorePVCinCGNameFormat      = "vs-cg-%s"
 	SnapshotGroup                 = "snapshot.storage.k8s.io"
 	SnapshotGroupKind             = "VolumeSnapshot"
 )

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -1711,6 +1711,7 @@ func (d *DRPCInstance) updateVRGOptionalFields(vrg, vrgFromView *rmn.VolumeRepli
 		DoNotDeletePVCAnnotation:        d.instance.GetAnnotations()[DoNotDeletePVCAnnotation],
 		DRPCUIDAnnotation:               string(d.instance.UID),
 		rmnutil.IsCGEnabledAnnotation:   d.instance.GetAnnotations()[rmnutil.IsCGEnabledAnnotation],
+		rmnutil.UseVolSyncAnnotation:   d.instance.GetAnnotations()[rmnutil.UseVolSyncAnnotation],
 	}
 
 	vrg.Spec.ProtectedNamespaces = d.instance.Spec.ProtectedNamespaces

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -1711,7 +1711,7 @@ func (d *DRPCInstance) updateVRGOptionalFields(vrg, vrgFromView *rmn.VolumeRepli
 		DoNotDeletePVCAnnotation:        d.instance.GetAnnotations()[DoNotDeletePVCAnnotation],
 		DRPCUIDAnnotation:               string(d.instance.UID),
 		rmnutil.IsCGEnabledAnnotation:   d.instance.GetAnnotations()[rmnutil.IsCGEnabledAnnotation],
-		rmnutil.UseVolSyncAnnotation:   d.instance.GetAnnotations()[rmnutil.UseVolSyncAnnotation],
+		rmnutil.UseVolSyncAnnotation:    d.instance.GetAnnotations()[rmnutil.UseVolSyncAnnotation],
 	}
 
 	vrg.Spec.ProtectedNamespaces = d.instance.Spec.ProtectedNamespaces

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -1929,8 +1929,7 @@ func (v *VSHandler) createPVCFromSnapshot(rd *volsyncv1alpha1.ReplicationDestina
 	snapshotRef *corev1.TypedLocalObjectReference,
 	snapRestoreSize *resource.Quantity,
 ) (*corev1.PersistentVolumeClaim, error) {
-	l := v.log.WithValues("pvcName", rd.GetName(), "snapshotRef", snapshotRef,
-		"snapRestoreSize", snapRestoreSize)
+	l := v.log.WithValues("pvcName", rd.GetName(), "snapshotRef", snapshotRef, "snapRestoreSize", snapRestoreSize)
 
 	storageClass, err := v.getStorageClass(rdSpec.ProtectedPVC.StorageClassName)
 	if err != nil {
@@ -1980,8 +1979,6 @@ func (v *VSHandler) createPVCFromSnapshot(rd *volsyncv1alpha1.ReplicationDestina
 		return nil
 	})
 	if err != nil {
-		l.Error(err, "Unable to createOrUpdate PVC from snapshot for localRS")
-
 		return nil, fmt.Errorf("error creating or updating PVC from snapshot for localRS (%w)", err)
 	}
 

--- a/internal/controller/volsync/vshandler_test.go
+++ b/internal/controller/volsync/vshandler_test.go
@@ -253,11 +253,17 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 				storageClassForTest)).To(Succeed())
 
 			vsHandler.ModifyRSSpecForCephFS(&testRsSpec, storageClassForTest)
-
-			Expect(testRsSpec.ProtectedPVC.AccessModes).To(Equal(
-				[]corev1.PersistentVolumeAccessMode{
-					corev1.ReadOnlyMany,
-				}))
+			if storageClassForTest.Provisioner == testCephFSStorageDriverName {
+				Expect(testRsSpec.ProtectedPVC.AccessModes).To(Equal(
+					[]corev1.PersistentVolumeAccessMode{
+						corev1.ReadOnlyMany,
+					}))
+			} else {
+				Expect(testRsSpec.ProtectedPVC.AccessModes).To(Equal(
+					[]corev1.PersistentVolumeAccessMode{
+						corev1.ReadWriteMany,
+					}))
+			}
 		})
 
 		Context("When the source PVC is not using a cephfs storageclass", func() {
@@ -272,128 +278,13 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 		})
 
 		Context("When the sourcePVC is using a cephfs storageclass", func() {
-			customBackingSnapshotStorageClassName := testCephFSStorageClassName + "-vrg"
-
 			BeforeEach(func() {
 				// Make sure the source PVC uses the cephfs storageclass
 				testSourcePVC.Spec.StorageClassName = &testCephFSStorageClassName
 			})
 
-			JustBeforeEach(func() {
-				// Common tests - rsSpec should be modified with settings to allow pvc from snapshot
-				// to use our custom cephfs storageclass and ReadOnlyMany accessModes
-				Expect(testRsSpecOrig).NotTo(Equal(testRsSpec))
-
-				// Should use the custom storageclass with backingsnapshot: true parameter
-				Expect(*testRsSpec.ProtectedPVC.StorageClassName).To(Equal(customBackingSnapshotStorageClassName))
-
-				// AccessModes should be updated to ReadOnlyMany
-				Expect(testRsSpec.ProtectedPVC.AccessModes).To(Equal(
-					[]corev1.PersistentVolumeAccessMode{
-						corev1.ReadOnlyMany,
-					}))
-			})
-
-			AfterEach(func() {
-				// Delete the custom storage class that may have been created by test
-				custStorageClass := &storagev1.StorageClass{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: customBackingSnapshotStorageClassName,
-					},
-				}
-				err := k8sClient.Delete(ctx, custStorageClass)
-				if err != nil {
-					Expect(kerrors.IsNotFound(err)).To(BeTrue())
-				}
-
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(custStorageClass), custStorageClass)
-
-					return kerrors.IsNotFound(err)
-				}, maxWait, interval).Should(BeTrue())
-			})
-
-			Context("When the custom cephfs backing storage class for readonly pvc from snap does not exist", func() {
-				// Delete the custom vrg storageclass if it exists
-				BeforeEach(func() {
-					custStorageClass := &storagev1.StorageClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: customBackingSnapshotStorageClassName,
-						},
-					}
-					err := k8sClient.Delete(ctx, custStorageClass)
-					if err != nil {
-						Expect(kerrors.IsNotFound(err)).To(BeTrue())
-					}
-
-					Eventually(func() bool {
-						err := k8sClient.Get(ctx, client.ObjectKeyFromObject(custStorageClass), custStorageClass)
-
-						return kerrors.IsNotFound(err)
-					}, maxWait, interval).Should(BeTrue())
-				})
-
-				It("ModifyRSSpecForCephFS should modify the rsSpec and create the new storageclass", func() {
-					// RSspec modification checks in the outer context JustBeforeEach()
-
-					newStorageClass := &storagev1.StorageClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: customBackingSnapshotStorageClassName,
-						},
-					}
-
-					Eventually(func() error {
-						return k8sClient.Get(ctx, client.ObjectKeyFromObject(newStorageClass), newStorageClass)
-					}, maxWait, interval).Should(Succeed())
-
-					Expect(newStorageClass.Parameters["backingSnapshot"]).To(Equal("true"))
-
-					// Other parameters from the test cephfs storageclass should be copied over
-					for k, v := range testCephFSStorageClass.Parameters {
-						Expect(newStorageClass.Parameters[k]).To(Equal(v))
-					}
-				})
-			})
-
-			Context("When the custom cephfs backing storage class for readonly pvc from snap exists", func() {
-				var preExistingCustStorageClass *storagev1.StorageClass
-
-				BeforeEach(func() {
-					preExistingCustStorageClass = &storagev1.StorageClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: customBackingSnapshotStorageClassName,
-						},
-						Provisioner: testCephFSStorageDriverName,
-						Parameters: map[string]string{ // Not the same params as our CephFS storageclass for test
-							"different-param-1": "abc",
-							"different-param-2": "def",
-							"backingSnapshot":   "true",
-						},
-					}
-					Expect(k8sClient.Create(ctx, preExistingCustStorageClass)).To(Succeed())
-
-					// Confirm it's created
-					Eventually(func() error {
-						return k8sClient.Get(ctx,
-							client.ObjectKeyFromObject(preExistingCustStorageClass), preExistingCustStorageClass)
-					}, maxWait, interval).Should(Succeed())
-				})
-
-				It("ModifyRSSpecForCephFS should modify the rsSpec but not modify the new custom storageclass", func() {
-					// Load the custom storageclass
-					newStorageClass := &storagev1.StorageClass{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: customBackingSnapshotStorageClassName,
-						},
-					}
-
-					Eventually(func() error {
-						return k8sClient.Get(ctx, client.ObjectKeyFromObject(newStorageClass), newStorageClass)
-					}, maxWait, interval).Should(Succeed())
-
-					// Parameters should match the original, unmodified
-					Expect(newStorageClass.Parameters).To(Equal(preExistingCustStorageClass.Parameters))
-				})
+			It("ModifyRSSpecForCephFS should modify the rsSpec protectedPVC accessModes", func() {
+				Expect(testRsSpecOrig).ToNot(Equal(testRsSpec))
 			})
 		})
 	})

--- a/internal/controller/volsync/vshandler_test.go
+++ b/internal/controller/volsync/vshandler_test.go
@@ -252,10 +252,12 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 				},
 				storageClassForTest)).To(Succeed())
 
-			//
-			// Call ModifyRSSpecForCephFS
-			//
-			Expect(vsHandler.ModifyRSSpecForCephFS(&testRsSpec, storageClassForTest)).To(Succeed())
+			vsHandler.ModifyRSSpecForCephFS(&testRsSpec, storageClassForTest)
+
+			Expect(testRsSpec.ProtectedPVC.AccessModes).To(Equal(
+				[]corev1.PersistentVolumeAccessMode{
+					corev1.ReadOnlyMany,
+				}))
 		})
 
 		Context("When the source PVC is not using a cephfs storageclass", func() {

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -759,6 +759,13 @@ func (v *VRGInstance) addConsistencyGroupLabel(pvc *corev1.PersistentVolumeClaim
 		return fmt.Errorf("missing storageID for PVC %s/%s", pvc.GetNamespace(), pvc.GetName())
 	}
 
+	// FIXME: a temporary workaround for issue DFBUGS-1209
+	// Remove this block once DFBUGS-1209 is fixed
+	storageID = "cephfs-" + storageID
+	if storageClass.Provisioner != DefaultCephFSCSIDriverName {
+		storageID = "rbd-" + storageID
+	}
+
 	// Add label for PVC, showing that this PVC is part of consistency group
 	return util.NewResourceUpdater(pvc).
 		AddLabel(ConsistencyGroupLabel, storageID).

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -437,7 +437,7 @@ func (v *VRGInstance) protectPVC(pvc *corev1.PersistentVolumeClaim, log logr.Log
 //     any further and it can be skipped. The pvc will go away eventually.
 func skipPVC(pvc *corev1.PersistentVolumeClaim, log logr.Logger) (bool, string) {
 	if pvc.Status.Phase != corev1.ClaimBound {
-		log.Info("Skipping handling of VR as PersistentVolumeClaim is not bound", "pvcPhase", pvc.Status.Phase)
+		log.Info("Skipping handling of VR as PVC is not bound", "pvcPhase", pvc.Status.Phase)
 
 		msg := "PVC not bound yet"
 		// v.updateProtectedPVCCondition(pvc.Name, VRGConditionReasonProgressing, msg)
@@ -451,7 +451,7 @@ func skipPVC(pvc *corev1.PersistentVolumeClaim, log logr.Logger) (bool, string) 
 func isPVCDeletedAndNotProtected(pvc *corev1.PersistentVolumeClaim, log logr.Logger) (bool, string) {
 	// If PVC deleted but not yet protected with a finalizer, skip it!
 	if !containsString(pvc.Finalizers, PvcVRFinalizerProtected) && rmnutil.ResourceIsDeleted(pvc) {
-		log.Info("Skipping PersistentVolumeClaim, as it is marked for deletion and not yet protected")
+		log.Info("Skipping PVC, as it is marked for deletion and not yet protected")
 
 		msg := "Skipping pvc marked for deletion"
 		// v.updateProtectedPVCCondition(pvc.Name, VRGConditionReasonProgressing, msg)

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -113,6 +113,12 @@ func (v *VRGInstance) reconcileVolSyncAsPrimary(finalSyncPrepared *bool) (requeu
 	}
 
 	for _, pvc := range v.volSyncPVCs {
+		if pvc.Status.Phase != corev1.ClaimBound {
+			v.log.Info("Skipping PVC - PVC is not Bound.", "name", pvc.GetName())
+
+			continue
+		}
+
 		requeuePVC := v.reconcilePVCAsVolSyncPrimary(pvc)
 		if requeuePVC {
 			requeue = true


### PR DESCRIPTION
- Enable VolSync protection on any PVC type through a DRPC annotation.
- Restrict ReadOnlyMany accessMode to temporary source CephFS PVCs.
- For non-Cephfs PVCs, the temporary source PVCs now inherit the accessModes of the source PVC (e.g., ReadWriteOnce or ReadWriteMany) instead of always ReadOnlyMany.
- On fresh deployment, delay the creation of tmp PVCs for consistency groups until the sync scheduled time.