### PR TITLE
e2e: Fix logger in CreateNamespaceAndAddAnnotation

### DIFF
--- a/e2e/deployers/discoveredapp.go
+++ b/e2e/deployers/discoveredapp.go
@@ -32,7 +32,7 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 	appNamespace := ctx.AppNamespace()
 
 	// create namespace in both dr clusters
-	if err := util.CreateNamespaceAndAddAnnotation(appNamespace); err != nil {
+	if err := util.CreateNamespaceAndAddAnnotation(appNamespace, log); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -78,7 +78,7 @@ func EnableProtection(ctx types.Context) error {
 	}
 
 	// For volsync based replication we must create the cluster namespaces with special annotation.
-	if err := util.CreateNamespaceAndAddAnnotation(ctx.AppNamespace()); err != nil {
+	if err := util.CreateNamespaceAndAddAnnotation(ctx.AppNamespace(), log); err != nil {
 		return err
 	}
 

--- a/e2e/util/namespace.go
+++ b/e2e/util/namespace.go
@@ -86,20 +86,20 @@ func DeleteNamespace(cluster Cluster, namespace string, log *zap.SugaredLogger) 
 // Problem: currently we must manually add an annotation to application’s namespace to make volsync work.
 // See this link https://volsync.readthedocs.io/en/stable/usage/permissionmodel.html#controlling-mover-permissions
 // Workaround: create ns in both drclusters and add annotation
-func CreateNamespaceAndAddAnnotation(namespace string) error {
-	if err := CreateNamespace(Ctx.C1, namespace, Ctx.Log); err != nil {
+func CreateNamespaceAndAddAnnotation(namespace string, log *zap.SugaredLogger) error {
+	if err := CreateNamespace(Ctx.C1, namespace, log); err != nil {
 		return err
 	}
 
-	if err := addNamespaceAnnotationForVolSync(Ctx.C1, namespace, Ctx.Log); err != nil {
+	if err := addNamespaceAnnotationForVolSync(Ctx.C1, namespace, log); err != nil {
 		return err
 	}
 
-	if err := CreateNamespace(Ctx.C2, namespace, Ctx.Log); err != nil {
+	if err := CreateNamespace(Ctx.C2, namespace, log); err != nil {
 		return err
 	}
 
-	return addNamespaceAnnotationForVolSync(Ctx.C2, namespace, Ctx.Log)
+	return addNamespaceAnnotationForVolSync(Ctx.C2, namespace, log)
 }
 
 func addNamespaceAnnotationForVolSync(cluster Cluster, namespace string, log *zap.SugaredLogger) error {


### PR DESCRIPTION
We used the main logger instead of the test logger. Add log argument so we can pass the right logger.
    
It would be nicer to pass the test context, but we cannot because the types packages depends on the utils package.

Example log:
[ramen-e2e.log](https://github.com/user-attachments/files/19045475/ramen-e2e.log)