### PR TITLE
e2e: log cluster name for all operations in e2e codebase

### DIFF
--- a/e2e/deployers/applicationset.go
+++ b/e2e/deployers/applicationset.go
@@ -45,7 +45,7 @@ func (a ApplicationSet) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	log.Infof("Deployed applicationset app \"%s/%s\" on cluster %q",
+	log.Infof("Deployed applicationset app \"%s/%s\" in cluster %q",
 		ctx.AppNamespace(), ctx.Workload().GetAppName(), clusterName)
 
 	return nil
@@ -67,7 +67,7 @@ func (a ApplicationSet) Undeploy(ctx types.Context) error {
 		return err
 	}
 
-	log.Infof("Undeployed applicationset app \"%s/%s\" on cluster %q",
+	log.Infof("Undeployed applicationset app \"%s/%s\" in cluster %q",
 		ctx.AppNamespace(), ctx.Workload().GetAppName(), clusterName)
 
 	err = DeleteConfigMap(ctx, name, managementNamespace)

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -56,10 +56,10 @@ func CreateManagedClusterSetBinding(ctx types.Context, name, namespace string) e
 			return err
 		}
 
-		log.Debugf("ManagedClusterSetBinding \"%s/%s\" already exist", namespace, name)
+		log.Debugf("ManagedClusterSetBinding \"%s/%s\" already exist in cluster %q", namespace, name, util.Ctx.Hub.Name)
 	}
 
-	log.Debugf("Created ManagedClusterSetBinding \"%s/%s\"", namespace, name)
+	log.Debugf("Created ManagedClusterSetBinding \"%s/%s\" in cluster %q", namespace, name, util.Ctx.Hub.Name)
 
 	return nil
 }
@@ -79,10 +79,10 @@ func DeleteManagedClusterSetBinding(ctx types.Context, name, namespace string) e
 			return err
 		}
 
-		log.Debugf("ManagedClusterSetBinding \"%s/%s\" not found", namespace, name)
+		log.Debugf("ManagedClusterSetBinding \"%s/%s\" not found in cluster %q", namespace, name, util.Ctx.Hub.Name)
 	}
 
-	log.Debugf("Deleted ManagedClusterSetBinding \"%s/%s\"", namespace, name)
+	log.Debugf("Deleted ManagedClusterSetBinding \"%s/%s\" in cluster %q", namespace, name, util.Ctx.Hub.Name)
 
 	return nil
 }
@@ -112,10 +112,10 @@ func CreatePlacement(ctx types.Context, name, namespace string) error {
 			return err
 		}
 
-		log.Debugf("Placement \"%s/%s\" already exists", namespace, name)
+		log.Debugf("Placement \"%s/%s\" already exists in cluster %q", namespace, name, util.Ctx.Hub.Name)
 	}
 
-	log.Debugf("Created placement \"%s/%s\"", namespace, name)
+	log.Debugf("Created placement \"%s/%s\" in cluster %q", namespace, name, util.Ctx.Hub.Name)
 
 	return nil
 }
@@ -135,10 +135,10 @@ func DeletePlacement(ctx types.Context, name, namespace string) error {
 			return err
 		}
 
-		log.Debugf("Placement \"%s/%s\" not found", namespace, name)
+		log.Debugf("Placement \"%s/%s\" not found in cluster %q", namespace, name, util.Ctx.Hub.Name)
 	}
 
-	log.Debugf("Deleted placement \"%s/%s\"", namespace, name)
+	log.Debugf("Deleted placement \"%s/%s\" in cluster %q", namespace, name, util.Ctx.Hub.Name)
 
 	return nil
 }
@@ -193,10 +193,10 @@ func CreateSubscription(ctx types.Context, s Subscription) error {
 			return err
 		}
 
-		log.Debugf("Subscription \"%s/%s\" already exists", managementNamespace, name)
+		log.Debugf("Subscription \"%s/%s\" already exists in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
 	}
 
-	log.Debugf("Created subscription \"%s/%s\"", managementNamespace, name)
+	log.Debugf("Created subscription \"%s/%s\" in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
 
 	return nil
 }
@@ -219,10 +219,10 @@ func DeleteSubscription(ctx types.Context, s Subscription) error {
 			return err
 		}
 
-		log.Debugf("Subscription \"%s/%s\" not found", managementNamespace, name)
+		log.Debugf("Subscription \"%s/%s\" not found in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
 	}
 
-	log.Debugf("Deleted subscription \"%s/%s\"", managementNamespace, name)
+	log.Debugf("Deleted subscription \"%s/%s\" in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
 
 	return nil
 }
@@ -258,10 +258,10 @@ func CreatePlacementDecisionConfigMap(ctx types.Context, cmName string, cmNamesp
 			return fmt.Errorf("could not create configMap %q", cmName)
 		}
 
-		log.Debugf("ConfigMap \"%s/%s\" already exists", cmNamespace, cmName)
+		log.Debugf("ConfigMap \"%s/%s\" already exists in cluster %q", cmNamespace, cmName, util.Ctx.Hub.Name)
 	}
 
-	log.Debugf("Created configMap \"%s/%s\"", cmNamespace, cmName)
+	log.Debugf("Created configMap \"%s/%s\" in cluster %q", cmNamespace, cmName, util.Ctx.Hub.Name)
 
 	return nil
 }
@@ -277,13 +277,13 @@ func DeleteConfigMap(ctx types.Context, cmName string, cmNamespace string) error
 	err := util.Ctx.Hub.Client.Delete(context.Background(), configMap)
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			return fmt.Errorf("could not delete configMap %q", cmName)
+			return fmt.Errorf("could not delete configMap %q in cluster %q", cmName, util.Ctx.Hub.Name)
 		}
 
-		log.Debugf("ConfigMap \"%s/%s\" not found", cmNamespace, cmName)
+		log.Debugf("ConfigMap \"%s/%s\" not found in cluster %q", cmNamespace, cmName, util.Ctx.Hub.Name)
 	}
 
-	log.Debugf("Deleted configMap \"%s/%s\"", cmNamespace, cmName)
+	log.Debugf("Deleted configMap \"%s/%s\" in cluster %q", cmNamespace, cmName, util.Ctx.Hub.Name)
 
 	return nil
 }
@@ -364,10 +364,10 @@ func CreateApplicationSet(ctx types.Context, a ApplicationSet) error {
 			return err
 		}
 
-		log.Debugf("Applicationset \"%s/%s\" already exists", managementNamespace, name)
+		log.Debugf("Applicationset \"%s/%s\" already exists in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
 	}
 
-	log.Debugf("Created applicationset \"%s/%s\"", managementNamespace, name)
+	log.Debugf("Created applicationset \"%s/%s\" in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
 
 	return nil
 }
@@ -390,10 +390,10 @@ func DeleteApplicationSet(ctx types.Context, a ApplicationSet) error {
 			return err
 		}
 
-		log.Debugf("Applicationset \"%s/%s\" not found", managementNamespace, name)
+		log.Debugf("Applicationset \"%s/%s\" not found in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
 	}
 
-	log.Debugf("Deleted applicationset \"%s/%s\"", managementNamespace, name)
+	log.Debugf("Deleted applicationset \"%s/%s\" in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
 
 	return nil
 }
