### PR TITLE
e2e: update info logs for deploy/undeploy

### DIFF
--- a/e2e/deployers/discoveredapp.go
+++ b/e2e/deployers/discoveredapp.go
@@ -31,8 +31,6 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 	log := ctx.Logger()
 	appNamespace := ctx.AppNamespace()
 
-	log.Infof("Deploying workload in namespace %q", appNamespace)
-
 	// create namespace in both dr clusters
 	if err := util.CreateNamespaceAndAddAnnotation(appNamespace); err != nil {
 		return err
@@ -70,7 +68,8 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	log.Info("Workload deployed")
+	log.Infof("Deployed discovered app \"%s/%s\" on cluster %q",
+		appNamespace, ctx.Workload().GetAppName(), drpolicy.Spec.DRClusters[0])
 
 	return nil
 }
@@ -79,8 +78,6 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 func (d DiscoveredApp) Undeploy(ctx types.Context) error {
 	log := ctx.Logger()
 	appNamespace := ctx.AppNamespace()
-
-	log.Infof("Undeploying workload in namespace %q", appNamespace)
 
 	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub.Client, util.DefaultDRPolicyName)
 	if err != nil {
@@ -113,7 +110,7 @@ func (d DiscoveredApp) Undeploy(ctx types.Context) error {
 		return err
 	}
 
-	log.Info("Workload undeployed")
+	log.Infof("Undeployed discovered app \"%s/%s\"", appNamespace, ctx.Workload().GetAppName())
 
 	return nil
 }

--- a/e2e/deployers/subscription.go
+++ b/e2e/deployers/subscription.go
@@ -35,8 +35,6 @@ func (s Subscription) Deploy(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	log.Infof("Deploying subscription in namespace %q", managementNamespace)
-
 	// create subscription namespace
 	err := util.CreateNamespace(util.Ctx.Hub.Client, managementNamespace)
 	if err != nil {
@@ -58,7 +56,20 @@ func (s Subscription) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	return waitSubscriptionPhase(ctx, managementNamespace, name, subscriptionv1.SubscriptionPropagated)
+	err = waitSubscriptionPhase(ctx, managementNamespace, name, subscriptionv1.SubscriptionPropagated)
+	if err != nil {
+		return err
+	}
+
+	clusterName, err := util.GetCurrentCluster(util.Ctx.Hub.Client, managementNamespace, name)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Deployed subscription app \"%s/%s\" on cluster %q",
+		ctx.AppNamespace(), ctx.Workload().GetAppName(), clusterName)
+
+	return nil
 }
 
 // Undeploy deletes a subscription from the hub cluster, deleting the workload from the managed clusters.
@@ -67,12 +78,18 @@ func (s Subscription) Undeploy(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	log.Infof("Undeploying subscription in namespace %q", managementNamespace)
-
 	err := DeleteSubscription(ctx, s)
 	if err != nil {
 		return err
 	}
+
+	clusterName, err := util.GetCurrentCluster(util.Ctx.Hub.Client, managementNamespace, name)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Undeployed subscription app \"%s/%s\" on cluster %q",
+		ctx.AppNamespace(), ctx.Workload().GetAppName(), clusterName)
 
 	err = DeletePlacement(ctx, name, managementNamespace)
 	if err != nil {


### PR DESCRIPTION
Changes:
Updated info logs in deploy/undeploy functions for appset, subscription and discoverd apps in deployers package to log cluster name.

Updated info logs during deploy and undeploy:
1. Discovered:
```
2025-02-19T10:29:20.018-0500	INFO	disapp-deploy-rbd-busybox	Deployed discovered app "e2e-disapp-deploy-rbd-busybox/busybox" on cluster "dr1"

2025-02-19T10:30:03.488-0500	INFO	disapp-deploy-rbd-busybox	Undeployed discovered app "e2e-disapp-deploy-rbd-busybox/busybox"
```
3. Appset:
```
2025-02-19T10:32:59.479-0500	INFO	appset-deploy-rbd-busybox	Deployed applicationset app "e2e-appset-deploy-rbd-busybox/busybox" on cluster "dr2"

2025-02-19T10:33:23.522-0500	INFO	appset-deploy-rbd-busybox	Undeployed applicationset app "e2e-appset-deploy-rbd-busybox/busybox" on cluster "dr2"
```
5. Subscription:
```
2025-02-19T10:31:19.420-0500	INFO	subscr-deploy-rbd-busybox	Deployed subscription app "e2e-subscr-deploy-rbd-busybox/busybox" on cluster "dr2"

2025-02-19T10:31:40.049-0500	INFO	subscr-deploy-rbd-busybox	Undeployed subscription app "e2e-subscr-deploy-rbd-busybox/busybox" on cluster "dr2"
```

Fixes #1843 