### PR TITLE
drenv: unify clusteradm & subctl install instructions

### DIFF
--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -141,14 +141,26 @@ enough resources:
    drenv is set up properly
    ```
 
-1. Install `clusteradm` tool. See
-   [Install clusteradm CLI tool](https://open-cluster-management.io/docs/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool)
-   for the details.
-   Version v0.8.1 or later is reuired.
+1. Install the `clusteradm` tool
 
-1. Install `subctl` tool, See
-   [Submariner subctl installation](https://submariner.io/operations/deployment/subctl/)
-   for the details.
+   ```
+   curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+   ```
+
+   For more info see
+   [Install clusteradm CLI tool](https://open-cluster-management.io/docs/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool).
+   Version v0.8.1 or later is required.
+
+1. Install the `subctl` tool
+
+   ```
+   curl -Ls https://get.submariner.io | bash
+   sudo install .local/bin/subctl /usr/local/bin/
+   rm .local/bin/subctl
+   ```
+
+   For more info see
+   [Submariner subctl installation](https://submariner.io/operations/deployment/subctl/).
    Version v0.18.0 or later is required.
 
 1. Install the `velero` tool

--- a/test/README.md
+++ b/test/README.md
@@ -41,14 +41,26 @@ environment.
    [Install and Set Up kubectl on Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
    Tested with version v1.31.3.
 
-1. Install `clusteradm` tool. See
-   [Install clusteradm CLI tool](https://open-cluster-management.io/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool)
-   for the details.
-   Version v0.8.1 or later is reuired.
+1. Install the `clusteradm` tool
 
-1. Install `subctl` tool, See
-   [Submariner subctl installation](https://submariner.io/operations/deployment/subctl/)
-   for the details.
+   ```
+   curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+   ```
+
+   For more info see
+   [Install clusteradm CLI tool](https://open-cluster-management.io/docs/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool).
+   Version v0.8.1 or later is required.
+
+1. Install the `subctl` tool
+
+   ```
+   curl -Ls https://get.submariner.io | bash
+   sudo install .local/bin/subctl /usr/local/bin/
+   rm .local/bin/subctl
+   ```
+
+   For more info see
+   [Submariner subctl installation](https://submariner.io/operations/deployment/subctl/).
    Version v0.18.0 or later is required.
 
 1. Install the `velero` tool
@@ -147,13 +159,27 @@ environment.
    lima version 1.0.0 or later is required, latest version is
    recommended.
 
-1. Install the `clusteradm` tool. See
-   [Install clusteradm CLI tool](https://open-cluster-management.io/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool)
-   for the details. Version v0.8.1 or later is required.
+1. Install the `clusteradm` tool
 
-1. Install the `subctl` tool, See
-   [Submariner subctl installation](https://submariner.io/operations/deployment/subctl/)
-   for the details. Version v0.18.0 or later is required.
+   ```
+   curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+   ```
+
+   For more info see
+   [Install clusteradm CLI tool](https://open-cluster-management.io/docs/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool).
+   Version v0.8.1 or later is required.
+
+1. Install the `subctl` tool
+
+   ```
+   curl -Ls https://get.submariner.io | bash
+   sudo install .local/bin/subctl /usr/local/bin/
+   rm .local/bin/subctl
+   ```
+
+   For more info see
+   [Submariner subctl installation](https://submariner.io/operations/deployment/subctl/).
+   Version v0.18.0 or later is required.
 
 1. Install the `kubectl-gather` plugin
 


### PR DESCRIPTION
Addressed: 
1. Updated the steps for installing clusteradm and subctl to follow a consistent pattern(similar to kubectl tool) in test/README.md and docs/user-quick-start.md.
2. Fixed broken link for clusteradm installation guide

Fixes #1776 
