### PR TITLE
Improve logging when annotating pvc/pv after upload to s3

### DIFF
--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -1933,6 +1933,9 @@ func (v *VRGInstance) addArchivedAnnotationForPVC(pvc *corev1.PersistentVolumeCl
 			v.instance.Name, err)
 	}
 
+	log.Info("Annotated PersistentVolumeClaim", "namespace", pvc.Namespace, "name", pvc.Name, "key",
+		pvcVRAnnotationArchivedKey, "value", pvcAnnotationValue)
+
 	pv, err := v.getPVFromPVC(pvc)
 	if err != nil {
 		log.Error(err, "Failed to get PV to add archived annotation")
@@ -1955,6 +1958,9 @@ func (v *VRGInstance) addArchivedAnnotationForPVC(pvc *corev1.PersistentVolumeCl
 			"VolumeReplicationGroup (%s/%s), %w",
 			pvc.Name, pvcVRAnnotationArchivedKey, pvAnnotationValue, v.instance.Namespace, v.instance.Name, err)
 	}
+
+	log.Info("Annotated PersistentVolume", "name", pv.Name, "key", pvcVRAnnotationArchivedKey, "value",
+		pvAnnotationValue)
 
 	return nil
 }


### PR DESCRIPTION
Log successful archived annotation with the annotation key and value, so it is easy to understand when the system state was changed.

If annotation failed, include also the annotation value in the error to make it easier to understand the system state at the point of the error.

Log the same annotation error once instead of logging multiple times with different log levels at multiple functions. The error is logged now at the top level reconcileVolRepsAsPrimary().

Result of debugging this CI failure:
https://github.com/RamenDR/ramen/actions/runs/12978252037/job/36221844090