@@ -405,7 +405,7 @@ func isLastAppsetInArgocdNs(namespace string) (bool, error) {
 	err := util.Ctx.Hub.Client.List(
 		context.Background(), appsetList, client.InNamespace(namespace))
 	if err != nil {
-		return false, fmt.Errorf("failed to list applicationsets: %w", err)
+		return false, fmt.Errorf("failed to list applicationsets in cluster %q: %w", util.Ctx.Hub.Name, err)
 	}
 
 	return len(appsetList.Items) == 1, nil
@@ -437,7 +437,7 @@ func DeleteDiscoveredApps(ctx types.Context, namespace, cluster string) error {
 		return err
 	}
 
-	log.Debugf("Deleted discovered app \"%s/%s\" on cluster %q",
+	log.Debugf("Deleted discovered app \"%s/%s\" in cluster %q",
 		namespace, ctx.Workload().GetAppName(), cluster)
 
 	return nil

--- a/e2e/deployers/discoveredapp.go
+++ b/e2e/deployers/discoveredapp.go
@@ -68,7 +68,7 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	log.Infof("Deployed discovered app \"%s/%s\" on cluster %q",
+	log.Infof("Deployed discovered app \"%s/%s\" in cluster %q",
 		appNamespace, ctx.Workload().GetAppName(), drpolicy.Spec.DRClusters[0])
 
 	return nil

--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -24,13 +24,14 @@ func waitSubscriptionPhase(ctx types.Context, namespace, name string, phase subs
 
 		currentPhase := sub.Status.Phase
 		if currentPhase == phase {
-			log.Debugf("Subscription \"%s/%s\" phase is %s", namespace, name, phase)
+			log.Debugf("Subscription \"%s/%s\" phase is %s in cluster %q", namespace, name, phase, util.Ctx.Hub.Name)
 
 			return nil
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			return fmt.Errorf("subscription %q status is not %q yet before timeout", name, phase)
+			return fmt.Errorf("subscription %q status is not %q yet before timeout in cluster %q",
+				name, phase, util.Ctx.Hub.Name)
 		}
 
 		time.Sleep(util.RetryInterval)
@@ -45,14 +46,14 @@ func WaitWorkloadHealth(ctx types.Context, cluster util.Cluster, namespace strin
 	for {
 		err := w.Health(ctx, cluster, namespace)
 		if err == nil {
-			log.Debugf("Workload \"%s/%s\" is ready", namespace, w.GetAppName())
+			log.Debugf("Workload \"%s/%s\" is ready in cluster %q", namespace, w.GetAppName(), cluster.Name)
 
 			return nil
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			return fmt.Errorf("workload %q is not ready yet before timeout of %v",
-				w.GetName(), util.Timeout)
+			return fmt.Errorf("workload %q is not ready yet before timeout of %v in cluster %q",
+				w.GetName(), util.Timeout, cluster.Name)
 		}
 
 		time.Sleep(util.RetryInterval)

--- a/e2e/deployers/subscription.go
+++ b/e2e/deployers/subscription.go
@@ -66,7 +66,7 @@ func (s Subscription) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	log.Infof("Deployed subscription app \"%s/%s\" on cluster %q",
+	log.Infof("Deployed subscription app \"%s/%s\" in cluster %q",
 		ctx.AppNamespace(), ctx.Workload().GetAppName(), clusterName)
 
 	return nil
@@ -88,7 +88,7 @@ func (s Subscription) Undeploy(ctx types.Context) error {
 		return err
 	}
 
-	log.Infof("Undeployed subscription app \"%s/%s\" on cluster %q",
+	log.Infof("Undeployed subscription app \"%s/%s\" in cluster %q",
 		ctx.AppNamespace(), ctx.Workload().GetAppName(), clusterName)
 
 	err = DeletePlacement(ctx, name, managementNamespace)

--- a/e2e/dractions/crud.go
+++ b/e2e/dractions/crud.go
@@ -43,7 +43,7 @@ func createDRPC(ctx types.Context, cluster util.Cluster, drpc *ramen.DRPlacement
 			return err
 		}
 
-		log.Debugf("drpc \"%s/%s\" already exist", drpc.Namespace, drpc.Name)
+		log.Debugf("drpc \"%s/%s\" already exist in cluster %q", drpc.Namespace, drpc.Name, cluster.Name)
 	}
 
 	spec, err := yaml.Marshal(drpc.Spec)
@@ -51,7 +51,8 @@ func createDRPC(ctx types.Context, cluster util.Cluster, drpc *ramen.DRPlacement
 		return err
 	}
 
-	log.Debugf("Created drpc \"%s/%s\" with spec:\n%s", drpc.Namespace, drpc.Name, string(spec))
+	log.Debugf("Created drpc \"%s/%s\" in cluster %q with spec:\n%s",
+		drpc.Namespace, drpc.Name, cluster.Name, string(spec))
 
 	return nil
 }
@@ -72,7 +73,7 @@ func deleteDRPC(ctx types.Context, cluster util.Cluster, namespace, name string)
 			return err
 		}
 
-		log.Debugf("drpc \"%s/%s\" not found", namespace, name)
+		log.Debugf("drpc \"%s/%s\" not found in cluster %q", namespace, name, cluster.Name)
 
 		return nil
 	}
@@ -81,7 +82,7 @@ func deleteDRPC(ctx types.Context, cluster util.Cluster, namespace, name string)
 		return err
 	}
 
-	log.Debugf("Deleted drpc \"%s/%s\"", namespace, name)
+	log.Debugf("Deleted drpc \"%s/%s\" in cluster %q", namespace, name, cluster.Name)
 
 	return nil
 }
@@ -143,10 +144,10 @@ func createPlacementManagedByRamen(ctx types.Context, name, namespace string) er
 			return err
 		}
 
-		log.Debugf("Placement \"%s/%s\" already Exists", namespace, name)
+		log.Debugf("Placement \"%s/%s\" already Exists in cluster %q", namespace, name, util.Ctx.Hub.Name)
 	}
 
-	log.Debugf("Created placement \"%s/%s\"", namespace, name)
+	log.Debugf("Created placement \"%s/%s\" in cluster %q", namespace, name, util.Ctx.Hub.Name)
 
 	return nil
 }

--- a/e2e/dractions/discovered.go
+++ b/e2e/dractions/discovered.go
@@ -17,8 +17,6 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 	managementNamespace := ctx.ManagementNamespace()
 	appNamespace := ctx.AppNamespace()
 
-	log.Infof("Protecting workload in app namespace %q, management namespace: %q", appNamespace, managementNamespace)
-
 	drPolicyName := util.DefaultDRPolicyName
 	appname := w.GetAppName()
 	placementName := name
@@ -42,6 +40,9 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 
 	clusterName := drpolicy.Spec.DRClusters[0]
 
