### PR TITLE
recipe: correcting compare issue

### DIFF
--- a/internal/controller/util/json_util_test.go
+++ b/internal/controller/util/json_util_test.go
@@ -8,13 +8,25 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/ramendr/ramen/internal/controller/kubeobjects"
 	"github.com/ramendr/ramen/internal/controller/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 type testCases struct {
 	jsonPathExprs string
 	result        bool
 	jsonText      []byte
+}
+
+type testCasesObject struct {
+	hook    *kubeobjects.HookSpec
+	result  bool
+	jsonObj client.Object
 }
 
 var jsonDeployment = []byte(`{
@@ -83,6 +95,8 @@ var jsonStatefulset = []byte(`{
 			}
 			}`)
 
+var rep int32 = 1
+
 var testCasesData = []testCases{
 	{
 		jsonPathExprs: "{$.status.conditions[0].status} == True",
@@ -101,6 +115,45 @@ var testCasesData = []testCases{
 	},
 }
 
+var testCasesObjectData = []testCasesObject{
+	{
+		hook:    getHookSpec("Pod", "{$.status.phase} == {'Running'}"),
+		result:  true,
+		jsonObj: getPodContent(),
+	},
+	{
+		hook:    getHookSpec("Pod", "{$.status.conditions[0].type} == {'Ready'}"),
+		result:  true,
+		jsonObj: getPodContent(),
+	},
+	{
+		hook:    getHookSpec("Pod", "{$.status.containerStatuses[0].restartCount} == 2"),
+		result:  true,
+		jsonObj: getPodContent(),
+	},
+	{
+		hook:    getHookSpec("Deployment", "{$.spec.replicas} == {$.status.readyReplicas}"),
+		result:  true,
+		jsonObj: getDeploymentContent(),
+	},
+	{
+		hook:    getHookSpec("Statefulset", "{$.status.readyReplicas} == {$.status.currentReplicas}"),
+		result:  true,
+		jsonObj: getStatefulSetContent(),
+	},
+}
+
+func getHookSpec(resourceType, condition string) *kubeobjects.HookSpec {
+	return &kubeobjects.HookSpec{
+		Name:           "test-hook",
+		SelectResource: resourceType,
+		Chk: kubeobjects.Check{
+			Name:      "test-check",
+			Condition: condition,
+		},
+	}
+}
+
 func TestEvaluateCheckHookExp(t *testing.T) {
 	for i, tt := range testCasesData {
 		test := tt
@@ -116,6 +169,22 @@ func TestEvaluateCheckHookExp(t *testing.T) {
 			_, err = util.EvaluateCheckHookExp(test.jsonPathExprs, jsonData)
 			if (err == nil) != test.result {
 				t.Errorf("EvaluateCheckHookExp() = %v, want %v", err, test.result)
+			}
+		})
+	}
+}
+
+func TestEvaluateCheckHookForObjects(t *testing.T) {
+	log := zap.New(zap.UseDevMode(true))
+
+	for i, tt := range testCasesObjectData {
+		test := tt
+		objs := []client.Object{test.jsonObj}
+
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			_, err := util.EvaluateCheckHookForObjects(objs, test.hook, log)
+			if (err == nil) != test.result {
+				t.Errorf("EvaluateCheckHookExpObject() = %v, want %v", err, test.result)
 			}
 		})
 	}
@@ -253,5 +322,76 @@ func Test_isValidJsonPathExpression(t *testing.T) {
 				t.Errorf("IsValidJSONPathExpression() = %v, want %v", got, test.want)
 			}
 		})
+	}
+}
+
+func getPodContent() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "test-container",
+					Image: "test-image",
+				},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "test-container",
+					Ready:        true,
+					RestartCount: 2,
+				},
+			},
+		},
+	}
+}
+
+func getDeploymentContent() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-deploy",
+			Namespace: "test-namespace",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &rep,
+		},
+		Status: appsv1.DeploymentStatus{
+			Replicas: 1,
+			Conditions: []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentProgressing,
+					Status: corev1.ConditionTrue,
+				},
+			},
+			ReadyReplicas: 1,
+		},
+	}
+}
+
+func getStatefulSetContent() *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-statefulset",
+			Namespace: "test-namespace",
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &rep,
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas:   3,
+			CurrentReplicas: 3,
+		},
 	}
 }


### PR DESCRIPTION
When json expressions contain parameters that are not of literal type
but a redeclared form of literal, for eg. `type ModifiedStatus string`
then, using client.Object to fetch the value using json expression will
result in the type being ModifiedStatus while the expectation is to
match with string. Hence, coverting the object data in to
map[string]interface{} helps resolve the issue.