### PR TITLE
e2e: Simplify test suites

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -75,11 +75,17 @@ jobs:
           source venv
           ramendev config test/envs/regional-dr.yaml
 
-    - name: Run e2e tests
-      run: |
-        cat e2e/config.yaml.sample >> e2e/config.yaml
-        cat ~/.config/drenv/rdr/config.yaml >> e2e/config.yaml
-        make e2e-rdr
+    - name: Prepare e2e config
+      working-directory: e2e
+      run: cat config.yaml.sample ~/.config/drenv/rdr/config.yaml > config.yaml
+
+    - name: Run e2e validation
+      working-directory: e2e
+      run: ./run.sh -test.run TestValidation -logfile validation.log
+
+    - name: Run e2e dr tests
+      working-directory: e2e
+      run: ./run.sh -test.run TestDR -logfile dr.log
 
     - name: Gather environment data
       if: always()
@@ -94,7 +100,7 @@ jobs:
     # https://github.com/actions/upload-artifact/issues/546
     - name: Archive artifacts
       if: always()
-      run: tar czf e2e.${{ env.BUILD_ID }}.tar.gz test/gather.rdr e2e/ramen-e2e.log
+      run: tar czf e2e.${{ env.BUILD_ID }}.tar.gz test/gather.rdr e2e/*.log
 
     - name: Upload artifacts
       if: always()

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -48,15 +48,100 @@ Clusters:
     kubeconfigpath: /path/to/kubeconfig/c2
 ```
 
-### Run all E2E tests
+### Validating the clusters
 
-`run.sh` is a shell script that runs the RamenDR E2E tests for regional DR.
-
-To run all the tests:
+Before running tests it is useful to validate that the clusters are accessible
+and ready for testing. You can verify it using:
 
 ```sh
-./run.sh
+./run.sh -test.run TestValidation
 ```
+
+Example output:
+
+```console
+2025-03-06T16:52:54.122+0200    INFO    Using config file "config.yaml"
+2025-03-06T16:52:54.122+0200    INFO    Using log file "ramen-e2e.log"
+2025-03-06T16:52:54.127+0200    INFO    Using Timeout: 10m0s
+2025-03-06T16:52:54.127+0200    INFO    Using RetryInterval: 5s
+...
+2025-03-06T16:52:54.149+0200    INFO    Ramen hub operator pod "ramen-hub-operator-865bdf6799-bgxkn" is running in cluster "hub"
+2025-03-06T16:52:54.152+0200    INFO    Ramen dr cluster operator pod "ramen-dr-cluster-operator-67dff877f5-vntt7" is running in cluster "dr1"
+2025-03-06T16:52:54.152+0200    INFO    Ramen dr cluster operator pod "ramen-dr-cluster-operator-67dff877f5-6v5sh" is running in cluster "dr2"
+--- PASS: TestValidation (0.00s)
+    --- PASS: TestValidation/hub (0.02s)
+    --- PASS: TestValidation/c1 (0.03s)
+    --- PASS: TestValidation/c2 (0.03s)
+PASS
+```
+
+Our clusters are ready for testing!
+
+### Running DR tests
+
+To run all the DR tests run the TestDR test:
+
+```sh
+./run.sh -test.run TestDR
+```
+
+The test perform a full DR flow with a tiny workload with multiple deployemnet
+methods and storage configurations.
+
+> [!TIP]
+> The tests typically complete in 10 minutes, depending the machine running the tests.
+
+When all tests complete we will see a test summary showing the status of all
+tests and the time to complete every step:
+
+```console
+--- PASS: TestDR (7.14s)
+    --- PASS: TestDR/subscr-deploy-rbd-busybox (533.34s)
+        --- PASS: TestDR/subscr-deploy-rbd-busybox/Deploy (10.38s)
+        --- PASS: TestDR/subscr-deploy-rbd-busybox/Enable (96.47s)
+        --- PASS: TestDR/subscr-deploy-rbd-busybox/Failover (210.97s)
+        --- PASS: TestDR/subscr-deploy-rbd-busybox/Relocate (146.22s)
+        --- PASS: TestDR/subscr-deploy-rbd-busybox/Disable (61.05s)
+        --- PASS: TestDR/subscr-deploy-rbd-busybox/Undeploy (8.24s)
+    --- PASS: TestDR/disapp-deploy-rbd-busybox (546.11s)
+        --- PASS: TestDR/disapp-deploy-rbd-busybox/Deploy (3.07s)
+        --- PASS: TestDR/disapp-deploy-rbd-busybox/Enable (95.33s)
+        --- PASS: TestDR/disapp-deploy-rbd-busybox/Failover (207.88s)
+        --- PASS: TestDR/disapp-deploy-rbd-busybox/Relocate (176.84s)
+        --- PASS: TestDR/disapp-deploy-rbd-busybox/Disable (40.70s)
+        --- PASS: TestDR/disapp-deploy-rbd-busybox/Undeploy (22.30s)
+    --- PASS: TestDR/subscr-deploy-cephfs-busybox (652.06s)
+        --- PASS: TestDR/subscr-deploy-cephfs-busybox/Deploy (5.31s)
+        --- PASS: TestDR/subscr-deploy-cephfs-busybox/Enable (187.23s)
+        --- PASS: TestDR/subscr-deploy-cephfs-busybox/Failover (146.48s)
+        --- PASS: TestDR/subscr-deploy-cephfs-busybox/Relocate (276.36s)
+        --- PASS: TestDR/subscr-deploy-cephfs-busybox/Disable (30.44s)
+        --- PASS: TestDR/subscr-deploy-cephfs-busybox/Undeploy (6.23s)
+    --- PASS: TestDR/appset-deploy-cephfs-busybox (670.70s)
+        --- PASS: TestDR/appset-deploy-cephfs-busybox/Deploy (5.40s)
+        --- PASS: TestDR/appset-deploy-cephfs-busybox/Enable (126.50s)
+        --- PASS: TestDR/appset-deploy-cephfs-busybox/Failover (115.80s)
+        --- PASS: TestDR/appset-deploy-cephfs-busybox/Relocate (367.66s)
+        --- PASS: TestDR/appset-deploy-cephfs-busybox/Disable (55.21s)
+        --- PASS: TestDR/appset-deploy-cephfs-busybox/Undeploy (0.13s)
+    --- PASS: TestDR/appset-deploy-rbd-busybox (671.39s)
+        --- PASS: TestDR/appset-deploy-rbd-busybox/Deploy (5.41s)
+        --- PASS: TestDR/appset-deploy-rbd-busybox/Enable (96.44s)
+        --- PASS: TestDR/appset-deploy-rbd-busybox/Failover (266.11s)
+        --- PASS: TestDR/appset-deploy-rbd-busybox/Relocate (247.42s)
+        --- PASS: TestDR/appset-deploy-rbd-busybox/Disable (55.89s)
+        --- PASS: TestDR/appset-deploy-rbd-busybox/Undeploy (0.12s)
+    --- PASS: TestDR/disapp-deploy-cephfs-busybox (749.75s)
+        --- PASS: TestDR/disapp-deploy-cephfs-busybox/Deploy (3.09s)
+        --- PASS: TestDR/disapp-deploy-cephfs-busybox/Enable (185.70s)
+        --- PASS: TestDR/disapp-deploy-cephfs-busybox/Failover (181.02s)
+        --- PASS: TestDR/disapp-deploy-cephfs-busybox/Relocate (296.31s)
+        --- PASS: TestDR/disapp-deploy-cephfs-busybox/Disable (60.28s)
+        --- PASS: TestDR/disapp-deploy-cephfs-busybox/Undeploy (23.36s)
+PASS
+```
+
+All tests completed successfully!
 
 ### Tests configuration
 
@@ -72,103 +157,47 @@ tests:
 ```
 
 The tests are generated from the configuration as
-"TestSuites/Exhaustive/{deployer}-{workload}-{pvcspec}-busybox".
-See [Test summary](#test-summary) for complete list of test names.
+"TestDR/{deployer}-{workload}-{pvcspec}-busybox".
+See [Running DR tests](#running-dr-tests) section for complete test list.
 
-### Run specific E2E tests
+### Run specific DR tests
 
-The `-test.run` option is commonly used when debugging a failing test, developing
-a new test, or working on a new deployer or workload. It allows to selectively
-execute specific tests by matching full test names using regular expressions,
-making it easier to focus on specific scenarios.
+Running specific tests is commonly used when debugging a failing test,
+developing a new test, or working on a new deployer or workload. It allows to
+selectively execute specific tests by matching full test names using regular
+expressions, making it easier to focus on specific scenarios.
 
-#### Run a single test
+#### Run a single DR test
 
 Example:
 
 ```sh
-./run.sh -test.run TestSuites/Exhaustive/subscr-deploy-rbd-busybox
+./run.sh -test.run TestDR/subscr-deploy-rbd-busybox
 ```
 
 This command runs the specific test for subscription based RBD busybox application.
 
-#### Run tests using a specific deployer
+#### Run DR tests using a specific deployer
 
 Example:
 
 ```sh
-./run.sh -test.run //appset
+./run.sh -test.run TestDR/appset
 ```
 
-This command runs all tests related to ApplicationSet, covering both RBD and
+This command runs all DR tests related to ApplicationSet, covering both RBD and
 CephFS PVC based applications. Useful when focusing on a specific deployer.
 
-#### Run tests using a specific storage
+#### Run DR tests using a specific storage
 
 Example:
 
 ```sh
-./run.sh -test.run //rbd
+./run.sh -test.run TestDR/rbd
 ```
 
-This command runs all tests related to RBD PVCs across all deployers.
-Ideal for verifying functionality specific to a storage type.
-
-### Test summary
-
-The below test list is generated by executing all e2e tests using `./run.sh`
-and capturing the output shown at the end of the run.
-
-```console
---- PASS: TestSuites (0.05s)
-    --- PASS: TestSuites/Validate (0.05s)
-        --- PASS: TestSuites/Validate/hub (0.02s)
-        --- PASS: TestSuites/Validate/c1 (0.01s)
-        --- PASS: TestSuites/Validate/c2 (0.01s)
-    --- PASS: TestSuites/Exhaustive (6.11s)
-        --- PASS: TestSuites/Exhaustive/subscr-deploy-rbd-busybox (425.72s)
-            --- PASS: TestSuites/Exhaustive/subscr-deploy-rbd-busybox/Deploy (5.17s)
-            --- PASS: TestSuites/Exhaustive/subscr-deploy-rbd-busybox/Enable (128.64s)
-            --- PASS: TestSuites/Exhaustive/subscr-deploy-rbd-busybox/Failover (165.50s)
-            --- PASS: TestSuites/Exhaustive/subscr-deploy-rbd-busybox/Relocate (90.24s)
-            --- PASS: TestSuites/Exhaustive/subscr-deploy-rbd-busybox/Disable (30.05s)
-            --- PASS: TestSuites/Exhaustive/subscr-deploy-rbd-busybox/Undeploy (6.10s)
-        --- PASS: TestSuites/Exhaustive/disapp-deploy-cephfs-busybox (434.67s)
-            --- PASS: TestSuites/Exhaustive/disapp-deploy-cephfs-busybox/Deploy (3.12s)
-            --- PASS: TestSuites/Exhaustive/disapp-deploy-cephfs-busybox/Enable (145.74s)
-            --- PASS: TestSuites/Exhaustive/disapp-deploy-cephfs-busybox/Failover (98.98s)
-            --- PASS: TestSuites/Exhaustive/disapp-deploy-cephfs-busybox/Relocate (138.90s)
-            --- PASS: TestSuites/Exhaustive/disapp-deploy-cephfs-busybox/Disable (30.09s)
-            --- PASS: TestSuites/Exhaustive/disapp-deploy-cephfs-busybox/Undeploy (17.83s)
-        --- PASS: TestSuites/Exhaustive/disapp-deploy-rbd-busybox (496.18s)
-            --- PASS: TestSuites/Exhaustive/disapp-deploy-rbd-busybox/Deploy (3.12s)
-            --- PASS: TestSuites/Exhaustive/disapp-deploy-rbd-busybox/Enable (135.70s)
-            --- PASS: TestSuites/Exhaustive/disapp-deploy-rbd-busybox/Failover (195.01s)
-            --- PASS: TestSuites/Exhaustive/disapp-deploy-rbd-busybox/Relocate (118.72s)
-            --- PASS: TestSuites/Exhaustive/disapp-deploy-rbd-busybox/Disable (25.07s)
-            --- PASS: TestSuites/Exhaustive/disapp-deploy-rbd-busybox/Undeploy (18.55s)
-        --- PASS: TestSuites/Exhaustive/subscr-deploy-cephfs-busybox (525.85s)
-            --- PASS: TestSuites/Exhaustive/subscr-deploy-cephfs-busybox/Deploy (5.17s)
-            --- PASS: TestSuites/Exhaustive/subscr-deploy-cephfs-busybox/Enable (183.82s)
-            --- PASS: TestSuites/Exhaustive/subscr-deploy-cephfs-busybox/Failover (140.29s)
-            --- PASS: TestSuites/Exhaustive/subscr-deploy-cephfs-busybox/Relocate (160.37s)
-            --- PASS: TestSuites/Exhaustive/subscr-deploy-cephfs-busybox/Disable (30.08s)
-            --- PASS: TestSuites/Exhaustive/subscr-deploy-cephfs-busybox/Undeploy (6.12s)
-        --- PASS: TestSuites/Exhaustive/appset-deploy-cephfs-busybox (536.09s)
-            --- PASS: TestSuites/Exhaustive/appset-deploy-cephfs-busybox/Deploy (0.25s)
-            --- PASS: TestSuites/Exhaustive/appset-deploy-cephfs-busybox/Enable (134.90s)
-            --- PASS: TestSuites/Exhaustive/appset-deploy-cephfs-busybox/Failover (145.46s)
-            --- PASS: TestSuites/Exhaustive/appset-deploy-cephfs-busybox/Relocate (225.37s)
-            --- PASS: TestSuites/Exhaustive/appset-deploy-cephfs-busybox/Disable (30.07s)
-            --- PASS: TestSuites/Exhaustive/appset-deploy-cephfs-busybox/Undeploy (0.04s)
-        --- PASS: TestSuites/Exhaustive/appset-deploy-rbd-busybox (733.34s)
-            --- PASS: TestSuites/Exhaustive/appset-deploy-rbd-busybox/Deploy (0.26s)
-            --- PASS: TestSuites/Exhaustive/appset-deploy-rbd-busybox/Enable (100.43s)
-            --- PASS: TestSuites/Exhaustive/appset-deploy-rbd-busybox/Failover (258.76s)
-            --- PASS: TestSuites/Exhaustive/appset-deploy-rbd-busybox/Relocate (250.45s)
-            --- PASS: TestSuites/Exhaustive/appset-deploy-rbd-busybox/Disable (123.42s)
-            --- PASS: TestSuites/Exhaustive/appset-deploy-rbd-busybox/Undeploy (0.03s)
-```
+This command runs all DR tests related to RBD PVCs across all deployers. Ideal
+for verifying functionality specific to a storage type.
 
 ### Using multiple config files
 

--- a/e2e/dr_test.go
+++ b/e2e/dr_test.go
@@ -13,10 +13,8 @@ import (
 	"github.com/ramendr/ramen/e2e/workloads"
 )
 
-//nolint:thelper
-func Exhaustive(dt *testing.T) {
+func TestDR(dt *testing.T) {
 	t := test.WithLog(dt, util.Ctx.Log)
-	t.Helper()
 	t.Parallel()
 
 	tests := config.GetTests()

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -15,10 +15,14 @@ import (
 	"github.com/ramendr/ramen/e2e/workloads"
 )
 
-var configFile string
+var (
+	configFile string
+	logFile    string
+)
 
 func init() {
 	flag.StringVar(&configFile, "config", "config.yaml", "e2e configuration file")
+	flag.StringVar(&logFile, "logfile", "ramen-e2e.log", "e2e log file")
 }
 
 func TestMain(m *testing.M) {
@@ -26,13 +30,14 @@ func TestMain(m *testing.M) {
 
 	flag.Parse()
 
-	log, err := test.CreateLogger()
+	log, err := test.CreateLogger(logFile)
 	if err != nil {
 		panic(err)
 	}
 	// TODO: Sync the log on exit
 
 	log.Infof("Using config file %q", configFile)
+	log.Infof("Using log file %q", logFile)
 
 	options := config.Options{
 		Deployers: deployers.AvailableNames(),

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -57,25 +57,3 @@ func TestMain(m *testing.M) {
 
 	os.Exit(m.Run())
 }
-
-type testDef struct {
-	name string
-	test func(t *testing.T)
-}
-
-var Suites = []testDef{
-	{"Exhaustive", Exhaustive},
-}
-
-func TestSuites(dt *testing.T) {
-	t := test.WithLog(dt, util.Ctx.Log)
-	t.Log(t.Name())
-
-	if !t.Run("Validate", Validate) {
-		t.FailNow()
-	}
-
-	for _, suite := range Suites {
-		t.Run(suite.name, suite.test)
-	}
-}

--- a/e2e/test/log.go
+++ b/e2e/test/log.go
@@ -10,9 +10,7 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-const logFilePath = "ramen-e2e.log"
-
-func CreateLogger() (*zap.SugaredLogger, error) {
+func CreateLogger(logFilePath string) (*zap.SugaredLogger, error) {
 	// In the console we don't want details such as file:line or stacktraces.
 	consoleConfig := zap.NewProductionEncoderConfig()
 	consoleConfig.EncodeTime = zapcore.ISO8601TimeEncoder

--- a/e2e/validation_test.go
+++ b/e2e/validation_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/ramendr/ramen/e2e/util"
 )
 
-func Validate(dt *testing.T) {
+func TestValidation(dt *testing.T) {
 	t := test.WithLog(dt, util.Ctx.Log)
-	t.Helper()
+	t.Parallel()
+
 	t.Run("hub", func(dt *testing.T) {
 		t := test.WithLog(dt, util.Ctx.Log)
+		t.Parallel()
 
 		err := util.ValidateRamenHubOperator(util.Ctx.Hub)
 		if err != nil {
@@ -23,6 +25,7 @@ func Validate(dt *testing.T) {
 	})
 	t.Run("c1", func(dt *testing.T) {
 		t := test.WithLog(dt, util.Ctx.Log)
+		t.Parallel()
 
 		err := util.ValidateRamenDRClusterOperator(util.Ctx.C1)
 		if err != nil {
@@ -31,6 +34,7 @@ func Validate(dt *testing.T) {
 	})
 	t.Run("c2", func(dt *testing.T) {
 		t := test.WithLog(dt, util.Ctx.Log)
+		t.Parallel()
 
 		err := util.ValidateRamenDRClusterOperator(util.Ctx.C2)
 		if err != nil {


### PR DESCRIPTION
A Go test suits is a file. Remove the tests suites and rename the test
files to reflect the purpose of the test.

Without the test suites we don't have a dependency between the dr tests
and the validation tests, and the dr tests will not be aborter if the
validation test fail. The easy solution is to run the tests separately
in different steps.

Both TestDR and TestValidation run in parallel, including all the sub
tests. We don't really need to run the quick validation sub tests in
parallel, but the linter complains if we don't.

With this change we can use go test -list option, showing the top level tests:

```console
% go test -list .
...
TestDR
TestValidation
```

Developers are expected to run the validation and dr separately. 

```console
$ ./run.sh -test.run TestValidation
...
2025-03-06T16:52:54.149+0200    INFO    Ramen hub operator pod "ramen-hub-operator-865bdf6799-bgxkn" is running in cluster "hub"
2025-03-06T16:52:54.152+0200    INFO    Ramen dr cluster operator pod "ramen-dr-cluster-operator-67dff877f5-vntt7" is running in cluster "dr1"
2025-03-06T16:52:54.152+0200    INFO    Ramen dr cluster operator pod "ramen-dr-cluster-operator-67dff877f5-6v5sh" is running in cluster "dr2"
--- PASS: TestValidation (0.00s)
    --- PASS: TestValidation/hub (0.02s)
    --- PASS: TestValidation/c1 (0.03s)
    --- PASS: TestValidation/c2 (0.03s)
PASS
```

In most case only the dr tests are needed:

```console
$ ./run.sh -test.run TestDR
...
--- PASS: TestDR (7.14s)
    --- PASS: TestDR/subscr-deploy-rbd-busybox (533.34s)
        --- PASS: TestDR/subscr-deploy-rbd-busybox/Deploy (10.38s)
        --- PASS: TestDR/subscr-deploy-rbd-busybox/Enable (96.47s)
        --- PASS: TestDR/subscr-deploy-rbd-busybox/Failover (210.97s)
        --- PASS: TestDR/subscr-deploy-rbd-busybox/Relocate (146.22s)
        --- PASS: TestDR/subscr-deploy-rbd-busybox/Disable (61.05s)
        --- PASS: TestDR/subscr-deploy-rbd-busybox/Undeploy (8.24s)
    --- PASS: TestDR/disapp-deploy-rbd-busybox (546.11s)
        --- PASS: TestDR/disapp-deploy-rbd-busybox/Deploy (3.07s)
        --- PASS: TestDR/disapp-deploy-rbd-busybox/Enable (95.33s)
        --- PASS: TestDR/disapp-deploy-rbd-busybox/Failover (207.88s)
        --- PASS: TestDR/disapp-deploy-rbd-busybox/Relocate (176.84s)
        --- PASS: TestDR/disapp-deploy-rbd-busybox/Disable (40.70s)
        --- PASS: TestDR/disapp-deploy-rbd-busybox/Undeploy (22.30s)
    --- PASS: TestDR/subscr-deploy-cephfs-busybox (652.06s)
        --- PASS: TestDR/subscr-deploy-cephfs-busybox/Deploy (5.31s)
        --- PASS: TestDR/subscr-deploy-cephfs-busybox/Enable (187.23s)
        --- PASS: TestDR/subscr-deploy-cephfs-busybox/Failover (146.48s)
        --- PASS: TestDR/subscr-deploy-cephfs-busybox/Relocate (276.36s)
        --- PASS: TestDR/subscr-deploy-cephfs-busybox/Disable (30.44s)
        --- PASS: TestDR/subscr-deploy-cephfs-busybox/Undeploy (6.23s)
    --- PASS: TestDR/appset-deploy-cephfs-busybox (670.70s)
        --- PASS: TestDR/appset-deploy-cephfs-busybox/Deploy (5.40s)
        --- PASS: TestDR/appset-deploy-cephfs-busybox/Enable (126.50s)
        --- PASS: TestDR/appset-deploy-cephfs-busybox/Failover (115.80s)
        --- PASS: TestDR/appset-deploy-cephfs-busybox/Relocate (367.66s)
        --- PASS: TestDR/appset-deploy-cephfs-busybox/Disable (55.21s)
        --- PASS: TestDR/appset-deploy-cephfs-busybox/Undeploy (0.13s)
    --- PASS: TestDR/appset-deploy-rbd-busybox (671.39s)
        --- PASS: TestDR/appset-deploy-rbd-busybox/Deploy (5.41s)
        --- PASS: TestDR/appset-deploy-rbd-busybox/Enable (96.44s)
        --- PASS: TestDR/appset-deploy-rbd-busybox/Failover (266.11s)
        --- PASS: TestDR/appset-deploy-rbd-busybox/Relocate (247.42s)
        --- PASS: TestDR/appset-deploy-rbd-busybox/Disable (55.89s)
        --- PASS: TestDR/appset-deploy-rbd-busybox/Undeploy (0.12s)
    --- PASS: TestDR/disapp-deploy-cephfs-busybox (749.75s)
        --- PASS: TestDR/disapp-deploy-cephfs-busybox/Deploy (3.09s)
        --- PASS: TestDR/disapp-deploy-cephfs-busybox/Enable (185.70s)
        --- PASS: TestDR/disapp-deploy-cephfs-busybox/Failover (181.02s)
        --- PASS: TestDR/disapp-deploy-cephfs-busybox/Relocate (296.31s)
        --- PASS: TestDR/disapp-deploy-cephfs-busybox/Disable (60.28s)
        --- PASS: TestDR/disapp-deploy-cephfs-busybox/Undeploy (23.36s)
PASS
```

New build artifacts structure:

```
% tree -L2 e2e.13703558920-2  
e2e.13703558920-2
├── e2e
│   ├── dr.log
│   └── validation.log
└── test
    └── gather.rdr
```