### PR TITLE
drenv: update external-snapshotter to v8.2.0 and rook to 1.16

### DIFF
--- a/test/addons/external-snapshotter/cache
+++ b/test/addons/external-snapshotter/cache
@@ -7,5 +7,5 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh("crds", "addons/external-snapshotter-crds-8.1.0.yaml")
-cache.refresh("controller", "addons/external-snapshotter-controller-8.1.0.yaml")
+cache.refresh("crds", "addons/external-snapshotter-crds-8.2.yaml")
+cache.refresh("controller", "addons/external-snapshotter-controller-8.2.yaml")

--- a/test/addons/external-snapshotter/controller/kustomization.yaml
+++ b/test/addons/external-snapshotter/controller/kustomization.yaml
@@ -3,3 +3,12 @@ resources:
   - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
   - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
 namespace: kube-system
+patches:
+  # Enable volume group replication support
+  - target:
+      kind: Deployment
+      name: snapshot-controller
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: "--feature-gates=CSIVolumeGroupSnapshot=true"

--- a/test/addons/external-snapshotter/controller/kustomization.yaml
+++ b/test/addons/external-snapshotter/controller/kustomization.yaml
@@ -1,5 +1,5 @@
 ---
 resources:
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/refs/tags/v8.1.0/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/refs/tags/v8.1.0/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
 namespace: kube-system

--- a/test/addons/external-snapshotter/crds/kustomization.yaml
+++ b/test/addons/external-snapshotter/crds/kustomization.yaml
@@ -1,8 +1,8 @@
 ---
 resources:
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/refs/tags/v8.1.0/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/refs/tags/v8.1.0/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/refs/tags/v8.1.0/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/refs/tags/v8.1.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/refs/tags/v8.1.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/refs/tags/v8.1.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml

--- a/test/addons/external-snapshotter/start
+++ b/test/addons/external-snapshotter/start
@@ -12,14 +12,14 @@ from drenv import cache
 
 def deploy(cluster):
     print("Deploying crds")
