### PR TITLE
lint: increase the funlen threshold to 100 lines

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,8 @@ run:
 
 # all available settings of specific linters
 linters-settings:
+  funlen:
+    lines: 100
   errcheck:
     # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
     # default is false: such cases aren't reported by default.


### PR DESCRIPTION
Funlen is a good linter and it is useful to make developers to write functions that fit on the screen. But GO is a verbose language and it is very hard to fit functions within the default of 60 lines.

A 1920x1080 monitor typically shows 50 lines on the screen, in this PR we increase the funlen threshold to double of that.