### PR TITLE
e2e: provide cluster name in CreatePlacement and improve info logs

### DIFF
--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -21,12 +21,17 @@ func (a ApplicationSet) Deploy(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	err := CreateManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
+	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub, config.GetDRPolicyName())
 	if err != nil {
 		return err
 	}
 
-	err = CreatePlacement(ctx, name, managementNamespace)
+	err = CreateManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
+	if err != nil {
+		return err
+	}
+
+	err = CreatePlacement(ctx, name, managementNamespace, drpolicy.Spec.DRClusters[0])
 	if err != nil {
 		return err
 	}

--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -26,6 +26,9 @@ func (a ApplicationSet) Deploy(ctx types.Context) error {
 		return err
 	}
 
+	log.Infof("Deploying applicationset app \"%s/%s\" in cluster %q",
+		ctx.AppNamespace(), ctx.Workload().GetAppName(), drpolicy.Spec.DRClusters[0])
+
 	err = CreateManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
 	if err != nil {
 		return err
@@ -46,13 +49,7 @@ func (a ApplicationSet) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	clusterName, err := util.GetCurrentCluster(util.Ctx.Hub, managementNamespace, name)
-	if err != nil {
-		return err
-	}
-
-	log.Infof("Deployed applicationset app \"%s/%s\" in cluster %q",
-		ctx.AppNamespace(), ctx.Workload().GetAppName(), clusterName)
+	log.Info("Workload deployed")
 
 	return nil
 }
@@ -63,18 +60,18 @@ func (a ApplicationSet) Undeploy(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	err := DeleteApplicationSet(ctx, a)
-	if err != nil {
-		return err
-	}
-
 	clusterName, err := util.GetCurrentCluster(util.Ctx.Hub, managementNamespace, name)
 	if err != nil {
 		return err
 	}
 
-	log.Infof("Undeployed applicationset app \"%s/%s\" in cluster %q",
+	log.Infof("Undeploying applicationset app \"%s/%s\" in cluster %q",
 		ctx.AppNamespace(), ctx.Workload().GetAppName(), clusterName)
+
+	err = DeleteApplicationSet(ctx, a)
+	if err != nil {
+		return err
+	}
 
 	err = DeleteConfigMap(ctx, name, managementNamespace)
 	if err != nil {
@@ -99,6 +96,8 @@ func (a ApplicationSet) Undeploy(ctx types.Context) error {
 			return err
 		}
 	}
+
+	log.Info("Workload undeployed")
 
 	return nil
 }

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -87,7 +87,7 @@ func DeleteManagedClusterSetBinding(ctx types.Context, name, namespace string) e
 	return nil
 }
 
