### PR TITLE
Validates clusterID field of DRClusterConfig

### DIFF
--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -766,13 +766,22 @@ func (u *drclusterInstance) generateDRClusterConfig() (*ramen.DRClusterConfig, e
 
 	util.AddLabel(&drcConfig, util.CreatedByRamenLabel, "true")
 
-	drpolicies, err := util.GetAllDRPolicies(u.ctx, u.reconciler.APIReader)
+	err = u.ensureNoDuplicateSchedules(&drcConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	// Ensure that schedules are not duplicated by, storing them in "added" to avoid adding a duplicate schedule from
-	// another DRPolicy
+	return &drcConfig, nil
+}
+
+// ensureNoDuplicateSchedules ensures that schedules are not duplicated by, storing them in "added" to avoid adding a duplicate
+// schedule from another DRPolicy
+func (u *drclusterInstance) ensureNoDuplicateSchedules(drcConfig *ramen.DRClusterConfig) error {
+	drpolicies, err := util.GetAllDRPolicies(u.ctx, u.reconciler.APIReader)
+	if err != nil {
+		return err
+	}
+
 	added := map[string]bool{}
 
 	for idx := range drpolicies.Items {
@@ -799,7 +808,7 @@ func (u *drclusterInstance) generateDRClusterConfig() (*ramen.DRClusterConfig, e
 		}
 	}
 
-	return &drcConfig, nil
+	return nil
 }
 
 // TODO:

--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -860,13 +860,22 @@ func (u *drclusterInstance) generateDRClusterConfig() (*ramen.DRClusterConfig, e
 
 	util.AddLabel(&drcConfig, util.CreatedByRamenLabel, "true")
 
-	drpolicies, err := util.GetAllDRPolicies(u.ctx, u.reconciler.APIReader)
+	err = u.ensureNoDuplicateSchedules(&drcConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	// Ensure that schedules are not duplicated by, storing them in "added" to avoid adding a duplicate schedule from
-	// another DRPolicy
+	return &drcConfig, nil
+}
+
+// ensureNoDuplicateSchedules ensures that schedules are not duplicated by, storing them in "added" to avoid adding a duplicate
+// schedule from another DRPolicy
+func (u *drclusterInstance) ensureNoDuplicateSchedules(drcConfig *ramen.DRClusterConfig) error {
+	drpolicies, err := util.GetAllDRPolicies(u.ctx, u.reconciler.APIReader)
+	if err != nil {
+		return err
+	}
+
 	added := map[string]bool{}
 
 	for idx := range drpolicies.Items {
@@ -893,7 +902,7 @@ func (u *drclusterInstance) generateDRClusterConfig() (*ramen.DRClusterConfig, e
 		}
 	}
 
-	return &drcConfig, nil
+	return nil
 }
 
 // TODO:

--- a/internal/controller/drclusterconfig_controller.go
+++ b/internal/controller/drclusterconfig_controller.go
@@ -35,9 +35,10 @@ import (
 )
 
 const (
-	drCConfigFinalizerName = "drclusterconfigs.ramendr.openshift.io/finalizer"
-	drCConfigOwnerLabel    = "drclusterconfigs.ramendr.openshift.io/owner"
-	drCConfigOwnerName     = "ramen"
+	drCConfigFinalizerName    = "drclusterconfigs.ramendr.openshift.io/finalizer"
+	drCConfigOwnerLabel       = "drclusterconfigs.ramendr.openshift.io/owner"
+	drCConfigOwnerName        = "ramen"
+	clusterIDClusterClaimName = "id.k8s.io"
 
 	maxReconcileBackoff = 5 * time.Minute
 )
@@ -244,6 +245,16 @@ func (r *DRClusterConfigReconciler) processCreateOrUpdate(
 	log logr.Logger,
 	drCConfig *ramen.DRClusterConfig,
 ) (ctrl.Result, error) {
+	// Validate cluster ID
+	if err := r.validateClusterIDFromClaim(ctx, drCConfig); err != nil {
+		log.Error(err, "failed to validate cluster ID claim")
+		setDRClusterConfigConfigurationProcessedCondition(&drCConfig.Status.Conditions, drCConfig.Generation,
+			err.Error(), metav1.ConditionFalse, DRClusterConfigConditionConfigurationFailed,
+		)
+
+		return ctrl.Result{Requeue: true}, err
+	}
+
 	if err := util.NewResourceUpdater(drCConfig).
 		AddFinalizer(drCConfigFinalizerName).
 		Update(ctx, r.Client); err != nil {
@@ -279,7 +290,40 @@ func (r *DRClusterConfigReconciler) processCreateOrUpdate(
 	return ctrl.Result{}, nil
 }
 
-// UpdateStatus updates DRClusterConfig status with a list of storage related classes that are marked for DR
+// validateClusterIDFromClaim fetches the cluster ID claim and validates it against the DRClusterConfig.
+// It only returns an error and leaves status handling to the caller.
+func (r *DRClusterConfigReconciler) validateClusterIDFromClaim(
+	ctx context.Context,
+	drCConfig *ramen.DRClusterConfig,
+) error {
+	clusterID, err := r.getClusterID(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster ID claim: %w", err)
+	}
+
+	if drCConfig.Spec.ClusterID != clusterID {
+		return fmt.Errorf("cluster ID claim value %q differs from DRClusterConfig ClusterID %q",
+			clusterID, drCConfig.Spec.ClusterID)
+	}
+
+	return nil
+}
+
+// getClusterID fetches the cluster ID directly from the id.k8s.io ClusterClaim.
+func (r *DRClusterConfigReconciler) getClusterID(ctx context.Context) (string, error) {
+	claim := &clusterv1alpha1.ClusterClaim{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: clusterIDClusterClaimName}, claim); err != nil {
+		return "", fmt.Errorf("failed to get ClusterClaim %q: %w", clusterIDClusterClaimName, err)
+	}
+
+	if claim.Spec.Value == "" {
+		return "", fmt.Errorf("ClusterClaim %q has an empty cluster ID value", clusterIDClusterClaimName)
+	}
+
+	return claim.Spec.Value, nil
+}
+
+// UpdateSupportedClasses updates DRClusterConfig status with a list of storage related classes that are marked for DR
 // support. The list is sorted alphabetically to avoid out of order listing and status updates due to the same
 func (r *DRClusterConfigReconciler) UpdateStatus(
 	ctx context.Context,

--- a/internal/controller/drclusterconfig_controller.go
+++ b/internal/controller/drclusterconfig_controller.go
@@ -37,9 +37,10 @@ import (
 )
 
 const (
-	drCConfigFinalizerName = "drclusterconfigs.ramendr.openshift.io/finalizer"
-	drCConfigOwnerLabel    = "drclusterconfigs.ramendr.openshift.io/owner"
-	drCConfigOwnerName     = "ramen"
+	drCConfigFinalizerName    = "drclusterconfigs.ramendr.openshift.io/finalizer"
+	drCConfigOwnerLabel       = "drclusterconfigs.ramendr.openshift.io/owner"
+	drCConfigOwnerName        = "ramen"
+	clusterIDClusterClaimName = "id.k8s.io"
 
 	maxReconcileBackoff = 5 * time.Minute
 )
@@ -275,6 +276,16 @@ func (r *DRClusterConfigReconciler) processCreateOrUpdate(
 	log logr.Logger,
 	drCConfig *ramen.DRClusterConfig,
 ) (ctrl.Result, error) {
+	// Validate cluster ID
+	if err := r.validateClusterIDFromClaim(ctx, drCConfig); err != nil {
+		log.Error(err, "failed to validate cluster ID claim")
+		setDRClusterConfigConfigurationProcessedCondition(&drCConfig.Status.Conditions, drCConfig.Generation,
+			err.Error(), metav1.ConditionFalse, DRClusterConfigConditionConfigurationFailed,
+		)
+
+		return ctrl.Result{Requeue: true}, err
+	}
+
 	if err := util.NewResourceUpdater(drCConfig).
 		AddFinalizer(drCConfigFinalizerName).
 		Update(ctx, r.Client); err != nil {
@@ -312,7 +323,40 @@ func (r *DRClusterConfigReconciler) processCreateOrUpdate(
 	return ctrl.Result{}, nil
 }
 
-// UpdateStatus updates DRClusterConfig status with a list of storage related classes that are marked for DR
+// validateClusterIDFromClaim fetches the cluster ID claim and validates it against the DRClusterConfig.
+// It only returns an error and leaves status handling to the caller.
+func (r *DRClusterConfigReconciler) validateClusterIDFromClaim(
+	ctx context.Context,
+	drCConfig *ramen.DRClusterConfig,
+) error {
+	clusterID, err := r.getClusterID(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster ID claim: %w", err)
+	}
+
+	if drCConfig.Spec.ClusterID != clusterID {
+		return fmt.Errorf("cluster ID claim value %q differs from DRClusterConfig ClusterID %q",
+			clusterID, drCConfig.Spec.ClusterID)
+	}
+
+	return nil
+}
+
+// getClusterID fetches the cluster ID directly from the id.k8s.io ClusterClaim.
+func (r *DRClusterConfigReconciler) getClusterID(ctx context.Context) (string, error) {
+	claim := &clusterv1alpha1.ClusterClaim{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: clusterIDClusterClaimName}, claim); err != nil {
+		return "", fmt.Errorf("failed to get ClusterClaim %q: %w", clusterIDClusterClaimName, err)
+	}
+
+	if claim.Spec.Value == "" {
+		return "", fmt.Errorf("ClusterClaim %q has an empty cluster ID value", clusterIDClusterClaimName)
+	}
+
+	return claim.Spec.Value, nil
+}
+
+// UpdateSupportedClasses updates DRClusterConfig status with a list of storage related classes that are marked for DR
 // support. The list is sorted alphabetically to avoid out of order listing and status updates due to the same
 func (r *DRClusterConfigReconciler) UpdateStatus(
 	ctx context.Context,

--- a/internal/controller/drclusterconfig_controller_test.go
+++ b/internal/controller/drclusterconfig_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
 	config "k8s.io/component-base/config/v1alpha1"
+	ocmv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -188,9 +189,19 @@ var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 
 		By("Creating a DClusterConfig")
 
+		clusterClaimClusterID := &ocmv1alpha1.ClusterClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "id.k8s.io",
+			},
+			Spec: ocmv1alpha1.ClusterClaimSpec{Value: "cid"},
+		}
+		Expect(k8sClient.Create(context.TODO(), clusterClaimClusterID)).To(Succeed())
+
 		drCConfig = &ramen.DRClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: "local"},
-			Spec:       ramen.DRClusterConfigSpec{ClusterID: "local-cid"},
+			Spec: ramen.DRClusterConfigSpec{
+				ClusterID: "cid",
+			},
 		}
 		Expect(k8sClient.Create(context.TODO(), drCConfig)).To(Succeed())
 		objectConditionExpectEventually(

--- a/internal/controller/drclusterconfig_controller_test.go
+++ b/internal/controller/drclusterconfig_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
+	ocmv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -184,9 +185,19 @@ var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 
 		By("Creating a DClusterConfig")
 
+		clusterClaimClusterID := &ocmv1alpha1.ClusterClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "id.k8s.io",
+			},
+			Spec: ocmv1alpha1.ClusterClaimSpec{Value: "cid"},
+		}
+		Expect(k8sClient.Create(context.TODO(), clusterClaimClusterID)).To(Succeed())
+
 		drCConfig = &ramen.DRClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: "local"},
-			Spec:       ramen.DRClusterConfigSpec{ClusterID: "local-cid"},
+			Spec: ramen.DRClusterConfigSpec{
+				ClusterID: "cid",
+			},
 		}
 		Expect(k8sClient.Create(context.TODO(), drCConfig)).To(Succeed())
 		objectConditionExpectEventually(


### PR DESCRIPTION
## Changes

- A sanity check to validate that the clusterID fetched from managed cluster's claim matches that of the cluster (differs for ocp/k8s)
- Refactors `generateDRClusterConfig` to avoid cyclomatic complexity exceeding its limit

Resolves [1804](https://github.com/RamenDR/ramen/issues/1804)