### PR TITLE
e2e: add debug logs for namespace related util functions

### DIFF
--- a/e2e/deployers/subscription.go
+++ b/e2e/deployers/subscription.go
@@ -38,7 +38,7 @@ func (s Subscription) Deploy(ctx types.Context) error {
 	log.Infof("Deploying subscription in namespace %q", managementNamespace)
 
 	// create subscription namespace
-	err := util.CreateNamespace(util.Ctx.Hub.Client, managementNamespace)
+	err := util.CreateNamespace(util.Ctx.Hub.Client, managementNamespace, log)
 	if err != nil {
 		return err
 	}

--- a/e2e/util/channel.go
+++ b/e2e/util/channel.go
@@ -14,7 +14,7 @@ import (
 
 func EnsureChannel() error {
 	// create channel namespace
-	err := CreateNamespace(Ctx.Hub.Client, GetChannelNamespace())
+	err := CreateNamespace(Ctx.Hub.Client, GetChannelNamespace(), Ctx.Log)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Changes:

- Added debug log after namespace creation
- Added debug log after creating namespace annotations and private constant for the annotation 
- Updated info to debug log in DeleteNamespace

Fixes: #1825 