### PR TITLE
vrg: don't protect kube resources as secondary during relocation

### DIFF
--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -423,7 +423,7 @@ func setStatusConditionIfNotFound(existingConditions *[]metav1.Condition, newCon
 	}
 }
 
-func setStatusCondition(existingConditions *[]metav1.Condition, newCondition metav1.Condition) {
+func setStatusCondition(existingConditions *[]metav1.Condition, newCondition metav1.Condition) metav1.Condition {
 	if existingConditions == nil {
 		existingConditions = &[]metav1.Condition{}
 	}
@@ -433,7 +433,7 @@ func setStatusCondition(existingConditions *[]metav1.Condition, newCondition met
 		newCondition.LastTransitionTime = metav1.NewTime(time.Now())
 		*existingConditions = append(*existingConditions, newCondition)
 
-		return
+		return newCondition
 	}
 
 	if existingCondition.Status != newCondition.Status {
@@ -458,6 +458,8 @@ func setStatusCondition(existingConditions *[]metav1.Condition, newCondition met
 		existingCondition.ObservedGeneration = newCondition.ObservedGeneration
 		existingCondition.LastTransitionTime = metav1.NewTime(time.Now())
 	}
+
+	return *existingCondition
 }
 
 func findCondition(existingConditions []metav1.Condition, conditionType string) *metav1.Condition {

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -78,7 +78,10 @@ const (
 	VRGConditionReasonStorageIDNotFound           = "StorageIDNotFound"
 )
 
-const clusterDataProtectedTrueMessage = "Kube objects protected"
+const (
+	vrgClusterDataProtectedTrueMessage         = "VRG object protected"
+	kubeObjectsClusterDataProtectedTrueMessage = "Kube objects protected"
+)
 
 // Just when VRG has been picked up for reconciliation when nothing has been
 // figured out yet.

--- a/internal/controller/util/conditions.go
+++ b/internal/controller/util/conditions.go
@@ -90,11 +90,11 @@ func ConditionAppend(
 
 // MergeConditions merges VRG conditions of the same type to generate a single condition for the Type
 func MergeConditions(
-	conditionSet func(*[]metav1.Condition, metav1.Condition),
+	conditionSet func(*[]metav1.Condition, metav1.Condition) metav1.Condition,
 	conditions *[]metav1.Condition,
 	ignoreReasons []string,
 	subConditions ...*metav1.Condition,
-) {
+) metav1.Condition {
 	trueSubConditions := []*metav1.Condition{}
 	falseSubConditions := []*metav1.Condition{}
 	unknownSubConditions := []*metav1.Condition{}
@@ -114,14 +114,18 @@ func MergeConditions(
 		}
 	}
 
+	var finalCondition metav1.Condition
+
 	switch {
 	case len(falseSubConditions) != 0:
-		conditionSet(conditions, mergedCondition(falseSubConditions, ignoreReasons))
+		finalCondition = conditionSet(conditions, mergedCondition(falseSubConditions, ignoreReasons))
 	case len(unknownSubConditions) != 0:
-		conditionSet(conditions, mergedCondition(unknownSubConditions, ignoreReasons))
+		finalCondition = conditionSet(conditions, mergedCondition(unknownSubConditions, ignoreReasons))
 	case len(trueSubConditions) != 0:
-		conditionSet(conditions, mergedCondition(trueSubConditions, ignoreReasons))
+		finalCondition = conditionSet(conditions, mergedCondition(trueSubConditions, ignoreReasons))
 	}
+
+	return finalCondition
 }
 
 // oldestConditions returns a list of conditions that are the same generation and the oldest among newCondition and

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -25,7 +25,6 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1244,6 +1243,13 @@ func (v *VRGInstance) shouldRestoreClusterData() bool {
 }
 
 func (v *VRGInstance) shouldRestoreKubeObjects() bool {
+	if v.instance.Spec.PrepareForFinalSync || v.instance.Spec.RunFinalSync {
+		msg := "kube objects restore skipped, as VRG is orchestrating final sync"
+		setVRGKubeObjectsReadyCondition(&v.instance.Status.Conditions, v.instance.Generation, msg)
+
+		return false
+	}
+
 	KubeObjectsRestored := findCondition(v.instance.Status.Conditions, VRGConditionTypeKubeObjectsReady)
 	if KubeObjectsRestored != nil {
 		v.log.Info("KubeObjectsReady condition",
@@ -1370,15 +1376,17 @@ func (v *VRGInstance) processAsSecondary() ctrl.Result {
 }
 
 func (v *VRGInstance) reconcileAsSecondary() ctrl.Result {
-	vrg := v.instance
 	result := ctrl.Result{}
 	result.Requeue = v.reconcileVolSyncAsSecondary() || result.Requeue
 	result.Requeue = v.reconcileVolRepsAsSecondary() || result.Requeue
 
-	if vrg.Spec.Action == ramendrv1alpha1.VRGActionRelocate {
-		// TODO: If RDSpec changes, and hence generation changes, a k8s backup would be initiated again as Secondary
-		v.relocate(&result)
-	}
+	// We already have the vrg.spec.state set to Secondary, so the user has been
+	// asked to cleanup the resources and we cannot upload the kube resources
+	// here. This final sync of kube resources should happen before the user is
+	// asked to cleanup the resources. This bug will be fixed in the future
+	// after we reconcile the volsync and volrep processes to be similar.
+	// TODO: Do a final sync of kube resources at the same place where we do the
+	// final sync of the volsync resources.
 
 	// Clear the conditions only if there are no more work as secondary and the RDSpec is not empty.
 	// Note: When using VolSync, we preserve the secondary and we need the status of the VRG to be
@@ -1388,17 +1396,6 @@ func (v *VRGInstance) reconcileAsSecondary() ctrl.Result {
 	}
 
 	return result
-}
-
-func (v *VRGInstance) relocate(result *ctrl.Result) {
-	vrg := v.instance
-
-	if clusterDataProtected := meta.FindStatusCondition(vrg.Status.Conditions,
-		VRGConditionTypeClusterDataProtected,
-	); clusterDataProtected != nil && (clusterDataProtected.Status != metav1.ConditionTrue ||
-		clusterDataProtected.ObservedGeneration != vrg.Generation) {
-		v.kubeObjectsProtectSecondary(result)
-	}
 }
 
 func (v *VRGInstance) invalid(err error, msg string, requeue bool) ctrl.Result {

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1552,11 +1552,14 @@ func getStatusStateFromSpecState(state ramendrv1alpha1.ReplicationState) ramendr
 // condition and is updated elsewhere.
 func (v *VRGInstance) updateVRGConditions() {
 	logAndSet := func(conditionName string, subconditions ...*metav1.Condition) {
-		v.log.Info(conditionName, "subconditions", subconditions)
-		util.MergeConditions(setStatusCondition,
+		msg := fmt.Sprintf("merging %s condition", conditionName)
+		v.log.Info(msg, "subconditions", subconditions)
+		finalCondition := util.MergeConditions(setStatusCondition,
 			&v.instance.Status.Conditions,
 			[]string{VRGConditionReasonUnused},
 			subconditions...)
+		msg = fmt.Sprintf("updated %s status to %s", conditionName, finalCondition.Status)
+		v.log.Info(msg, "finalCondition", finalCondition)
 	}
 
 	var volSyncDataReady, volSyncDataProtected, volSyncClusterDataProtected *metav1.Condition

--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -435,7 +435,8 @@ func (v *VRGInstance) kubeObjectsCaptureIdentifierUpdateComplete(
 		return
 	}
 
-	v.kubeObjectsCaptureStatus(metav1.ConditionTrue, VRGConditionReasonUploaded, clusterDataProtectedTrueMessage)
+	v.kubeObjectsCaptureStatus(metav1.ConditionTrue, VRGConditionReasonUploaded,
+		kubeObjectsClusterDataProtectedTrueMessage)
 
 	captureStartTimeSince := time.Since(captureToRecoverFromIdentifier.StartTime.Time)
 	v.log.Info("Kube objects captured", "recovery point", captureToRecoverFromIdentifier,

--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -779,7 +779,14 @@ func (v *VRGInstance) kubeObjectProtectionDisabled(caller string) bool {
 	vrgDisabled := v.instance.Spec.KubeObjectProtection == nil
 	cmDisabled := v.ramenConfig.KubeObjectProtection.Disabled
 	disabled := vrgDisabled || cmDisabled
-	v.log.Info("Kube object protection", "disabled", disabled, "VRG", vrgDisabled, "configMap", cmDisabled, "for", caller)
+
+	status := "enabled"
+	if disabled {
+		status = "disabled"
+	}
+
+	msg := fmt.Sprintf("Kube object protection configuration is %v for operation %s", status, caller)
+	v.log.Info(msg, "is disabled in vrg", vrgDisabled, "is disabled in configMap", cmDisabled)
 
 	return disabled
 }

--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -64,14 +64,6 @@ func (v *VRGInstance) kubeObjectsProtectPrimary(result *ctrl.Result) {
 	)
 }
 
-func (v *VRGInstance) kubeObjectsProtectSecondary(result *ctrl.Result) {
-	v.kubeObjectsProtect(result, kubeObjectsCaptureStartConditionallySecondary,
-		func() {
-			v.kubeObjectsCaptureStatusFalse(VRGConditionReasonUploading, "Kube objects capture for relocate in-progress")
-		},
-	)
-}
-
 type (
 	captureStartConditionally     func(*VRGInstance, *ctrl.Result, int64, time.Duration, time.Duration, func())
 	captureInProgressStatusUpdate func()
@@ -167,24 +159,6 @@ func (v *VRGInstance) kubeObjectsCaptureStartOrResumeOrDelay(
 			captureStartOrResume(vrg.GetGeneration(), "start")
 		},
 	)
-}
-
-func kubeObjectsCaptureStartConditionallySecondary(
-	v *VRGInstance, result *ctrl.Result,
-	captureStartGeneration int64, captureStartTimeSince, captureStartInterval time.Duration,
-	captureStart func(),
-) {
-	generation := v.instance.Generation
-	log := v.log.WithValues("generation", generation)
-
-	if captureStartGeneration == generation {
-		log.Info("Kube objects capture for relocate complete")
-
-		return
-	}
-
-	v.kubeObjectsCaptureStatusFalse(VRGConditionReasonUploading, "Kube objects capture for relocate pending")
-	captureStart()
 }
 
 func kubeObjectsCaptureStartConditionallyPrimary(

--- a/internal/controller/vrg_vrgobject.go
+++ b/internal/controller/vrg_vrgobject.go
@@ -58,7 +58,7 @@ func (v *VRGInstance) vrgObjectProtectThrottled(result *ctrl.Result,
 		log1.Info("VRG Kube object protected")
 
 		vrgLastUploadVersion[v.namespacedName] = vrg.ResourceVersion
-		v.vrgObjectProtected = newVRGClusterDataProtectedCondition(vrg.Generation, clusterDataProtectedTrueMessage)
+		v.vrgObjectProtected = newVRGClusterDataProtectedCondition(vrg.Generation, vrgClusterDataProtectedTrueMessage)
 	}
 
 	success()


### PR DESCRIPTION
This is not the right place to protect the kube resources as one final sync when we are relocating. It is too late as the user has already been informed to cleanup the resources and some of the resources might have been deleted already.

The right time to do it is before the application resource cleanup but we cannot do it right now because of the difference in how volrep and volsync behave.

We will fix it in a future release.