### PR TITLE
Add new SC Names and Pools for Ceph-FS

### DIFF
--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -7,5 +7,5 @@ pvcspecs:
     storageclassname: rook-ceph-block
     accessmodes: ReadWriteOnce
   - name: cephfs
-    storageclassname: rook-cephfs
+    storageclassname: rook-cephfs-test-fs1
     accessmodes: ReadWriteMany

--- a/test/addons/rook-cephfs/filesystem.yaml
+++ b/test/addons/rook-cephfs/filesystem.yaml
@@ -10,7 +10,7 @@
 apiVersion: ceph.rook.io/v1
 kind: CephFilesystem
 metadata:
-  name: myfs
+  name: $name
   namespace: rook-ceph
 spec:
   metadataPool:

--- a/test/addons/rook-cephfs/provision-test/pvc.yaml
+++ b/test/addons/rook-cephfs/provision-test/pvc.yaml
@@ -12,4 +12,4 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  storageClassName: rook-cephfs
+  storageClassName: rook-cephfs-test-fs1

--- a/test/addons/rook-cephfs/start
+++ b/test/addons/rook-cephfs/start
@@ -9,16 +9,20 @@ import sys
 import drenv
 from drenv import kubectl
 
+FILE_SYSTEMS = ["test-fs1", "test-fs2"]
+
 
 def deploy(cluster):
+    for file_system in FILE_SYSTEMS:
+        print("Creating CephFS instance")
+        template = drenv.template("filesystem.yaml")
+        yaml = template.substitute(cluster=cluster, name=file_system)
+        kubectl.apply("--filename=-", input=yaml, context=cluster)
 
-    print("Creating CephFS instance")
-    kubectl.apply("--filename=filesystem.yaml", context=cluster)
-
-    print("Creating StorageClass")
-    template = drenv.template("storage-class.yaml")
-    yaml = template.substitute(cluster=cluster)
-    kubectl.apply("--filename=-", input=yaml, context=cluster)
+        print("Creating StorageClass")
+        template = drenv.template("storage-class.yaml")
+        yaml = template.substitute(cluster=cluster, fsname=file_system)
+        kubectl.apply("--filename=-", input=yaml, context=cluster)
 
     print("Creating SnapshotClass")
     template = drenv.template("snapshot-class.yaml")
@@ -27,21 +31,23 @@ def deploy(cluster):
 
 
 def wait(cluster):
-    print("Waiting until CephFS is ready")
-    drenv.wait_for(
-        "cephfilesystem/myfs",
-        output="jsonpath={.status.phase}",
-        namespace="rook-ceph",
-        timeout=120,
-        profile=cluster,
-    )
-    kubectl.wait(
-        "cephfilesystem/myfs",
-        "--for=jsonpath={.status.phase}=Ready",
-        "--namespace=rook-ceph",
-        "--timeout=300s",
-        context=cluster,
-    )
+    print("Waiting until Ceph File Systems are ready")
+
+    for file_system in FILE_SYSTEMS:
+        drenv.wait_for(
+            f"cephfilesystem/{file_system}",
+            output="jsonpath={.status.phase}",
+            namespace="rook-ceph",
+            timeout=120,
+            profile=cluster,
+        )
+        kubectl.wait(
+            f"cephfilesystem/{file_system}",
+            "--for=jsonpath={.status.phase}=Ready",
+            "--namespace=rook-ceph",
+            "--timeout=300s",
+            context=cluster,
+        )
 
 
 if len(sys.argv) != 2:

--- a/test/addons/rook-cephfs/storage-class.yaml
+++ b/test/addons/rook-cephfs/storage-class.yaml
@@ -9,14 +9,14 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: rook-cephfs
+  name: rook-cephfs-$fsname
   labels:
     ramendr.openshift.io/storageid: rook-cephfs-$cluster-1
 provisioner: rook-ceph.cephfs.csi.ceph.com
 parameters:
   clusterID: rook-ceph
-  fsName: myfs
-  pool: myfs-replicated
+  fsName: $fsname
+  pool: $fsname-replicated
   csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
   csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
   csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner

--- a/test/addons/volsync/app/file/kustomization.yaml
+++ b/test/addons/volsync/app/file/kustomization.yaml
@@ -14,7 +14,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/storageClassName
-        value: rook-cephfs
+        value: rook-cephfs-test-fs1
       - op: replace
         path: /spec/accessModes
         value:

--- a/test/addons/volsync/rd/file/kustomization.yaml
+++ b/test/addons/volsync/rd/file/kustomization.yaml
@@ -13,7 +13,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/storageClassName
-        value: rook-cephfs
+        value: rook-cephfs-test-fs1
       - op: replace
         path: /spec/accessModes
         value:
@@ -27,7 +27,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/rsyncTLS/storageClassName
-        value: rook-cephfs
+        value: rook-cephfs-test-fs1
       - op: replace
         path: /spec/rsyncTLS/volumeSnapshotClassName
         value: csi-cephfsplugin-snapclass


### PR DESCRIPTION
These commit adds a new storage classes and pools for Cephfs, which
allows the ramen code base to exercise the filtering logic when there
are multiple storage classes in the environment. This also prepares the
environment for scenarios where more than two workloads use different
storage classes.

The older Ceph-FS names have been renamed and  accordingly the
changes have been made to the other test files like drenv-self-tests 
and e2e
