### PR TITLE
Stop creation of new PV on Failover/Relocate

### DIFF
--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1188,6 +1188,10 @@ func (v *VRGInstance) processAsPrimary() ctrl.Result {
 		if numOfRestoredRes != 0 {
 			return v.updateVRGConditionsAndStatus(v.result)
 		}
+
+		if v.instance.Spec.Action != "" && numOfRestoredRes == 0 {
+			return v.clusterDataError(err, "Failed to restore PVs/PVCs, No PV found", v.result)
+		}
 	}
 
 	v.reconcileAsPrimary()

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -2016,6 +2016,11 @@ func (v *VRGInstance) restorePVsAndPVCsFromS3(result *ctrl.Result) (int, error) 
 			continue
 		}
 
+		// If no PVs found in the s3 store, the next profile will be retried
+		if v.instance.Spec.Action != "" && pvCount == 0 {
+			continue
+		}
+
 		// Attempt to restore all PVCs from this profile. If a PVC is missing from this s3 stores or fails
 		// to restore, there will be a warning, but not a failure (no retry). In such cases, the PVC may be
 		// created when the application is created and it will bind to the PV correctly if the PVC name


### PR DESCRIPTION
Stop creation of new PV on Failover or Relocate due to S3 access issue. 
Fixes: DFBUGS-1341