### PR TITLE
e2e: fix disable and undeploy actions if resources not found

### DIFF
--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 type ApplicationSet struct{}
@@ -58,11 +59,16 @@ func (a ApplicationSet) Undeploy(ctx types.Context) error {
 
 	clusterName, err := util.GetCurrentCluster(util.Ctx.Hub, managementNamespace, name)
 	if err != nil {
-		return err
-	}
+		if !k8serrors.IsNotFound(err) {
+			return err
+		}
 
-	log.Infof("Undeploying applicationset app \"%s/%s\" in cluster %q",
-		ctx.AppNamespace(), ctx.Workload().GetAppName(), clusterName)
+		log.Debugf("Could not retrieve the cluster name: %s", err)
+		log.Infof("Undeploying applicationset app \"%s/%s\"", ctx.AppNamespace(), ctx.Workload().GetAppName())
+	} else {
+		log.Infof("Undeploying applicationset app \"%s/%s\" in cluster %q",
+			ctx.AppNamespace(), ctx.Workload().GetAppName(), clusterName)
+	}
 
 	err = DeleteApplicationSet(ctx, a)
 	if err != nil {


### PR DESCRIPTION
This change ensures that undeploy and disable actions handle missing placement resources gracefully when calling GetCurrentCluster, making them idempotent. This is required for ramenctl aswell.


Tests done without existing resources(rebased and updated):
1. `./run.sh -test.run TestDR//Undeploy`
```
2025-03-10T20:02:13.148+0530	INFO	subscr-deploy-cephfs-busybox	Undeploying subscription app "e2e-subscr-deploy-cephfs-busybox/busybox"
2025-03-10T20:02:13.148+0530	INFO	appset-deploy-rbd-busybox	Undeploying applicationset app "e2e-appset-deploy-rbd-busybox/busybox"
2025-03-10T20:02:13.148+0530	INFO	subscr-deploy-rbd-busybox	Undeploying subscription app "e2e-subscr-deploy-rbd-busybox/busybox"
2025-03-10T20:02:13.148+0530	INFO	appset-deploy-cephfs-busybox	Undeploying applicationset app "e2e-appset-deploy-cephfs-busybox/busybox"
2025-03-10T20:02:13.150+0530	INFO	disapp-deploy-rbd-busybox	Undeploying discovered app "e2e-disapp-deploy-rbd-busybox/busybox" in clusters "dr1" and "dr2"
2025-03-10T20:02:13.150+0530	INFO	disapp-deploy-cephfs-busybox	Undeploying discovered app "e2e-disapp-deploy-cephfs-busybox/busybox" in clusters "dr1" and "dr2"
2025-03-10T20:02:13.160+0530	INFO	appset-deploy-cephfs-busybox	Workload undeployed
2025-03-10T20:02:13.161+0530	INFO	subscr-deploy-rbd-busybox	Workload undeployed
2025-03-10T20:02:13.161+0530	INFO	appset-deploy-rbd-busybox	Workload undeployed
2025-03-10T20:02:13.162+0530	INFO	subscr-deploy-cephfs-busybox	Workload undeployed
2025-03-10T20:02:18.524+0530	INFO	disapp-deploy-cephfs-busybox	Workload undeployed
2025-03-10T20:02:18.647+0530	INFO	disapp-deploy-rbd-busybox	Workload undeployed
2025-03-10T20:02:18.649+0530	INFO	Deleted channel "e2e-gitops/https-github-com-ramendr-ocm-ramen-samples-git" in cluster "hub"
--- PASS: TestDR (6.03s)
    --- PASS: TestDR/appset-deploy-cephfs-busybox (0.02s)
        --- PASS: TestDR/appset-deploy-cephfs-busybox/Undeploy (0.02s)
    --- PASS: TestDR/subscr-deploy-rbd-busybox (0.02s)
        --- PASS: TestDR/subscr-deploy-rbd-busybox/Undeploy (0.02s)
    --- PASS: TestDR/appset-deploy-rbd-busybox (0.02s)
        --- PASS: TestDR/appset-deploy-rbd-busybox/Undeploy (0.02s)
    --- PASS: TestDR/subscr-deploy-cephfs-busybox (0.02s)
        --- PASS: TestDR/subscr-deploy-cephfs-busybox/Undeploy (0.02s)
    --- PASS: TestDR/disapp-deploy-cephfs-busybox (5.38s)
        --- PASS: TestDR/disapp-deploy-cephfs-busybox/Undeploy (5.38s)
    --- PASS: TestDR/disapp-deploy-rbd-busybox (5.50s)
        --- PASS: TestDR/disapp-deploy-rbd-busybox/Undeploy (5.50s)
```
2. `./run.sh -test.run TestDR//Disable`
```
2025-03-10T20:02:30.463+0530	INFO	appset-deploy-rbd-busybox	Unprotecting workload "e2e-appset-deploy-rbd-busybox/busybox"
2025-03-10T20:02:30.463+0530	INFO	appset-deploy-cephfs-busybox	Unprotecting workload "e2e-appset-deploy-cephfs-busybox/busybox"
2025-03-10T20:02:30.464+0530	INFO	disapp-deploy-rbd-busybox	Unprotecting workload "e2e-disapp-deploy-rbd-busybox/busybox"
2025-03-10T20:02:30.464+0530	INFO	disapp-deploy-cephfs-busybox	Unprotecting workload "e2e-disapp-deploy-cephfs-busybox/busybox"
2025-03-10T20:02:30.464+0530	INFO	subscr-deploy-cephfs-busybox	Unprotecting workload "e2e-subscr-deploy-cephfs-busybox/busybox"
2025-03-10T20:02:30.464+0530	INFO	subscr-deploy-rbd-busybox	Unprotecting workload "e2e-subscr-deploy-rbd-busybox/busybox"
2025-03-10T20:02:30.467+0530	INFO	subscr-deploy-cephfs-busybox	Workload unprotected
2025-03-10T20:02:30.467+0530	INFO	subscr-deploy-rbd-busybox	Workload unprotected
2025-03-10T20:02:30.471+0530	INFO	disapp-deploy-cephfs-busybox	Workload unprotected
2025-03-10T20:02:30.471+0530	INFO	disapp-deploy-rbd-busybox	Workload unprotected
2025-03-10T20:02:30.667+0530	INFO	appset-deploy-rbd-busybox	Workload unprotected
2025-03-10T20:02:30.867+0530	INFO	appset-deploy-cephfs-busybox	Workload unprotected
2025-03-10T20:02:30.869+0530	INFO	Deleted channel "e2e-gitops/https-github-com-ramendr-ocm-ramen-samples-git" in cluster "hub"
--- PASS: TestDR (6.03s)
    --- PASS: TestDR/subscr-deploy-cephfs-busybox (0.01s)
        --- PASS: TestDR/subscr-deploy-cephfs-busybox/Disable (0.01s)
    --- PASS: TestDR/subscr-deploy-rbd-busybox (0.01s)
        --- PASS: TestDR/subscr-deploy-rbd-busybox/Disable (0.01s)
    --- PASS: TestDR/disapp-deploy-cephfs-busybox (0.01s)
        --- PASS: TestDR/disapp-deploy-cephfs-busybox/Disable (0.01s)
    --- PASS: TestDR/disapp-deploy-rbd-busybox (0.01s)
        --- PASS: TestDR/disapp-deploy-rbd-busybox/Disable (0.01s)
    --- PASS: TestDR/appset-deploy-rbd-busybox (0.21s)
        --- PASS: TestDR/appset-deploy-rbd-busybox/Disable (0.21s)
    --- PASS: TestDR/appset-deploy-cephfs-busybox (0.41s)
        --- PASS: TestDR/appset-deploy-cephfs-busybox/Disable (0.41s)
```
3. Added debug log example:
```
DEBUG   appset-deploy-rbd-busybox       deployers/appset.go:66  Could not retrieve the cluster name: placements.cluster.open-cluster-management.io "appset-deploy-rbd-busybox" not found
```

Fixes #1878
Fixes #1879