### PR TITLE
drenv:  Add New VRCs & VSCs, FixDuplicate SC-ID Issue

### DIFF
--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -18,7 +18,26 @@ from drenv import ceph
 from drenv import commands
 from drenv import kubectl
 
-POOL_NAME = "replicapool"
+POOL_NAMES = ["replicapool", "replicapool-2"]
+VOLUME_REPLICATION_CLASSES = ["vrc-sample", "vrc-sample-2"]
+VOLUME_GROUP_REPLICATION_CLASSES = ["vgrc-sample", "vgrc-sample-2"]
+STORAGE_CLASS_NAMES = ["rook-ceph-block", "rook-ceph-block-2"]
+
+
+STORAGE_CLASSES_MAP = [
+    {
+        "name": sc,
+        "pool": pool,
+        "vrc": vrc,
+        "vgrc": vgrc,
+    }
+    for sc, pool, vrc, vgrc in zip(
+        STORAGE_CLASS_NAMES,
+        POOL_NAMES,
+        VOLUME_REPLICATION_CLASSES,
+        VOLUME_GROUP_REPLICATION_CLASSES,
+    )
+]
 
 
 def log_blocklist(cluster):
@@ -33,7 +52,7 @@ def fetch_secret_info(cluster):
 
     print(f"Getting mirroring info site name for cluster '{cluster}'")
     info["name"] = drenv.wait_for(
-        f"cephblockpools.ceph.rook.io/{POOL_NAME}",
+        f"cephblockpools.ceph.rook.io/{POOL_NAMES[0]}",
         output="jsonpath={.status.mirroringInfo.site_name}",
         namespace="rook-ceph",
         profile=cluster,
@@ -42,7 +61,7 @@ def fetch_secret_info(cluster):
     print(f"Getting rbd mirror boostrap peer secret name for cluster '{cluster}'")
     secret_name = kubectl.get(
         "cephblockpools.ceph.rook.io",
-        POOL_NAME,
+        POOL_NAMES[0],
         "--output=jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}",
         "--namespace=rook-ceph",
         context=cluster,
@@ -58,7 +77,7 @@ def fetch_secret_info(cluster):
     )
 
     # Must be encoded as base64 in secret .data section.
-    info["pool"] = base64.b64encode(POOL_NAME.encode()).decode()
+    info["pool"] = base64.b64encode(POOL_NAMES[0].encode()).decode()
 
     return info
 
@@ -99,23 +118,29 @@ def configure_rbd_mirroring(cluster, peer_info):
     patch = {"spec": {"mirroring": {"peers": {"secretNames": [peer_info["name"]]}}}}
     kubectl.patch(
         "cephblockpool",
-        POOL_NAME,
+        POOL_NAMES[0],
         "--type=merge",
         f"--patch={json.dumps(patch)}",
         "--namespace=rook-ceph",
         context=cluster,
     )
 
-    print("Creating VolumeReplicationClass")
-    template = drenv.template("start-data/vrc-sample.yaml")
-    yaml = template.substitute(cluster=cluster, scname="rook-ceph-block")
-    kubectl.apply("--filename=-", input=yaml, context=cluster)
+    for storage_class in STORAGE_CLASSES_MAP:
+        print("Creating VolumeReplicationClass")
+        template = drenv.template("start-data/vrc-sample.yaml")
+        yaml = template.substitute(
+            cluster=cluster, vrcname=storage_class["vrc"], scname=storage_class["name"]
+        )
+        kubectl.apply("--filename=-", input=yaml, context=cluster)
 
-    template = drenv.template("start-data/vgrc-sample.yaml")
-    yaml = template.substitute(
-        cluster=cluster, pool=POOL_NAME, scname="rook-ceph-block"
-    )
-    kubectl.apply("--filename=-", input=yaml, context=cluster)
+        template = drenv.template("start-data/vgrc-sample.yaml")
+        yaml = template.substitute(
+            cluster=cluster,
+            pool=storage_class["pool"],
+            vgrcname=storage_class["vgrc"],
+            scname=storage_class["name"],
+        )
+        kubectl.apply("--filename=-", input=yaml, context=cluster)
 
     print(f"Apply rbd mirror to cluster '{cluster}'")
     kubectl.apply("--kustomize=start-data", context=cluster)
@@ -165,7 +190,7 @@ def wait_until_pool_mirroring_is_healthy(cluster, attempts=3):
 
     status = kubectl.get(
         "cephblockpools.ceph.rook.io",
-        POOL_NAME,
+        POOL_NAMES[0],
         "--output=jsonpath={.status}",
         "--namespace=rook-ceph",
         context=cluster,
@@ -185,7 +210,7 @@ def watch_pool_mirroring_status(cluster, timeout=180):
     while True:
         remaining = deadline - time.monotonic()
         watcher = kubectl.watch(
-            f"cephblockpool/{POOL_NAME}",
+            f"cephblockpool/{POOL_NAMES[0]}",
             jsonpath="{.status.mirroringStatus.summary}",
             namespace="rook-ceph",
             timeout=remaining,

--- a/test/addons/rbd-mirror/start-data/vgrc-sample.yaml
+++ b/test/addons/rbd-mirror/start-data/vgrc-sample.yaml
@@ -5,10 +5,10 @@
 apiVersion: replication.storage.openshift.io/v1alpha1
 kind: VolumeGroupReplicationClass
 metadata:
-  name: vgrc-sample
+  name: $vgrcname
   labels:
     ramendr.openshift.io/storageid: $scname-$cluster-1
-    ramendr.openshift.io/replicationid: rook-ceph-replication-1
+    ramendr.openshift.io/replicationid: $scname-replication-1
 spec:
   provisioner: rook-ceph.rbd.csi.ceph.com
   parameters:

--- a/test/addons/rbd-mirror/start-data/vrc-sample.yaml
+++ b/test/addons/rbd-mirror/start-data/vrc-sample.yaml
@@ -5,10 +5,10 @@
 apiVersion: replication.storage.openshift.io/v1alpha1
 kind: VolumeReplicationClass
 metadata:
-  name: vrc-sample
+  name: $vrcname
   labels:
     ramendr.openshift.io/storageid: $scname-$cluster-1
-    ramendr.openshift.io/replicationid: rook-ceph-replication-1
+    ramendr.openshift.io/replicationid: $scname-replication-1
 spec:
   provisioner: rook-ceph.rbd.csi.ceph.com
   parameters:

--- a/test/addons/rook-cephfs/snapshot-class.yaml
+++ b/test/addons/rook-cephfs/snapshot-class.yaml
@@ -11,7 +11,7 @@ deletionPolicy: Delete
 driver: rook-ceph.cephfs.csi.ceph.com
 kind: VolumeSnapshotClass
 metadata:
-  name: csi-cephfsplugin-snapclass
+  name: $vscname
   labels:
     ramendr.openshift.io/storageid: $scname-$cluster-1
 parameters:

--- a/test/addons/rook-cephfs/start
+++ b/test/addons/rook-cephfs/start
@@ -10,44 +10,56 @@ import drenv
 from drenv import kubectl
 
 STORAGE_CLASS_NAME_PREFIX = "rook-cephfs-"
-FILE_SYSTEMS = ["test-fs1", "test-fs2"]
+FS_NAMES = ["test-fs1", "test-fs2"]
+CEPHFS_VOLUME_SNAPSHOT_CLASSES = [
+    "csi-cephfsplugin-snapclass",
+    "csi-cephfsplugin-snapclass-2",
+]
+
+STORAGE_CLASSES_MAP = [
+    {"fs": fs, "name": f"{STORAGE_CLASS_NAME_PREFIX}{fs}", "vsc": vsc}
+    for fs, vsc in zip(FS_NAMES, CEPHFS_VOLUME_SNAPSHOT_CLASSES)
+]
 
 
 def deploy(cluster):
-    for file_system in FILE_SYSTEMS:
-        print("Creating CephFS instance")
+    for storage_class in STORAGE_CLASSES_MAP:
+        print("Creating CephFS instances")
         template = drenv.template("filesystem.yaml")
-        yaml = template.substitute(cluster=cluster, name=file_system)
+        yaml = template.substitute(cluster=cluster, name=storage_class["fs"])
         kubectl.apply("--filename=-", input=yaml, context=cluster)
 
-        print("Creating StorageClass")
+        print("Creating StorageClasses")
         template = drenv.template("storage-class.yaml")
-        storage_class_name = STORAGE_CLASS_NAME_PREFIX + file_system
         yaml = template.substitute(
-            cluster=cluster, fsname=file_system, name=storage_class_name
+            cluster=cluster, fsname=storage_class["fs"], name=storage_class["name"]
         )
         kubectl.apply("--filename=-", input=yaml, context=cluster)
 
-    print("Creating SnapshotClass")
-    template = drenv.template("snapshot-class.yaml")
-    storage_class_name = STORAGE_CLASS_NAME_PREFIX + FILE_SYSTEMS[0]
-    yaml = template.substitute(cluster=cluster, scname=storage_class_name)
-    kubectl.apply("--filename=-", input=yaml, context=cluster)
+        print("Creating SnapshotClasses")
+        template = drenv.template("snapshot-class.yaml")
+        yaml = template.substitute(
+            cluster=cluster,
+            vscname=storage_class["vsc"],
+            scname=storage_class["name"],
+            fsname=storage_class["fs"],
+        )
+        kubectl.apply("--filename=-", input=yaml, context=cluster)
 
 
 def wait(cluster):
     print("Waiting until Ceph File Systems are ready")
 
-    for file_system in FILE_SYSTEMS:
+    for fs_name in FS_NAMES:
         drenv.wait_for(
-            f"cephfilesystem/{file_system}",
+            f"cephfilesystem/{fs_name}",
             output="jsonpath={.status.phase}",
             namespace="rook-ceph",
             timeout=120,
             profile=cluster,
         )
         kubectl.wait(
-            f"cephfilesystem/{file_system}",
+            f"cephfilesystem/{fs_name}",
             "--for=jsonpath={.status.phase}=Ready",
             "--namespace=rook-ceph",
             "--timeout=300s",

--- a/test/addons/rook-pool/snapshot-class.yaml
+++ b/test/addons/rook-pool/snapshot-class.yaml
@@ -7,7 +7,7 @@
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
-  name: csi-rbdplugin-snapclass
+  name: $vscname
   labels:
     ramendr.openshift.io/storageid: $scname-$cluster-1
 driver: rook-ceph.rbd.csi.ceph.com

--- a/test/addons/rook-pool/start
+++ b/test/addons/rook-pool/start
@@ -13,32 +13,40 @@ import drenv
 from drenv import kubectl
 
 POOL_NAMES = ["replicapool", "replicapool-2"]
+RBD_VOLUME_SNAPSHOT_CLASSES = ["csi-rbdplugin-snapclass", "csi-rbdplugin-snapclass-2"]
+STORAGE_CLASS_NAMES = ["rook-ceph-block", "rook-ceph-block-2"]
+
+STORAGE_CLASSES_MAP = [
+    {"name": sc, "pool": pool, "vsc": vsc}
+    for sc, pool, vsc in zip(
+        STORAGE_CLASS_NAMES, POOL_NAMES, RBD_VOLUME_SNAPSHOT_CLASSES
+    )
+]
 
 
 def deploy(cluster):
-    storage_classes = [
-        {"name": "rook-ceph-block", "pool": POOL_NAMES[0]},
-        {"name": "rook-ceph-block-2", "pool": POOL_NAMES[1]},
-    ]
-
-    print("Creating StorageClasses")
-    for storage_class in storage_classes:
-        template = drenv.template("storage-class.yaml")
-        yaml = template.substitute(
-            cluster=cluster, name=storage_class["name"], pool=storage_class["pool"]
-        )
-        kubectl.apply("--filename=-", input=yaml, context=cluster)
-
     print("Creating RBD pools")
     for pool in POOL_NAMES:
         template = drenv.template("replica-pool.yaml")
         yaml = template.substitute(cluster=cluster, name=pool)
         kubectl.apply("--filename=-", input=yaml, context=cluster)
 
-    print("Creating SnapshotClass")
-    template = drenv.template("snapshot-class.yaml")
-    yaml = template.substitute(cluster=cluster, scname="rook-ceph-block")
-    kubectl.apply("--filename=-", input=yaml, context=cluster)
+    print("Creating StorageClasses")
+    for storage_class in STORAGE_CLASSES_MAP:
+        template = drenv.template("storage-class.yaml")
+        yaml = template.substitute(
+            cluster=cluster, name=storage_class["name"], pool=storage_class["pool"]
+        )
+        kubectl.apply("--filename=-", input=yaml, context=cluster)
+
+        print("Creating SnapshotClasses")
+        template = drenv.template("snapshot-class.yaml")
+        yaml = template.substitute(
+            cluster=cluster,
+            vscname=storage_class["vsc"],
+            scname=storage_class["name"],
+        )
+        kubectl.apply("--filename=-", input=yaml, context=cluster)
 
 
 def wait(cluster):


### PR DESCRIPTION
This PR continues the improvements introduced in [1] and [2] by adding new VRCs and VSCs based on the newly created SCs. Additionally, it includes fixes to prevent duplicate SC-ID generation.

References:
[1] https://github.com/RamenDR/ramen/pull/1756
[2] https://github.com/RamenDR/ramen/pull/1756

Here is the tree of all the resources. I have not made any changes to the existing names. I will try to fix them in the next updates. However, I believe this is a necessary change with multiple SCs in the cluster.

```
clusters:
  - dr1:
      RDB-SC:
        - sc-name: rook-ceph-block
          sc-id: rook-ceph-block-dr1-1
        - sc-name: rook-ceph-block-2
          sc-id: rook-ceph-block-2-dr1-1
      Ceph-FS-SC:
        - sc-name: rook-cephfs-test-fs1
          sc-id: rook-cephfs-test-fs1-dr1-1
        - sc-name: rook-cephfs-test-fs2
          sc-id: rook-cephfs-test-fs2-dr1-1
      VolumeReplicationClass:
        - name: vrc-sample
          sc-id: rook-ceph-block-dr1-1
          replication-id: rook-ceph-block-replication-1
        - name: vrc-sample-2
          sc-id: rook-ceph-block-2-dr1-1
          replication-id: rook-ceph-block-2-replication-1
      VolumeGroupReplicationClass:
        - name: vgrc-sample
          sc-id: rook-ceph-block-dr1-1
          replication-id: rook-ceph-block-replication-1
        - name: vgrc-sample-2
          sc-id: rook-ceph-block-2-dr1-1
          replication-id: rook-ceph-block-2-replication-1
      SnapshotClass-RDB:
        - name: csi-rbdplugin-snapclass
          sc-id: rook-ceph-block-dr1-1
        - name: csi-rbdplugin-snapclass-2
          sc-id: rook-ceph-block-2-dr1-1
      SnapshotClass-CephFS:
        - name: csi-cephfsplugin-snapclass
          sc-id: rook-cephfs-test-fs1-dr1-1
        - name: csi-cephfsplugin-snapclass-2
          sc-id: rook-cephfs-test-fs2-dr1-1

  - dr2:
      RDB-SC:
        - sc-name: rook-ceph-block
          sc-id: rook-ceph-block-dr2-1
        - sc-name: rook-ceph-block-2
          sc-id: rook-ceph-block-2-dr2-1
      Ceph-FS-SC:
        - sc-name: rook-cephfs-test-fs1
          sc-id: rook-cephfs-test-fs1-dr2-1
        - sc-name: rook-cephfs-test-fs2
          sc-id: rook-cephfs-test-fs2-dr2-1
      VolumeReplicationClass:
        - name: vrc-sample
          sc-id: rook-ceph-block-dr2-1
          replication-id: rook-ceph-block-replication-1
        - name: vrc-sample-2
          sc-id: rook-ceph-block-2-dr2-1
          replication-id: rook-ceph-block-2-replication-1
      VolumeGroupReplicationClass:
        - name: vgrc-sample
          sc-id: rook-ceph-block-dr2-1
          replication-id: rook-ceph-block-replication-1
        - name: vgrc-sample-2
          sc-id: rook-ceph-block-2-dr2-1
          replication-id: rook-ceph-block-2-replication-1
      SnapshotClass-RDB:
        - name: csi-rbdplugin-snapclass
          sc-id: rook-ceph-block-dr2-1
        - name: csi-rbdplugin-snapclass-2
          sc-id: rook-ceph-block-2-dr2-1
      SnapshotClass-CephFS:
        - name: csi-cephfsplugin-snapclass
          sc-id: rook-cephfs-test-fs1-dr2-1
        - name: csi-cephfsplugin-snapclass-2
          sc-id: rook-cephfs-test-fs2-dr2-1
```
This is the status of `PeerClasses` from DRPolicy 

```
status:
  async:
    peerClasses:
      - clusterIDs:
          - cluster-id-1
          - cluster-id-2
        replicationID: rook-ceph-block-replication-1
        storageClassName: rook-ceph-block
        storageID:
          - rook-ceph-block-dr1-1
          - rook-ceph-block-dr2-1
      - clusterIDs:
          - cluster-id-1
          - cluster-id-2
        replicationID: rook-ceph-block-2-replication-1
        storageClassName: rook-ceph-block-2
        storageID:
          - rook-ceph-block-2-dr1-1
          - rook-ceph-block-2-dr2-1
      - clusterIDs:
          - cluster-id-1
          - cluster-id-2
        storageClassName: rook-cephfs-test-fs1
        storageID:
          - rook-cephfs-test-fs1-dr1-1
          - rook-cephfs-test-fs1-dr2-1
      - clusterIDs:
          - cluster-id-1
          - cluster-id-2
        storageClassName: rook-cephfs-test-fs2
        storageID:
          - rook-cephfs-test-fs2-dr1-1
          - rook-cephfs-test-fs2-dr2-1
```
