### PR TITLE
github-ci: cancel in-progress runs if PR is updated

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,6 +14,11 @@ env:
   MAX_WORKERS: 4
   BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
 
+# cancel the in-progress workflow when PR is refreshed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   e2e-rdr:
     runs-on: [self-hosted, e2e-rdr]


### PR DESCRIPTION
This is no point in running the whole e2e test if the PR is updated. We should only run the tests for the latest version.