### PR TITLE
e2e: Make config reusable for ramenctl

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -23,16 +23,16 @@ type PVCSpec struct {
 	UnsupportedDeployers []string
 }
 
-type ClusterConfig struct {
+type Cluster struct {
 	Name           string
 	KubeconfigPath string
 }
 
-type TestConfig struct {
+type Config struct {
 	// User configurable values.
 	ChannelNamespace string
 	GitURL           string
-	Clusters         map[string]ClusterConfig
+	Clusters         map[string]Cluster
 	PVCSpecs         []PVCSpec
 
 	// Generated values
@@ -41,7 +41,7 @@ type TestConfig struct {
 
 var (
 	resourceNameForbiddenCharacters *regexp.Regexp
-	config                          = &TestConfig{}
+	config                          = &Config{}
 )
 
 //nolint:cyclop
@@ -96,7 +96,7 @@ func GetPVCSpecs() []PVCSpec {
 	return config.PVCSpecs
 }
 
-func GetClusters() map[string]ClusterConfig {
+func GetClusters() map[string]Cluster {
 	return config.Clusters
 }
 

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: The RamenDR authors
 // SPDX-License-Identifier: Apache-2.0
 
-package util
+package config
 
 import (
 	"fmt"
@@ -94,6 +94,10 @@ func GetGitURL() string {
 
 func GetPVCSpecs() []PVCSpec {
 	return config.PVCSpecs
+}
+
+func GetClusters() map[string]ClusterConfig {
+	return config.Clusters
 }
 
 // resourceName convert a URL to conventional k8s resource name:

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -172,7 +173,7 @@ func CreateSubscription(ctx types.Context, s Subscription) error {
 			Annotations: annotations,
 		},
 		Spec: subscriptionv1.SubscriptionSpec{
-			Channel:   util.GetChannelNamespace() + "/" + util.GetChannelName(),
+			Channel:   config.GetChannelNamespace() + "/" + config.GetChannelName(),
 			Placement: placementRulePlacement,
 		},
 	}
@@ -323,7 +324,7 @@ func CreateApplicationSet(ctx types.Context, a ApplicationSet) error {
 				},
 				Spec: argocdv1alpha1hack.ApplicationSpec{
 					Source: &argocdv1alpha1hack.ApplicationSource{
-						RepoURL:        util.GetGitURL(),
+						RepoURL:        config.GetGitURL(),
 						Path:           w.GetPath(),
 						TargetRevision: w.GetRevision(),
 					},
@@ -448,7 +449,7 @@ type CombinedData map[string]interface{}
 func CreateKustomizationFile(ctx types.Context, dir string) error {
 	w := ctx.Workload()
 	yamlData := `resources:
-- ` + util.GetGitURL() + `/` + w.GetPath() + `?ref=` + w.GetRevision()
+- ` + config.GetGitURL() + `/` + w.GetPath() + `?ref=` + w.GetRevision()
 
 	var yamlContent CombinedData
 

--- a/e2e/exhaustive_suite_test.go
+++ b/e2e/exhaustive_suite_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/deployers"
 	"github.com/ramendr/ramen/e2e/test"
 	"github.com/ramendr/ramen/e2e/types"
@@ -33,7 +34,7 @@ var (
 )
 
 func generateWorkloads([]types.Workload) {
-	pvcSpecs := util.GetPVCSpecs()
+	pvcSpecs := config.GetPVCSpecs()
 	for _, pvcSpec := range pvcSpecs {
 		// add storageclass name to deployment name
 		deployment := &workloads.Deployment{

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/test"
 	"github.com/ramendr/ramen/e2e/util"
 )
@@ -31,7 +32,11 @@ func TestMain(m *testing.M) {
 
 	log.Infof("Using config file %q", configFile)
 
-	util.Ctx, err = util.NewContext(log, configFile)
+	if err := config.ReadConfig(configFile); err != nil {
+		log.Fatalf("Failed to read config: %s", err)
+	}
+
+	util.Ctx, err = util.NewContext(log)
 	if err != nil {
 		log.Fatalf("Failed to create testing context: %s", err)
 	}

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/ramendr/ramen/e2e/util"
 )
 
+var configFile string
+
 func init() {
-	flag.StringVar(&util.ConfigFile, "config", "", "Path to the config file")
+	flag.StringVar(&configFile, "config", "config.yaml", "e2e configuration file")
 }
 
 func TestMain(m *testing.M) {
@@ -27,7 +29,9 @@ func TestMain(m *testing.M) {
 	}
 	// TODO: Sync the log on exit
 
-	util.Ctx, err = util.NewContext(log, util.ConfigFile)
+	log.Infof("Using config file %q", configFile)
+
+	util.Ctx, err = util.NewContext(log, configFile)
 	if err != nil {
 		log.Fatalf("Failed to create testing context: %s", err)
 	}

--- a/e2e/util/channel.go
+++ b/e2e/util/channel.go
@@ -6,6 +6,7 @@ package util
 import (
 	"context"
 
+	"github.com/ramendr/ramen/e2e/config"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,7 +15,7 @@ import (
 
 func EnsureChannel() error {
 	// create channel namespace
-	err := CreateNamespace(Ctx.Hub, GetChannelNamespace(), Ctx.Log)
+	err := CreateNamespace(Ctx.Hub, config.GetChannelNamespace(), Ctx.Log)
 	if err != nil {
 		return err
 	}
@@ -27,17 +28,17 @@ func EnsureChannelDeleted() error {
 		return err
 	}
 
-	return DeleteNamespace(Ctx.Hub, GetChannelNamespace(), Ctx.Log)
+	return DeleteNamespace(Ctx.Hub, config.GetChannelNamespace(), Ctx.Log)
 }
 
 func createChannel() error {
 	objChannel := &channelv1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      GetChannelName(),
-			Namespace: GetChannelNamespace(),
+			Name:      config.GetChannelName(),
+			Namespace: config.GetChannelNamespace(),
 		},
 		Spec: channelv1.ChannelSpec{
-			Pathname: GetGitURL(),
+			Pathname: config.GetGitURL(),
 			Type:     channelv1.ChannelTypeGitHub,
 		},
 	}
@@ -49,9 +50,10 @@ func createChannel() error {
 		}
 
 		Ctx.Log.Debugf("Channel \"%s/%s\" already exists in cluster %q",
-			GetChannelNamespace(), GetChannelName(), Ctx.Hub.Name)
+			config.GetChannelNamespace(), config.GetChannelName(), Ctx.Hub.Name)
 	} else {
-		Ctx.Log.Infof("Created channel \"%s/%s\" in cluster %q", GetChannelNamespace(), GetChannelName(), Ctx.Hub.Name)
+		Ctx.Log.Infof("Created channel \"%s/%s\" in cluster %q",
+			config.GetChannelNamespace(), config.GetChannelName(), Ctx.Hub.Name)
 	}
 
 	return nil
@@ -60,8 +62,8 @@ func createChannel() error {
 func deleteChannel() error {
 	channel := &channelv1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      GetChannelName(),
-			Namespace: GetChannelNamespace(),
+			Name:      config.GetChannelName(),
+			Namespace: config.GetChannelNamespace(),
 		},
 	}
 
@@ -71,9 +73,11 @@ func deleteChannel() error {
 			return err
 		}
 
-		Ctx.Log.Debugf("Channel \"%s/%s\" not found in cluster %q", GetChannelNamespace(), GetChannelName(), Ctx.Hub.Name)
+		Ctx.Log.Debugf("Channel \"%s/%s\" not found in cluster %q",
+			config.GetChannelNamespace(), config.GetChannelName(), Ctx.Hub.Name)
 	} else {
-		Ctx.Log.Infof("Deleted channel \"%s/%s\" in cluster %q", GetChannelNamespace(), GetChannelName(), Ctx.Hub.Name)
+		Ctx.Log.Infof("Deleted channel \"%s/%s\" in cluster %q",
+			config.GetChannelNamespace(), config.GetChannelName(), Ctx.Hub.Name)
 	}
 
 	return nil

--- a/e2e/util/config.go
+++ b/e2e/util/config.go
@@ -48,14 +48,6 @@ func ReadConfig(log *zap.SugaredLogger, configFile string) error {
 	viper.SetDefault("ChannelNamespace", defaultChannelNamespace)
 	viper.SetDefault("GitURL", defaultGitURL)
 
-	if err := viper.BindEnv("ChannelNamespace", "ChannelNamespace"); err != nil {
-		return (err)
-	}
-
-	if err := viper.BindEnv("GitURL", "GitURL"); err != nil {
-		return (err)
-	}
-
 	if configFile == "" {
 		log.Info("No configuration file specified, using default value config.yaml")
 

--- a/e2e/util/config.go
+++ b/e2e/util/config.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/spf13/viper"
-	"go.uber.org/zap"
 )
 
 const (
@@ -44,15 +43,9 @@ var (
 )
 
 //nolint:cyclop
-func ReadConfig(log *zap.SugaredLogger, configFile string) error {
+func ReadConfig(configFile string) error {
 	viper.SetDefault("ChannelNamespace", defaultChannelNamespace)
 	viper.SetDefault("GitURL", defaultGitURL)
-
-	if configFile == "" {
-		log.Info("No configuration file specified, using default value config.yaml")
-
-		configFile = "config.yaml"
-	}
 
 	viper.SetConfigFile(configFile)
 

--- a/e2e/util/config.go
+++ b/e2e/util/config.go
@@ -22,10 +22,12 @@ type PVCSpec struct {
 	AccessModes          string
 	UnsupportedDeployers []string
 }
+
 type ClusterConfig struct {
 	Name           string
 	KubeconfigPath string
 }
+
 type TestConfig struct {
 	// User configurable values.
 	ChannelNamespace string

--- a/e2e/util/context.go
+++ b/e2e/util/context.go
@@ -24,8 +24,6 @@ import (
 	placementrule "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 )
 
-var ConfigFile string
-
 type Cluster struct {
 	Name   string
 	Client client.Client
@@ -105,7 +103,7 @@ func NewContext(log *zap.SugaredLogger, configFile string) (*Context, error) {
 	ctx := new(Context)
 	ctx.Log = log
 
-	if err := ReadConfig(log, configFile); err != nil {
+	if err := ReadConfig(configFile); err != nil {
 		panic(err)
 	}
 

--- a/e2e/util/context.go
+++ b/e2e/util/context.go
@@ -98,15 +98,11 @@ func setupClient(kubeconfigPath string) (client.Client, error) {
 	return client, nil
 }
 
-func NewContext(log *zap.SugaredLogger, configFile string) (*Context, error) {
+func NewContext(log *zap.SugaredLogger) (*Context, error) {
 	var err error
 
 	ctx := new(Context)
 	ctx.Log = log
-
-	if err := config.ReadConfig(configFile); err != nil {
-		panic(err)
-	}
 
 	clusters := config.GetClusters()
 

--- a/e2e/util/context.go
+++ b/e2e/util/context.go
@@ -20,6 +20,7 @@ import (
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	argocdv1alpha1hack "github.com/ramendr/ramen/e2e/argocd"
+	"github.com/ramendr/ramen/e2e/config"
 	subscription "open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
 	placementrule "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 )
@@ -103,39 +104,41 @@ func NewContext(log *zap.SugaredLogger, configFile string) (*Context, error) {
 	ctx := new(Context)
 	ctx.Log = log
 
-	if err := ReadConfig(configFile); err != nil {
+	if err := config.ReadConfig(configFile); err != nil {
 		panic(err)
 	}
 
-	ctx.Hub.Name = config.Clusters["hub"].Name
+	clusters := config.GetClusters()
+
+	ctx.Hub.Name = clusters["hub"].Name
 	if ctx.Hub.Name == "" {
 		ctx.Hub.Name = defaultHubClusterName
 		log.Infof("Cluster \"hub\" name not set, using default name %q", defaultHubClusterName)
 	}
 
-	ctx.Hub.Client, err = setupClient(config.Clusters["hub"].KubeconfigPath)
+	ctx.Hub.Client, err = setupClient(clusters["hub"].KubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clients for hub cluster: %w", err)
 	}
 
-	ctx.C1.Name = config.Clusters["c1"].Name
+	ctx.C1.Name = clusters["c1"].Name
 	if ctx.C1.Name == "" {
 		ctx.C1.Name = defaultC1ClusterName
 		log.Infof("Cluster \"c1\" name not set, using default name %q", defaultC1ClusterName)
 	}
 
-	ctx.C1.Client, err = setupClient(config.Clusters["c1"].KubeconfigPath)
+	ctx.C1.Client, err = setupClient(clusters["c1"].KubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clients for c1 cluster: %w", err)
 	}
 
-	ctx.C2.Name = config.Clusters["c2"].Name
+	ctx.C2.Name = clusters["c2"].Name
 	if ctx.C2.Name == "" {
 		ctx.C2.Name = defaultC2ClusterName
 		log.Infof("Cluster \"c2\" name not set, using default name %q", defaultC2ClusterName)
 	}
 
-	ctx.C2.Client, err = setupClient(config.Clusters["c2"].KubeconfigPath)
+	ctx.C2.Client, err = setupClient(clusters["c2"].KubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clients for c2 cluster: %w", err)
 	}

--- a/e2e/workloads/deployment.go
+++ b/e2e/workloads/deployment.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -19,7 +20,7 @@ type Deployment struct {
 	Revision string
 	AppName  string
 	Name     string
-	PVCSpec  util.PVCSpec
+	PVCSpec  config.PVCSpec
 }
 
 func (w Deployment) GetAppName() string {


### PR DESCRIPTION
We wan to use the same configuration file for ramenctl, but the way the config is coupled with the e2e utils packages makes it impossible to use.

This change extract e2e/config package and decouple it from the utils package. More work is needed to pass read a config and pass it to the tests.