### PR TITLE
e2e: add distro e2e config and get required namespaces

### DIFF
--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -1,6 +1,9 @@
 # Configuration for RamenDR End to End testing.
 
 ---
+# Kubernetes distribution (possible distro values: k8s, ocp)
+distro: k8s
+
 # Git repository url and branch containing application manifests
 # to be deployed on the clusters.
 repo:

--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -9,10 +9,6 @@ import (
 	"github.com/ramendr/ramen/e2e/util"
 )
 
-const (
-	argocdNamespace = "argocd"
-)
-
 type ApplicationSet struct{}
 
 // Deploy creates an ApplicationSet on the hub cluster, creating the workload on one of the managed clusters.
@@ -103,7 +99,7 @@ func (a ApplicationSet) GetName() string {
 }
 
 func (a ApplicationSet) GetNamespace() string {
-	return argocdNamespace
+	return config.GetNamespaces().ArgocdNamespace
 }
 
 func (a ApplicationSet) IsDiscovered() bool {

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -13,10 +13,6 @@ import (
 	"github.com/ramendr/ramen/e2e/util"
 )
 
-const (
-	ramenOpsNamespace = "ramen-ops"
-)
-
 type DiscoveredApp struct{}
 
 func (d DiscoveredApp) GetName() string {
@@ -24,7 +20,7 @@ func (d DiscoveredApp) GetName() string {
 }
 
 func (d DiscoveredApp) GetNamespace() string {
-	return ramenOpsNamespace
+	return config.GetNamespaces().RamenOpsNamespace
 }
 
 // Deploy creates a workload on the first managed cluster.

--- a/e2e/util/validation.go
+++ b/e2e/util/validation.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ramendr/ramen/e2e/config"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -16,20 +17,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	ramenSystemNamespace = "ramen-system"
-)
-
 func ValidateRamenHubOperator(cluster Cluster) error {
 	labelSelector := "app=ramen-hub"
 	podIdentifier := "ramen-hub-operator"
 
-	ramenNameSpace, err := GetRamenNameSpace(cluster)
-	if err != nil {
-		return err
-	}
-
-	pod, err := FindPod(cluster, ramenNameSpace, labelSelector, podIdentifier)
+	pod, err := FindPod(cluster, config.GetNamespaces().RamenHubNamespace, labelSelector, podIdentifier)
 	if err != nil {
 		return err
 	}
@@ -48,12 +40,7 @@ func ValidateRamenDRClusterOperator(cluster Cluster) error {
 	labelSelector := "app=ramen-dr-cluster"
 	podIdentifier := "ramen-dr-cluster-operator"
 
-	ramenNameSpace, err := GetRamenNameSpace(cluster)
-	if err != nil {
-		return err
-	}
-
-	pod, err := FindPod(cluster, ramenNameSpace, labelSelector, podIdentifier)
+	pod, err := FindPod(cluster, config.GetNamespaces().RamenDRClusterNamespace, labelSelector, podIdentifier)
 	if err != nil {
 		return err
 	}
@@ -66,19 +53,6 @@ func ValidateRamenDRClusterOperator(cluster Cluster) error {
 	Ctx.Log.Infof("Ramen dr cluster operator pod %q is running in cluster %q", pod.Name, cluster.Name)
 
 	return nil
-}
-
-func GetRamenNameSpace(cluster Cluster) (string, error) {
-	isOpenShift, err := IsOpenShiftCluster(cluster)
-	if err != nil {
-		return "", err
-	}
-
-	if isOpenShift {
-		return "openshift-operators", nil
-	}
-
-	return ramenSystemNamespace, nil
 }
 
 // IsOpenShiftCluster checks if the given Kubernetes cluster is an OpenShift cluster.


### PR DESCRIPTION
Below changes improves configurability in the e2e framework by getting required k8s or openshift namespaces based on distro.

Tested valid/invalid distro values.

Out of scope of this PR:
Testing on Openshift cluster

Fixes #1771 