### PR TITLE
config: events permissions for the hub role

### DIFF
--- a/config/hub/rbac/role.yaml
+++ b/config/hub/rbac/role.yaml
@@ -14,6 +14,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - create


### PR DESCRIPTION
In commit[1], we mistakely deleted the events permissions for the hub controller. This leads to errors in patching events by the DRPC controller.

[1] https://github.com/RamenDR/ramen/commit/546f89cc1bdce38dfb1275b2218083dac5964fd6