### PR TITLE
drenv macOS: Update lima to 1.0.4 & install qemu dependency

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -138,6 +138,7 @@ environment.
        helm \
        kubectl \
        kustomize \
+       qemu \
        lima \
        minio-mc \
        velero \
@@ -145,7 +146,7 @@ environment.
    ```
 
    lima version 1.0.0 or later is required, latest version is
-   recommended.
+   recommended. Tested with lima version 1.0.4.
 
 1. Install the `clusteradm` tool. See
    [Install clusteradm CLI tool](https://open-cluster-management.io/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool)


### PR DESCRIPTION

* Tested with env/regional-dr.yaml cluster creation on mac, [log](https://github.com/RamenDR/ramen/issues/1763#issuecomment-2621643613)
* Updated lima version in test/README.md
* Updated test/README.md to install qemu for macOS due to lima dependency with qemu ([issue #3169](https://github.com/lima-vm/lima/issues/3169))

Fixes #1763 