### PR TITLE
e2e: make clusterset and drpolicy configurable 

### DIFF
--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -10,6 +10,9 @@ repo:
 # DRPolicy name in the hub cluster.
 drPolicy: dr-policy
 
+# Add ClusterSet name to match your Open Cluster Management configuration.
+clusterSet: default
+
 # List of PVC specifications for workloads.
 # These define storage configurations, such as 'storageClassName' and
 # 'accessModes', and are used to kustomize workloads.

--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -7,6 +7,9 @@ repo:
   url: "https://github.com/RamenDR/ocm-ramen-samples.git"
   branch: main
 
+# DRPolicy name in the hub cluster.
+drPolicy: dr-policy
+
 # List of PVC specifications for workloads.
 # These define storage configurations, such as 'storageClassName' and
 # 'accessModes', and are used to kustomize workloads.

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -17,6 +17,7 @@ const (
 	defaultGitURL           = "https://github.com/RamenDR/ocm-ramen-samples.git"
 	defaultGitBranch        = "main"
 	defaultDRPolicyName     = "dr-policy"
+	defaultClusterSetName   = "default"
 )
 
 // Channel defines the name and namespace for the channel CR.
@@ -53,11 +54,12 @@ type Test struct {
 
 type Config struct {
 	// User configurable values.
-	Repo     Repo
-	DRPolicy string
-	Clusters map[string]Cluster
-	PVCSpecs []PVCSpec
-	Tests    []Test
+	Repo       Repo
+	DRPolicy   string
+	ClusterSet string
+	Clusters   map[string]Cluster
+	PVCSpecs   []PVCSpec
+	Tests      []Test
 
 	// Generated values
 	Channel Channel
@@ -79,6 +81,7 @@ func ReadConfig(configFile string, options Options) error {
 	viper.SetDefault("Repo.URL", defaultGitURL)
 	viper.SetDefault("Repo.Branch", defaultGitBranch)
 	viper.SetDefault("DRPolicy", defaultDRPolicyName)
+	viper.SetDefault("ClusterSet", defaultClusterSetName)
 
 	viper.SetConfigFile(configFile)
 
@@ -170,6 +173,10 @@ func GetGitBranch() string {
 
 func GetDRPolicyName() string {
 	return config.DRPolicy
+}
+
+func GetClusterSetName() string {
+	return config.ClusterSet
 }
 
 func GetPVCSpecs() map[string]PVCSpec {

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -16,6 +16,7 @@ const (
 	defaultChannelNamespace = "e2e-gitops"
 	defaultGitURL           = "https://github.com/RamenDR/ocm-ramen-samples.git"
 	defaultGitBranch        = "main"
+	defaultDRPolicyName     = "dr-policy"
 )
 
 // Channel defines the name and namespace for the channel CR.
@@ -53,6 +54,7 @@ type Test struct {
 type Config struct {
 	// User configurable values.
 	Repo     Repo
+	DRPolicy string
 	Clusters map[string]Cluster
 	PVCSpecs []PVCSpec
 	Tests    []Test
@@ -76,6 +78,7 @@ var (
 func ReadConfig(configFile string, options Options) error {
 	viper.SetDefault("Repo.URL", defaultGitURL)
 	viper.SetDefault("Repo.Branch", defaultGitBranch)
+	viper.SetDefault("DRPolicy", defaultDRPolicyName)
 
 	viper.SetConfigFile(configFile)
 
@@ -163,6 +166,10 @@ func GetGitURL() string {
 
 func GetGitBranch() string {
 	return config.Repo.Branch
+}
+
+func GetDRPolicyName() string {
+	return config.DRPolicy
 }
 
 func GetPVCSpecs() map[string]PVCSpec {

--- a/e2e/deployers/applicationset.go
+++ b/e2e/deployers/applicationset.go
@@ -4,6 +4,7 @@
 package deployers
 
 import (
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 )
@@ -20,7 +21,7 @@ func (a ApplicationSet) Deploy(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	err := CreateManagedClusterSetBinding(ctx, McsbName, managementNamespace)
+	err := CreateManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
 	if err != nil {
 		return err
 	}
@@ -88,7 +89,7 @@ func (a ApplicationSet) Undeploy(ctx types.Context) error {
 	}
 
 	if lastAppset {
-		err = DeleteManagedClusterSetBinding(ctx, McsbName, managementNamespace)
+		err = DeleteManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
 		if err != nil {
 			return err
 		}

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -30,8 +30,7 @@ import (
 )
 
 const (
-	AppLabelKey    = "app"
-	ClusterSetName = "default"
+	AppLabelKey = "app"
 
 	fMode = 0o600
 )
@@ -47,7 +46,7 @@ func CreateManagedClusterSetBinding(ctx types.Context, name, namespace string) e
 			Labels:    labels,
 		},
 		Spec: ocmv1b2.ManagedClusterSetBindingSpec{
-			ClusterSet: ClusterSetName,
+			ClusterSet: config.GetClusterSetName(),
 		},
 	}
 
@@ -92,7 +91,7 @@ func CreatePlacement(ctx types.Context, name, namespace string) error {
 	log := ctx.Logger()
 	labels := make(map[string]string)
 	labels[AppLabelKey] = name
-	clusterSet := []string{ClusterSetName}
+	clusterSet := []string{config.GetClusterSetName()}
 
 	var numClusters int32 = 1
 	placement := &ocmv1b1.Placement{

--- a/e2e/deployers/discoveredapp.go
+++ b/e2e/deployers/discoveredapp.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 )
@@ -48,7 +49,7 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub, util.DefaultDRPolicyName)
+	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub, config.GetDRPolicyName())
 	if err != nil {
 		return err
 	}
@@ -79,7 +80,7 @@ func (d DiscoveredApp) Undeploy(ctx types.Context) error {
 	log := ctx.Logger()
 	appNamespace := ctx.AppNamespace()
 
-	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub, util.DefaultDRPolicyName)
+	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub, config.GetDRPolicyName())
 	if err != nil {
 		return err
 	}

--- a/e2e/deployers/subscription.go
+++ b/e2e/deployers/subscription.go
@@ -4,13 +4,11 @@
 package deployers
 
 import (
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 	subscriptionv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 )
-
-// mcsb name must be same as the target ManagedClusterSet
-const McsbName = ClusterSetName
 
 type Subscription struct{}
 
@@ -41,7 +39,7 @@ func (s Subscription) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	err = CreateManagedClusterSetBinding(ctx, McsbName, managementNamespace)
+	err = CreateManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
 	if err != nil {
 		return err
 	}
@@ -96,7 +94,7 @@ func (s Subscription) Undeploy(ctx types.Context) error {
 		return err
 	}
 
-	err = DeleteManagedClusterSetBinding(ctx, McsbName, managementNamespace)
+	err = DeleteManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
 	if err != nil {
 		return err
 	}

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -5,6 +5,7 @@ package dractions
 
 import (
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 	"k8s.io/client-go/util/retry"
@@ -33,7 +34,7 @@ func EnableProtection(ctx types.Context) error {
 	appNamespace := ctx.AppNamespace()
 	log := ctx.Logger()
 
-	drPolicyName := util.DefaultDRPolicyName
+	drPolicyName := config.GetDRPolicyName()
 	appname := w.GetAppName()
 	placementName := name
 	drpcName := name

--- a/e2e/dractions/discovered.go
+++ b/e2e/dractions/discovered.go
@@ -24,7 +24,7 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 	drpcName := name
 
 	// create mcsb default in ramen-ops ns
-	if err := deployers.CreateManagedClusterSetBinding(ctx, deployers.McsbName, managementNamespace); err != nil {
+	if err := deployers.CreateManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace); err != nil {
 		return err
 	}
 
@@ -86,7 +86,7 @@ func DisableProtectionDiscoveredApps(ctx types.Context) error {
 		return err
 	}
 
-	return deployers.DeleteManagedClusterSetBinding(ctx, deployers.McsbName, managementNamespace)
+	return deployers.DeleteManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
 }
 
 // nolint:funlen,cyclop

--- a/e2e/dractions/discovered.go
+++ b/e2e/dractions/discovered.go
@@ -5,6 +5,7 @@ package dractions
 
 import (
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/deployers"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
@@ -17,7 +18,7 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 	managementNamespace := ctx.ManagementNamespace()
 	appNamespace := ctx.AppNamespace()
 
-	drPolicyName := util.DefaultDRPolicyName
+	drPolicyName := config.GetDRPolicyName()
 	appname := w.GetAppName()
 	placementName := name
 	drpcName := name
@@ -102,7 +103,7 @@ func failoverRelocateDiscoveredApps(
 
 	drpcName := name
 
-	drPolicyName := util.DefaultDRPolicyName
+	drPolicyName := config.GetDRPolicyName()
 
 	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub, drPolicyName)
 	if err != nil {

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -89,7 +90,7 @@ func getDRCluster(clusterName string, drpolicy *ramen.DRPolicy) util.Cluster {
 }
 
 func getTargetCluster(cluster util.Cluster, currentCluster string) (string, error) {
-	drpolicy, err := util.GetDRPolicy(cluster, util.DefaultDRPolicyName)
+	drpolicy, err := util.GetDRPolicy(cluster, config.GetDRPolicyName())
 	if err != nil {
 		return "", err
 	}

--- a/e2e/util/drpolicy.go
+++ b/e2e/util/drpolicy.go
@@ -10,8 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-const DefaultDRPolicyName = "dr-policy"
-
 // nolint:unparam
 func GetDRPolicy(cluster Cluster, name string) (*ramen.DRPolicy, error) {
 	drpolicy := &ramen.DRPolicy{}


### PR DESCRIPTION
This change makes ClusterSet and DRPolicy configurable, removing hardcoded values and allowing users to define them in e2e config.yaml.