### PR TITLE
Check for PVC label selector conflicts against the secondary cluster

### DIFF
--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -45,6 +45,10 @@ const (
 	VRGConditionTypeVolSyncFinalSyncInProgress = "FinalSyncInProgress"
 	VRGConditionTypeVolSyncRepDestinationSetup = "ReplicationDestinationSetup"
 	VRGConditionTypeVolSyncPVsRestored         = "PVsRestored"
+
+	// Indicates no conflict in PVC and Kubernetes resource data
+	// between primary and secondary clusters.
+	VRGConditionTypeNoClusterDataConflict = "NoClusterDataConflict"
 )
 
 // VRG condition reasons
@@ -73,6 +77,15 @@ const (
 	VRGConditionReasonClusterDataAnnotationFailed = "AnnotationFailed"
 	VRGConditionReasonPeerClassNotFound           = "PeerClassNotFound"
 	VRGConditionReasonStorageIDNotFound           = "StorageIDNotFound"
+
+	// Indicates a conflict in cluster data detected on the primary cluster.
+	VRGConditionReasonClusterDataConflictPrimary = "ClusterDataConflictPrimary"
+
+	// Indicates a conflict in cluster data detected on the secondary cluster.
+	VRGConditionReasonClusterDataConflictSecondary = "ClusterDataConflictSecondary"
+
+	// Indicates no conflict in cluster data detected on both the primary and secondary cluster.
+	VRGConditionReasonConflictResolved = "ConflictResolved"
 )
 
 const (
@@ -537,4 +550,17 @@ func setVRGConditionTypeVolSyncPVRestoreError(conditions *[]metav1.Condition, ob
 		Status:             metav1.ConditionFalse,
 		Message:            message,
 	})
+}
+
+// set condition when a Cluster Data Conflict is detected
+func newVRGAsClusterDataConflictCondition(
+	observedGeneration int64, message string, reason string,
+) *metav1.Condition {
+	return &metav1.Condition{
+		Type:               VRGConditionTypeNoClusterDataConflict,
+		Reason:             reason,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	}
 }

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1645,10 +1645,11 @@ func (v *VRGInstance) updateVRGConditions() {
 		v.log.Info(msg, "finalCondition", finalCondition)
 	}
 
-	var volSyncDataReady, volSyncDataProtected, volSyncClusterDataProtected *metav1.Condition
+	var volSyncDataReady, volSyncDataProtected, volSyncClusterDataProtected, volSyncClusterDataConflict *metav1.Condition
 	if v.instance.Spec.Sync == nil {
 		volSyncDataReady = v.aggregateVolSyncDataReadyCondition()
 		volSyncDataProtected, volSyncClusterDataProtected = v.aggregateVolSyncDataProtectedConditions()
+		volSyncClusterDataConflict = v.aggregateVolSyncClusterDataConflictCondition()
 	}
 
 	logAndSet(VRGConditionTypeDataReady,
@@ -1665,6 +1666,10 @@ func (v *VRGInstance) updateVRGConditions() {
 		v.aggregateVolRepClusterDataProtectedCondition(),
 		v.vrgObjectProtected,
 		v.kubeObjectsProtected,
+	)
+	logAndSet(VRGConditionTypeNoClusterDataConflict,
+		volSyncClusterDataConflict,
+		v.aggregateVolRepClusterDataConflictCondition(),
 	)
 	v.updateVRGLastGroupSyncTime()
 	v.updateVRGLastGroupSyncDuration()

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -639,3 +639,51 @@ func (v *VRGInstance) doCleanupResources(name, namespace string) error {
 
 	return nil
 }
+
+func (v *VRGInstance) isSecondaryWithVolSyncProtectedPVCs() bool {
+	return v.IsSecondaryVRG() && len(v.volSyncPVCs) > 0
+}
+
+func (v *VRGInstance) validateSecondaryPVCConflictForVolsync() bool {
+	if !v.isSecondaryWithVolSyncProtectedPVCs() {
+		return false
+	}
+
+	// Validate that only replication destination PVCs match the label selector.
+	for _, pvc := range v.volSyncPVCs {
+		matchFound := false
+
+		for _, rdSpec := range v.instance.Spec.VolSync.RDSpec {
+			if pvc.GetName() == rdSpec.ProtectedPVC.Name {
+				matchFound = true
+
+				break // Found a match, no need to check further for this PVC
+			}
+		}
+
+		if !matchFound {
+			return true // No match found for this PVC, conflict detected!
+		}
+	}
+
+	return false // No conflicts found
+}
+
+func (v *VRGInstance) aggregateVolSyncClusterDataConflictCondition() *metav1.Condition {
+	noClusterDataConflictCondition := &metav1.Condition{
+		Status:             metav1.ConditionTrue,
+		Type:               VRGConditionTypeNoClusterDataConflict,
+		Reason:             VRGConditionReasonConflictResolved,
+		ObservedGeneration: v.instance.Generation,
+		Message:            "No PVC conflict detected for VolumeSync scheme",
+	}
+
+	if v.validateSecondaryPVCConflictForVolsync() {
+		return newVRGAsClusterDataConflictCondition(v.instance.Generation,
+			"A PVC that is not a replication destination should not match the label selector.",
+			VRGConditionReasonClusterDataConflictSecondary,
+		)
+	}
+
+	return noClusterDataConflictCondition
+}


### PR DESCRIPTION
**Applying PVC Label Conflict Check on the Secondary Cluster**

The PR introduces a mechanism in `vrg_volrep.go` and `vrg_volsync.go` that applies the **PVCLabelSelector** from the **secondary VRG** and checks whether any PVCs are selected.

**Expected behavior:**

* A **secondary VRG** should not match any PVCs using the **PVCLabelSelector**.
* If a PVC is selected on the secondary cluster, it indicates a conflict because the label selector should not apply to unintended PVCs after failover/relocation.
* In case of a conflict, the reconciliation process will be required, and the VRG will log the issue.
* For VolSync, the behavior is slightly different, if the label selector matches any PVC that is not part of RDSpec, it is considered a conflict.

For more: https://github.com/RamenDR/ramen/issues/1861