### PR TITLE
e2e: Fix validation when tests not configured

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -114,8 +114,9 @@ func ReadConfig(configFile string, options Options) error {
 }
 
 func validateTests(config *Config, options *Options) error {
+	// We allow an empty test list so one can run the validation tests or unit tests without a fully configured file.
 	if len(config.Tests) == 0 {
-		return fmt.Errorf("no tests found")
+		return nil
 	}
 
 	pvcSpecNames := make([]string, 0, len(config.PVCSpecs))

--- a/e2e/exhaustive_suite_test.go
+++ b/e2e/exhaustive_suite_test.go
@@ -19,6 +19,11 @@ func Exhaustive(dt *testing.T) {
 	t.Helper()
 	t.Parallel()
 
+	tests := config.GetTests()
+	if len(tests) == 0 {
+		t.Fatal("No tests found in the configuration file")
+	}
+
 	if err := util.EnsureChannel(); err != nil {
 		t.Fatalf("Failed to ensure channel: %s", err)
 	}
@@ -31,7 +36,7 @@ func Exhaustive(dt *testing.T) {
 
 	pvcSpecs := config.GetPVCSpecs()
 
-	for _, tc := range config.GetTests() {
+	for _, tc := range tests {
 		pvcSpec, ok := pvcSpecs[tc.PVCSpec]
 		if !ok {
 			panic("unknown pvcSpec")


### PR DESCRIPTION
The tests are required only by the exhaustive suite. The validation suite does not use the test list, but you must configure the tests to be able to run the validation suite.

Fixed by allowing empty test list when reading the config, and failing the exhaustive test suites when no tests are configured.

Fixes: #1892