### PR TITLE
Ensure Consistent Iteration Order by Using DRClusters Slice

### DIFF
--- a/internal/controller/drplacementcontrolvolsync.go
+++ b/internal/controller/drplacementcontrolvolsync.go
@@ -63,8 +63,8 @@ func (d *DRPCInstance) EnsureVolSyncReplicationSetup(srcCluster string) error {
 	pskSecretNameCluster := volsync.GetVolSyncPSKSecretNameFromVRGName(d.instance.GetName()) // VRG name == DRPC name
 
 	clustersToPropagateSecret := []string{}
-	for clusterName := range d.vrgs {
-		clustersToPropagateSecret = append(clustersToPropagateSecret, clusterName)
+	for _, drCluster := range d.drClusters {
+		clustersToPropagateSecret = append(clustersToPropagateSecret, drCluster.Name)
 	}
 
 	err = volsync.PropagateSecretToClusters(d.ctx, d.reconciler.Client, pskSecretHub,


### PR DESCRIPTION
Use the DRClusters slice instead of the map of queried VRGs to ensure a consistent iteration order. Since map iteration is unpredictable, even when the map contents remain the same. Additionally, DRClusters are known in advance and should be used instead of the queried clusters, as secrets are propagated to all DR clusters, not just the successfully queried ones.