### PR TITLE
e2e: debug logs for enable/disable, drpc and placement  

### DIFF
--- a/e2e/deployers/applicationset.go
+++ b/e2e/deployers/applicationset.go
@@ -21,7 +21,7 @@ func (a ApplicationSet) Deploy(ctx types.Context) error {
 
 	log.Infof("Deploying applicationset in namespace %q", managementNamespace)
 
-	err := CreateManagedClusterSetBinding(McsbName, managementNamespace)
+	err := CreateManagedClusterSetBinding(ctx, McsbName, managementNamespace)
 	if err != nil {
 		return err
 	}

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -35,7 +35,8 @@ const (
 	fMode = 0o600
 )
 
-func CreateManagedClusterSetBinding(name, namespace string) error {
+func CreateManagedClusterSetBinding(ctx types.Context, name, namespace string) error {
+	log := ctx.Logger()
 	labels := make(map[string]string)
 	labels[AppLabelKey] = namespace
 	mcsb := &ocmv1b2.ManagedClusterSetBinding{
@@ -54,7 +55,11 @@ func CreateManagedClusterSetBinding(name, namespace string) error {
 		if !errors.IsAlreadyExists(err) {
 			return err
 		}
+
+		log.Debugf("ManagedClusterSetBinding \"%s/%s\" already exist", namespace, name)
 	}
+
+	log.Debugf("Created ManagedClusterSetBinding \"%s/%s\"", namespace, name)
 
 	return nil
 }
@@ -74,8 +79,10 @@ func DeleteManagedClusterSetBinding(ctx types.Context, name, namespace string) e
 			return err
 		}
 
-		log.Infof("ManagedClusterSetBinding %q not found", name)
+		log.Debugf("ManagedClusterSetBinding \"%s/%s\" not found", namespace, name)
 	}
+
+	log.Debugf("Deleted ManagedClusterSetBinding \"%s/%s\"", namespace, name)
 
 	return nil
 }
@@ -105,8 +112,10 @@ func CreatePlacement(ctx types.Context, name, namespace string) error {
 			return err
 		}
 
-		log.Info("Placement already Exists")
+		log.Debugf("Placement \"%s/%s\" already Exists", namespace, name)
 	}
+
+	log.Debugf("Created placement \"%s/%s\"", namespace, name)
 
 	return nil
 }
@@ -126,8 +135,10 @@ func DeletePlacement(ctx types.Context, name, namespace string) error {
 			return err
 		}
 
-		log.Info("Placement not found")
+		log.Debugf("Placement \"%s/%s\" not found", namespace, name)
 	}
+
+	log.Debugf("Deleted placement \"%s/%s\"", namespace, name)
 
 	return nil
 }

--- a/e2e/deployers/subscription.go
+++ b/e2e/deployers/subscription.go
@@ -43,7 +43,7 @@ func (s Subscription) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	err = CreateManagedClusterSetBinding(McsbName, managementNamespace)
+	err = CreateManagedClusterSetBinding(ctx, McsbName, managementNamespace)
 	if err != nil {
 		return err
 	}

--- a/e2e/dractions/crud.go
+++ b/e2e/dractions/crud.go
@@ -135,8 +135,10 @@ func createPlacementManagedByRamen(ctx types.Context, name, namespace string) er
 			return err
 		}
 
-		log.Info("Placement already Exists")
+		log.Debugf("Placement \"%s/%s\" already Exists", namespace, name)
 	}
+
+	log.Debugf("Created placement \"%s/%s\"", namespace, name)
 
 	return nil
 }

--- a/e2e/dractions/discovered.go
+++ b/e2e/dractions/discovered.go
@@ -25,7 +25,7 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 	drpcName := name
 
 	// create mcsb default in ramen-ops ns
