### PR TITLE
vrg: cleanup rd when vrg is secondary

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,7 +47,6 @@ linters-settings:
       - name: error-strings
       - name: error-naming
       - name: exported
-      - name: if-return
       - name: increment-decrement
       - name: var-naming
       - name: var-declaration

--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -9,5 +9,3 @@ pvcspecs:
   - name: cephfs
     storageclassname: rook-cephfs
     accessmodes: ReadWriteMany
-    unsupportedDeployers:
-      - disapp

--- a/internal/controller/vrg_recipe.go
+++ b/internal/controller/vrg_recipe.go
@@ -81,7 +81,7 @@ func GetPVCSelector(ctx context.Context, reader client.Reader, vrg ramen.VolumeR
 ) (PvcSelector, error) {
 	recipeElements, err := RecipeElementsGet(ctx, reader, vrg, ramenConfig, log)
 	if err != nil {
-		return recipeElements.PvcSelector, err
+		return PvcSelector{}, err
 	}
 
 	return recipeElements.PvcSelector, nil


### PR DESCRIPTION
In processForDeletion, we cleanup the resources that are related to volsync. It relies on v.volSyncPVCs but the list is empty when the vrg is secondary because it is populated by looking at the vrg.status.ProtectedPVCs.

For managed applications, the RD,RS and Snapshots were being as a consequence of the deletion of VRG as the VRG is the owner for them.

In the case of discovered apps, the vrg is not the owner and therefore the RD was being left behind.