### PR TITLE
Volumes in recipes should be used to override LabelSelector and ignored for velero backups

### DIFF
--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -549,9 +549,10 @@ func (v *VRGInstance) processVRG() ctrl.Result {
 		}
 	}
 
-	if err := RecipeElementsGet(
-		v.ctx, v.reconciler.Client, *v.instance, *v.ramenConfig, v.log, &v.recipeElements,
-	); err != nil {
+	var err error
+
+	v.recipeElements, err = RecipeElementsGet(v.ctx, v.reconciler.Client, *v.instance, *v.ramenConfig, v.log)
+	if err != nil {
 		return v.invalid(err, "Failed to get recipe", false)
 	}
 

--- a/internal/controller/vrg_recipe.go
+++ b/internal/controller/vrg_recipe.go
@@ -81,25 +81,12 @@ func GetPVCSelector(ctx context.Context, reader client.Reader, vrg ramen.VolumeR
 ) (PvcSelector, error) {
 	var recipeElements RecipeElements
 
-	return recipeElements.PvcSelector, recipeVolumesAndOptionallyWorkflowsGet(
-		ctx, reader, vrg, ramenConfig, log, &recipeElements,
-		func(recipe.Recipe, *RecipeElements, ramen.VolumeReplicationGroup, ramen.RamenConfig) error {
-			return nil
-		},
-	)
+	return recipeElements.PvcSelector, RecipeElementsGet(
+		ctx, reader, vrg, ramenConfig, log, &recipeElements)
 }
 
 func RecipeElementsGet(ctx context.Context, reader client.Reader, vrg ramen.VolumeReplicationGroup,
 	ramenConfig ramen.RamenConfig, log logr.Logger, recipeElements *RecipeElements,
-) error {
-	return recipeVolumesAndOptionallyWorkflowsGet(ctx, reader, vrg, ramenConfig, log, recipeElements,
-		recipeWorkflowsGet,
-	)
-}
-
-func recipeVolumesAndOptionallyWorkflowsGet(ctx context.Context, reader client.Reader, vrg ramen.VolumeReplicationGroup,
-	ramenConfig ramen.RamenConfig, log logr.Logger, recipeElements *RecipeElements,
-	workflowsGet func(recipe.Recipe, *RecipeElements, ramen.VolumeReplicationGroup, ramen.RamenConfig) error,
 ) error {
 	if vrg.Spec.KubeObjectProtection == nil {
 		*recipeElements = RecipeElements{
@@ -145,7 +132,7 @@ func recipeVolumesAndOptionallyWorkflowsGet(ctx context.Context, reader client.R
 		PvcSelector: selector,
 	}
 
-	if err := workflowsGet(recipe, recipeElements, vrg, ramenConfig); err != nil {
+	if err := recipeWorkflowsGet(recipe, recipeElements, vrg, ramenConfig); err != nil {
 		return err
 	}
 

--- a/internal/controller/vrg_recipe.go
+++ b/internal/controller/vrg_recipe.go
@@ -79,31 +79,35 @@ func GetPVCSelector(ctx context.Context, reader client.Reader, vrg ramen.VolumeR
 	ramenConfig ramen.RamenConfig,
 	log logr.Logger,
 ) (PvcSelector, error) {
-	var recipeElements RecipeElements
+	recipeElements, err := RecipeElementsGet(ctx, reader, vrg, ramenConfig, log)
+	if err != nil {
+		return recipeElements.PvcSelector, err
+	}
 
-	return recipeElements.PvcSelector, RecipeElementsGet(
-		ctx, reader, vrg, ramenConfig, log, &recipeElements)
+	return recipeElements.PvcSelector, nil
 }
 
 func RecipeElementsGet(ctx context.Context, reader client.Reader, vrg ramen.VolumeReplicationGroup,
-	ramenConfig ramen.RamenConfig, log logr.Logger, recipeElements *RecipeElements,
-) error {
+	ramenConfig ramen.RamenConfig, log logr.Logger,
+) (RecipeElements, error) {
+	var recipeElements RecipeElements
+
 	if vrg.Spec.KubeObjectProtection == nil {
-		*recipeElements = RecipeElements{
+		recipeElements = RecipeElements{
 			PvcSelector: getPVCSelector(vrg, ramenConfig, nil, nil),
 		}
 
-		return nil
+		return recipeElements, nil
 	}
 
 	if vrg.Spec.KubeObjectProtection.RecipeRef == nil {
-		*recipeElements = RecipeElements{
+		recipeElements = RecipeElements{
 			PvcSelector:     getPVCSelector(vrg, ramenConfig, nil, nil),
 			CaptureWorkflow: captureWorkflowDefault(vrg, ramenConfig),
 			RecoverWorkflow: recoverWorkflowDefault(vrg, ramenConfig),
 		}
 
-		return nil
+		return recipeElements, nil
 	}
 
 	recipeNamespacedName := types.NamespacedName{
@@ -113,11 +117,11 @@ func RecipeElementsGet(ctx context.Context, reader client.Reader, vrg ramen.Volu
 
 	recipe := recipe.Recipe{}
 	if err := reader.Get(ctx, recipeNamespacedName, &recipe); err != nil {
-		return fmt.Errorf("recipe %v get error: %w", recipeNamespacedName.String(), err)
+		return recipeElements, fmt.Errorf("recipe %v get error: %w", recipeNamespacedName.String(), err)
 	}
 
 	if err := RecipeParametersExpand(&recipe, vrg.Spec.KubeObjectProtection.RecipeParameters, log); err != nil {
-		return err
+		return recipeElements, fmt.Errorf("recipe %v parameters expansion error: %w", recipeNamespacedName.String(), err)
 	}
 
 	var selector PvcSelector
@@ -128,15 +132,19 @@ func RecipeElementsGet(ctx context.Context, reader client.Reader, vrg ramen.Volu
 			recipe.Spec.Volumes.LabelSelector)
 	}
 
-	*recipeElements = RecipeElements{
+	recipeElements = RecipeElements{
 		PvcSelector: selector,
 	}
 
-	if err := recipeWorkflowsGet(recipe, recipeElements, vrg, ramenConfig); err != nil {
-		return err
+	if err := recipeWorkflowsGet(recipe, &recipeElements, vrg, ramenConfig); err != nil {
+		return recipeElements, fmt.Errorf("recipe %v workflows get error: %w", recipeNamespacedName.String(), err)
 	}
 
-	return recipeNamespacesValidate(*recipeElements, vrg, ramenConfig)
+	if err := recipeNamespacesValidate(recipeElements, vrg, ramenConfig); err != nil {
+		return recipeElements, fmt.Errorf("recipe %v namespaces validation error: %w", recipeNamespacedName.String(), err)
+	}
+
+	return recipeElements, nil
 }
 
 func RecipeParametersExpand(recipe *recipe.Recipe, parameters map[string][]string,


### PR DESCRIPTION
- Removed function pointer that changed behavior of the recipeVolumesAndOptionallyWorkflowsGet()
- RecipeElementsGet always returns complete recipe data
- Ignore volume group in a workflow sequence
- Fix tests