### PR TITLE
make: add `lint-config-verify` target for config validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,9 +119,12 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 # see https://github.com/golangci/golangci-lint/issues/828
 
 .PHONY: lint
-lint: golangci-bin lint-e2e lint-api ## Run configured golangci-lint and pre-commit.sh linters against the code.
+lint: golangci-bin lint-config-verify lint-e2e lint-api ## Run configured golangci-lint and pre-commit.sh linters against the code.
 	testbin/golangci-lint run ./... --config=./.golangci.yaml
 	hack/pre-commit.sh
+
+lint-config-verify: golangci-bin ## Verify golangci-lint configuration file
+	testbin/golangci-lint config verify --config=./.golangci.yaml
 
 lint-e2e: golangci-bin ## Run configured golangci-lint for e2e module
 	cd e2e && ../testbin/golangci-lint run ./... --config=../.golangci.yaml


### PR DESCRIPTION
Changes:

Added a new Makefile target `lint-config-verify`, which runs:`golangci-lint config verify --config=./.golangci.yaml` locally to detect issues in `.golangci.yaml`. This allows to detect issues with the config file quickly without running the entire ci. Additionally, `lint` now depends on `lint-config-verify` to ensure the config is always valid before running lint checks.

Tested locally by providing incorrect config in .golangci.yaml:
```
make lint-config-verify
testbin/golangci-lint config verify --config=./.golangci.yaml
jsonschema: "linters-settings.wsl" does not validate with "/properties/linters-settings/properties/wsl/additionalProperties": additionalProperties 'enforce-err-cuddling' not allowed
Failed executing command with error: the configuration contains invalid elements
make: *** [Makefile:127: lint-config-verify] Error 3
```
