### PR TITLE
Fix Negative Requeue Duration in getStatusCheckDelay

### DIFF
--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -1257,7 +1257,10 @@ func (r *DRPlacementControlReconciler) getStatusCheckDelay(
 	// iteration of the reconcile loop.  Hence, the next attempt to update the
 	// status should be after the remaining duration of this polling interval has
 	// elapsed: (beforeProcessing + StatusCheckDelay - time.Now())
-	return time.Until(beforeProcessing.Add(StatusCheckDelay))
+	// If the scheduled time is already in the past, requeue immediately.
+	remaining := time.Until(beforeProcessing.Add(StatusCheckDelay))
+
+	return max(0, remaining)
 }
 
 // updateDRPCStatus updates the DRPC sub-resource status with,


### PR DESCRIPTION
This PR fixes an issue in the `getStatusCheckDelay` function where a negative requeue duration could be returned if the scheduled time had already passed. The fix ensures that if the computed remaining time is negative, the function returns 0 to trigger an immediate requeue instead of a negative duration.

Changes:

- Added a check to prevent negative requeue durations.

- If the computed duration is negative, it now returns 0.


This improves the stability of the reconciliation loop and prevents unexpected scheduling behavior.


Fix: #1838 