### PR TITLE
Disable stacktraces for Error logs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -63,7 +63,9 @@ func configureLogOptions() *zap.Options {
 		ZapOpts: []uberzap.Option{
 			uberzap.AddCaller(),
 		},
-		TimeEncoder: zapcore.ISO8601TimeEncoder,
+		// Don't show stacktraces for log.Error.
+		StacktraceLevel: zapcore.FatalLevel,
+		TimeEncoder:     zapcore.ISO8601TimeEncoder,
 	}
 
 	return &opts


### PR DESCRIPTION
Stacktraces are not very helpful and create lot of noise in the logs and cause the log to be rotated too early, losing essential info for debugging problems.

Because of this issue, developers use log.Info() instead of log.Error(), using many different ways to describe the error. This makes it very hard to follow errors in the logs, since you need to look for many "error" like strings (e.g. "failed|"error|unable|cannot").

Fix the issue by changing zap StacktraceLevel to Fatal. With this we can safely log errors using log.Error(), and search for errors using "ERROR".

Status:
✅ tested with e2e job