+	log.Infof("Protecting workload running in cluster %q (app namespace: %q, management namespace: %q)",
+		clusterName, appNamespace, managementNamespace)
+
 	drpc := generateDRPCDiscoveredApps(
 		name, managementNamespace, clusterName, drPolicyName, placementName, appname, appNamespace)
 	if err = createDRPC(ctx, util.Ctx.Hub, drpc); err != nil {
@@ -60,10 +61,16 @@ func DisableProtectionDiscoveredApps(ctx types.Context) error {
 	managementNamespace := ctx.ManagementNamespace()
 	appNamespace := ctx.AppNamespace()
 
-	log.Infof("Unprotecting workload in app namespace %q, management namespace: %q", appNamespace, managementNamespace)
-
 	placementName := name
 	drpcName := name
+
+	clusterName, err := util.GetCurrentCluster(util.Ctx.Hub, managementNamespace, placementName)
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Unprotecting workload running in cluster %q (app namespace: %q, management namespace: %q)",
+		clusterName, appNamespace, managementNamespace)
 
 	if err := deleteDRPC(ctx, util.Ctx.Hub, managementNamespace, drpcName); err != nil {
 		return err

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -19,7 +19,7 @@ func waitDRPCReady(ctx types.Context, cluster util.Cluster, namespace string, dr
 	log := ctx.Logger()
 	startTime := time.Now()
 
-	log.Debugf("Waiting until drpc \"%s/%s\" is ready", namespace, drpcName)
+	log.Debugf("Waiting until drpc \"%s/%s\" is ready in cluster %q", namespace, drpcName, cluster.Name)
 
 	for {
 		drpc, err := getDRPC(cluster, namespace, drpcName)
@@ -31,14 +31,15 @@ func waitDRPCReady(ctx types.Context, cluster util.Cluster, namespace string, dr
 		peerReady := conditionMet(drpc.Status.Conditions, ramen.ConditionPeerReady)
 
 		if available && peerReady && drpc.Status.LastGroupSyncTime != nil {
-			log.Debugf("drpc \"%s/%s\" is ready", namespace, drpcName)
+			log.Debugf("drpc \"%s/%s\" is ready in cluster %q", namespace, drpcName, cluster.Name)
 
 			return nil
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			return fmt.Errorf("timeout waiting for drpc to become ready (Available: %v, PeerReady: %v, lastGroupSyncTime: %v)",
-				available, peerReady, drpc.Status.LastGroupSyncTime)
+			return fmt.Errorf("timeout waiting for drpc to become ready in cluster %q"+
+				" (Available: %v, PeerReady: %v, lastGroupSyncTime: %v)",
+				cluster.Name, available, peerReady, drpc.Status.LastGroupSyncTime)
 		}
 
 		time.Sleep(util.RetryInterval)
@@ -55,7 +56,7 @@ func waitDRPCPhase(ctx types.Context, cluster util.Cluster, namespace, name stri
 	log := ctx.Logger()
 	startTime := time.Now()
 
-	log.Debugf("Waiting until drpc \"%s/%s\" reach phase %q", namespace, name, phase)
+	log.Debugf("Waiting until drpc \"%s/%s\" reach phase %q in cluster %q", namespace, name, phase, cluster.Name)
 
 	for {
 		drpc, err := getDRPC(cluster, namespace, name)
@@ -65,13 +66,13 @@ func waitDRPCPhase(ctx types.Context, cluster util.Cluster, namespace, name stri
 
 		currentPhase := drpc.Status.Phase
 		if currentPhase == phase {
-			log.Debugf("drpc \"%s/%s\" phase is %q", namespace, name, phase)
+			log.Debugf("drpc \"%s/%s\" phase is %q in cluster %q", namespace, name, phase, cluster.Name)
 
 			return nil
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			return fmt.Errorf("drpc %q status is not %q yet before timeout, fail", name, phase)
+			return fmt.Errorf("drpc %q status is not %q yet before timeout in cluster %q, fail", name, phase, cluster.Name)
 		}
 
 		time.Sleep(util.RetryInterval)
@@ -107,22 +108,22 @@ func waitDRPCDeleted(ctx types.Context, cluster util.Cluster, namespace string, 
 	log := ctx.Logger()
 	startTime := time.Now()
 
-	log.Debugf("Waiting until drpc \"%s/%s\" is deleted", namespace, name)
+	log.Debugf("Waiting until drpc \"%s/%s\" is deleted in cluster %q", namespace, name, cluster.Name)
 
 	for {
 		_, err := getDRPC(cluster, namespace, name)
 		if err != nil {
 			if errors.IsNotFound(err) {
-				log.Debugf("drpc \"%s/%s\" is deleted", namespace, name)
+				log.Debugf("drpc \"%s/%s\" is deleted in cluster %q", namespace, name, cluster.Name)
 
 				return nil
 			}
 
-			log.Debugf("Failed to get drpc \"%s/%s\": %s", namespace, name, err)
+			log.Debugf("Failed to get drpc \"%s/%s\" in cluster %q: %s", namespace, name, cluster.Name, err)
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			return fmt.Errorf("drpc %q is not deleted yet before timeout, fail", name)
+			return fmt.Errorf("drpc %q is not deleted yet before timeout in cluster %q, fail", name, cluster.Name)
 		}
 
 		time.Sleep(util.RetryInterval)
@@ -139,7 +140,8 @@ func waitDRPCProgression(
 	log := ctx.Logger()
 	startTime := time.Now()
 
-	log.Debugf("Waiting until drpc \"%s/%s\" reach progression %q", namespace, name, progression)
+	log.Debugf("Waiting until drpc \"%s/%s\" reach progression %q in cluster %q",
+		namespace, name, progression, cluster.Name)
 
 	for {
 		drpc, err := getDRPC(cluster, namespace, name)
@@ -149,14 +151,14 @@ func waitDRPCProgression(
 
 		currentProgression := drpc.Status.Progression
 		if currentProgression == progression {
-			log.Debugf("drpc \"%s/%s\" progression is %q", namespace, name, progression)
+			log.Debugf("drpc \"%s/%s\" progression is %q in cluster %q", namespace, name, progression, cluster.Name)
 
 			return nil
 		}
 
 		if time.Since(startTime) > util.Timeout {
-			return fmt.Errorf("drpc %q progression is not %q yet before timeout of %v",
-				name, progression, util.Timeout)
+			return fmt.Errorf("drpc %q progression is not %q yet before timeout of %v in cluster %q",
+				name, progression, util.Timeout, cluster.Name)
 		}
 
 		time.Sleep(util.RetryInterval)

--- a/e2e/util/channel.go
+++ b/e2e/util/channel.go
@@ -48,9 +48,10 @@ func createChannel() error {
 			return err
 		}
 
-		Ctx.Log.Debugf("Channel \"%s/%s\" already exists", GetChannelNamespace(), GetChannelName())
+		Ctx.Log.Debugf("Channel \"%s/%s\" already exists in cluster %q",
+			GetChannelNamespace(), GetChannelName(), Ctx.Hub.Name)
 	} else {
-		Ctx.Log.Infof("Created channel \"%s/%s\"", GetChannelNamespace(), GetChannelName())
+		Ctx.Log.Infof("Created channel \"%s/%s\" in cluster %q", GetChannelNamespace(), GetChannelName(), Ctx.Hub.Name)
 	}
 
 	return nil
@@ -70,9 +71,9 @@ func deleteChannel() error {
 			return err
 		}
 
-		Ctx.Log.Debugf("Channel \"%s/%s\" not found", GetChannelNamespace(), GetChannelName())
+		Ctx.Log.Debugf("Channel \"%s/%s\" not found in cluster %q", GetChannelNamespace(), GetChannelName(), Ctx.Hub.Name)
 	} else {
-		Ctx.Log.Infof("Deleted channel \"%s/%s\"", GetChannelNamespace(), GetChannelName())
+		Ctx.Log.Infof("Deleted channel \"%s/%s\" in cluster %q", GetChannelNamespace(), GetChannelName(), Ctx.Hub.Name)
 	}
 
 	return nil

--- a/e2e/util/namespace.go
+++ b/e2e/util/namespace.go
@@ -33,10 +33,10 @@ func CreateNamespace(cluster Cluster, namespace string, log *zap.SugaredLogger) 
 			return err
 		}
 
-		log.Debugf("Namespace %q already exist", namespace)
+		log.Debugf("Namespace %q already exist in cluster %q", namespace, cluster.Name)
 	}
 
-	log.Debugf("Created namespace %q", namespace)
+	log.Debugf("Created namespace %q in cluster %q", namespace, cluster.Name)
 
 	return nil
 }
@@ -54,12 +54,12 @@ func DeleteNamespace(cluster Cluster, namespace string, log *zap.SugaredLogger) 
 			return err
 		}
 
-		log.Debugf("Namespace %q not found", namespace)
+		log.Debugf("Namespace %q not found in cluster %q", namespace, cluster.Name)
 
 		return nil
 	}
 
-	log.Debugf("Waiting until namespace %q is deleted", namespace)
+	log.Debugf("Waiting until namespace %q is deleted in cluster %q", namespace, cluster.Name)
 
 	startTime := time.Now()
 	key := types.NamespacedName{Name: namespace}
@@ -70,13 +70,13 @@ func DeleteNamespace(cluster Cluster, namespace string, log *zap.SugaredLogger) 
 				return err
 			}
 
-			log.Debugf("Namespace %q deleted", namespace)
+			log.Debugf("Namespace %q deleted in cluster %q", namespace, cluster.Name)
 
 			return nil
 		}
 
 		if time.Since(startTime) > 60*time.Second {
-			return fmt.Errorf("timeout deleting namespace %q", namespace)
+			return fmt.Errorf("timeout deleting namespace %q in cluster %q", namespace, cluster.Name)
 		}
 
 		time.Sleep(time.Second)
@@ -122,8 +122,8 @@ func addNamespaceAnnotationForVolSync(cluster Cluster, namespace string, log *za
 		return err
 	}
 
-	log.Debugf("Annotated namespace %q with \"%s: %s\"",
-		namespace, volsyncPrivilegedMovers, annotations[volsyncPrivilegedMovers])
+	log.Debugf("Annotated namespace %q with \"%s: %s\" in cluster %q",
+		namespace, volsyncPrivilegedMovers, annotations[volsyncPrivilegedMovers], cluster.Name)
 
 	return nil
 }

--- a/e2e/util/placement.go
+++ b/e2e/util/placement.go
@@ -59,7 +59,7 @@ func waitPlacementDecision(cluster Cluster, namespace string, placementName stri
 		}
 
 		if time.Since(startTime) > Timeout {
-			return nil, fmt.Errorf("timeout waiting for placement decisions for %q ", placementName)
+			return nil, fmt.Errorf("timeout waiting for placement decisions for %q in cluster %q", placementName, cluster.Name)
 		}
 
 		time.Sleep(RetryInterval)
@@ -79,8 +79,8 @@ func getPlacementDecisionFromPlacement(cluster Cluster, placement *v1beta1.Place
 
 	plDecisions := &v1beta1.PlacementDecisionList{}
 	if err := cluster.Client.List(context.Background(), plDecisions, listOptions...); err != nil {
-		return nil, fmt.Errorf("failed to list PlacementDecisions (placement: %s)",
-			placement.GetNamespace()+"/"+placement.GetName())
+		return nil, fmt.Errorf("failed to list PlacementDecisions (placement: %s) in cluster %q",
+			placement.GetNamespace()+"/"+placement.GetName(), cluster.Name)
 	}
 
 	if len(plDecisions.Items) == 0 {
@@ -88,8 +88,8 @@ func getPlacementDecisionFromPlacement(cluster Cluster, placement *v1beta1.Place
 	}
 
 	if len(plDecisions.Items) > 1 {
-		return nil, fmt.Errorf("multiple PlacementDecisions found for Placement (count: %d, placement: %s)",
-			len(plDecisions.Items), placement.GetNamespace()+"/"+placement.GetName())
+		return nil, fmt.Errorf("multiple PlacementDecisions found for Placement (count: %d, placement: %s) in cluster %q",
+			len(plDecisions.Items), placement.GetNamespace()+"/"+placement.GetName(), cluster.Name)
 	}
 
 	plDecision := plDecisions.Items[0]
@@ -97,10 +97,10 @@ func getPlacementDecisionFromPlacement(cluster Cluster, placement *v1beta1.Place
 
 	if len(plDecision.Status.Decisions) > 1 {
 		return nil, fmt.Errorf("multiple placements found in PlacementDecision"+
-			" (count: %d, Placement: %s, PlacementDecision: %s)",
+			" (count: %d, Placement: %s, PlacementDecision: %s) in cluster %q",
 			len(plDecision.Status.Decisions),
 			placement.GetNamespace()+"/"+placement.GetName(),
-			plDecision.GetName()+"/"+plDecision.GetNamespace())
+			plDecision.GetName()+"/"+plDecision.GetNamespace(), cluster.Name)
 	}
 
 	return &plDecision, nil

--- a/e2e/workloads/deployment.go
+++ b/e2e/workloads/deployment.go
@@ -86,7 +86,7 @@ func (w Deployment) Health(ctx types.Context, cluster util.Cluster, namespace st
 	}
 
 	if deploy.Status.Replicas == deploy.Status.ReadyReplicas {
-		log.Debugf("Deployment \"%s/%s\" is ready", namespace, w.GetAppName())
+		log.Debugf("Deployment \"%s/%s\" is ready in cluster %q", namespace, w.GetAppName(), cluster.Name)
 
 		return nil
 	}


### PR DESCRIPTION
This change logs cluster name for all operations in the e2e codebase, improving traceability and debugging. This change is done in deployers, dractions, utils and workload packages.

Fixes logging part of #1845 

<details>
  <summary>Click to expand logs</summary>

```log
2025-02-28T20:49:02.234+0530	DEBUG	util/namespace.go:39	Created namespace "e2e-gitops" in cluster "hub"
2025-02-28T20:49:02.240+0530	INFO	util/channel.go:54	Created channel "e2e-gitops/https-github-com-ramendr-ocm-ramen-samples-git" in cluster "hub"
2025-02-28T20:49:02.244+0530	DEBUG	util/namespace.go:39	Created namespace "e2e-disapp-deploy-cephfs-busybox" in cluster "dr1"
2025-02-28T20:49:02.245+0530	DEBUG	util/namespace.go:39	Created namespace "e2e-disapp-deploy-rbd-busybox" in cluster "dr1"
2025-02-28T20:49:02.251+0530	DEBUG	util/namespace.go:125	Annotated namespace "e2e-disapp-deploy-rbd-busybox" with "volsync.backube/privileged-movers: true" in cluster "dr1"
2025-02-28T20:49:02.253+0530	DEBUG	util/namespace.go:125	Annotated namespace "e2e-disapp-deploy-cephfs-busybox" with "volsync.backube/privileged-movers: true" in cluster "dr1"
2025-02-28T20:49:02.256+0530	DEBUG	util/namespace.go:39	Created namespace "e2e-disapp-deploy-rbd-busybox" in cluster "dr2"
2025-02-28T20:49:02.261+0530	DEBUG	util/namespace.go:125	Annotated namespace "e2e-disapp-deploy-rbd-busybox" with "volsync.backube/privileged-movers: true" in cluster "dr2"
2025-02-28T20:49:02.336+0530	DEBUG	subscr-deploy-cephfs-busybox	util/namespace.go:39	Created namespace "e2e-subscr-deploy-cephfs-busybox" in cluster "hub"
2025-02-28T20:49:02.337+0530	DEBUG	subscr-deploy-rbd-busybox	util/namespace.go:39	Created namespace "e2e-subscr-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:49:02.343+0530	DEBUG	appset-deploy-rbd-busybox	deployers/crud.go:62	Created ManagedClusterSetBinding "argocd/default" in cluster "hub"
2025-02-28T20:49:02.344+0530	DEBUG	appset-deploy-cephfs-busybox	deployers/crud.go:59	ManagedClusterSetBinding "argocd/default" already exist in cluster "hub"
2025-02-28T20:49:02.344+0530	DEBUG	appset-deploy-cephfs-busybox	deployers/crud.go:62	Created ManagedClusterSetBinding "argocd/default" in cluster "hub"
2025-02-28T20:49:02.356+0530	DEBUG	util/namespace.go:39	Created namespace "e2e-disapp-deploy-cephfs-busybox" in cluster "dr2"
2025-02-28T20:49:02.357+0530	DEBUG	subscr-deploy-cephfs-busybox	deployers/crud.go:62	Created ManagedClusterSetBinding "e2e-subscr-deploy-cephfs-busybox/default" in cluster "hub"
2025-02-28T20:49:02.357+0530	DEBUG	appset-deploy-rbd-busybox	deployers/crud.go:118	Created placement "argocd/appset-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:49:02.358+0530	DEBUG	appset-deploy-cephfs-busybox	deployers/crud.go:118	Created placement "argocd/appset-deploy-cephfs-busybox" in cluster "hub"
2025-02-28T20:49:02.360+0530	DEBUG	util/namespace.go:125	Annotated namespace "e2e-disapp-deploy-cephfs-busybox" with "volsync.backube/privileged-movers: true" in cluster "dr2"
2025-02-28T20:49:02.368+0530	DEBUG	subscr-deploy-rbd-busybox	deployers/crud.go:62	Created ManagedClusterSetBinding "e2e-subscr-deploy-rbd-busybox/default" in cluster "hub"
2025-02-28T20:49:02.369+0530	DEBUG	subscr-deploy-cephfs-busybox	deployers/crud.go:118	Created placement "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" in cluster "hub"
2025-02-28T20:49:02.370+0530	DEBUG	appset-deploy-cephfs-busybox	deployers/crud.go:264	Created configMap "argocd/appset-deploy-cephfs-busybox" in cluster "hub"
2025-02-28T20:49:02.370+0530	DEBUG	appset-deploy-rbd-busybox	deployers/crud.go:264	Created configMap "argocd/appset-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:49:02.377+0530	DEBUG	subscr-deploy-rbd-busybox	deployers/crud.go:118	Created placement "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:49:02.383+0530	DEBUG	subscr-deploy-cephfs-busybox	deployers/crud.go:199	Created subscription "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" in cluster "hub"
2025-02-28T20:49:02.386+0530	DEBUG	subscr-deploy-rbd-busybox	deployers/crud.go:199	Created subscription "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:49:02.386+0530	DEBUG	appset-deploy-rbd-busybox	deployers/crud.go:370	Created applicationset "argocd/appset-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:49:02.404+0530	DEBUG	appset-deploy-cephfs-busybox	deployers/crud.go:370	Created applicationset "argocd/appset-deploy-cephfs-busybox" in cluster "hub"
2025-02-28T20:49:02.416+0530	INFO	appset-deploy-cephfs-busybox	deployers/applicationset.go:48	Deployed applicationset app "e2e-appset-deploy-cephfs-busybox/busybox" in cluster "dr1"
2025-02-28T20:49:02.421+0530	INFO	appset-deploy-cephfs-busybox	dractions/actions.go:46	Protecting workload running in cluster "dr1" (app namespace: "e2e-appset-deploy-cephfs-busybox", management namespace: "argocd")
2025-02-28T20:49:02.433+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/actions.go:65	Annotated placement "argocd/appset-deploy-cephfs-busybox" with "cluster.open-cluster-management.io/experimental-scheduling-disable: true" in cluster "hub"
2025-02-28T20:49:02.438+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/crud.go:54	Created drpc "argocd/appset-deploy-cephfs-busybox" in cluster "hub" with spec:
drPolicyRef:
  name: dr-policy
placementRef:
  kind: placement
  name: appset-deploy-cephfs-busybox
preferredCluster: dr1
pvcSelector:
  matchLabels:
    appname: busybox

2025-02-28T20:49:02.441+0530	DEBUG	util/namespace.go:36	Namespace "e2e-appset-deploy-cephfs-busybox" already exist in cluster "dr1"
2025-02-28T20:49:02.441+0530	DEBUG	util/namespace.go:39	Created namespace "e2e-appset-deploy-cephfs-busybox" in cluster "dr1"
2025-02-28T20:49:02.443+0530	DEBUG	util/namespace.go:125	Annotated namespace "e2e-appset-deploy-cephfs-busybox" with "volsync.backube/privileged-movers: true" in cluster "dr1"
2025-02-28T20:49:02.457+0530	DEBUG	util/namespace.go:36	Namespace "e2e-appset-deploy-cephfs-busybox" already exist in cluster "dr2"
2025-02-28T20:49:02.457+0530	DEBUG	util/namespace.go:39	Created namespace "e2e-appset-deploy-cephfs-busybox" in cluster "dr2"
2025-02-28T20:49:02.459+0530	DEBUG	util/namespace.go:125	Annotated namespace "e2e-appset-deploy-cephfs-busybox" with "volsync.backube/privileged-movers: true" in cluster "dr2"
2025-02-28T20:49:02.459+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/retry.go:22	Waiting until drpc "argocd/appset-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:49:05.191+0530	DEBUG	disapp-deploy-rbd-busybox	workloads/deployment.go:89	Deployment "e2e-disapp-deploy-rbd-busybox/busybox" is ready in cluster "dr1"
2025-02-28T20:49:05.191+0530	DEBUG	disapp-deploy-rbd-busybox	deployers/retry.go:49	Workload "e2e-disapp-deploy-rbd-busybox/busybox" is ready in cluster "dr1"
2025-02-28T20:49:05.191+0530	INFO	disapp-deploy-rbd-busybox	deployers/discoveredapp.go:71	Deployed discovered app "e2e-disapp-deploy-rbd-busybox/busybox" in cluster "dr1"
2025-02-28T20:49:05.200+0530	DEBUG	disapp-deploy-rbd-busybox	deployers/crud.go:62	Created ManagedClusterSetBinding "ramen-ops/default" in cluster "hub"
2025-02-28T20:49:05.204+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/crud.go:150	Created placement "ramen-ops/disapp-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:49:05.207+0530	INFO	disapp-deploy-rbd-busybox	dractions/discovered.go:43	Protecting workload running in cluster "dr1" (app namespace: "e2e-disapp-deploy-rbd-busybox", management namespace: "ramen-ops")
2025-02-28T20:49:05.212+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/crud.go:54	Created drpc "ramen-ops/disapp-deploy-rbd-busybox" in cluster "hub" with spec:
drPolicyRef:
  name: dr-policy
kubeObjectProtection:
  kubeObjectSelector:
    matchExpressions:
    - key: appname
      operator: In
      values:
      - busybox
placementRef:
  kind: placement
  name: disapp-deploy-rbd-busybox
preferredCluster: dr1
protectedNamespaces:
- e2e-disapp-deploy-rbd-busybox
pvcSelector:
  matchLabels:
    appname: busybox

2025-02-28T20:49:05.212+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:22	Waiting until drpc "ramen-ops/disapp-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:49:05.314+0530	DEBUG	disapp-deploy-cephfs-busybox	workloads/deployment.go:89	Deployment "e2e-disapp-deploy-cephfs-busybox/busybox" is ready in cluster "dr1"
2025-02-28T20:49:05.314+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/retry.go:49	Workload "e2e-disapp-deploy-cephfs-busybox/busybox" is ready in cluster "dr1"
2025-02-28T20:49:05.314+0530	INFO	disapp-deploy-cephfs-busybox	deployers/discoveredapp.go:71	Deployed discovered app "e2e-disapp-deploy-cephfs-busybox/busybox" in cluster "dr1"
2025-02-28T20:49:05.331+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/crud.go:59	ManagedClusterSetBinding "ramen-ops/default" already exist in cluster "hub"
2025-02-28T20:49:05.331+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/crud.go:62	Created ManagedClusterSetBinding "ramen-ops/default" in cluster "hub"
2025-02-28T20:49:05.340+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/crud.go:150	Created placement "ramen-ops/disapp-deploy-cephfs-busybox" in cluster "hub"
2025-02-28T20:49:05.342+0530	INFO	disapp-deploy-cephfs-busybox	dractions/discovered.go:43	Protecting workload running in cluster "dr1" (app namespace: "e2e-disapp-deploy-cephfs-busybox", management namespace: "ramen-ops")
2025-02-28T20:49:05.346+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/crud.go:54	Created drpc "ramen-ops/disapp-deploy-cephfs-busybox" in cluster "hub" with spec:
drPolicyRef:
  name: dr-policy
kubeObjectProtection:
  kubeObjectSelector:
    matchExpressions:
    - key: appname
      operator: In
      values:
      - busybox
placementRef:
  kind: placement
  name: disapp-deploy-cephfs-busybox
preferredCluster: dr1
protectedNamespaces:
- e2e-disapp-deploy-cephfs-busybox
pvcSelector:
  matchLabels:
    appname: busybox

2025-02-28T20:49:05.346+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:22	Waiting until drpc "ramen-ops/disapp-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:49:07.394+0530	DEBUG	subscr-deploy-rbd-busybox	deployers/retry.go:27	Subscription "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" phase is Propagated in cluster "hub"
2025-02-28T20:49:07.395+0530	DEBUG	subscr-deploy-cephfs-busybox	deployers/retry.go:27	Subscription "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" phase is Propagated in cluster "hub"
2025-02-28T20:49:07.400+0530	INFO	subscr-deploy-cephfs-busybox	deployers/subscription.go:69	Deployed subscription app "e2e-subscr-deploy-cephfs-busybox/busybox" in cluster "dr1"
2025-02-28T20:49:07.400+0530	INFO	subscr-deploy-rbd-busybox	deployers/subscription.go:69	Deployed subscription app "e2e-subscr-deploy-rbd-busybox/busybox" in cluster "dr2"
2025-02-28T20:49:07.404+0530	INFO	appset-deploy-rbd-busybox	deployers/applicationset.go:48	Deployed applicationset app "e2e-appset-deploy-rbd-busybox/busybox" in cluster "dr2"
2025-02-28T20:49:07.405+0530	INFO	subscr-deploy-cephfs-busybox	dractions/actions.go:46	Protecting workload running in cluster "dr1" (app namespace: "e2e-subscr-deploy-cephfs-busybox", management namespace: "e2e-subscr-deploy-cephfs-busybox")
2025-02-28T20:49:07.406+0530	INFO	subscr-deploy-rbd-busybox	dractions/actions.go:46	Protecting workload running in cluster "dr2" (app namespace: "e2e-subscr-deploy-rbd-busybox", management namespace: "e2e-subscr-deploy-rbd-busybox")
2025-02-28T20:49:07.412+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/actions.go:65	Annotated placement "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" with "cluster.open-cluster-management.io/experimental-scheduling-disable: true" in cluster "hub"
2025-02-28T20:49:07.415+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/actions.go:65	Annotated placement "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" with "cluster.open-cluster-management.io/experimental-scheduling-disable: true" in cluster "hub"
2025-02-28T20:49:07.419+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/crud.go:54	Created drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" in cluster "hub" with spec:
drPolicyRef:
  name: dr-policy
placementRef:
  kind: placement
  name: subscr-deploy-rbd-busybox
preferredCluster: dr2
pvcSelector:
  matchLabels:
    appname: busybox

2025-02-28T20:49:07.420+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/crud.go:54	Created drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" in cluster "hub" with spec:
drPolicyRef:
  name: dr-policy
placementRef:
  kind: placement
  name: subscr-deploy-cephfs-busybox
preferredCluster: dr1
pvcSelector:
  matchLabels:
    appname: busybox

2025-02-28T20:49:07.424+0530	DEBUG	util/namespace.go:36	Namespace "e2e-subscr-deploy-rbd-busybox" already exist in cluster "dr1"
2025-02-28T20:49:07.424+0530	DEBUG	util/namespace.go:39	Created namespace "e2e-subscr-deploy-rbd-busybox" in cluster "dr1"
2025-02-28T20:49:07.424+0530	DEBUG	util/namespace.go:36	Namespace "e2e-subscr-deploy-cephfs-busybox" already exist in cluster "dr1"
2025-02-28T20:49:07.424+0530	DEBUG	util/namespace.go:39	Created namespace "e2e-subscr-deploy-cephfs-busybox" in cluster "dr1"
2025-02-28T20:49:07.428+0530	DEBUG	util/namespace.go:125	Annotated namespace "e2e-subscr-deploy-rbd-busybox" with "volsync.backube/privileged-movers: true" in cluster "dr1"
2025-02-28T20:49:07.429+0530	DEBUG	util/namespace.go:125	Annotated namespace "e2e-subscr-deploy-cephfs-busybox" with "volsync.backube/privileged-movers: true" in cluster "dr1"
2025-02-28T20:49:07.432+0530	DEBUG	util/namespace.go:36	Namespace "e2e-subscr-deploy-rbd-busybox" already exist in cluster "dr2"
2025-02-28T20:49:07.432+0530	DEBUG	util/namespace.go:39	Created namespace "e2e-subscr-deploy-rbd-busybox" in cluster "dr2"
2025-02-28T20:49:07.433+0530	DEBUG	util/namespace.go:36	Namespace "e2e-subscr-deploy-cephfs-busybox" already exist in cluster "dr2"
2025-02-28T20:49:07.433+0530	DEBUG	util/namespace.go:39	Created namespace "e2e-subscr-deploy-cephfs-busybox" in cluster "dr2"
2025-02-28T20:49:07.435+0530	DEBUG	util/namespace.go:125	Annotated namespace "e2e-subscr-deploy-rbd-busybox" with "volsync.backube/privileged-movers: true" in cluster "dr2"
2025-02-28T20:49:07.435+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:22	Waiting until drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:49:07.437+0530	DEBUG	util/namespace.go:125	Annotated namespace "e2e-subscr-deploy-cephfs-busybox" with "volsync.backube/privileged-movers: true" in cluster "dr2"
2025-02-28T20:49:07.437+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:22	Waiting until drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:49:07.501+0530	INFO	appset-deploy-rbd-busybox	dractions/actions.go:46	Protecting workload running in cluster "dr2" (app namespace: "e2e-appset-deploy-rbd-busybox", management namespace: "argocd")
2025-02-28T20:49:07.799+0530	DEBUG	appset-deploy-rbd-busybox	dractions/actions.go:65	Annotated placement "argocd/appset-deploy-rbd-busybox" with "cluster.open-cluster-management.io/experimental-scheduling-disable: true" in cluster "hub"
2025-02-28T20:49:07.803+0530	DEBUG	appset-deploy-rbd-busybox	dractions/crud.go:54	Created drpc "argocd/appset-deploy-rbd-busybox" in cluster "hub" with spec:
drPolicyRef:
  name: dr-policy
placementRef:
  kind: placement
  name: appset-deploy-rbd-busybox
preferredCluster: dr2
pvcSelector:
  matchLabels:
    appname: busybox

2025-02-28T20:49:07.818+0530	DEBUG	util/namespace.go:36	Namespace "e2e-appset-deploy-rbd-busybox" already exist in cluster "dr1"
2025-02-28T20:49:07.818+0530	DEBUG	util/namespace.go:39	Created namespace "e2e-appset-deploy-rbd-busybox" in cluster "dr1"
2025-02-28T20:49:07.822+0530	DEBUG	util/namespace.go:125	Annotated namespace "e2e-appset-deploy-rbd-busybox" with "volsync.backube/privileged-movers: true" in cluster "dr1"
2025-02-28T20:49:07.826+0530	DEBUG	util/namespace.go:36	Namespace "e2e-appset-deploy-rbd-busybox" already exist in cluster "dr2"
2025-02-28T20:49:07.826+0530	DEBUG	util/namespace.go:39	Created namespace "e2e-appset-deploy-rbd-busybox" in cluster "dr2"
2025-02-28T20:49:07.831+0530	DEBUG	util/namespace.go:125	Annotated namespace "e2e-appset-deploy-rbd-busybox" with "volsync.backube/privileged-movers: true" in cluster "dr2"
2025-02-28T20:49:07.831+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:22	Waiting until drpc "argocd/appset-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:50:22.874+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:34	drpc "argocd/appset-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:50:22.878+0530	INFO	appset-deploy-rbd-busybox	dractions/actions.go:134	Failing over workload from cluster "dr2" to cluster "dr1"
2025-02-28T20:50:22.878+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:22	Waiting until drpc "argocd/appset-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:50:22.880+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:34	drpc "argocd/appset-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:50:22.885+0530	DEBUG	appset-deploy-rbd-busybox	dractions/actions.go:219	Updated drpc "argocd/appset-deploy-rbd-busybox" with action "Failover" to target cluster "dr1"
2025-02-28T20:50:22.885+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:59	Waiting until drpc "argocd/appset-deploy-rbd-busybox" reach phase "FailedOver" in cluster "hub"
2025-02-28T20:50:27.512+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/retry.go:34	drpc "argocd/appset-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:50:27.516+0530	INFO	appset-deploy-cephfs-busybox	dractions/actions.go:134	Failing over workload from cluster "dr1" to cluster "dr2"
2025-02-28T20:50:27.516+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/retry.go:22	Waiting until drpc "argocd/appset-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:50:27.517+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/retry.go:34	drpc "argocd/appset-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:50:27.522+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/actions.go:219	Updated drpc "argocd/appset-deploy-cephfs-busybox" with action "Failover" to target cluster "dr2"
2025-02-28T20:50:27.522+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/retry.go:59	Waiting until drpc "argocd/appset-deploy-cephfs-busybox" reach phase "FailedOver" in cluster "hub"
2025-02-28T20:50:35.268+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:34	drpc "ramen-ops/disapp-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:50:35.273+0530	INFO	disapp-deploy-rbd-busybox	dractions/actions.go:134	Failing over workload from cluster "dr1" to cluster "dr2"
2025-02-28T20:50:35.275+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:22	Waiting until drpc "ramen-ops/disapp-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:50:35.277+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:34	drpc "ramen-ops/disapp-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:50:35.288+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/actions.go:219	Updated drpc "ramen-ops/disapp-deploy-rbd-busybox" with action "Failover" to target cluster "dr2"
2025-02-28T20:50:35.288+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:143	Waiting until drpc "ramen-ops/disapp-deploy-rbd-busybox" reach progression "WaitOnUserToCleanUp" in cluster "hub"
2025-02-28T20:50:37.496+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:34	drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:50:37.500+0530	INFO	subscr-deploy-rbd-busybox	dractions/actions.go:134	Failing over workload from cluster "dr2" to cluster "dr1"
2025-02-28T20:50:37.500+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:22	Waiting until drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:50:37.501+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:34	drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:50:37.508+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/actions.go:219	Updated drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" with action "Failover" to target cluster "dr1"
2025-02-28T20:50:37.508+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:59	Waiting until drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" reach phase "FailedOver" in cluster "hub"
2025-02-28T20:50:52.905+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:69	drpc "argocd/appset-deploy-rbd-busybox" phase is "FailedOver" in cluster "hub"
2025-02-28T20:50:52.906+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:22	Waiting until drpc "argocd/appset-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:50:57.541+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/retry.go:69	drpc "argocd/appset-deploy-cephfs-busybox" phase is "FailedOver" in cluster "hub"
2025-02-28T20:50:57.541+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/retry.go:22	Waiting until drpc "argocd/appset-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:51:05.414+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:34	drpc "ramen-ops/disapp-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:51:05.420+0530	INFO	disapp-deploy-cephfs-busybox	dractions/actions.go:134	Failing over workload from cluster "dr1" to cluster "dr2"
2025-02-28T20:51:05.422+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:22	Waiting until drpc "ramen-ops/disapp-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:51:05.426+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:34	drpc "ramen-ops/disapp-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:51:05.436+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/actions.go:219	Updated drpc "ramen-ops/disapp-deploy-cephfs-busybox" with action "Failover" to target cluster "dr2"
2025-02-28T20:51:05.436+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:143	Waiting until drpc "ramen-ops/disapp-deploy-cephfs-busybox" reach progression "WaitOnUserToCleanUp" in cluster "hub"
2025-02-28T20:51:07.514+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:34	drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:51:07.518+0530	INFO	subscr-deploy-cephfs-busybox	dractions/actions.go:134	Failing over workload from cluster "dr1" to cluster "dr2"
2025-02-28T20:51:07.518+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:22	Waiting until drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:51:07.520+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:34	drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:51:07.529+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:69	drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" phase is "FailedOver" in cluster "hub"
2025-02-28T20:51:07.529+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:22	Waiting until drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:51:07.539+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/actions.go:219	Updated drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" with action "Failover" to target cluster "dr2"
2025-02-28T20:51:07.539+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:59	Waiting until drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" reach phase "FailedOver" in cluster "hub"
2025-02-28T20:51:10.309+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:154	drpc "ramen-ops/disapp-deploy-rbd-busybox" progression is "WaitOnUserToCleanUp" in cluster "hub"
2025-02-28T20:51:35.460+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:154	drpc "ramen-ops/disapp-deploy-cephfs-busybox" progression is "WaitOnUserToCleanUp" in cluster "hub"
2025-02-28T20:51:37.561+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:69	drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" phase is "FailedOver" in cluster "hub"
2025-02-28T20:51:37.561+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:22	Waiting until drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:51:39.275+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/crud.go:440	Deleted discovered app "e2e-disapp-deploy-cephfs-busybox/busybox" in cluster "dr1"
2025-02-28T20:51:39.276+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:59	Waiting until drpc "ramen-ops/disapp-deploy-cephfs-busybox" reach phase "FailedOver" in cluster "hub"
2025-02-28T20:51:39.279+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:69	drpc "ramen-ops/disapp-deploy-cephfs-busybox" phase is "FailedOver" in cluster "hub"
2025-02-28T20:51:39.279+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:22	Waiting until drpc "ramen-ops/disapp-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:52:27.582+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/retry.go:34	drpc "argocd/appset-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:52:27.586+0530	INFO	appset-deploy-cephfs-busybox	dractions/actions.go:158	Relocating workload from cluster "dr2" to cluster "dr1"
2025-02-28T20:52:27.586+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/retry.go:22	Waiting until drpc "argocd/appset-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:52:27.587+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/retry.go:34	drpc "argocd/appset-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:52:27.593+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/actions.go:219	Updated drpc "argocd/appset-deploy-cephfs-busybox" with action "Relocate" to target cluster "dr1"
2025-02-28T20:52:27.593+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/retry.go:59	Waiting until drpc "argocd/appset-deploy-cephfs-busybox" reach phase "Relocated" in cluster "hub"
2025-02-28T20:53:37.628+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:34	drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:53:37.633+0530	INFO	subscr-deploy-cephfs-busybox	dractions/actions.go:158	Relocating workload from cluster "dr2" to cluster "dr1"
2025-02-28T20:53:37.633+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:22	Waiting until drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:53:37.635+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:34	drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:53:37.641+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/actions.go:219	Updated drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" with action "Relocate" to target cluster "dr1"
2025-02-28T20:53:37.641+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:59	Waiting until drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" reach phase "Relocated" in cluster "hub"
2025-02-28T20:53:38.298+0530	DEBUG	disapp-deploy-rbd-busybox	deployers/crud.go:440	Deleted discovered app "e2e-disapp-deploy-rbd-busybox/busybox" in cluster "dr1"
2025-02-28T20:53:38.300+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:59	Waiting until drpc "ramen-ops/disapp-deploy-rbd-busybox" reach phase "FailedOver" in cluster "hub"
2025-02-28T20:53:38.303+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:69	drpc "ramen-ops/disapp-deploy-rbd-busybox" phase is "FailedOver" in cluster "hub"
2025-02-28T20:53:38.303+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:22	Waiting until drpc "ramen-ops/disapp-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:53:39.357+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:34	drpc "ramen-ops/disapp-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:53:39.369+0530	DEBUG	disapp-deploy-cephfs-busybox	workloads/deployment.go:89	Deployment "e2e-disapp-deploy-cephfs-busybox/busybox" is ready in cluster "dr2"
2025-02-28T20:53:39.369+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/retry.go:49	Workload "e2e-disapp-deploy-cephfs-busybox/busybox" is ready in cluster "dr2"
2025-02-28T20:53:39.373+0530	INFO	disapp-deploy-cephfs-busybox	dractions/actions.go:158	Relocating workload from cluster "dr2" to cluster "dr1"
2025-02-28T20:53:39.375+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:22	Waiting until drpc "ramen-ops/disapp-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:53:39.376+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:34	drpc "ramen-ops/disapp-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:53:39.382+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/actions.go:219	Updated drpc "ramen-ops/disapp-deploy-cephfs-busybox" with action "Relocate" to target cluster "dr1"
2025-02-28T20:53:39.382+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:143	Waiting until drpc "ramen-ops/disapp-deploy-cephfs-busybox" reach progression "WaitOnUserToCleanUp" in cluster "hub"
2025-02-28T20:53:53.007+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:34	drpc "argocd/appset-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:53:53.011+0530	INFO	appset-deploy-rbd-busybox	dractions/actions.go:158	Relocating workload from cluster "dr1" to cluster "dr2"
2025-02-28T20:53:53.011+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:22	Waiting until drpc "argocd/appset-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:53:53.013+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:34	drpc "argocd/appset-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:53:53.019+0530	DEBUG	appset-deploy-rbd-busybox	dractions/actions.go:219	Updated drpc "argocd/appset-deploy-rbd-busybox" with action "Relocate" to target cluster "dr2"
2025-02-28T20:53:53.019+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:59	Waiting until drpc "argocd/appset-deploy-rbd-busybox" reach phase "Relocated" in cluster "hub"
2025-02-28T20:54:07.648+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:34	drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:54:07.653+0530	INFO	subscr-deploy-rbd-busybox	dractions/actions.go:158	Relocating workload from cluster "dr1" to cluster "dr2"
2025-02-28T20:54:07.653+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:22	Waiting until drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:54:07.655+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:34	drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:54:07.661+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/actions.go:219	Updated drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" with action "Relocate" to target cluster "dr2"
2025-02-28T20:54:07.661+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:59	Waiting until drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" reach phase "Relocated" in cluster "hub"
2025-02-28T20:54:08.325+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:34	drpc "ramen-ops/disapp-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:54:08.326+0530	DEBUG	disapp-deploy-rbd-busybox	workloads/deployment.go:89	Deployment "e2e-disapp-deploy-rbd-busybox/busybox" is ready in cluster "dr2"
2025-02-28T20:54:08.326+0530	DEBUG	disapp-deploy-rbd-busybox	deployers/retry.go:49	Workload "e2e-disapp-deploy-rbd-busybox/busybox" is ready in cluster "dr2"
2025-02-28T20:54:08.333+0530	INFO	disapp-deploy-rbd-busybox	dractions/actions.go:158	Relocating workload from cluster "dr2" to cluster "dr1"
2025-02-28T20:54:08.335+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:22	Waiting until drpc "ramen-ops/disapp-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:54:08.337+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:34	drpc "ramen-ops/disapp-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:54:08.347+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/actions.go:219	Updated drpc "ramen-ops/disapp-deploy-rbd-busybox" with action "Relocate" to target cluster "dr1"
2025-02-28T20:54:08.347+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:143	Waiting until drpc "ramen-ops/disapp-deploy-rbd-busybox" reach progression "WaitOnUserToCleanUp" in cluster "hub"
2025-02-28T20:54:09.402+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:154	drpc "ramen-ops/disapp-deploy-cephfs-busybox" progression is "WaitOnUserToCleanUp" in cluster "hub"
2025-02-28T20:54:38.367+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:154	drpc "ramen-ops/disapp-deploy-rbd-busybox" progression is "WaitOnUserToCleanUp" in cluster "hub"
2025-02-28T20:56:23.115+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:69	drpc "argocd/appset-deploy-rbd-busybox" phase is "Relocated" in cluster "hub"
2025-02-28T20:56:23.115+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:22	Waiting until drpc "argocd/appset-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:56:23.117+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:34	drpc "argocd/appset-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:56:23.120+0530	INFO	appset-deploy-rbd-busybox	dractions/actions.go:107	Unprotecting workload running in cluster "dr2" (app namespace: "e2e-appset-deploy-rbd-busybox", management namespace: "argocd")
2025-02-28T20:56:23.127+0530	DEBUG	appset-deploy-rbd-busybox	dractions/crud.go:85	Deleted drpc "argocd/appset-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:56:23.127+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:111	Waiting until drpc "argocd/appset-deploy-rbd-busybox" is deleted in cluster "hub"
2025-02-28T20:56:32.167+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/crud.go:440	Deleted discovered app "e2e-disapp-deploy-cephfs-busybox/busybox" in cluster "dr2"
2025-02-28T20:56:32.169+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:59	Waiting until drpc "ramen-ops/disapp-deploy-cephfs-busybox" reach phase "Relocated" in cluster "hub"
2025-02-28T20:56:37.745+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:69	drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" phase is "Relocated" in cluster "hub"
2025-02-28T20:56:37.745+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:22	Waiting until drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:56:37.747+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:34	drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:56:37.749+0530	INFO	subscr-deploy-rbd-busybox	dractions/actions.go:107	Unprotecting workload running in cluster "dr2" (app namespace: "e2e-subscr-deploy-rbd-busybox", management namespace: "e2e-subscr-deploy-rbd-busybox")
2025-02-28T20:56:37.754+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/crud.go:85	Deleted drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:56:37.754+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:111	Waiting until drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" is deleted in cluster "hub"
2025-02-28T20:56:59.226+0530	DEBUG	disapp-deploy-rbd-busybox	deployers/crud.go:440	Deleted discovered app "e2e-disapp-deploy-rbd-busybox/busybox" in cluster "dr2"
2025-02-28T20:56:59.228+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:59	Waiting until drpc "ramen-ops/disapp-deploy-rbd-busybox" reach phase "Relocated" in cluster "hub"
2025-02-28T20:56:59.232+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:69	drpc "ramen-ops/disapp-deploy-rbd-busybox" phase is "Relocated" in cluster "hub"
2025-02-28T20:56:59.232+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:22	Waiting until drpc "ramen-ops/disapp-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:56:59.234+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:34	drpc "ramen-ops/disapp-deploy-rbd-busybox" is ready in cluster "hub"
2025-02-28T20:56:59.244+0530	DEBUG	disapp-deploy-rbd-busybox	workloads/deployment.go:89	Deployment "e2e-disapp-deploy-rbd-busybox/busybox" is ready in cluster "dr1"
2025-02-28T20:56:59.244+0530	DEBUG	disapp-deploy-rbd-busybox	deployers/retry.go:49	Workload "e2e-disapp-deploy-rbd-busybox/busybox" is ready in cluster "dr1"
2025-02-28T20:56:59.248+0530	INFO	disapp-deploy-rbd-busybox	dractions/discovered.go:72	Unprotecting workload running in cluster "dr1" (app namespace: "e2e-disapp-deploy-rbd-busybox", management namespace: "ramen-ops")
2025-02-28T20:56:59.254+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/crud.go:85	Deleted drpc "ramen-ops/disapp-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:56:59.254+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:111	Waiting until drpc "ramen-ops/disapp-deploy-rbd-busybox" is deleted in cluster "hub"
2025-02-28T20:57:07.761+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:69	drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" phase is "Relocated" in cluster "hub"
2025-02-28T20:57:07.761+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:22	Waiting until drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:57:23.162+0530	DEBUG	appset-deploy-rbd-busybox	dractions/retry.go:117	drpc "argocd/appset-deploy-rbd-busybox" is deleted in cluster "hub"
2025-02-28T20:57:23.165+0530	DEBUG	appset-deploy-rbd-busybox	deployers/crud.go:396	Deleted applicationset "argocd/appset-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:57:23.168+0530	INFO	appset-deploy-rbd-busybox	deployers/applicationset.go:70	Undeployed applicationset app "e2e-appset-deploy-rbd-busybox/busybox" in cluster "dr2"
2025-02-28T20:57:23.170+0530	DEBUG	appset-deploy-rbd-busybox	deployers/crud.go:286	Deleted configMap "argocd/appset-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:57:23.172+0530	DEBUG	appset-deploy-rbd-busybox	deployers/crud.go:141	Deleted placement "argocd/appset-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:57:23.178+0530	DEBUG	appset-deploy-rbd-busybox	deployers/crud.go:85	Deleted ManagedClusterSetBinding "argocd/default" in cluster "hub"
2025-02-28T20:57:37.213+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:69	drpc "ramen-ops/disapp-deploy-cephfs-busybox" phase is "Relocated" in cluster "hub"
2025-02-28T20:57:37.213+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:22	Waiting until drpc "ramen-ops/disapp-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:57:37.778+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:34	drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:57:37.782+0530	INFO	subscr-deploy-cephfs-busybox	dractions/actions.go:107	Unprotecting workload running in cluster "dr1" (app namespace: "e2e-subscr-deploy-cephfs-busybox", management namespace: "e2e-subscr-deploy-cephfs-busybox")
2025-02-28T20:57:37.786+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/crud.go:85	Deleted drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" in cluster "hub"
2025-02-28T20:57:37.786+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:111	Waiting until drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" is deleted in cluster "hub"
2025-02-28T20:57:37.788+0530	DEBUG	subscr-deploy-rbd-busybox	dractions/retry.go:117	drpc "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" is deleted in cluster "hub"
2025-02-28T20:57:37.791+0530	DEBUG	subscr-deploy-rbd-busybox	deployers/crud.go:225	Deleted subscription "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:57:37.817+0530	INFO	subscr-deploy-rbd-busybox	deployers/subscription.go:91	Undeployed subscription app "e2e-subscr-deploy-rbd-busybox/busybox" in cluster "dr2"
2025-02-28T20:57:37.827+0530	DEBUG	subscr-deploy-rbd-busybox	deployers/crud.go:141	Deleted placement "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:57:37.836+0530	DEBUG	subscr-deploy-rbd-busybox	deployers/crud.go:85	Deleted ManagedClusterSetBinding "e2e-subscr-deploy-rbd-busybox/default" in cluster "hub"
2025-02-28T20:57:37.856+0530	DEBUG	subscr-deploy-rbd-busybox	util/namespace.go:62	Waiting until namespace "e2e-subscr-deploy-rbd-busybox" is deleted in cluster "hub"
2025-02-28T20:57:39.282+0530	DEBUG	disapp-deploy-rbd-busybox	dractions/retry.go:117	drpc "ramen-ops/disapp-deploy-rbd-busybox" is deleted in cluster "hub"
2025-02-28T20:57:39.284+0530	DEBUG	disapp-deploy-rbd-busybox	deployers/crud.go:141	Deleted placement "ramen-ops/disapp-deploy-rbd-busybox" in cluster "hub"
2025-02-28T20:57:39.288+0530	DEBUG	disapp-deploy-rbd-busybox	deployers/crud.go:85	Deleted ManagedClusterSetBinding "ramen-ops/default" in cluster "hub"
2025-02-28T20:57:43.874+0530	DEBUG	subscr-deploy-rbd-busybox	util/namespace.go:73	Namespace "e2e-subscr-deploy-rbd-busybox" deleted in cluster "hub"
2025-02-28T20:57:45.182+0530	DEBUG	disapp-deploy-rbd-busybox	deployers/crud.go:440	Deleted discovered app "e2e-disapp-deploy-rbd-busybox/busybox" in cluster "dr1"
2025-02-28T20:57:47.872+0530	DEBUG	disapp-deploy-rbd-busybox	deployers/crud.go:440	Deleted discovered app "e2e-disapp-deploy-rbd-busybox/busybox" in cluster "dr2"
2025-02-28T20:57:47.876+0530	DEBUG	disapp-deploy-rbd-busybox	util/namespace.go:62	Waiting until namespace "e2e-disapp-deploy-rbd-busybox" is deleted in cluster "dr1"
2025-02-28T20:57:53.891+0530	DEBUG	disapp-deploy-rbd-busybox	util/namespace.go:73	Namespace "e2e-disapp-deploy-rbd-busybox" deleted in cluster "dr1"
2025-02-28T20:57:53.903+0530	DEBUG	disapp-deploy-rbd-busybox	util/namespace.go:62	Waiting until namespace "e2e-disapp-deploy-rbd-busybox" is deleted in cluster "dr2"
2025-02-28T20:57:59.919+0530	DEBUG	disapp-deploy-rbd-busybox	util/namespace.go:73	Namespace "e2e-disapp-deploy-rbd-busybox" deleted in cluster "dr2"
2025-02-28T20:57:59.920+0530	INFO	disapp-deploy-rbd-busybox	deployers/discoveredapp.go:105	Undeployed discovered app "e2e-disapp-deploy-rbd-busybox/busybox"
2025-02-28T20:58:07.233+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:34	drpc "ramen-ops/disapp-deploy-cephfs-busybox" is ready in cluster "hub"
2025-02-28T20:58:07.235+0530	DEBUG	disapp-deploy-cephfs-busybox	workloads/deployment.go:89	Deployment "e2e-disapp-deploy-cephfs-busybox/busybox" is ready in cluster "dr1"
2025-02-28T20:58:07.235+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/retry.go:49	Workload "e2e-disapp-deploy-cephfs-busybox/busybox" is ready in cluster "dr1"
2025-02-28T20:58:07.239+0530	INFO	disapp-deploy-cephfs-busybox	dractions/discovered.go:72	Unprotecting workload running in cluster "dr1" (app namespace: "e2e-disapp-deploy-cephfs-busybox", management namespace: "ramen-ops")
2025-02-28T20:58:07.244+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/crud.go:85	Deleted drpc "ramen-ops/disapp-deploy-cephfs-busybox" in cluster "hub"
2025-02-28T20:58:07.244+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:111	Waiting until drpc "ramen-ops/disapp-deploy-cephfs-busybox" is deleted in cluster "hub"
2025-02-28T20:58:37.813+0530	DEBUG	subscr-deploy-cephfs-busybox	dractions/retry.go:117	drpc "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" is deleted in cluster "hub"
2025-02-28T20:58:37.816+0530	DEBUG	subscr-deploy-cephfs-busybox	deployers/crud.go:225	Deleted subscription "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" in cluster "hub"
2025-02-28T20:58:37.821+0530	INFO	subscr-deploy-cephfs-busybox	deployers/subscription.go:91	Undeployed subscription app "e2e-subscr-deploy-cephfs-busybox/busybox" in cluster "dr1"
2025-02-28T20:58:37.824+0530	DEBUG	subscr-deploy-cephfs-busybox	deployers/crud.go:141	Deleted placement "e2e-subscr-deploy-cephfs-busybox/subscr-deploy-cephfs-busybox" in cluster "hub"
2025-02-28T20:58:37.837+0530	DEBUG	subscr-deploy-cephfs-busybox	deployers/crud.go:85	Deleted ManagedClusterSetBinding "e2e-subscr-deploy-cephfs-busybox/default" in cluster "hub"
2025-02-28T20:58:37.853+0530	DEBUG	subscr-deploy-cephfs-busybox	util/namespace.go:62	Waiting until namespace "e2e-subscr-deploy-cephfs-busybox" is deleted in cluster "hub"
2025-02-28T20:58:43.870+0530	DEBUG	subscr-deploy-cephfs-busybox	util/namespace.go:73	Namespace "e2e-subscr-deploy-cephfs-busybox" deleted in cluster "hub"
2025-02-28T20:59:07.287+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:117	drpc "ramen-ops/disapp-deploy-cephfs-busybox" is deleted in cluster "hub"
2025-02-28T20:59:07.291+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/crud.go:141	Deleted placement "ramen-ops/disapp-deploy-cephfs-busybox" in cluster "hub"
2025-02-28T20:59:07.294+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/crud.go:82	ManagedClusterSetBinding "ramen-ops/default" not found in cluster "hub"
2025-02-28T20:59:07.294+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/crud.go:85	Deleted ManagedClusterSetBinding "ramen-ops/default" in cluster "hub"
2025-02-28T20:59:11.411+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/crud.go:440	Deleted discovered app "e2e-disapp-deploy-cephfs-busybox/busybox" in cluster "dr1"
2025-02-28T20:59:14.344+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/crud.go:440	Deleted discovered app "e2e-disapp-deploy-cephfs-busybox/busybox" in cluster "dr2"
2025-02-28T20:59:14.349+0530	DEBUG	disapp-deploy-cephfs-busybox	util/namespace.go:62	Waiting until namespace "e2e-disapp-deploy-cephfs-busybox" is deleted in cluster "dr1"
2025-02-28T20:59:20.363+0530	DEBUG	disapp-deploy-cephfs-busybox	util/namespace.go:73	Namespace "e2e-disapp-deploy-cephfs-busybox" deleted in cluster "dr1"
2025-02-28T20:59:20.366+0530	DEBUG	disapp-deploy-cephfs-busybox	util/namespace.go:62	Waiting until namespace "e2e-disapp-deploy-cephfs-busybox" is deleted in cluster "dr2"
2025-02-28T20:59:26.379+0530	DEBUG	disapp-deploy-cephfs-busybox	util/namespace.go:73	Namespace "e2e-disapp-deploy-cephfs-busybox" deleted in cluster "dr2"
2025-02-28T20:59:26.379+0530	INFO	disapp-deploy-cephfs-busybox	deployers/discoveredapp.go:105	Undeployed discovered app "e2e-disapp-deploy-cephfs-busybox/busybox"
2025-02-28T21:02:27.964+0530	INFO	util/channel.go:76	Deleted channel "e2e-gitops/https-github-com-ramendr-ocm-ramen-samples-git" in cluster "hub"
2025-02-28T21:02:27.969+0530	DEBUG	util/namespace.go:62	Waiting until namespace "e2e-gitops" is deleted in cluster "hub"
2025-02-28T21:02:33.988+0530	DEBUG	util/namespace.go:73	Namespace "e2e-gitops" deleted in cluster "hub"
```