### PR TITLE
UT fix for vshandler-test

### DIFF
--- a/internal/controller/volsync/vshandler_test.go
+++ b/internal/controller/volsync/vshandler_test.go
@@ -694,7 +694,13 @@ var _ = Describe("VolSync_Handler", func() {
 						Expect(finalSyncCompl).To(BeFalse())
 						Expect(rs).ToNot(BeNil())
 
-						// ReconcileRS should have created the replication source - since the secret isn't there
+						// Ensure replication source is created
+						Eventually(func() error {
+							return k8sClient.Get(ctx,
+								types.NamespacedName{Name: rsSpec.ProtectedPVC.Name, Namespace: testNamespace.GetName()}, createdRS)
+						}, maxWait, interval).Should(Succeed())
+
+						// Consistently continue to synchronize PVC data to a remote location
 						Consistently(func() error {
 							return k8sClient.Get(ctx,
 								types.NamespacedName{Name: rsSpec.ProtectedPVC.Name, Namespace: testNamespace.GetName()}, createdRS)


### PR DESCRIPTION
Fix for UT failure.

Individual test has been executed with a repeat count of 10 times and this has passed, result has been pasted here for reference:
```
# ginkgo -focus="When no running pod is mounting the PVC to be protected" -repeat=10
:
:
All tests passed...
This was attempt 10 of 11.
Running Suite: Volsync Suite - /root/DR/ut-fix/ramen/internal/controller/volsync
================================================================================
Random Seed: 1739818202

Will run 1 of 56 specs
SSSSSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 56 Specs in 11.563 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 55 Skipped
PASS

Ginkgo ran 1 suite in 2m13.075674648s
Test Suite Passed
```

Fixes #1812
There could be intermittent failures due to #1835, which was prevalent prior to this fix.