### PR TITLE
Fix for panic observed while processing VRG

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -1595,6 +1595,11 @@ func updatePeers(
 	peerClasses := vrgPeerClasses
 
 	for pvcIdx := range vrgFromView.Status.ProtectedPVCs {
+		if vrgFromView.Status.ProtectedPVCs[pvcIdx].StorageClassName == nil ||
+			len(*vrgFromView.Status.ProtectedPVCs[pvcIdx].StorageClassName) == 0 {
+			continue
+		}
+
 		for policyPeerClassIdx := range policyPeerClasses {
 			if policyPeerClasses[policyPeerClassIdx].StorageClassName ==
 				*vrgFromView.Status.ProtectedPVCs[pvcIdx].StorageClassName {


### PR DESCRIPTION
Fix for the[ panic observed](https://github.com/RamenDR/ramen/issues/1888) while updating VRG: 
```
{"controller": "drplacementcontrol", "controllerGroup": "ramendr.openshift.io", "controllerKind": "DRPlacementControl", "DRPlacementControl": {"name":"test-dr","namespace":"ramen-ops"}, "namespace": "ramen-ops", "name": "test-dr", "reconcileID": "a4eebec5-088a-4235-9661-de29a0c4882b", "panic": "runtime error: invalid memory address or nil pointer dereference", "panicGoValue": "\"invalid memory address or nil pointer dereference\"", "stacktrace": "goroutine 322 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x271d538, 0xc000a800f0}, {0x1d3e3a0, 0x37d0630})
\t/go/pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/runtime/runtime.go:107 +0xbc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:105 +0x114
panic({0x1d3e3a0?, 0x37d0630?})
\t/usr/local/go/src/runtime/panic.go:770 +0x132
github.com/ramendr/ramen/internal/controller.updatePeers(0xc000f93d48, {0xc0004cd400, 0x2, 0x0?}, {0xc0004ccc80, 0x2, 0x0?})
\t/workspace/internal/controller/drplacementcontrol.go:1600 +0xe6
github.com/ramendr/ramen/internal/controller.(*DRPCInstance).updateVRGAsyncSpec(0xc0007186c8, 0xc000f93d48, 0xc000718908)
\t/workspace/internal/controller/drplacementcontrol.go:1643 +0x26c
github.com/ramendr/ramen/internal/controller.(*DRPCInstance).updateVRGDRTypeSpec(0xc000604008?, 0x2?, 0x2096d66?)
\t/workspace/internal/controller/drplacementcontrol.go:1694 +0x4e
github.com/ramendr/ramen/internal/controller.(*DRPCInstance).updateVRGOptionalFields(0xc0007186c8, 0xc000718908, 0xc000f93d48, {0xc0011b8999, 0x3})
\t/workspace/internal/controller/drplacementcontrol.go:1734 +0x654
github.com/ramendr/ramen/internal/controller.(*DRPCInstance).ensureVRGManifestWork(0xc0007186c8, {0xc0011b8999, 0x3})
\t/workspace/internal/controller/drplacementcontrol.go:1571 +0x3fb
github.com/ramendr/ramen/internal/controller.(*DRPCInstance).RunInitialDeployment(0xc0007186c8)
\t/workspace/internal/controller/drplacementcontrol.go:173 +0x63a
github.com/ramendr/ramen/internal/controller.(*DRPCInstance).processPlacement(0xc0007186c8)
\t/workspace/internal/controller/drplacementcontrol.go:119 +0x112
github.com/ramendr/ramen/internal/controller.(*DRPCInstance).startProcessing(0xc0007186c8)
\t/workspace/internal/controller/drplacementcontrol.go:81 +0x58
github.com/ramendr/ramen/internal/controller.(*DRPlacementControlReconciler).reconcileDRPCInstance(0xc000618ea0, 0xc0007186c8, {{0x2721fb8?, 0xc000a80120?}, 0x271d538?})
\t/workspace/internal/controller/drplacementcontrol_controller.go:477 +0x13e
github.com/ramendr/ramen/internal/controller.(*DRPlacementControlReconciler).Reconcile(0xc000618ea0, {0x271d538, 0xc000a800f0}, {{{0xc0006faa47, 0x9}, {0xc0006faa40, 0x7}}})
\t/workspace/internal/controller/drplacementcontrol_controller.go:241 +0xe45
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0xc000a80060?, {0x271d538?, 0xc000a800f0?}, {{{0xc0006faa47?, 0x0?}, {0xc0006faa40?, 0x0?}}})
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:116 +0xd4
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x272dde0, {0x271d570, 0xc00071a7d0}, {{{0xc0006faa47, 0x9}, {0xc0006faa40, 0x7}}})
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:303 +0x3b8
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x272dde0, {0x271d570, 0xc00071a7d0})
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:263 +0x23f
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2()
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:224 +0x8a
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2 in goroutine 83
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.1/pkg/internal/controller/controller.go:220 +0x490
"}
```