-	if err := deployers.CreateManagedClusterSetBinding(deployers.McsbName, managementNamespace); err != nil {
+	if err := deployers.CreateManagedClusterSetBinding(ctx, deployers.McsbName, managementNamespace); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/discovered.go
+++ b/e2e/dractions/discovered.go
@@ -44,7 +44,7 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 
 	drpc := generateDRPCDiscoveredApps(
 		name, managementNamespace, clusterName, drPolicyName, placementName, appname, appNamespace)
-	if err = createDRPC(util.Ctx.Hub.Client, drpc); err != nil {
+	if err = createDRPC(ctx, util.Ctx.Hub.Client, drpc); err != nil {
 		return err
 	}
 
@@ -67,7 +67,7 @@ func DisableProtectionDiscoveredApps(ctx types.Context) error {
 
 	client := util.Ctx.Hub.Client
 
-	if err := deleteDRPC(client, managementNamespace, drpcName); err != nil {
+	if err := deleteDRPC(ctx, client, managementNamespace, drpcName); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/discovered.go
+++ b/e2e/dractions/discovered.go
@@ -17,8 +17,7 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 	managementNamespace := ctx.ManagementNamespace()
 	appNamespace := ctx.AppNamespace()
 
-	// TODO: log cluster namespace for completeness?
-	log.Infof("Protecting workload in namespace %q", managementNamespace)
+	log.Infof("Protecting workload in app namespace %q, management namespace: %q", appNamespace, managementNamespace)
 
 	drPolicyName := util.DefaultDRPolicyName
 	appname := w.GetAppName()
@@ -41,8 +40,6 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 		return err
 	}
 
-	log.Info("Creating drpc")
-
 	clusterName := drpolicy.Spec.DRClusters[0]
 
 	drpc := generateDRPCDiscoveredApps(
@@ -61,16 +58,14 @@ func DisableProtectionDiscoveredApps(ctx types.Context) error {
 	name := ctx.Name()
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
+	appNamespace := ctx.AppNamespace()
 
-	// TODO: log cluster namespace for completeness?
-	log.Infof("Unprotecting workload in namespace %q", managementNamespace)
+	log.Infof("Unprotecting workload in app namespace %q, management namespace: %q", appNamespace, managementNamespace)
 
 	placementName := name
 	drpcName := name
 
 	client := util.Ctx.Hub.Client
-
-	log.Info("Deleting drpc")
 
 	if err := deleteDRPC(client, managementNamespace, drpcName); err != nil {
 		return err

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -50,7 +50,7 @@ func waitDRPCReady(ctx types.Context, client client.Client, namespace string, dr
 	log := ctx.Logger()
 	startTime := time.Now()
 
-	log.Info("Waiting until drpc is ready")
+	log.Debugf("Waiting until drpc \"%s/%s\" is ready", namespace, drpcName)
 
 	for {
 		drpc, err := getDRPC(client, namespace, drpcName)
@@ -62,7 +62,7 @@ func waitDRPCReady(ctx types.Context, client client.Client, namespace string, dr
 		peerReady := conditionMet(drpc.Status.Conditions, ramen.ConditionPeerReady)
 
 		if available && peerReady && drpc.Status.LastGroupSyncTime != nil {
-			log.Info("drpc is ready")
+			log.Debugf("drpc \"%s/%s\" is ready", namespace, drpcName)
 
 			return nil
 		}
@@ -86,6 +86,8 @@ func waitDRPCPhase(ctx types.Context, client client.Client, namespace, name stri
 	log := ctx.Logger()
 	startTime := time.Now()
 
+	log.Debugf("Waiting until drpc \"%s/%s\" reach phase %q", namespace, name, phase)
+
 	for {
 		drpc, err := getDRPC(client, namespace, name)
 		if err != nil {
@@ -94,7 +96,7 @@ func waitDRPCPhase(ctx types.Context, client client.Client, namespace, name stri
 
 		currentPhase := drpc.Status.Phase
 		if currentPhase == phase {
-			log.Infof("drpc phase is %q", phase)
+			log.Debugf("drpc \"%s/%s\" phase is %q", namespace, name, phase)
 
 			return nil
 		}
@@ -145,16 +147,18 @@ func waitDRPCDeleted(ctx types.Context, client client.Client, namespace string, 
 	log := ctx.Logger()
 	startTime := time.Now()
 
+	log.Debugf("Waiting until drpc \"%s/%s\" is deleted", namespace, name)
+
 	for {
 		_, err := getDRPC(client, namespace, name)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				log.Info("drpc is deleted")
+				log.Debugf("drpc \"%s/%s\" is deleted", namespace, name)
 
 				return nil
 			}
 
-			log.Infof("Failed to get drpc: %s", err)
+			log.Debugf("Failed to get drpc \"%s/%s\": %s", namespace, name, err)
 		}
 
 		if time.Since(startTime) > util.Timeout {
@@ -175,6 +179,8 @@ func waitDRPCProgression(
 	log := ctx.Logger()
 	startTime := time.Now()
 
+	log.Debugf("Waiting until drpc \"%s/%s\" reach progression %q", namespace, name, progression)
+
 	for {
 		drpc, err := getDRPC(client, namespace, name)
 		if err != nil {
@@ -183,7 +189,7 @@ func waitDRPCProgression(
 
 		currentProgression := drpc.Status.Progression
 		if currentProgression == progression {
-			log.Infof("drpc progression is %q", progression)
+			log.Debugf("drpc \"%s/%s\" progression is %q", namespace, name, progression)
 
 			return nil
 		}

--- a/e2e/test/log.go
+++ b/e2e/test/log.go
@@ -33,8 +33,8 @@ func CreateLogger() (*zap.SugaredLogger, error) {
 	}
 
 	core := zapcore.NewTee(
-		zapcore.NewCore(logfileEncoder, zapcore.AddSync(logfile), zapcore.DebugLevel),
-		zapcore.NewCore(consoleEncoder, zapcore.AddSync(os.Stderr), zapcore.InfoLevel),
+		zapcore.NewCore(logfileEncoder, zapcore.Lock(logfile), zapcore.DebugLevel),
+		zapcore.NewCore(consoleEncoder, zapcore.Lock(os.Stderr), zapcore.InfoLevel),
 	)
 	logger := zap.New(core, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel))
 


### PR DESCRIPTION
- updated logs in EnableProtection and DisableProtection for managed and discovered apps
- Added debug logs for drpc related function
- Added debug logs for mcsb and placement related function
- Replaced zapcore.AddSync with zapcore.Lock to ensure safe concurrent writes to logfile

before/after [logs](https://github.com/RamenDR/ramen/issues/1808#issuecomment-2654429632).

Issue #1808 