### PR TITLE
e2e: add logfile for e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ ramenctl/build
 # Generated disk images
 *.qcow2
 *.iso
+
+# e2e generated files
+/e2e/ramen-e2e
+/e2e/ramen-e2e.log

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ramendr/ramen/e2e/test"
 	"github.com/ramendr/ramen/e2e/util"
-	"go.uber.org/zap"
 )
 
 func init() {
@@ -22,12 +21,11 @@ func TestMain(m *testing.M) {
 
 	flag.Parse()
 
-	logger, err := zap.NewDevelopment()
+	log, err := test.CreateLogger()
 	if err != nil {
 		panic(err)
 	}
-
-	log := logger.Sugar()
+	// TODO: Sync the log on exit
 
 	util.Ctx, err = util.NewContext(log, util.ConfigFile)
 	if err != nil {

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -10,4 +10,4 @@ set -o pipefail
 go test -c -o ramen-e2e
 
 # With an executable -test.timeout is disabled by default.
-./ramen-e2e -test.v "$@" 2>&1 | tee ramen-e2e.log
+./ramen-e2e -test.v "$@"

--- a/e2e/test/log.go
+++ b/e2e/test/log.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+const logFilePath = "ramen-e2e.log"
+
+func CreateLogger() (*zap.SugaredLogger, error) {
+	// Console encoder config
+	consoleConfig := zap.NewProductionEncoderConfig()
+	consoleConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	consoleConfig.EncodeLevel = zapcore.CapitalLevelEncoder
+	consoleConfig.CallerKey = zapcore.OmitKey
+	consoleEncoder := zapcore.NewConsoleEncoder(consoleConfig)
+
+	// Logfile encoder config
+	logfileConfig := zap.NewProductionEncoderConfig()
+	logfileConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logfileConfig.EncodeLevel = zapcore.CapitalLevelEncoder
+	logfileEncoder := zapcore.NewConsoleEncoder(logfileConfig)
+
+	logfile, err := os.Create(logFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	core := zapcore.NewTee(
+		zapcore.NewCore(logfileEncoder, zapcore.AddSync(logfile), zapcore.DebugLevel),
+		zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stderr), zapcore.InfoLevel),
+	)
+	logger := zap.New(core).Sugar()
+
+	return logger, nil
+}


### PR DESCRIPTION
* Creates a log file (ramen-e2e.log) in the current directory by default.
* Log DEBUG level messages to the file and INFO level messages to the console.
* Remove caller (file:lineno) from console logs for cleaner output.
* Added ramen-e2e and ramen-e2e.log to gitignore
* Reverted https://github.com/RamenDR/ramen/commit/2cd063a6d10369806fab970a00a2f1e8820beb93 , which previously redirected e2e test logs to ramen-e2e.log using tee. This change is no longer needed because the new logger implementation now writes to ramen-e2e.log by default.



Fixes: #1722 