### PR TITLE
drpc: extracting method for better readability

### DIFF
--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -2371,7 +2371,7 @@ func ensureDRPCValidNamespace(drpc *rmn.DRPlacementControl, ramenConfig *rmn.Ram
 		return nil
 	}
 
-	if drpc.Spec.ProtectedNamespaces != nil && len(*drpc.Spec.ProtectedNamespaces) > 0 {
+	if isDiscoveredApp(drpc) {
 		adminNamespace := drpcAdminNamespaceName(*ramenConfig)
 
 		return fmt.Errorf("drpc in non-admin namespace(%v) cannot have protected namespaces, admin-namespaces: %v",
@@ -2394,7 +2394,7 @@ func drpcsProtectCommonNamespace(drpcProtectedNs []string, otherDRPCProtectedNs 
 func (r *DRPlacementControlReconciler) getProtectedNamespaces(drpc *rmn.DRPlacementControl,
 	log logr.Logger,
 ) ([]string, error) {
-	if drpc.Spec.ProtectedNamespaces != nil && len(*drpc.Spec.ProtectedNamespaces) > 0 {
+	if isDiscoveredApp(drpc) {
 		return *drpc.Spec.ProtectedNamespaces, nil
 	}
 


### PR DESCRIPTION
Logic used for determining if DRPC belongs to discovered app or not is made more readable by extracting a func and invoking it in all the places previously used.

