### PR TITLE
volrep: Fix and simplify archived annotation functions

### DIFF
--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -576,9 +576,6 @@ func (v *VRGInstance) generateArchiveAnnotation(gen int64) string {
 }
 
 func (v *VRGInstance) isArchivedAlready(pvc *corev1.PersistentVolumeClaim, log logr.Logger) bool {
-	pvHasAnnotation := false
-	pvcHasAnnotation := false
-
 	pv, err := v.getPVFromPVC(pvc)
 	if err != nil {
 		log.Error(err, "Failed to get PV to check if archived")
@@ -586,17 +583,11 @@ func (v *VRGInstance) isArchivedAlready(pvc *corev1.PersistentVolumeClaim, log l
 		return false
 	}
 
-	pvcDesiredValue := v.generateArchiveAnnotation(pvc.Generation)
-	if v, ok := pvc.ObjectMeta.Annotations[pvcVRAnnotationArchivedKey]; ok && (v == pvcDesiredValue) {
-		pvcHasAnnotation = true
+	if pvc.Annotations[pvcVRAnnotationArchivedKey] != v.generateArchiveAnnotation(pvc.Generation) {
+		return false
 	}
 
-	pvDesiredValue := v.generateArchiveAnnotation(pv.Generation)
-	if v, ok := pv.ObjectMeta.Annotations[pvcVRAnnotationArchivedKey]; ok && (v == pvDesiredValue) {
-		pvHasAnnotation = true
-	}
-
-	if !pvHasAnnotation || !pvcHasAnnotation {
+	if pv.Annotations[pvcVRAnnotationArchivedKey] != v.generateArchiveAnnotation(pv.Generation) {
 		return false
 	}
 

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -573,7 +572,7 @@ func undoPVRetention(pv *corev1.PersistentVolume) {
 }
 
 func (v *VRGInstance) generateArchiveAnnotation(gen int64) string {
-	return fmt.Sprintf("%s-%s", pvcVRAnnotationArchivedVersionV1, strconv.Itoa(int(gen)))
+	return fmt.Sprintf("%s-%d", pvcVRAnnotationArchivedVersionV1, gen)
 }
 
 func (v *VRGInstance) isArchivedAlready(pvc *corev1.PersistentVolumeClaim, log logr.Logger) bool {


### PR DESCRIPTION
Fix and simplify archived annotation value, and the way we check if PVC and PV are already archived.

Result of debugging this CI failure:
https://github.com/RamenDR/ramen/actions/runs/12978252037/job/36221844090