### PR TITLE
e2e: refactor `ValidateRamenDRClusterOperator` and improve validation logs

### DIFF
--- a/e2e/util/validation.go
+++ b/e2e/util/validation.go
@@ -35,16 +35,16 @@ func ValidateRamenHubOperator(cluster Cluster) error {
 	}
 
 	if pod.Status.Phase != "Running" {
-		return fmt.Errorf("ramen hub operator pod %q not running (phase %q)",
-			pod.Name, pod.Status.Phase)
+		return fmt.Errorf("ramen hub operator pod %q not running (phase %q) in cluster %q",
+			pod.Name, pod.Status.Phase, cluster.Name)
 	}
 
-	Ctx.Log.Infof("Ramen hub operator pod %q is running", pod.Name)
+	Ctx.Log.Infof("Ramen hub operator pod %q is running in cluster %q", pod.Name, cluster.Name)
 
 	return nil
 }
 
-func ValidateRamenDRClusterOperator(cluster Cluster, clusterName string) error {
+func ValidateRamenDRClusterOperator(cluster Cluster) error {
 	labelSelector := "app=ramen-dr-cluster"
 	podIdentifier := "ramen-dr-cluster-operator"
 
@@ -59,11 +59,11 @@ func ValidateRamenDRClusterOperator(cluster Cluster, clusterName string) error {
 	}
 
 	if pod.Status.Phase != "Running" {
-		return fmt.Errorf("ramen dr cluster operator pod %q not running (phase %q)",
-			pod.Name, pod.Status.Phase)
+		return fmt.Errorf("ramen dr cluster operator pod %q not running (phase %q) in cluster %q",
+			pod.Name, pod.Status.Phase, cluster.Name)
 	}
 
-	Ctx.Log.Infof("Ramen dr cluster operator pod %q is running in cluster %q", pod.Name, clusterName)
+	Ctx.Log.Infof("Ramen dr cluster operator pod %q is running in cluster %q", pod.Name, cluster.Name)
 
 	return nil
 }
@@ -113,7 +113,7 @@ func FindPod(cluster Cluster, namespace, labelSelector, podIdentifier string) (
 ) {
 	ls, err := labels.Parse(labelSelector)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse label selector %q: %v", labelSelector, err)
+		return nil, fmt.Errorf("failed to parse label selector %q in cluster %q: %v", labelSelector, cluster.Name, err)
 	}
 
 	pods := &v1.PodList{}
@@ -126,7 +126,7 @@ func FindPod(cluster Cluster, namespace, labelSelector, podIdentifier string) (
 
 	err = cluster.Client.List(context.Background(), pods, listOptions...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list pods in namespace %s: %v", namespace, err)
+		return nil, fmt.Errorf("failed to list pods in namespace %s in cluster %q: %v", namespace, cluster.Name, err)
 	}
 
 	for i := range pods.Items {
@@ -136,6 +136,6 @@ func FindPod(cluster Cluster, namespace, labelSelector, podIdentifier string) (
 		}
 	}
 
-	return nil, fmt.Errorf("no pod with label selector %q and identifier %q in namespace %q",
-		labelSelector, podIdentifier, namespace)
+	return nil, fmt.Errorf("no pod with label selector %q and identifier %q in namespace %q in cluster %q",
+		labelSelector, podIdentifier, namespace, cluster.Name)
 }

--- a/e2e/validation_suite_test.go
+++ b/e2e/validation_suite_test.go
@@ -18,23 +18,23 @@ func Validate(dt *testing.T) {
 
 		err := util.ValidateRamenHubOperator(util.Ctx.Hub)
 		if err != nil {
-			t.Fatalf("Failed to validated hub cluster: %s", err)
+			t.Fatalf("Failed to validate hub cluster %q: %s", util.Ctx.Hub.Name, err)
 		}
 	})
 	t.Run("c1", func(dt *testing.T) {
 		t := test.WithLog(dt, util.Ctx.Log)
 
-		err := util.ValidateRamenDRClusterOperator(util.Ctx.C1, "c1")
+		err := util.ValidateRamenDRClusterOperator(util.Ctx.C1)
 		if err != nil {
-			t.Fatalf("Failed to validated dr cluster c1: %s", err)
+			t.Fatalf("Failed to validate dr cluster %q: %s", util.Ctx.C1.Name, err)
 		}
 	})
 	t.Run("c2", func(dt *testing.T) {
 		t := test.WithLog(dt, util.Ctx.Log)
 
-		err := util.ValidateRamenDRClusterOperator(util.Ctx.C2, "c2")
+		err := util.ValidateRamenDRClusterOperator(util.Ctx.C2)
 		if err != nil {
-			t.Fatalf("Failed to validated dr cluster c2: %s", err)
+			t.Fatalf("Failed to validate dr cluster %q: %s", util.Ctx.C2.Name, err)
 		}
 	})
 }


### PR DESCRIPTION
This commit refactors `ValidateRamenDRClusterOperator` to remove the explicit cluster name parameter and instead use `cluster.Name`. Changes simplifies function calls and improves logs by logging cluster names.

Changes:
- updated `ValidateRamenDRClusterOperator` to use `cluster.Name` instead of passing the cluster name as a parameter.
- added `cluster.Name` and fixed "validated" to "validate" in fatal logs.
- improved info and error logs to include cluster names in validation.go.

Validation logs update:
before:
```
=== RUN   TestSuites/Validate/hub
2025-02-27T13:19:26.834+0530	INFO	Ramen hub operator pod "ramen-hub-operator-84d7dc89bd-c2qxs" is running
=== RUN   TestSuites/Validate/c1
2025-02-27T13:19:26.856+0530	INFO	Ramen dr cluster operator pod "ramen-dr-cluster-operator-896d8c9f6-5wpjf" is running in cluster "c1"
=== RUN   TestSuites/Validate/c2
2025-02-27T13:19:26.887+0530	INFO	Ramen dr cluster operator pod "ramen-dr-cluster-operator-896d8c9f6-67plq" is running in cluster "c2"
```
after:
```
=== RUN   TestSuites/Validate/hub
2025-02-28T02:58:33.734-0500	INFO	Ramen hub operator pod "ramen-hub-operator-865bdf6799-78rfw" is running in cluster "hub"
=== RUN   TestSuites/Validate/c1
2025-02-28T02:58:48.454-0500	INFO	Ramen dr cluster operator pod "ramen-dr-cluster-operator-67dff877f5-hq9sg" is running in cluster "dr1"
=== RUN   TestSuites/Validate/c2
2025-02-28T02:58:50.823-0500	INFO	Ramen dr cluster operator pod "ramen-dr-cluster-operator-67dff877f5-mzlvw" is running in cluster "dr2"
```