### PR TITLE
VM DR recipe template

### DIFF
--- a/internal/controller/core/recipes.go
+++ b/internal/controller/core/recipes.go
@@ -24,17 +24,15 @@ spec:
     - replicaset
     - persistentvolumeclaims
     - pods
-    includedResources:
-    - namespaces
-    - nodes
     includedNamespaces:
-    - ${ALL_NAMESPACES}
+    - ${VM_NAMESPACE}
+    includeClusterResources: true
     labelSelector: 
       matchExpressions:
-      - key: appname
+      - key: ramendr.openshift.io/k8s-resource-selector
         operator: In
         values:
-        - ${LABEL_SELECTOR}
+        - ${K8S_RESOURCE_SELECTOR}
     name: vm-backup
     type: resource
   workflows:
@@ -48,14 +46,14 @@ spec:
     - group: vm-backup
   volumes:
     includedNamespaces:
-    - ${ALL_NAMESPACES}
+    - ${VM_NAMESPACE}
     name: vm-volumes
     type: volume
     labelSelector:
       matchExpressions:
-      - key: appname
+      - key: ramendr.openshift.io/k8s-resource-selector
         operator: In
         values:
-        - vm
+        - ${PVC_RESOURCE_SELECTOR}
 `
 )


### PR DESCRIPTION
1. Updated the static inline recipe template for protecting independent VMs or group of VMs and its resources within a namespace.
2. Update recipe.Spec.IncludedNamespaces with the drpc.Spec.ProtectedNamespaces in the Ramen backend.

#### Sample drpc.Spec:
```
spec:
  drPolicyRef:
    name: dr-policy
  kubeObjectProtection:
    captureInterval: 5m0s
    recipeParameters:
      K8S_RESOURCE_SELECTOR:
      - protected-by-ramendr
      PROTECTED_VMS:
      - vm-1-test
      PVC_RESOURCE_SELECTOR:
      - protected-by-ramendr
    recipeRef:
      name: vm-recipe
      namespace: ramen-ops
  placementRef:
    name: vm-cirros-placement-1
    namespace: ramen-ops
  preferredCluster: dr1
  protectedNamespaces:
  - kubevirt-test
  pvcSelector: {}
```

#### Recipe expansion inline:
```
2025-03-12T15:08:39.543Z	DEBUG	controllers.VolumeReplicationGroup	controller/vrg_recipe.go:196	Recipe pre-expansion	{"VolumeReplicationGroup": {"name":"vm-cirros-dr","namespace":"ramen-ops"}, "rid": "8867002b-2c43-4646-88bf-eecac4660159", "spec": {"appType":"vm-app","groups":[{"name":"vm-backup","backupRef":"vm-backup","type":"resource","excludedResourceTypes":["events","event.events.k8s.io","persistentvolumes","replicaset","persistentvolumeclaims","pods"],"labelSelector":{"matchExpressions":[{"key":"ramendr.openshift.io/k8s-resource-selector","operator":"In","values":["${K8S_RESOURCE_SELECTOR}"]}]},"includeClusterResources":true,"includedNamespaces":["${VM_NAMESPACE}"]}],"volumes":{"name":"vm-volumes","type":"volume","labelSelector":{"matchExpressions":[{"key":"ramendr.openshift.io/k8s-resource-selector","operator":"In","values":["${PVC_RESOURCE_SELECTOR}"]}]},"includedNamespaces":["${VM_NAMESPACE}"]},"workflows":[{"name":"backup","sequence":[{"group":"vm-backup"}],"failOn":"any-error"},{"name":"restore","sequence":[{"group":"vm-backup"}],"failOn":"any-error"}]}, "parameters": {"K8S_RESOURCE_SELECTOR":["protected-by-ramendr"],"PROTECTED_VMS":["vm-1-test"],"PVC_RESOURCE_SELECTOR":["protected-by-ramendr"],"VM_NAMESPACE":["kubevirt-test"]}}
:
2025-03-12T15:08:39.553Z	DEBUG	controllers.VolumeReplicationGroup	controller/vrg_recipe.go:210	Recipe post-expansion	{
   "VolumeReplicationGroup":{
      "name":"vm-cirros-dr",
      "namespace":"ramen-ops"
   },
   "rid":"9d18df87-88bd-43bc-b71d-5b6301011e92",
   "spec":{
      "appType":"vm-app",
      "groups":[
         {
            "name":"vm-backup",
            "backupRef":"vm-backup",
            "type":"resource",
            "excludedResourceTypes":[
               "events",
               "event.events.k8s.io",
               "persistentvolumes",
               "replicaset",
               "persistentvolumeclaims",
               "pods"
            ],
            "labelSelector":{
               "matchExpressions":[
                  {
                     "key":"ramendr.openshift.io/k8s-resource-selector",
                     "operator":"In",
                     "values":[
                        "protected-by-ramendr"
                     ]
                  }
               ]
            },
            "includeClusterResources":true,
            "includedNamespaces":[
               "kubevirt-test"
            ]
         }
      ],
      "volumes":{
         "name":"vm-volumes",
         "type":"volume",
         "labelSelector":{
            "matchExpressions":[
               {
                  "key":"ramendr.openshift.io/k8s-resource-selector",
                  "operator":"In",
                  "values":[
                     "protected-by-ramendr"
                  ]
               }
            ]
         },
         "includedNamespaces":[
            "kubevirt-test"
         ]
      },
      "workflows":[
         {
            "name":"backup",
            "sequence":[
               {
                  "group":"vm-backup"
               }
            ],
            "failOn":"any-error"
         },
         {
            "name":"restore",
            "sequence":[
               {
                  "group":"vm-backup"
               }
            ],
            "failOn":"any-error"
         }
      ]
   }
}
```