### PR TITLE
e2e: update docs/e2e.md and config.yaml.sample

### DIFF
--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -32,16 +32,20 @@ Create a `config.yaml` file by copying the `config.yaml.sample` template:
 cp config.yaml.sample config.yaml
 ```
 
-Update `config.yaml` by adding kubeconfig paths of the clusters, with format:
+Update `config.yaml` by uncommenting and adding cluster names and kubeconfig paths
+for the hub and managed clusters.
 
 ```yaml
 Clusters:
+  hub:
+    name: hub
+    kubeconfigpath: /path/to/kubeconfig/hub
   c1:
+    name: dr1
     kubeconfigpath: /path/to/kubeconfig/c1
   c2:
+    name: dr2
     kubeconfigpath: /path/to/kubeconfig/c2
-  hub:
-    kubeconfigpath: /path/to/kubeconfig/hub
 ```
 
 ### Run all E2E tests

--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -44,14 +44,14 @@ tests:
 
 # Sample cluster configurations:
 # Uncomment and edit the following lines to set cluster names
-# and their kubeconfig paths for the managed and hub clusters.
+# and their kubeconfig paths for the hub and managed clusters.
 # Clusters:
+#   hub:
+#     name: hub
+#     kubeconfigpath: /path/to/kubeconfig/hub
 #   c1:
 #     name: dr1
 #     kubeconfigpath: /path/to/kubeconfig/dr1
 #   c2:
 #     name: dr2
 #     kubeconfigpath: /path/to/kubeconfig/dr2
-#   hub:
-#     name: hub
-#     kubeconfigpath: /path/to/kubeconfig/hub


### PR DESCRIPTION
Added cluster names as part of #1863 but docs were not updated.

Updated preparing config file for real cluster section in `docs/e2e.md` to include cluster names and also changed the order so the hub is at the top. Similarly changed order in config.yaml.sample to reflect the same order. (similar to ramenctl)