### PR TITLE
Fix Duplicate SID issue for RBD and CephFS SCs

### DIFF
--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -108,11 +108,13 @@ def configure_rbd_mirroring(cluster, peer_info):
 
     print("Creating VolumeReplicationClass")
     template = drenv.template("start-data/vrc-sample.yaml")
-    yaml = template.substitute(cluster=cluster)
+    yaml = template.substitute(cluster=cluster, scname="rook-ceph-block")
     kubectl.apply("--filename=-", input=yaml, context=cluster)
 
     template = drenv.template("start-data/vgrc-sample.yaml")
-    yaml = template.substitute(cluster=cluster, pool=POOL_NAME)
+    yaml = template.substitute(
+        cluster=cluster, pool=POOL_NAME, scname="rook-ceph-block"
+    )
     kubectl.apply("--filename=-", input=yaml, context=cluster)
 
     print(f"Apply rbd mirror to cluster '{cluster}'")

--- a/test/addons/rbd-mirror/start-data/vgrc-sample.yaml
+++ b/test/addons/rbd-mirror/start-data/vgrc-sample.yaml
@@ -7,7 +7,7 @@ kind: VolumeGroupReplicationClass
 metadata:
   name: vgrc-sample
   labels:
-    ramendr.openshift.io/storageid: rook-ceph-$cluster-1
+    ramendr.openshift.io/storageid: $scname-$cluster-1
     ramendr.openshift.io/replicationid: rook-ceph-replication-1
 spec:
   provisioner: rook-ceph.rbd.csi.ceph.com

--- a/test/addons/rbd-mirror/start-data/vrc-sample.yaml
+++ b/test/addons/rbd-mirror/start-data/vrc-sample.yaml
@@ -7,7 +7,7 @@ kind: VolumeReplicationClass
 metadata:
   name: vrc-sample
   labels:
-    ramendr.openshift.io/storageid: rook-ceph-$cluster-1
+    ramendr.openshift.io/storageid: $scname-$cluster-1
     ramendr.openshift.io/replicationid: rook-ceph-replication-1
 spec:
   provisioner: rook-ceph.rbd.csi.ceph.com

--- a/test/addons/rook-cephfs/snapshot-class.yaml
+++ b/test/addons/rook-cephfs/snapshot-class.yaml
@@ -13,7 +13,7 @@ kind: VolumeSnapshotClass
 metadata:
   name: csi-cephfsplugin-snapclass
   labels:
-    ramendr.openshift.io/storageid: rook-cephfs-$cluster-1
+    ramendr.openshift.io/storageid: $scname-$cluster-1
 parameters:
   clusterID: rook-ceph
   csi.storage.k8s.io/snapshotter-secret-name: rook-csi-cephfs-provisioner

--- a/test/addons/rook-cephfs/start
+++ b/test/addons/rook-cephfs/start
@@ -9,6 +9,7 @@ import sys
 import drenv
 from drenv import kubectl
 
+STORAGE_CLASS_NAME_PREFIX = "rook-cephfs-"
 FILE_SYSTEMS = ["test-fs1", "test-fs2"]
 
 
@@ -21,12 +22,16 @@ def deploy(cluster):
 
         print("Creating StorageClass")
         template = drenv.template("storage-class.yaml")
-        yaml = template.substitute(cluster=cluster, fsname=file_system)
+        storage_class_name = STORAGE_CLASS_NAME_PREFIX + file_system
+        yaml = template.substitute(
+            cluster=cluster, fsname=file_system, name=storage_class_name
+        )
         kubectl.apply("--filename=-", input=yaml, context=cluster)
 
     print("Creating SnapshotClass")
     template = drenv.template("snapshot-class.yaml")
-    yaml = template.substitute(cluster=cluster)
+    storage_class_name = STORAGE_CLASS_NAME_PREFIX + FILE_SYSTEMS[0]
+    yaml = template.substitute(cluster=cluster, scname=storage_class_name)
     kubectl.apply("--filename=-", input=yaml, context=cluster)
 
 

--- a/test/addons/rook-cephfs/storage-class.yaml
+++ b/test/addons/rook-cephfs/storage-class.yaml
@@ -9,9 +9,9 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: rook-cephfs-$fsname
+  name: $name
   labels:
-    ramendr.openshift.io/storageid: rook-cephfs-$cluster-1
+    ramendr.openshift.io/storageid: $name-$cluster-1
 provisioner: rook-ceph.cephfs.csi.ceph.com
 parameters:
   clusterID: rook-ceph

--- a/test/addons/rook-pool/snapshot-class.yaml
+++ b/test/addons/rook-pool/snapshot-class.yaml
@@ -9,7 +9,7 @@ kind: VolumeSnapshotClass
 metadata:
   name: csi-rbdplugin-snapclass
   labels:
-    ramendr.openshift.io/storageid: rook-ceph-$cluster-1
+    ramendr.openshift.io/storageid: $scname-$cluster-1
 driver: rook-ceph.rbd.csi.ceph.com
 parameters:
   clusterID: rook-ceph

--- a/test/addons/rook-pool/start
+++ b/test/addons/rook-pool/start
@@ -37,7 +37,7 @@ def deploy(cluster):
 
     print("Creating SnapshotClass")
     template = drenv.template("snapshot-class.yaml")
-    yaml = template.substitute(cluster=cluster)
+    yaml = template.substitute(cluster=cluster, scname="rook-ceph-block")
     kubectl.apply("--filename=-", input=yaml, context=cluster)
 
 

--- a/test/addons/rook-pool/storage-class.yaml
+++ b/test/addons/rook-pool/storage-class.yaml
@@ -7,7 +7,7 @@ kind: StorageClass
 metadata:
     name: $name
     labels:
-        ramendr.openshift.io/storageid: rook-ceph-$cluster-1
+        ramendr.openshift.io/storageid: $name-$cluster-1
 provisioner: rook-ceph.rbd.csi.ceph.com
 parameters:
     clusterID: rook-ceph


### PR DESCRIPTION
In the referenced PRs [1] and [2], two StorageClasses were created for RBD and two for CephFS. Both RBD and CephFS StorageClasses had duplicate storageIDs. This commit resolves the duplicate storageID issue.

References:
[1] https://github.com/RamenDR/ramen/pull/1756
[2] https://github.com/RamenDR/ramen/pull/1770