### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# For supported syntax see docs:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners if there is no more specific rule.
+*   @ShyamsundarR @BenamarMk
+
+# volrep
+/internal/controllers/vrg_volrep*.go    @ShyamsundarR @ELENAGER
+
+# volsync
+/internal/controllers/volsync/          @BenamarMk @ELENAGER
+/internal/controllers/vrg_volsync*.go   @BenamarMk @ELENAGER
+
+# cephfs consistency groups
+/internal/controllers/cephfscg/     @BenamarMk @ELENAGER
+
+# Metrics
+/docs/metrics.md                    @rakeshgm @ShyamsundarR
+/internal/controllers/metrics.go    @rakeshgm @ShyamsundarR
+/internal/controllers/cel/          @rakeshgm @ShyamsundarR
+
+# Kube object protection
+/docs/recipe.md                             @raghavendra-talur @ShyamsundarR
+/docs/krp.md                                @raghavendra-talur @ShyamsundarR
+/internal/controllers/kubeobjects/          @raghavendra-talur @ShyamsundarR
+/internal/controllers/vrg_kubeobjects*.go   @raghavendra-talur @ShyamsundarR
+/internal/controllers/vrg_recipe*.go        @raghavendra-talur @ShyamsundarR
+
+# Testing
+/test/                          @nirs @raghavendra-talur
+/e2e/                           @nirs @raghavendra-talur
+/docs/testing.md                @nirs @raghavendra-talur
+/docs/devel-quick-start.md      @nirs @raghavendra-talur
+/docs/user-quick-start.md       @nirs @raghavendra-talur


### PR DESCRIPTION
The CODEOWNERS[1] file define individuals or teams that are responsible for code in a repository.

People with write permissions for the repository can create or edit the CODEOWNERS file and be listed as code owners. People with admin or owner permissions can require that pull requests have to be approved by code owners before they can be merged.

How this change the development flow?

- When a pull request is created, owners of file touched by the pull request are added automatically as reviewers. This improves the experience for new contributors.

- Using branch protection we can require that at least one of the owners will approve the pull request before it can be merged.

- New contributors can learn who owns the code that want to change.

Issues:
- Need a second owner for most rules, both for another  review, and to avoid blocking merge if a single code owner is not available.

[1] https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

Fixes: #1766