### PR TITLE
Unify test namespaces and storage class names

### DIFF
--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -16,7 +16,7 @@ pvcspecs:
     storageclassname: rook-ceph-block
     accessmodes: ReadWriteOnce
   - name: cephfs
-    storageclassname: rook-cephfs-test-fs1
+    storageclassname: rook-cephfs-fs1
     accessmodes: ReadWriteMany
 
 # Sample cluster configurations:

--- a/test/addons/rook-cephfs/provision-test/kustomization.yaml
+++ b/test/addons/rook-cephfs/provision-test/kustomization.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ---
-namespace: drenv-addon-test
+namespace: rook-cephfs-test
 
 resources:
 - namespace.yaml

--- a/test/addons/rook-cephfs/provision-test/namespace.yaml
+++ b/test/addons/rook-cephfs/provision-test/namespace.yaml
@@ -5,4 +5,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: drenv-addon-test
+  name: rook-cephfs-test

--- a/test/addons/rook-cephfs/provision-test/pvc.yaml
+++ b/test/addons/rook-cephfs/provision-test/pvc.yaml
@@ -8,8 +8,8 @@ metadata:
   name: cephfs-pvc
 spec:
   accessModes:
-  - ReadWriteMany
+    - ReadWriteMany
   resources:
     requests:
       storage: 1Gi
-  storageClassName: rook-cephfs-test-fs1
+  storageClassName: rook-cephfs-fs1

--- a/test/addons/rook-cephfs/start
+++ b/test/addons/rook-cephfs/start
@@ -10,7 +10,7 @@ import drenv
 from drenv import kubectl
 
 STORAGE_CLASS_NAME_PREFIX = "rook-cephfs-"
-FILE_SYSTEMS = ["test-fs1", "test-fs2"]
+FILE_SYSTEMS = ["fs1", "fs2"]
 
 
 def deploy(cluster):

--- a/test/addons/rook-cephfs/test
+++ b/test/addons/rook-cephfs/test
@@ -10,7 +10,7 @@ from drenv import kubectl
 
 PVC_NAME = "cephfs-pvc"
 SNAP_NAME = "cephfs-snap"
-NAMESPACE = "drenv-addon-test"
+NAMESPACE = "rook-cephfs-test"
 
 
 def test_provisioning(cluster):

--- a/test/addons/volsync/app/file/kustomization.yaml
+++ b/test/addons/volsync/app/file/kustomization.yaml
@@ -14,7 +14,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/storageClassName
-        value: rook-cephfs-test-fs1
+        value: rook-cephfs-fs1
       - op: replace
         path: /spec/accessModes
         value:

--- a/test/addons/volsync/rd/file/kustomization.yaml
+++ b/test/addons/volsync/rd/file/kustomization.yaml
@@ -13,7 +13,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/storageClassName
-        value: rook-cephfs-test-fs1
+        value: rook-cephfs-fs1
       - op: replace
         path: /spec/accessModes
         value:
@@ -27,7 +27,7 @@ patches:
     patch: |-
       - op: replace
         path: /spec/rsyncTLS/storageClassName
-        value: rook-cephfs-test-fs1
+        value: rook-cephfs-fs1
       - op: replace
         path: /spec/rsyncTLS/volumeSnapshotClassName
         value: csi-cephfsplugin-snapclass


### PR DESCRIPTION
- Rename test namespace "drenv-addon-cephfs" to "rook-cephfs-test"
- Rename rook-cephfs storage classes from "rook-ceph-test-fs{N}" to "rook-cephfs-fs{N}" for consistency with "rook-ceph-block"