### PR TITLE
vrg: fix KubeObjectProtected and KubeObjectsReady condition

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -2396,6 +2396,7 @@ func IsPreRelocateProgression(status rmn.ProgressionStatus) bool {
 		rmn.ProgressionRunningFinalSync,
 		rmn.ProgressionFinalSyncComplete,
 		rmn.ProgressionEnsuringVolumesAreSecondary,
+		rmn.ProgressionWaitOnUserToCleanUp,
 	}
 
 	return slices.Contains(preRelocateProgressions, status)


### PR DESCRIPTION
Changes:
1. consolidated KubeObjectsProtected condition functions to
   kubeObjectsCaptureStatusFalse() for failure cases
   kubeObjectsCaptureStatusTrue() for success cases
   kubeObjectsCaptureStatusNil() to clear status when protection is
   disabled

2. processAsPrimary() requeues after each major operation

3. Add new resetKubeObjectsCaptureStatusIfRequired() function to
   properly initialize kubeObjectsProtected condition based on
   configuration and replication state