### PR TITLE
e2e: enhance e2e logs for Failover and Relocate actions with cluster details

### DIFF
--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -119,10 +119,30 @@ func Failover(ctx types.Context) error {
 
 	managementNamespace := ctx.ManagementNamespace()
 	log := ctx.Logger()
+	name := ctx.Name()
 
-	log.Infof("Failing over workload in namespace %q", managementNamespace)
+	drpcName := name
+	client := util.Ctx.Hub.Client
+	drPolicyName := util.DefaultDRPolicyName
 
-	return failoverRelocate(ctx, ramen.ActionFailover, ramen.FailedOver)
+	currentCluster, err := getCurrentCluster(client, managementNamespace, name)
+	if err != nil {
+		return err
+	}
+
+	drpolicy, err := util.GetDRPolicy(client, drPolicyName)
+	if err != nil {
+		return err
+	}
+
+	targetCluster, err := getTargetCluster(client, managementNamespace, drpcName, drpolicy)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Failing over workload from cluster %q to cluster %q", currentCluster, targetCluster)
+
+	return failoverRelocate(ctx, ramen.ActionFailover, ramen.FailedOver, targetCluster)
 }
 
 // Determine DRPC
@@ -137,18 +157,38 @@ func Relocate(ctx types.Context) error {
 
 	managementNamespace := ctx.ManagementNamespace()
 	log := ctx.Logger()
+	name := ctx.Name()
 
-	log.Infof("Relocating workload in namespace %q", managementNamespace)
+	drpcName := name
+	client := util.Ctx.Hub.Client
+	drPolicyName := util.DefaultDRPolicyName
 
-	return failoverRelocate(ctx, ramen.ActionRelocate, ramen.Relocated)
+	currentCluster, err := getCurrentCluster(client, managementNamespace, name)
+	if err != nil {
+		return err
+	}
+
+	drpolicy, err := util.GetDRPolicy(client, drPolicyName)
+	if err != nil {
+		return err
+	}
+
+	targetCluster, err := getTargetCluster(client, managementNamespace, drpcName, drpolicy)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Relocating workload from cluster %q to cluster %q", currentCluster, targetCluster)
+
+	return failoverRelocate(ctx, ramen.ActionRelocate, ramen.Relocated, targetCluster)
 }
 
-func failoverRelocate(ctx types.Context, action ramen.DRAction, state ramen.DRState) error {
+func failoverRelocate(ctx types.Context, action ramen.DRAction, state ramen.DRState, targetCluster string) error {
 	drpcName := ctx.Name()
 	managementNamespace := ctx.ManagementNamespace()
 	client := util.Ctx.Hub.Client
 
-	if err := waitAndUpdateDRPC(ctx, client, managementNamespace, drpcName, action); err != nil {
+	if err := waitAndUpdateDRPC(ctx, client, managementNamespace, drpcName, action, targetCluster); err != nil {
 		return err
 	}
 
@@ -164,23 +204,12 @@ func waitAndUpdateDRPC(
 	client client.Client,
 	namespace, drpcName string,
 	action ramen.DRAction,
+	targetCluster string,
 ) error {
 	log := ctx.Logger()
 
 	// here we expect drpc should be ready before action
 	if err := waitDRPCReady(ctx, client, namespace, drpcName); err != nil {
-		return err
-	}
-
-	drPolicyName := util.DefaultDRPolicyName
-
-	drpolicy, err := util.GetDRPolicy(client, drPolicyName)
-	if err != nil {
-		return err
-	}
-
-	targetCluster, err := getTargetCluster(client, namespace, drpcName, drpolicy)
-	if err != nil {
 		return err
 	}
 

--- a/e2e/dractions/discovered.go
+++ b/e2e/dractions/discovered.go
@@ -133,7 +133,7 @@ func failoverRelocateDiscoveredApps(ctx types.Context, action ramen.DRAction, st
 		return err
 	}
 
-	if err := waitAndUpdateDRPC(ctx, client, managementNamespace, drpcName, action); err != nil {
+	if err := waitAndUpdateDRPC(ctx, client, managementNamespace, drpcName, action, targetCluster); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/discovered.go
+++ b/e2e/dractions/discovered.go
@@ -88,26 +88,14 @@ func DisableProtectionDiscoveredApps(ctx types.Context) error {
 	return deployers.DeleteManagedClusterSetBinding(ctx, deployers.McsbName, managementNamespace)
 }
 
-func FailoverDiscoveredApps(ctx types.Context) error {
-	log := ctx.Logger()
-	managementNamespace := ctx.ManagementNamespace()
-
-	log.Infof("Failing over workload in namespace %q", managementNamespace)
-
-	return failoverRelocateDiscoveredApps(ctx, ramen.ActionFailover, ramen.FailedOver)
-}
-
-func RelocateDiscoveredApps(ctx types.Context) error {
-	log := ctx.Logger()
-	managementNamespace := ctx.ManagementNamespace()
-
-	log.Infof("Relocating workload in namespace %q", managementNamespace)
-
-	return failoverRelocateDiscoveredApps(ctx, ramen.ActionRelocate, ramen.Relocated)
-}
-
 // nolint:funlen,cyclop
-func failoverRelocateDiscoveredApps(ctx types.Context, action ramen.DRAction, state ramen.DRState) error {
+func failoverRelocateDiscoveredApps(
+	ctx types.Context,
+	action ramen.DRAction,
+	state ramen.DRState,
+	currentCluster string,
+	targetCluster string,
+) error {
 	name := ctx.Name()
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
@@ -116,19 +104,9 @@ func failoverRelocateDiscoveredApps(ctx types.Context, action ramen.DRAction, st
 	drpcName := name
 	client := util.Ctx.Hub.Client
 
-	currentCluster, err := getCurrentCluster(client, managementNamespace, name)
-	if err != nil {
-		return err
-	}
-
 	drPolicyName := util.DefaultDRPolicyName
 
 	drpolicy, err := util.GetDRPolicy(client, drPolicyName)
-	if err != nil {
-		return err
-	}
-
-	targetCluster, err := getTargetCluster(client, managementNamespace, drpcName, drpolicy)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Enhanced INFO Logs, displays current cluster and target cluster during failover and relocate actions.
- Refactored functions to pass currentCluster and targetCluster as parameters for failoverRelocate functions for managed and discovered apps
- Removed: FailoverDiscoveredApps and RelocateDiscoveredApps (merged functionality into failoverRelocate()).

Info log before:
```
2025-02-04T11:29:39.726+0530	INFO	appset-deploy-rbd-busybox	Failing over workload in namespace "argocd"
2025-02-04T11:34:07.482+0530	INFO	appset-deploy-rbd-busybox	Relocating workload in namespace "argocd"
```
Info log after:
```
2025-02-04T10:26:46.060-0500	INFO	appset-deploy-rbd-busybox	Failing over workload from cluster "dr1" to cluster "dr2"
2025-02-04T10:31:21.836-0500	INFO	appset-deploy-rbd-busybox	Relocating workload from cluster "dr2" to cluster "dr1"
```
discovered app after changes:
```
2025-02-04T10:55:22.406-0500	INFO	disapp-deploy-rbd-busybox	Failing over workload from cluster "dr1" to cluster "dr2"
2025-02-04T10:57:54.432-0500	INFO	disapp-deploy-rbd-busybox	Relocating workload from cluster "dr2" to cluster "dr1"
```


Fixes: https://github.com/RamenDR/ramen/issues/1797