### PR TITLE
e2e: add channel and repo to improve e2e config  

### DIFF
--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -1,9 +1,11 @@
 # Configuration for RamenDR End to End testing.
 
 ---
-# Git repository URL containing application manifests to be deployed on
-# the clusters.
-giturl: "https://github.com/RamenDR/ocm-ramen-samples.git"
+# Git repository url and branch containing application manifests
+# to be deployed on the clusters.
+repo:
+  url: "https://github.com/RamenDR/ocm-ramen-samples.git"
+  branch: main
 
 # List of PVC specifications for workloads.
 # These define storage configurations, such as 'storageClassName' and

--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -1,9 +1,6 @@
 # Configuration for RamenDR End to End testing.
 
 ---
-# Namespace where the channel CR will be created.
-channelnamespace: "e2e-gitops"
-
 # Git repository URL containing application manifests to be deployed on
 # the clusters.
 giturl: "https://github.com/RamenDR/ocm-ramen-samples.git"

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -16,6 +16,13 @@ const (
 	defaultGitURL           = "https://github.com/RamenDR/ocm-ramen-samples.git"
 )
 
+// Channel defines the name and namespace for the channel CR.
+// This is not user-configurable and always uses default values.
+type Channel struct {
+	Name      string
+	Namespace string
+}
+
 type PVCSpec struct {
 	Name                 string
 	StorageClassName     string
@@ -30,13 +37,12 @@ type Cluster struct {
 
 type Config struct {
 	// User configurable values.
-	ChannelNamespace string
-	GitURL           string
-	Clusters         map[string]Cluster
-	PVCSpecs         []PVCSpec
+	GitURL   string
+	Clusters map[string]Cluster
+	PVCSpecs []PVCSpec
 
 	// Generated values
-	channelName string
+	Channel Channel
 }
 
 var (
@@ -46,7 +52,6 @@ var (
 
 //nolint:cyclop
 func ReadConfig(configFile string) error {
-	viper.SetDefault("ChannelNamespace", defaultChannelNamespace)
 	viper.SetDefault("GitURL", defaultGitURL)
 
 	viper.SetConfigFile(configFile)
@@ -75,17 +80,18 @@ func ReadConfig(configFile string) error {
 		return fmt.Errorf("failed to find pvcs in configuration")
 	}
 
-	config.channelName = resourceName(config.GitURL)
+	config.Channel.Name = resourceName(config.GitURL)
+	config.Channel.Namespace = defaultChannelNamespace
 
 	return nil
 }
 
 func GetChannelName() string {
-	return config.channelName
+	return config.Channel.Name
 }
 
 func GetChannelNamespace() string {
-	return config.ChannelNamespace
+	return config.Channel.Namespace
 }
 
 func GetGitURL() string {

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -14,6 +14,7 @@ import (
 const (
 	defaultChannelNamespace = "e2e-gitops"
 	defaultGitURL           = "https://github.com/RamenDR/ocm-ramen-samples.git"
+	defaultGitBranch        = "main"
 )
 
 // Channel defines the name and namespace for the channel CR.
@@ -21,6 +22,13 @@ const (
 type Channel struct {
 	Name      string
 	Namespace string
+}
+
+// Repo represents the user-configurable git repository settings.
+// It includes the repository url and branch to be used for deploying workload.
+type Repo struct {
+	URL    string
+	Branch string
 }
 
 type PVCSpec struct {
@@ -37,7 +45,7 @@ type Cluster struct {
 
 type Config struct {
 	// User configurable values.
-	GitURL   string
+	Repo     Repo
 	Clusters map[string]Cluster
 	PVCSpecs []PVCSpec
 
@@ -52,7 +60,8 @@ var (
 
 //nolint:cyclop
 func ReadConfig(configFile string) error {
-	viper.SetDefault("GitURL", defaultGitURL)
+	viper.SetDefault("Repo.URL", defaultGitURL)
+	viper.SetDefault("Repo.Branch", defaultGitBranch)
 
 	viper.SetConfigFile(configFile)
 
@@ -80,7 +89,7 @@ func ReadConfig(configFile string) error {
 		return fmt.Errorf("failed to find pvcs in configuration")
 	}
 
-	config.Channel.Name = resourceName(config.GitURL)
+	config.Channel.Name = resourceName(config.Repo.URL)
 	config.Channel.Namespace = defaultChannelNamespace
 
 	return nil
@@ -95,7 +104,11 @@ func GetChannelNamespace() string {
 }
 
 func GetGitURL() string {
-	return config.GitURL
+	return config.Repo.URL
+}
+
+func GetGitBranch() string {
+	return config.Repo.Branch
 }
 
 func GetPVCSpecs() []PVCSpec {

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -154,7 +154,7 @@ func CreateSubscription(ctx types.Context, s Subscription) error {
 	labels[AppLabelKey] = name
 
 	annotations := make(map[string]string)
-	annotations["apps.open-cluster-management.io/github-branch"] = w.GetRevision()
+	annotations["apps.open-cluster-management.io/github-branch"] = w.GetBranch()
 	annotations["apps.open-cluster-management.io/github-path"] = w.GetPath()
 
 	placementRef := corev1.ObjectReference{
@@ -326,7 +326,7 @@ func CreateApplicationSet(ctx types.Context, a ApplicationSet) error {
 					Source: &argocdv1alpha1hack.ApplicationSource{
 						RepoURL:        config.GetGitURL(),
 						Path:           w.GetPath(),
-						TargetRevision: w.GetRevision(),
+						TargetRevision: w.GetBranch(),
 					},
 					Destination: argocdv1alpha1hack.ApplicationDestination{
 						Server:    "{{server}}",
@@ -449,7 +449,7 @@ type CombinedData map[string]interface{}
 func CreateKustomizationFile(ctx types.Context, dir string) error {
 	w := ctx.Workload()
 	yamlData := `resources:
-- ` + config.GetGitURL() + `/` + w.GetPath() + `?ref=` + w.GetRevision()
+- ` + config.GetGitURL() + `/` + w.GetPath() + `?ref=` + w.GetBranch()
 
 	var yamlContent CombinedData
 

--- a/e2e/exhaustive_suite_test.go
+++ b/e2e/exhaustive_suite_test.go
@@ -20,9 +20,8 @@ import (
 // Classes   = {"rbd", "cephfs"}
 
 const (
-	GITPATH     = "workloads/deployment/base"
-	GITREVISION = "main"
-	APPNAME     = "busybox"
+	GITPATH = "workloads/deployment/base"
+	APPNAME = "busybox"
 )
 
 var (
@@ -38,11 +37,11 @@ func generateWorkloads([]types.Workload) {
 	for _, pvcSpec := range pvcSpecs {
 		// add storageclass name to deployment name
 		deployment := &workloads.Deployment{
-			Path:     GITPATH,
-			Revision: GITREVISION,
-			AppName:  APPNAME,
-			Name:     fmt.Sprintf("Deploy-%s", pvcSpec.Name),
-			PVCSpec:  pvcSpec,
+			Path:    GITPATH,
+			Branch:  config.GetGitBranch(),
+			AppName: APPNAME,
+			Name:    fmt.Sprintf("Deploy-%s", pvcSpec.Name),
+			PVCSpec: pvcSpec,
 		}
 		Workloads = append(Workloads, deployment)
 	}

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -26,7 +26,7 @@ type Workload interface {
 	GetName() string
 	GetAppName() string
 	GetPath() string
-	GetRevision() string
+	GetBranch() string
 
 	// SupportsDeployer returns tue if this workload is compatible with deployer.
 	SupportsDeployer(Deployer) bool

--- a/e2e/workloads/deployment.go
+++ b/e2e/workloads/deployment.go
@@ -16,11 +16,11 @@ import (
 )
 
 type Deployment struct {
-	Path     string
-	Revision string
-	AppName  string
-	Name     string
-	PVCSpec  config.PVCSpec
+	Path    string
+	Branch  string
+	AppName string
+	Name    string
+	PVCSpec config.PVCSpec
 }
 
 func (w Deployment) GetAppName() string {
@@ -35,8 +35,8 @@ func (w Deployment) GetPath() string {
 	return w.Path
 }
 
-func (w Deployment) GetRevision() string {
-	return w.Revision
+func (w Deployment) GetBranch() string {
+	return w.Branch
 }
 
 func (w Deployment) SupportsDeployer(d types.Deployer) bool {


### PR DESCRIPTION
splitting first 2 commits from #1883 to unblock #1884

Changes:

- Channel config: Added Channel struct to group channel-related settings.
- Repo config: Moved repo-related constants to config.go under the Repo struct. Updated config.yaml.sample to allow users to specify repo branch.