### PR TITLE
ci: Timeout gather job after 3 minutes

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -79,6 +79,8 @@ jobs:
     - name: Gather environment data
       if: failure()
       working-directory: test
+      # Gathering typically takes less than 15 seconds.
+      timeout_minutes: 3
       run: drenv gather --directory ${{ env.GATHER_DIR }} envs/regional-dr.yaml
 
     # Tar manually to work around github limitations with special chracters (:)


### PR DESCRIPTION
Gathering typically takes less than 15 seconds, but we have seen one case when it was stuck for 5 hours[1]. In this case the job was terminated without archiving the logs and we have no way to debug the issue.

Add a 3 minutes timeout to the gather job. If the command times out, we kill it and archive what we got. This is likely to collect enough logs to help debugging the original failure and the secondary gather failure (using gather.log).

[1] https://github.com/RamenDR/ramen/actions/runs/12712182155/job/35437188040