### PR TITLE
config: events permissions for the hub role

### DIFF
--- a/config/hub/rbac/role.yaml
+++ b/config/hub/rbac/role.yaml
@@ -14,6 +14,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - create


### PR DESCRIPTION
Adding events permissions for the hub controller.
Without this, it leads to errors in patching events by the DRPC controller.