### PR TITLE
Use verbose gather log

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -79,7 +79,7 @@ jobs:
     - name: Gather environment data
       if: failure()
       working-directory: test
-      run: drenv gather --directory ${{ env.GATHER_DIR }} envs/regional-dr.yaml
+      run: drenv gather --directory ${{ env.GATHER_DIR }} envs/regional-dr.yaml --verbose
 
     # Tar manually to work around github limitations with special chracters (:)
     # in file names, and getting much smaller archives comapred with zip (6m vs

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -285,6 +285,8 @@ def do_gather(args):
         [p["name"] for p in env["profiles"]],
         directory=args.directory,
         namespaces=args.namespaces,
+        verbose=args.verbose,
+        name=env["name"],
     )
     logging.info(
         "[%s] Environment gathered in %.2f seconds",


### PR DESCRIPTION
Pass drenv --verbose flag to kubectl gather command to allow verbose gather logs, and add --verbose flag to the drenv gather job.

The second change is only for debugging and we probably want to revert it after we debug the issue of stuck gather job:
https://github.com/RamenDR/ramen/actions/runs/12712182155/job/35437188040