### PR TITLE
e2e: Enable caller info and stacktraces in e2e logfile

### DIFF
--- a/e2e/test/log.go
+++ b/e2e/test/log.go
@@ -13,14 +13,15 @@ import (
 const logFilePath = "ramen-e2e.log"
 
 func CreateLogger() (*zap.SugaredLogger, error) {
-	// Console encoder config
+	// In the console we don't want details such as file:line or stacktraces.
 	consoleConfig := zap.NewProductionEncoderConfig()
 	consoleConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	consoleConfig.EncodeLevel = zapcore.CapitalLevelEncoder
 	consoleConfig.CallerKey = zapcore.OmitKey
+	consoleConfig.StacktraceKey = zapcore.OmitKey
 	consoleEncoder := zapcore.NewConsoleEncoder(consoleConfig)
 
-	// Logfile encoder config
+	// In the log file we want everything that can help to debug failure.
 	logfileConfig := zap.NewProductionEncoderConfig()
 	logfileConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	logfileConfig.EncodeLevel = zapcore.CapitalLevelEncoder
@@ -35,7 +36,7 @@ func CreateLogger() (*zap.SugaredLogger, error) {
 		zapcore.NewCore(logfileEncoder, zapcore.AddSync(logfile), zapcore.DebugLevel),
 		zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stderr), zapcore.InfoLevel),
 	)
-	logger := zap.New(core).Sugar()
+	logger := zap.New(core, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel))
 
-	return logger, nil
+	return logger.Sugar(), nil
 }


### PR DESCRIPTION
When using zap.New we need to add options to enable these features. The 
feature will be applied to cores that did not disable the feature.

We disable now stacktraces in the console to keep the log cleaner. The 
logfile in the build artifacts contains all the possible info that can 
help to debug issues.

Finally improve the comments to explain why we configure the logfile and 
console logs differently.

Example error in the console log:

    2025-02-02T09:06:37.285+0530        ERROR   subscr-deploy-cephfs-busybox    fake error for testing logging

In the logfile we see the same error with caller info and stacktrace:

    2025-02-02T09:06:37.285+0530    ERROR   subscr-deploy-cephfs-busybox    test/testing.go:49      fake error for testing logging
    github.com/ramendr/ramen/e2e/test.(*T).Fatal
            /home/github/actions-runner/_work/ramen/ramen/e2e/test/testing.go:49
    github.com/ramendr/ramen/e2e_test.runTestFlow
            /home/github/actions-runner/_work/ramen/ramen/e2e/exhaustive_suite_test.go:111
    github.com/ramendr/ramen/e2e_test.Exhaustive.func2
            /home/github/actions-runner/_work/ramen/ramen/e2e/exhaustive_suite_test.go:74
    testing.tRunner
            /usr/local/go/src/testing/testing.go:1690
