### PR TITLE
Eliminate channel name configuration

### DIFF
--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -1,10 +1,6 @@
 # Configuration for RamenDR End to End testing.
 
 ---
-# Name of the channel used for the Channel CR. This channel is used by
-# OCM to pull the application from the specified Git repository.
-channelname: "ramen-gitops"
-
 # Namespace where the channel CR will be created.
 channelnamespace: "ramen-samples"
 

--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -2,7 +2,7 @@
 
 ---
 # Namespace where the channel CR will be created.
-channelnamespace: "ramen-samples"
+channelnamespace: "e2e-gitops"
 
 # Git repository URL containing application manifests to be deployed on
 # the clusters.

--- a/e2e/util/channel.go
+++ b/e2e/util/channel.go
@@ -48,9 +48,9 @@ func createChannel() error {
 			return err
 		}
 
-		Ctx.Log.Infof("Channel %q already exists", GetChannelName())
+		Ctx.Log.Debugf("Channel \"%s/%s\" already exists", GetChannelNamespace(), GetChannelName())
 	} else {
-		Ctx.Log.Infof("Created channel %q", GetChannelName())
+		Ctx.Log.Infof("Created channel \"%s/%s\"", GetChannelNamespace(), GetChannelName())
 	}
 
 	return nil
@@ -70,9 +70,9 @@ func deleteChannel() error {
 			return err
 		}
 
-		Ctx.Log.Infof("Channel %q not found", GetChannelName())
+		Ctx.Log.Debugf("Channel \"%s/%s\" not found", GetChannelNamespace(), GetChannelName())
 	} else {
-		Ctx.Log.Infof("Channel %q is deleted", GetChannelName())
+		Ctx.Log.Infof("Deleted channel \"%s/%s\"", GetChannelNamespace(), GetChannelName())
 	}
 
 	return nil

--- a/e2e/util/config.go
+++ b/e2e/util/config.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultChannelNamespace = "ramen-samples"
+	defaultChannelNamespace = "e2e-gitops"
 	defaultGitURL           = "https://github.com/RamenDR/ocm-ramen-samples.git"
 )
 

--- a/e2e/util/config.go
+++ b/e2e/util/config.go
@@ -5,13 +5,14 @@ package util
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 )
 
 const (
-	defaultChannelName      = "ramen-gitops"
 	defaultChannelNamespace = "ramen-samples"
 	defaultGitURL           = "https://github.com/RamenDR/ocm-ramen-samples.git"
 )
@@ -23,26 +24,27 @@ type PVCSpec struct {
 	UnsupportedDeployers []string
 }
 type TestConfig struct {
-	ChannelName      string
+	// User configurable values.
 	ChannelNamespace string
 	GitURL           string
 	Clusters         map[string]struct {
 		KubeconfigPath string
 	}
 	PVCSpecs []PVCSpec
+
+	// Generated values
+	channelName string
 }
 
-var config = &TestConfig{}
+var (
+	resourceNameForbiddenCharacters *regexp.Regexp
+	config                          = &TestConfig{}
+)
 
 //nolint:cyclop
 func ReadConfig(log *zap.SugaredLogger, configFile string) error {
-	viper.SetDefault("ChannelName", defaultChannelName)
 	viper.SetDefault("ChannelNamespace", defaultChannelNamespace)
 	viper.SetDefault("GitURL", defaultGitURL)
-
-	if err := viper.BindEnv("ChannelName", "ChannelName"); err != nil {
-		return (err)
-	}
 
 	if err := viper.BindEnv("ChannelNamespace", "ChannelNamespace"); err != nil {
 		return (err)
@@ -84,11 +86,13 @@ func ReadConfig(log *zap.SugaredLogger, configFile string) error {
 		return fmt.Errorf("failed to find pvcs in configuration")
 	}
 
+	config.channelName = resourceName(config.GitURL)
+
 	return nil
 }
 
 func GetChannelName() string {
-	return config.ChannelName
+	return config.channelName
 }
 
 func GetChannelNamespace() string {
@@ -101,4 +105,16 @@ func GetGitURL() string {
 
 func GetPVCSpecs() []PVCSpec {
 	return config.PVCSpecs
+}
+
+// resourceName convert a URL to conventional k8s resource name:
+// "https://github.com/foo/bar.git" -> "https-github-com-foo-bar-git"
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+func resourceName(url string) string {
+	return strings.ToLower(resourceNameForbiddenCharacters.ReplaceAllString(url, "-"))
+}
+
+func init() {
+	// Matches one of more forbidden characters, so we can replace them with single replacement character.
+	resourceNameForbiddenCharacters = regexp.MustCompile(`[^\w]+`)
 }


### PR DESCRIPTION
Generate the channel name from the git URL instead of complicating the config file and improve channel namespace name.