-func CreatePlacement(ctx types.Context, name, namespace string) error {
+func CreatePlacement(ctx types.Context, name, namespace string, clusterName string) error {
 	log := ctx.Logger()
 	labels := make(map[string]string)
 	labels[AppLabelKey] = name
@@ -103,6 +103,22 @@ func CreatePlacement(ctx types.Context, name, namespace string) error {
 		Spec: ocmv1b1.PlacementSpec{
 			ClusterSets:      clusterSet,
 			NumberOfClusters: &numClusters,
+			// Restricts to the specified cluster using requiredClusterSelector.
+			Predicates: []ocmv1b1.ClusterPredicate{
+				{
+					RequiredClusterSelector: ocmv1b1.ClusterSelector{
+						LabelSelector: metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "name",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{clusterName},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -54,6 +54,9 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 		return err
 	}
 
+	log.Infof("Deploying discovered app \"%s/%s\" in cluster %q",
+		appNamespace, ctx.Workload().GetAppName(), drpolicy.Spec.DRClusters[0])
+
 	cmd := exec.Command("kubectl", "apply", "-k", tempDir, "-n", appNamespace,
 		"--context", drpolicy.Spec.DRClusters[0], "--timeout=5m")
 
@@ -69,8 +72,7 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	log.Infof("Deployed discovered app \"%s/%s\" in cluster %q",
-		appNamespace, ctx.Workload().GetAppName(), drpolicy.Spec.DRClusters[0])
+	log.Info("Workload deployed")
 
 	return nil
 }
@@ -84,6 +86,9 @@ func (d DiscoveredApp) Undeploy(ctx types.Context) error {
 	if err != nil {
 		return err
 	}
+
+	log.Infof("Undeploying discovered app \"%s/%s\" in clusters %q and %q",
+		appNamespace, ctx.Workload().GetAppName(), drpolicy.Spec.DRClusters[0], drpolicy.Spec.DRClusters[1])
 
 	// delete app on both clusters
 	if err := DeleteDiscoveredApps(ctx, appNamespace, drpolicy.Spec.DRClusters[0]); err != nil {
@@ -103,7 +108,7 @@ func (d DiscoveredApp) Undeploy(ctx types.Context) error {
 		return err
 	}
 
-	log.Infof("Undeployed discovered app \"%s/%s\"", appNamespace, ctx.Workload().GetAppName())
+	log.Info("Workload undeployed")
 
 	return nil
 }

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -33,8 +33,13 @@ func (s Subscription) Deploy(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
+	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub, config.GetDRPolicyName())
+	if err != nil {
+		return err
+	}
+
 	// create subscription namespace
-	err := util.CreateNamespace(util.Ctx.Hub, managementNamespace, log)
+	err = util.CreateNamespace(util.Ctx.Hub, managementNamespace, log)
 	if err != nil {
 		return err
 	}
@@ -44,7 +49,7 @@ func (s Subscription) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	err = CreatePlacement(ctx, name, managementNamespace)
+	err = CreatePlacement(ctx, name, managementNamespace, drpolicy.Spec.DRClusters[0])
 	if err != nil {
 		return err
 	}

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -38,6 +38,9 @@ func (s Subscription) Deploy(ctx types.Context) error {
 		return err
 	}
 
+	log.Infof("Deploying subscription app \"%s/%s\" in cluster %q",
+		ctx.AppNamespace(), ctx.Workload().GetAppName(), drpolicy.Spec.DRClusters[0])
+
 	// create subscription namespace
 	err = util.CreateNamespace(util.Ctx.Hub, managementNamespace, log)
 	if err != nil {
@@ -64,13 +67,7 @@ func (s Subscription) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	clusterName, err := util.GetCurrentCluster(util.Ctx.Hub, managementNamespace, name)
-	if err != nil {
-		return err
-	}
-
-	log.Infof("Deployed subscription app \"%s/%s\" in cluster %q",
-		ctx.AppNamespace(), ctx.Workload().GetAppName(), clusterName)
+	log.Info("Workload deployed")
 
 	return nil
 }
@@ -81,18 +78,18 @@ func (s Subscription) Undeploy(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	err := DeleteSubscription(ctx, s)
-	if err != nil {
-		return err
-	}
-
 	clusterName, err := util.GetCurrentCluster(util.Ctx.Hub, managementNamespace, name)
 	if err != nil {
 		return err
 	}
 
-	log.Infof("Undeployed subscription app \"%s/%s\" in cluster %q",
+	log.Infof("Undeploying subscription app \"%s/%s\" in cluster %q",
 		ctx.AppNamespace(), ctx.Workload().GetAppName(), clusterName)
+
+	err = DeleteSubscription(ctx, s)
+	if err != nil {
+		return err
+	}
 
 	err = DeletePlacement(ctx, name, managementNamespace)
 	if err != nil {
@@ -104,7 +101,14 @@ func (s Subscription) Undeploy(ctx types.Context) error {
 		return err
 	}
 
-	return util.DeleteNamespace(util.Ctx.Hub, managementNamespace, log)
+	err = util.DeleteNamespace(util.Ctx.Hub, managementNamespace, log)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Workload undeployed")
+
+	return nil
 }
 
 func (s Subscription) IsDiscovered() bool {

--- a/e2e/dractions/crud.go
+++ b/e2e/dractions/crud.go
@@ -132,6 +132,7 @@ func createPlacementManagedByRamen(ctx types.Context, name, namespace string) er
 			Labels:      labels,
 			Annotations: annotations,
 		},
+		// Predicate is not required since OCM is not managing this app.
 		Spec: clusterv1beta1.PlacementSpec{
 			ClusterSets:      clusterSet,
 			NumberOfClusters: &numClusters,

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -41,8 +41,7 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 
 	clusterName := drpolicy.Spec.DRClusters[0]
 
-	log.Infof("Protecting workload running in cluster %q (app namespace: %q, management namespace: %q)",
-		clusterName, appNamespace, managementNamespace)
+	log.Infof("Protecting workload \"%s/%s\" in cluster %q", appNamespace, appname, clusterName)
 
 	drpc := generateDRPCDiscoveredApps(
 		name, managementNamespace, clusterName, drPolicyName, placementName, appname, appNamespace)
@@ -51,7 +50,14 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 	}
 
 	// wait for drpc ready
-	return waitDRPCReady(ctx, util.Ctx.Hub, managementNamespace, drpcName)
+	err = waitDRPCReady(ctx, util.Ctx.Hub, managementNamespace, drpcName)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Workload protected")
+
+	return nil
 }
 
 // remove DRPC
@@ -70,8 +76,8 @@ func DisableProtectionDiscoveredApps(ctx types.Context) error {
 		return err
 	}
 
-	log.Infof("Unprotecting workload running in cluster %q (app namespace: %q, management namespace: %q)",
-		clusterName, appNamespace, managementNamespace)
+	log.Infof("Unprotecting workload \"%s/%s\" in cluster %q",
+		appNamespace, ctx.Workload().GetAppName(), clusterName)
 
 	if err := deleteDRPC(ctx, util.Ctx.Hub, managementNamespace, drpcName); err != nil {
 		return err
@@ -86,7 +92,14 @@ func DisableProtectionDiscoveredApps(ctx types.Context) error {
 		return err
 	}
 
-	return deployers.DeleteManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
+	err = deployers.DeleteManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
+	if err != nil {
+		return err
+	}
+
+	log.Info("Workload unprotected")
+
+	return nil
 }
 
 // nolint:funlen,cyclop


### PR DESCRIPTION
This change updates CreatePlacement to accept a cluster name instead of selecting randomly and also enhances INFO logs before and after every action.

Info log for all tests (apps deployed on primary cluster):
[info.log](https://github.com/user-attachments/files/19112129/info.log)
[dr.log](https://github.com/user-attachments/files/19124121/dr.log) (updated info)



Fixes #1851 (check for more info on this change)  