### PR TITLE
vrg: use reader instead of client for check hooks

### DIFF
--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -288,7 +288,7 @@ func (v *VRGInstance) kubeObjectsCaptureStartOrResume(
 
 func (v *VRGInstance) executeHook(hook kubeobjects.HookSpec, log1 logr.Logger) error {
 	if hook.Type == "check" {
-		hookResult, err := util.EvaluateCheckHook(v.reconciler.Client, &hook, log1)
+		hookResult, err := util.EvaluateCheckHook(v.reconciler.APIReader, &hook, log1)
 
 		if err != nil {
 			log1.Error(err, "error occurred during check hook ")


### PR DESCRIPTION
When using the cached client, we fail to find the resource if it is recently created.