### PR TITLE
e2e: Refine sample config comment

### DIFF
--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -1,6 +1,6 @@
----
-# Configuration file for RamenDR E2E testing on Regional DR.
+# Configuration for RamenDR End to End testing.
 
+---
 # Name of the channel used for the Channel CR. This channel is used by
 # OCM to pull the application from the specified Git repository.
 channelname: "ramen-gitops"


### PR DESCRIPTION
- Replace "E2E" with "End to End"
- Remove unneeded "file"
- Remove RegionalDR, this configuration is not specific to Regional DR
- Move the file comment outside of the yaml document