### PR TITLE
vrg: remove the extra naming in the logger

### DIFF
--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -567,7 +567,7 @@ func (v *VRGInstance) processVRG() ctrl.Result {
 		return v.invalid(err, "Failed to label PVCs for consistency groups", true)
 	}
 
-	v.log = v.log.WithName("vrginstance").WithValues("State", v.instance.Spec.ReplicationState)
+	v.log = v.log.WithValues("State", v.instance.Spec.ReplicationState)
 	v.s3StoreAccessorsGet()
 
 	if util.ResourceIsDeleted(v.instance) {


### PR DESCRIPTION
Most of the vrg logs have the name controllers.VolumeReplicationGroup. In this code, we were adding suffix of .vrginstance to it with no use.