### PR TITLE
Progression can't go backwards

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -2382,6 +2382,46 @@ specialProgressions are used to indicate special cases irrespective of action or
 		ProgressionActionPaused,
 	}
 */
+
+var deployProgressionList = []rmn.ProgressionStatus{
+	rmn.ProgressionCreatingMW,
+	rmn.ProgressionUpdatingPlRule,
+	rmn.ProgressionEnsuringVolSyncSetup,
+	rmn.ProgressionSettingupVolsyncDest,
+	rmn.ProgressionCompleted,
+}
+
+var failoverProgressionList = []rmn.ProgressionStatus{
+	rmn.ProgressionCheckingFailoverPrerequisites,
+	rmn.ProgressionWaitForFencing,
+	rmn.ProgressionWaitForStorageMaintenanceActivation,
+	rmn.ProgressionFailingOverToCluster,
+	rmn.ProgressionWaitingForResourceRestore,
+	rmn.ProgressionEnsuringVolSyncSetup,
+	rmn.ProgressionSettingupVolsyncDest,
+	rmn.ProgressionWaitForReadiness,
+	rmn.ProgressionUpdatedPlacement,
+	rmn.ProgressionCleaningUp,
+	rmn.ProgressionWaitOnUserToCleanUp,
+	rmn.ProgressionCompleted,
+}
+
+var relocateProgressionList = []rmn.ProgressionStatus{
+	rmn.ProgressionPreparingFinalSync,
+	rmn.ProgressionClearingPlacement,
+	rmn.ProgressionRunningFinalSync,
+	rmn.ProgressionFinalSyncComplete,
+	rmn.ProgressionEnsuringVolumesAreSecondary,
+	rmn.ProgressionWaitOnUserToCleanUp,
+	rmn.ProgressionCleaningUp,
+	rmn.ProgressionWaitingForResourceRestore,
+	rmn.ProgressionWaitForReadiness,
+	rmn.ProgressionUpdatedPlacement,
+	rmn.ProgressionEnsuringVolSyncSetup,
+	rmn.ProgressionSettingupVolsyncDest,
+	rmn.ProgressionCompleted,
+}
+
 func (d *DRPCInstance) setProgression(nextProgression rmn.ProgressionStatus) {
 	updateDRPCProgression(d.instance, nextProgression, d.log)
 }


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/DFBUGS-612

We have encountered several bugs where DRPC progression unexpectedly reverts from advanced stages to earlier ones. In this particular case, it regresses during Failover from Completed to WaitingForReadiness due to conflicts in VRG generations. While these changes typically resolve themselves over time, users may find the regression alarming.

To address this, we will introduce a check before updating the DRPC status to prevent regression, ensuring it remains at the previous progression level. However, this safeguard will apply only when the Phase remains unchanged—when transitioning between Phases, progression can still move in either direction.