### PR TITLE
vrg: Add Kube object restore condition

### DIFF
--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -30,6 +30,10 @@ const (
 	// after this condition is true.
 	VRGConditionTypeClusterDataReady = "ClusterDataReady"
 
+	// Kube objects are ready. This condition is used to indicate that all the
+	// Kube objects required for the app to be active in the cluster are ready.
+	VRGConditionTypeKubeObjectsReady = "KubeObjectsReady"
+
 	// PV cluster data is protected.  This condition indicates whether an app,
 	// which is active in a cluster, has all its PV related cluster data
 	// protected from a disaster by uploading it to the required S3 store(s).
@@ -58,6 +62,7 @@ const (
 	VRGConditionReasonDataProtected               = "DataProtected"
 	VRGConditionReasonProgressing                 = "Progressing"
 	VRGConditionReasonClusterDataRestored         = "Restored"
+	VRGConditionReasonKubeObjectsRestored         = "KubeObjectsRestored"
 	VRGConditionReasonError                       = "Error"
 	VRGConditionReasonErrorUnknown                = "UnknownError"
 	VRGConditionReasonUploading                   = "Uploading"
@@ -110,6 +115,14 @@ func setVRGInitialCondition(conditions *[]metav1.Condition, observedGeneration i
 	})
 	setStatusConditionIfNotFound(conditions, metav1.Condition{
 		Type:               VRGConditionTypeClusterDataProtected,
+		Reason:             VRGConditionReasonInitializing,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionUnknown,
+		LastTransitionTime: time,
+		Message:            message,
+	})
+	setStatusConditionIfNotFound(conditions, metav1.Condition{
+		Type:               VRGConditionTypeKubeObjectsReady,
 		Reason:             VRGConditionReasonInitializing,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionUnknown,
@@ -369,6 +382,28 @@ func newVRGClusterDataUnprotectedCondition(observedGeneration int64, reason, mes
 		Status:             metav1.ConditionFalse,
 		Message:            message,
 	}
+}
+
+// sets conditions when Kube objects are restored
+func setVRGKubeObjectsReadyCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               VRGConditionTypeKubeObjectsReady,
+		Reason:             VRGConditionReasonKubeObjectsRestored,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+}
+
+// sets conditions when Kube objects failed to restore
+func setVRGKubeObjectsErrorCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               VRGConditionTypeKubeObjectsReady,
+		Reason:             VRGConditionReasonError,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
 }
 
 func setStatusConditionIfNotFound(existingConditions *[]metav1.Condition, newCondition metav1.Condition) {

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -641,9 +641,11 @@ func (v *VRGInstance) clusterDataRestore(result *ctrl.Result) (int, error) {
 	}
 
 	// Only after both succeed, we mark ClusterDataReady as true
-	msg := "Restored PVs and PVCs"
+	var msg string
 	if numRestoredForVS+numRestoredForVR == 0 {
 		msg = "Nothing to restore"
+	} else {
+		msg = fmt.Sprintf("Restored %d volsync PVs/PVCs and %d volrep PVs/PVCs", numRestoredForVS, numRestoredForVR)
 	}
 
 	setVRGClusterDataReadyCondition(&v.instance.Status.Conditions, v.instance.Generation, msg)
@@ -1183,6 +1185,22 @@ func (v *VRGInstance) processAsPrimary() ctrl.Result {
 
 	v.reconcileAsPrimary()
 
+	if v.shouldRestoreKubeObjects() {
+		err := v.kubeObjectsRecover(&v.result)
+		if err != nil {
+			v.log.Info("Kube objects restore failed", "error", err)
+			v.errorConditionLogAndSet(err, "Failed to restore kube objects", setVRGKubeObjectsErrorCondition)
+
+			return v.updateVRGStatus(v.result)
+		}
+
+		v.log.Info("Kube objects restored")
+		setVRGKubeObjectsReadyCondition(&v.instance.Status.Conditions, v.instance.Generation, "Kube objects restored")
+	}
+
+	v.kubeObjectsProtectPrimary(&v.result)
+	v.vrgObjectProtect(&v.result)
+
 	// If requeue is false, then VRG was successfully processed as primary.
 	// Hence the event to be generated is Success of type normal.
 	// Expectation is that, if something failed and requeue is true, then
@@ -1224,6 +1242,28 @@ func (v *VRGInstance) shouldRestoreClusterData() bool {
 	return true
 }
 
+func (v *VRGInstance) shouldRestoreKubeObjects() bool {
+	KubeObjectsRestored := findCondition(v.instance.Status.Conditions, VRGConditionTypeKubeObjectsReady)
+	if KubeObjectsRestored != nil {
+		v.log.Info("KubeObjectsReady condition",
+			"status", KubeObjectsRestored.Status,
+			"reason", KubeObjectsRestored.Reason,
+			"message", KubeObjectsRestored.Message,
+			"observedGeneration", KubeObjectsRestored.ObservedGeneration,
+			"generation", v.instance.Generation,
+		)
+
+		if KubeObjectsRestored.Status == metav1.ConditionTrue &&
+			KubeObjectsRestored.ObservedGeneration == v.instance.Generation {
+			v.log.Info("VRG's KubeObjectsReady condition found. All kube objects must have already been restored")
+
+			return false
+		}
+	}
+
+	return true
+}
+
 func (v *VRGInstance) reconcileAsPrimary() {
 	var finalSyncPrepared struct {
 		volSync bool
@@ -1232,8 +1272,6 @@ func (v *VRGInstance) reconcileAsPrimary() {
 	vrg := v.instance
 	v.result.Requeue = v.reconcileVolSyncAsPrimary(&finalSyncPrepared.volSync)
 	v.reconcileVolRepsAsPrimary()
-	v.kubeObjectsProtectPrimary(&v.result)
-	v.vrgObjectProtect(&v.result)
 
 	if vrg.Spec.PrepareForFinalSync {
 		vrg.Status.PrepareForFinalSyncComplete = finalSyncPrepared.volSync

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -2044,7 +2044,7 @@ func (v *VRGInstance) restorePVsAndPVCsFromS3(result *ctrl.Result) (int, error) 
 
 		v.log.Info(fmt.Sprintf("Restored %d PVs and %d PVCs using profile %s", pvCount, pvcCount, s3ProfileName))
 
-		return pvCount + pvcCount, v.kubeObjectsRecover(result, s3ProfileName)
+		return pvCount + pvcCount, nil
 	}
 
 	if NoS3 {


### PR DESCRIPTION
Earlier, we used to restore kube objects along with PV and PVCs.

However, with the introduction of hooks this is not correct. The hooks depend on the successful restoration of the PV and PVCs to succeed. There is a strict dependency in the order of operations and both cannot be performed in the same function call.

We introduce a new condition to keep track of the restore status for Kube Objects. Once the pv and pvcs are restored then we proceed to the kube objects restoration.