### PR TITLE
e2e: Don't hide test failures

### DIFF
--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -1,4 +1,7 @@
-#!/bin/sh
+#!/bin/bash
+
+set -eu
+set -o pipefail
 
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Test failure is hidden because we pipe the output to tee. Change the script to use bash and enable error checking.