### PR TITLE
Adding new SC and Pool for RBD

### DIFF
--- a/test/addons/rook-pool/replica-pool.yaml
+++ b/test/addons/rook-pool/replica-pool.yaml
@@ -5,7 +5,7 @@
 apiVersion: ceph.rook.io/v1
 kind: CephBlockPool
 metadata:
-  name: replicapool
+  name: $name
   namespace: rook-ceph
 spec:
   replicated:

--- a/test/addons/rook-pool/start
+++ b/test/addons/rook-pool/start
@@ -12,16 +12,28 @@ import yaml
 import drenv
 from drenv import kubectl
 
+POOL_NAMES = ["replicapool", "replicapool-2"]
+
 
 def deploy(cluster):
+    storage_classes = [
+        {"name": "rook-ceph-block", "pool": POOL_NAMES[0]},
+        {"name": "rook-ceph-block-2", "pool": POOL_NAMES[1]},
+    ]
 
-    print("Creating StorageClass")
-    template = drenv.template("storage-class.yaml")
-    yaml = template.substitute(cluster=cluster)
-    kubectl.apply("--filename=-", input=yaml, context=cluster)
+    print("Creating StorageClasses")
+    for storage_class in storage_classes:
+        template = drenv.template("storage-class.yaml")
+        yaml = template.substitute(
+            cluster=cluster, name=storage_class["name"], pool=storage_class["pool"]
+        )
+        kubectl.apply("--filename=-", input=yaml, context=cluster)
 
-    print("Creating RBD pool")
-    kubectl.apply("--filename=replica-pool.yaml", context=cluster)
+    print("Creating RBD pools")
+    for pool in POOL_NAMES:
+        template = drenv.template("replica-pool.yaml")
+        yaml = template.substitute(cluster=cluster, name=pool)
+        kubectl.apply("--filename=-", input=yaml, context=cluster)
 
     print("Creating SnapshotClass")
     template = drenv.template("snapshot-class.yaml")

--- a/test/addons/rook-pool/storage-class.yaml
+++ b/test/addons/rook-pool/storage-class.yaml
@@ -5,13 +5,13 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-    name: rook-ceph-block
+    name: $name
     labels:
         ramendr.openshift.io/storageid: rook-ceph-$cluster-1
 provisioner: rook-ceph.rbd.csi.ceph.com
 parameters:
     clusterID: rook-ceph
-    pool: replicapool
+    pool: $pool
     imageFormat: "2"
     imageFeatures: layering
     csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner


### PR DESCRIPTION
This commit adds a new storage class and pool for RBD, which allows the ramen code base to exercise the filtering logic when there are multiple storage classes in the environment. This also prepares the environment for scenarios where more than two workloads use different storage classes.