-    path = cache.get("crds", "addons/external-snapshotter-crds-8.1.0.yaml")
+    path = cache.get("crds", "addons/external-snapshotter-crds-8.2.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
     print("Waiting until crds are established")
     kubectl.wait("--for=condition=established", "--filename", path, context=cluster)
 
     print("Deploying snapshot-controller")
-    path = cache.get("controller", "addons/external-snapshotter-controller-8.1.0.yaml")
+    path = cache.get("controller", "addons/external-snapshotter-controller-8.2.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
 

--- a/test/addons/rook-cephfs/filesystem.yaml
+++ b/test/addons/rook-cephfs/filesystem.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable-line rule:line-length
-# Source: https://raw.githubusercontent.com/rook/rook/release-1.13/deploy/examples/filesystem-test.yaml
+# Source: https://raw.githubusercontent.com/rook/rook/release-1.16/deploy/examples/filesystem-test.yaml
 # Modifications:
 #  - Remove additional resource CephFilesystemSubVolumeGroup
 

--- a/test/addons/rook-cephfs/snapshot-class.yaml
+++ b/test/addons/rook-cephfs/snapshot-class.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable-line rule:line-length
-# Source: https://raw.githubusercontent.com/rook/rook/release-1.15/deploy/examples/csi/cephfs/snapshotclass.yaml
+# Source: https://raw.githubusercontent.com/rook/rook/release-1.16/deploy/examples/csi/cephfs/snapshotclass.yaml
 # Modifications:
 #  - Added storageID
 ---

--- a/test/addons/rook-cephfs/storage-class.yaml
+++ b/test/addons/rook-cephfs/storage-class.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable-line rule:line-length
-# Source: https://raw.githubusercontent.com/rook/rook/release-1.15/deploy/examples/csi/cephfs/storageclass.yaml
+# Source: https://raw.githubusercontent.com/rook/rook/release-1.16/deploy/examples/csi/cephfs/storageclass.yaml
 # Modifications:
 #  - Added storageID
 ---

--- a/test/addons/rook-cluster/cache
+++ b/test/addons/rook-cluster/cache
@@ -7,4 +7,4 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh(".", "addons/rook-cluster-1.15.yaml")
+cache.refresh(".", "addons/rook-cluster-1.16.yaml")

--- a/test/addons/rook-cluster/kustomization.yaml
+++ b/test/addons/rook-cluster/kustomization.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://raw.githubusercontent.com/rook/rook/release-1.15/deploy/examples/cluster-test.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.16/deploy/examples/cluster-test.yaml
 patches:
   - target:
       kind: CephCluster

--- a/test/addons/rook-cluster/start
+++ b/test/addons/rook-cluster/start
@@ -20,7 +20,7 @@ TIMEOUT = 600
 
 def deploy(cluster):
     print("Deploying rook ceph cluster")
-    path = cache.get(".", "addons/rook-cluster-1.15.yaml")
+    path = cache.get(".", "addons/rook-cluster-1.16.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
 

--- a/test/addons/rook-operator/cache
+++ b/test/addons/rook-operator/cache
@@ -7,4 +7,4 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh(".", "addons/rook-operator-1.15.yaml")
+cache.refresh(".", "addons/rook-operator-1.16.yaml")

--- a/test/addons/rook-operator/kustomization.yaml
+++ b/test/addons/rook-operator/kustomization.yaml
@@ -4,9 +4,9 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://raw.githubusercontent.com/rook/rook/release-1.15/deploy/examples/crds.yaml
-  - https://raw.githubusercontent.com/rook/rook/release-1.15/deploy/examples/common.yaml
-  - https://raw.githubusercontent.com/rook/rook/release-1.15/deploy/examples/operator.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.16/deploy/examples/crds.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.16/deploy/examples/common.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.16/deploy/examples/operator.yaml
 
 patches:
   - target:

--- a/test/addons/rook-operator/start
+++ b/test/addons/rook-operator/start
@@ -12,7 +12,7 @@ from drenv import cache
 
 def deploy(cluster):
     print("Deploying rook ceph operator")
-    path = cache.get(".", "addons/rook-operator-1.15.yaml")
+    path = cache.get(".", "addons/rook-operator-1.16.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
 

--- a/test/addons/rook-pool/snapshot-class.yaml
+++ b/test/addons/rook-pool/snapshot-class.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable rule:line-length
-# Drived from https://raw.githubusercontent.com/rook/rook/release-1.15/deploy/examples/csi/rbd/snapshotclass.yaml
+# Drived from https://raw.githubusercontent.com/rook/rook/release-1.16/deploy/examples/csi/rbd/snapshotclass.yaml
 ---
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass

--- a/test/addons/rook-toolbox/cache
+++ b/test/addons/rook-toolbox/cache
@@ -7,4 +7,4 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh(".", "addons/rook-toolbox-1.15.yaml")
+cache.refresh(".", "addons/rook-toolbox-1.16.yaml")

--- a/test/addons/rook-toolbox/kustomization.yaml
+++ b/test/addons/rook-toolbox/kustomization.yaml
@@ -4,4 +4,4 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://raw.githubusercontent.com/rook/rook/release-1.15/deploy/examples/toolbox.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.16/deploy/examples/toolbox.yaml

--- a/test/addons/rook-toolbox/start
+++ b/test/addons/rook-toolbox/start
@@ -13,7 +13,7 @@ from drenv import cache
 
 def deploy(cluster):
     print("Deploying rook ceph toolbox")
-    path = cache.get(".", "addons/rook-toolbox-1.15.yaml")
+    path = cache.get(".", "addons/rook-toolbox-1.16.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
 


### PR DESCRIPTION
Changes

1. Updated external-snapshotter addon from v8.1.0 to v8.2.0 (Issue #1813 )
2. Updated rook 1.16 (Issue #1821 )
3. Added patch to enable VolumeGroupSnapshot using feature gate "--feature-gates=CSIVolumeGroupSnapshot=true"
```
spec:
  containers:
  - args:
    - --v=5
    - --leader-election=true
    - --feature-gates=CSIVolumeGroupSnapshot=true
    image: registry.k8s.io/sig-storage/snapshot-controller:v8.2.0
    imagePullPolicy: IfNotPresent
    name: snapshot-controller
```

Tested envs/rook.yaml and envs/regional-dr.yaml deployments locally. Deployed.

Fixes #1821, #1813
