### PR TITLE
e2e: Access config and clusters via test context

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -94,8 +94,8 @@ jobs:
       timeout-minutes: 3
       run: drenv gather --directory gather.rdr envs/regional-dr.yaml
 
-    # Tar manually to work around github limitations with special chracters (:)
-    # in file names, and getting much smaller archives comapred with zip (6m vs
+    # Tar manually to work around github limitations with special characters (:)
+    # in file names, and getting much smaller archives compared with zip (6m vs
     # 12m). This is also useful to collect all files in one archive.
     # https://github.com/actions/upload-artifact/issues/546
     - name: Archive artifacts

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -55,36 +55,35 @@ var ocpNamespaces = types.NamespacesConfig{
 	ArgocdNamespace:         "openshift-gitops",
 }
 
-var (
-	resourceNameForbiddenCharacters *regexp.Regexp
-	config                          = &types.Config{}
-)
+var resourceNameForbiddenCharacters *regexp.Regexp
 
-func ReadConfig(configFile string, options Options) error {
+func ReadConfig(configFile string, options Options) (*types.Config, error) {
+	config := &types.Config{}
+
 	if err := readConfig(configFile, config); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := validateDistro(config); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := validateClusters(config); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := validatePVCSpecs(config); err != nil {
-		return err
+		return nil, err
 	}
 
 	if err := validateTests(config, &options); err != nil {
-		return err
+		return nil, err
 	}
 
 	config.Channel.Name = resourceName(config.Repo.URL)
 	config.Channel.Namespace = defaultChannelNamespace
 
-	return nil
+	return config, nil
 }
 
 func readConfig(configFile string, config *types.Config) error {
@@ -181,49 +180,14 @@ func validateTests(config *types.Config, options *Options) error {
 	return nil
 }
 
-func GetChannelName() string {
-	return config.Channel.Name
-}
-
-func GetChannelNamespace() string {
-	return config.Channel.Namespace
-}
-
-func GetGitURL() string {
-	return config.Repo.URL
-}
-
-func GetGitBranch() string {
-	return config.Repo.Branch
-}
-
-func GetDRPolicyName() string {
-	return config.DRPolicy
-}
-
-func GetClusterSetName() string {
-	return config.ClusterSet
-}
-
-func GetNamespaces() types.NamespacesConfig {
-	return config.Namespaces
-}
-
-func GetPVCSpecs() map[string]types.PVCSpecConfig {
+// PVCSpecMap returns a mapping from PVCSpec.Name to PVCSpec.
+func PVCSpecsMap(config *types.Config) map[string]types.PVCSpecConfig {
 	res := map[string]types.PVCSpecConfig{}
 	for _, spec := range config.PVCSpecs {
 		res[spec.Name] = spec
 	}
 
 	return res
-}
-
-func GetClusters() map[string]types.ClusterConfig {
-	return config.Clusters
-}
-
-func GetTests() []types.TestConfig {
-	return config.Tests
 }
 
 // resourceName convert a URL to conventional k8s resource name:

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -61,19 +61,8 @@ var (
 )
 
 func ReadConfig(configFile string, options Options) error {
-	viper.SetDefault("Repo.URL", defaultGitURL)
-	viper.SetDefault("Repo.Branch", defaultGitBranch)
-	viper.SetDefault("DRPolicy", defaultDRPolicyName)
-	viper.SetDefault("ClusterSet", defaultClusterSetName)
-
-	viper.SetConfigFile(configFile)
-
-	if err := viper.ReadInConfig(); err != nil {
-		return fmt.Errorf("failed to read config: %v", err)
-	}
-
-	if err := viper.Unmarshal(config); err != nil {
-		return fmt.Errorf("failed to unmarshal config: %v", err)
+	if err := readConfig(configFile, config); err != nil {
+		return err
 	}
 
 	if err := validateDistro(config); err != nil {
@@ -94,6 +83,25 @@ func ReadConfig(configFile string, options Options) error {
 
 	config.Channel.Name = resourceName(config.Repo.URL)
 	config.Channel.Namespace = defaultChannelNamespace
+
+	return nil
+}
+
+func readConfig(configFile string, config *types.Config) error {
+	viper.SetDefault("Repo.URL", defaultGitURL)
+	viper.SetDefault("Repo.Branch", defaultGitBranch)
+	viper.SetDefault("DRPolicy", defaultDRPolicyName)
+	viper.SetDefault("ClusterSet", defaultClusterSetName)
+
+	viper.SetConfigFile(configFile)
+
+	if err := viper.ReadInConfig(); err != nil {
+		return fmt.Errorf("failed to read config: %v", err)
+	}
+
+	if err := viper.Unmarshal(config); err != nil {
+		return fmt.Errorf("failed to unmarshal config: %v", err)
+	}
 
 	return nil
 }

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -107,7 +107,12 @@ func readConfig(configFile string, config *types.Config) error {
 }
 
 func validateDistro(config *types.Config) error {
-	if config.Distro != distroK8s && config.Distro != distroOcp {
+	switch config.Distro {
+	case distroK8s:
+		config.Namespaces = k8sNamespaces
+	case distroOcp:
+		config.Namespaces = ocpNamespaces
+	default:
 		return fmt.Errorf("invalid distro %q: (choose one of %q, %q)",
 			config.Distro, distroK8s, distroOcp)
 	}
@@ -201,14 +206,7 @@ func GetClusterSetName() string {
 }
 
 func GetNamespaces() types.NamespacesConfig {
-	switch config.Distro {
-	case distroK8s:
-		return k8sNamespaces
-	case distroOcp:
-		return ocpNamespaces
-	default:
-		panic("invalid distro")
-	}
+	return config.Namespaces
 }
 
 func GetPVCSpecs() map[string]types.PVCSpecConfig {

--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -18,7 +18,7 @@ func (a ApplicationSet) Deploy(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub, config.GetDRPolicyName())
+	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, config.GetDRPolicyName())
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func (a ApplicationSet) Undeploy(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	clusterName, err := util.GetCurrentCluster(util.Ctx.Hub, managementNamespace, name)
+	clusterName, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, name)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
@@ -87,7 +87,7 @@ func (a ApplicationSet) Undeploy(ctx types.Context) error {
 
 	// multiple appsets could use the same mcsb in argocd ns.
 	// so delete mcsb if only 1 appset is in argocd ns
-	lastAppset, err := isLastAppsetInArgocdNs(managementNamespace)
+	lastAppset, err := isLastAppsetInArgocdNs(ctx, managementNamespace)
 	if err != nil {
 		return err
 	}

--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -4,7 +4,6 @@
 package deployers
 
 import (
-	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -16,9 +15,10 @@ type ApplicationSet struct{}
 func (a ApplicationSet) Deploy(ctx types.Context) error {
 	name := ctx.Name()
 	log := ctx.Logger()
+	config := ctx.Config()
 	managementNamespace := ctx.ManagementNamespace()
 
-	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, config.GetDRPolicyName())
+	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, config.DRPolicy)
 	if err != nil {
 		return err
 	}
@@ -26,7 +26,7 @@ func (a ApplicationSet) Deploy(ctx types.Context) error {
 	log.Infof("Deploying applicationset app \"%s/%s\" in cluster %q",
 		ctx.AppNamespace(), ctx.Workload().GetAppName(), drpolicy.Spec.DRClusters[0])
 
-	err = CreateManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
+	err = CreateManagedClusterSetBinding(ctx, config.ClusterSet, managementNamespace)
 	if err != nil {
 		return err
 	}
@@ -55,6 +55,7 @@ func (a ApplicationSet) Deploy(ctx types.Context) error {
 func (a ApplicationSet) Undeploy(ctx types.Context) error {
 	name := ctx.Name()
 	log := ctx.Logger()
+	config := ctx.Config()
 	managementNamespace := ctx.ManagementNamespace()
 
 	clusterName, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, name)
@@ -93,7 +94,7 @@ func (a ApplicationSet) Undeploy(ctx types.Context) error {
 	}
 
 	if lastAppset {
-		err = DeleteManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
+		err = DeleteManagedClusterSetBinding(ctx, config.ClusterSet, managementNamespace)
 		if err != nil {
 			return err
 		}
@@ -108,8 +109,8 @@ func (a ApplicationSet) GetName() string {
 	return "appset"
 }
 
-func (a ApplicationSet) GetNamespace() string {
-	return config.GetNamespaces().ArgocdNamespace
+func (a ApplicationSet) GetNamespace(ctx types.Context) string {
+	return ctx.Config().Namespaces.ArgocdNamespace
 }
 
 func (a ApplicationSet) IsDiscovered() bool {

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -243,7 +243,7 @@ func DeleteSubscription(ctx types.Context, s Subscription) error {
 	return nil
 }
 
-func getSubscription(cluster util.Cluster, namespace, name string) (*subscriptionv1.Subscription, error) {
+func getSubscription(cluster types.Cluster, namespace, name string) (*subscriptionv1.Subscription, error) {
 	subscription := &subscriptionv1.Subscription{}
 	key := k8stypes.NamespacedName{Name: name, Namespace: namespace}
 

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
@@ -52,7 +52,7 @@ func CreateManagedClusterSetBinding(ctx types.Context, name, namespace string) e
 
 	err := util.Ctx.Hub.Client.Create(context.Background(), mcsb)
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
+		if !k8serrors.IsAlreadyExists(err) {
 			return err
 		}
 
@@ -75,7 +75,7 @@ func DeleteManagedClusterSetBinding(ctx types.Context, name, namespace string) e
 
 	err := util.Ctx.Hub.Client.Delete(context.Background(), mcsb)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 
@@ -124,7 +124,7 @@ func CreatePlacement(ctx types.Context, name, namespace string, clusterName stri
 
 	err := util.Ctx.Hub.Client.Create(context.Background(), placement)
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
+		if !k8serrors.IsAlreadyExists(err) {
 			return err
 		}
 
@@ -147,7 +147,7 @@ func DeletePlacement(ctx types.Context, name, namespace string) error {
 
 	err := util.Ctx.Hub.Client.Delete(context.Background(), placement)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 
@@ -205,7 +205,7 @@ func CreateSubscription(ctx types.Context, s Subscription) error {
 
 	err := util.Ctx.Hub.Client.Create(context.Background(), subscription)
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
+		if !k8serrors.IsAlreadyExists(err) {
 			return err
 		}
 
@@ -231,7 +231,7 @@ func DeleteSubscription(ctx types.Context, s Subscription) error {
 
 	err := util.Ctx.Hub.Client.Delete(context.Background(), subscription)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 
@@ -270,7 +270,7 @@ func CreatePlacementDecisionConfigMap(ctx types.Context, cmName string, cmNamesp
 
 	err := util.Ctx.Hub.Client.Create(context.Background(), configMap)
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
+		if !k8serrors.IsAlreadyExists(err) {
 			return fmt.Errorf("could not create configMap %q", cmName)
 		}
 
@@ -292,7 +292,7 @@ func DeleteConfigMap(ctx types.Context, cmName string, cmNamespace string) error
 
 	err := util.Ctx.Hub.Client.Delete(context.Background(), configMap)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return fmt.Errorf("could not delete configMap %q in cluster %q", cmName, util.Ctx.Hub.Name)
 		}
 
@@ -376,7 +376,7 @@ func CreateApplicationSet(ctx types.Context, a ApplicationSet) error {
 
 	err := util.Ctx.Hub.Client.Create(context.Background(), appset)
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
+		if !k8serrors.IsAlreadyExists(err) {
 			return err
 		}
 
@@ -402,7 +402,7 @@ func DeleteApplicationSet(ctx types.Context, a ApplicationSet) error {
 
 	err := util.Ctx.Hub.Client.Delete(context.Background(), appset)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -25,7 +25,6 @@ import (
 	argocdv1alpha1hack "github.com/ramendr/ramen/e2e/argocd"
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
-	"github.com/ramendr/ramen/e2e/util"
 )
 
 const (
@@ -49,16 +48,16 @@ func CreateManagedClusterSetBinding(ctx types.Context, name, namespace string) e
 		},
 	}
 
-	err := util.Ctx.Hub.Client.Create(context.Background(), mcsb)
+	err := ctx.Env().Hub.Client.Create(context.Background(), mcsb)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
 		}
 
-		log.Debugf("ManagedClusterSetBinding \"%s/%s\" already exist in cluster %q", namespace, name, util.Ctx.Hub.Name)
+		log.Debugf("ManagedClusterSetBinding \"%s/%s\" already exist in cluster %q", namespace, name, ctx.Env().Hub.Name)
 	}
 
-	log.Debugf("Created ManagedClusterSetBinding \"%s/%s\" in cluster %q", namespace, name, util.Ctx.Hub.Name)
+	log.Debugf("Created ManagedClusterSetBinding \"%s/%s\" in cluster %q", namespace, name, ctx.Env().Hub.Name)
 
 	return nil
 }
@@ -72,16 +71,16 @@ func DeleteManagedClusterSetBinding(ctx types.Context, name, namespace string) e
 		},
 	}
 
-	err := util.Ctx.Hub.Client.Delete(context.Background(), mcsb)
+	err := ctx.Env().Hub.Client.Delete(context.Background(), mcsb)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 
-		log.Debugf("ManagedClusterSetBinding \"%s/%s\" not found in cluster %q", namespace, name, util.Ctx.Hub.Name)
+		log.Debugf("ManagedClusterSetBinding \"%s/%s\" not found in cluster %q", namespace, name, ctx.Env().Hub.Name)
 	}
 
-	log.Debugf("Deleted ManagedClusterSetBinding \"%s/%s\" in cluster %q", namespace, name, util.Ctx.Hub.Name)
+	log.Debugf("Deleted ManagedClusterSetBinding \"%s/%s\" in cluster %q", namespace, name, ctx.Env().Hub.Name)
 
 	return nil
 }
@@ -121,16 +120,16 @@ func CreatePlacement(ctx types.Context, name, namespace string, clusterName stri
 		},
 	}
 
-	err := util.Ctx.Hub.Client.Create(context.Background(), placement)
+	err := ctx.Env().Hub.Client.Create(context.Background(), placement)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
 		}
 
-		log.Debugf("Placement \"%s/%s\" already exists in cluster %q", namespace, name, util.Ctx.Hub.Name)
+		log.Debugf("Placement \"%s/%s\" already exists in cluster %q", namespace, name, ctx.Env().Hub.Name)
 	}
 
-	log.Debugf("Created placement \"%s/%s\" in cluster %q", namespace, name, util.Ctx.Hub.Name)
+	log.Debugf("Created placement \"%s/%s\" in cluster %q", namespace, name, ctx.Env().Hub.Name)
 
 	return nil
 }
@@ -144,16 +143,16 @@ func DeletePlacement(ctx types.Context, name, namespace string) error {
 		},
 	}
 
-	err := util.Ctx.Hub.Client.Delete(context.Background(), placement)
+	err := ctx.Env().Hub.Client.Delete(context.Background(), placement)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 
-		log.Debugf("Placement \"%s/%s\" not found in cluster %q", namespace, name, util.Ctx.Hub.Name)
+		log.Debugf("Placement \"%s/%s\" not found in cluster %q", namespace, name, ctx.Env().Hub.Name)
 	}
 
-	log.Debugf("Deleted placement \"%s/%s\" in cluster %q", namespace, name, util.Ctx.Hub.Name)
+	log.Debugf("Deleted placement \"%s/%s\" in cluster %q", namespace, name, ctx.Env().Hub.Name)
 
 	return nil
 }
@@ -202,16 +201,16 @@ func CreateSubscription(ctx types.Context, s Subscription) error {
 		})
 	}
 
-	err := util.Ctx.Hub.Client.Create(context.Background(), subscription)
+	err := ctx.Env().Hub.Client.Create(context.Background(), subscription)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
 		}
 
-		log.Debugf("Subscription \"%s/%s\" already exists in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
+		log.Debugf("Subscription \"%s/%s\" already exists in cluster %q", managementNamespace, name, ctx.Env().Hub.Name)
 	}
 
-	log.Debugf("Created subscription \"%s/%s\" in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
+	log.Debugf("Created subscription \"%s/%s\" in cluster %q", managementNamespace, name, ctx.Env().Hub.Name)
 
 	return nil
 }
@@ -228,16 +227,16 @@ func DeleteSubscription(ctx types.Context, s Subscription) error {
 		},
 	}
 
-	err := util.Ctx.Hub.Client.Delete(context.Background(), subscription)
+	err := ctx.Env().Hub.Client.Delete(context.Background(), subscription)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 
-		log.Debugf("Subscription \"%s/%s\" not found in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
+		log.Debugf("Subscription \"%s/%s\" not found in cluster %q", managementNamespace, name, ctx.Env().Hub.Name)
 	}
 
-	log.Debugf("Deleted subscription \"%s/%s\" in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
+	log.Debugf("Deleted subscription \"%s/%s\" in cluster %q", managementNamespace, name, ctx.Env().Hub.Name)
 
 	return nil
 }
@@ -267,16 +266,16 @@ func CreatePlacementDecisionConfigMap(ctx types.Context, cmName string, cmNamesp
 
 	configMap := &corev1.ConfigMap{ObjectMeta: object, Data: data}
 
-	err := util.Ctx.Hub.Client.Create(context.Background(), configMap)
+	err := ctx.Env().Hub.Client.Create(context.Background(), configMap)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return fmt.Errorf("could not create configMap %q", cmName)
 		}
 
-		log.Debugf("ConfigMap \"%s/%s\" already exists in cluster %q", cmNamespace, cmName, util.Ctx.Hub.Name)
+		log.Debugf("ConfigMap \"%s/%s\" already exists in cluster %q", cmNamespace, cmName, ctx.Env().Hub.Name)
 	}
 
-	log.Debugf("Created configMap \"%s/%s\" in cluster %q", cmNamespace, cmName, util.Ctx.Hub.Name)
+	log.Debugf("Created configMap \"%s/%s\" in cluster %q", cmNamespace, cmName, ctx.Env().Hub.Name)
 
 	return nil
 }
@@ -289,16 +288,16 @@ func DeleteConfigMap(ctx types.Context, cmName string, cmNamespace string) error
 		ObjectMeta: object,
 	}
 
-	err := util.Ctx.Hub.Client.Delete(context.Background(), configMap)
+	err := ctx.Env().Hub.Client.Delete(context.Background(), configMap)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
-			return fmt.Errorf("could not delete configMap %q in cluster %q", cmName, util.Ctx.Hub.Name)
+			return fmt.Errorf("could not delete configMap %q in cluster %q", cmName, ctx.Env().Hub.Name)
 		}
 
-		log.Debugf("ConfigMap \"%s/%s\" not found in cluster %q", cmNamespace, cmName, util.Ctx.Hub.Name)
+		log.Debugf("ConfigMap \"%s/%s\" not found in cluster %q", cmNamespace, cmName, ctx.Env().Hub.Name)
 	}
 
-	log.Debugf("Deleted configMap \"%s/%s\" in cluster %q", cmNamespace, cmName, util.Ctx.Hub.Name)
+	log.Debugf("Deleted configMap \"%s/%s\" in cluster %q", cmNamespace, cmName, ctx.Env().Hub.Name)
 
 	return nil
 }
@@ -373,16 +372,16 @@ func CreateApplicationSet(ctx types.Context, a ApplicationSet) error {
 		appset.Spec.Template.Spec.Source.Kustomize = patches
 	}
 
-	err := util.Ctx.Hub.Client.Create(context.Background(), appset)
+	err := ctx.Env().Hub.Client.Create(context.Background(), appset)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
 		}
 
-		log.Debugf("Applicationset \"%s/%s\" already exists in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
+		log.Debugf("Applicationset \"%s/%s\" already exists in cluster %q", managementNamespace, name, ctx.Env().Hub.Name)
 	}
 
-	log.Debugf("Created applicationset \"%s/%s\" in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
+	log.Debugf("Created applicationset \"%s/%s\" in cluster %q", managementNamespace, name, ctx.Env().Hub.Name)
 
 	return nil
 }
@@ -399,28 +398,28 @@ func DeleteApplicationSet(ctx types.Context, a ApplicationSet) error {
 		},
 	}
 
-	err := util.Ctx.Hub.Client.Delete(context.Background(), appset)
+	err := ctx.Env().Hub.Client.Delete(context.Background(), appset)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 
-		log.Debugf("Applicationset \"%s/%s\" not found in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
+		log.Debugf("Applicationset \"%s/%s\" not found in cluster %q", managementNamespace, name, ctx.Env().Hub.Name)
 	}
 
-	log.Debugf("Deleted applicationset \"%s/%s\" in cluster %q", managementNamespace, name, util.Ctx.Hub.Name)
+	log.Debugf("Deleted applicationset \"%s/%s\" in cluster %q", managementNamespace, name, ctx.Env().Hub.Name)
 
 	return nil
 }
 
 // check if only the last appset is in the argocd namespace
-func isLastAppsetInArgocdNs(namespace string) (bool, error) {
+func isLastAppsetInArgocdNs(ctx types.Context, namespace string) (bool, error) {
 	appsetList := &argocdv1alpha1hack.ApplicationSetList{}
 
-	err := util.Ctx.Hub.Client.List(
+	err := ctx.Env().Hub.Client.List(
 		context.Background(), appsetList, client.InNamespace(namespace))
 	if err != nil {
-		return false, fmt.Errorf("failed to list applicationsets in cluster %q: %w", util.Ctx.Hub.Name, err)
+		return false, fmt.Errorf("failed to list applicationsets in cluster %q: %w", ctx.Env().Hub.Name, err)
 	}
 
 	return len(appsetList.Items) == 1, nil

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -10,23 +10,22 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/ramendr/ramen/e2e/config"
-	"github.com/ramendr/ramen/e2e/types"
-	"github.com/ramendr/ramen/e2e/util"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8stypes "k8s.io/apimachinery/pkg/types"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/yaml"
-
-	argocdv1alpha1hack "github.com/ramendr/ramen/e2e/argocd"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ocmv1b1 "open-cluster-management.io/api/cluster/v1beta1"
 	ocmv1b2 "open-cluster-management.io/api/cluster/v1beta2"
 	placementrulev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 	subscriptionv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	argocdv1alpha1hack "github.com/ramendr/ramen/e2e/argocd"
+	"github.com/ramendr/ramen/e2e/config"
+	"github.com/ramendr/ramen/e2e/types"
+	"github.com/ramendr/ramen/e2e/util"
 )
 
 const (

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -29,7 +29,7 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 	appNamespace := ctx.AppNamespace()
 
 	// create namespace in both dr clusters
-	if err := util.CreateNamespaceAndAddAnnotation(appNamespace, log); err != nil {
+	if err := util.CreateNamespaceAndAddAnnotation(ctx.Env(), appNamespace, log); err != nil {
 		return err
 	}
 
@@ -45,7 +45,7 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub, config.GetDRPolicyName())
+	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, config.GetDRPolicyName())
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	if err = WaitWorkloadHealth(ctx, util.Ctx.C1, appNamespace); err != nil {
+	if err = WaitWorkloadHealth(ctx, ctx.Env().C1, appNamespace); err != nil {
 		return err
 	}
 
@@ -78,7 +78,7 @@ func (d DiscoveredApp) Undeploy(ctx types.Context) error {
 	log := ctx.Logger()
 	appNamespace := ctx.AppNamespace()
 
-	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub, config.GetDRPolicyName())
+	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, config.GetDRPolicyName())
 	if err != nil {
 		return err
 	}
@@ -96,11 +96,11 @@ func (d DiscoveredApp) Undeploy(ctx types.Context) error {
 	}
 
 	// delete namespace on both clusters
-	if err := util.DeleteNamespace(util.Ctx.C1, appNamespace, log); err != nil {
+	if err := util.DeleteNamespace(ctx.Env().C1, appNamespace, log); err != nil {
 		return err
 	}
 
-	if err := util.DeleteNamespace(util.Ctx.C2, appNamespace, log); err != nil {
+	if err := util.DeleteNamespace(ctx.Env().C2, appNamespace, log); err != nil {
 		return err
 	}
 

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 )
@@ -19,13 +18,14 @@ func (d DiscoveredApp) GetName() string {
 	return "disapp"
 }
 
-func (d DiscoveredApp) GetNamespace() string {
-	return config.GetNamespaces().RamenOpsNamespace
+func (d DiscoveredApp) GetNamespace(ctx types.Context) string {
+	return ctx.Config().Namespaces.RamenOpsNamespace
 }
 
 // Deploy creates a workload on the first managed cluster.
 func (d DiscoveredApp) Deploy(ctx types.Context) error {
 	log := ctx.Logger()
+	config := ctx.Config()
 	appNamespace := ctx.AppNamespace()
 
 	// create namespace in both dr clusters
@@ -45,7 +45,7 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, config.GetDRPolicyName())
+	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, config.DRPolicy)
 	if err != nil {
 		return err
 	}
@@ -76,9 +76,10 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 // Undeploy deletes the workload from the managed clusters.
 func (d DiscoveredApp) Undeploy(ctx types.Context) error {
 	log := ctx.Logger()
+	config := ctx.Config()
 	appNamespace := ctx.AppNamespace()
 
-	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, config.GetDRPolicyName())
+	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, config.DRPolicy)
 	if err != nil {
 		return err
 	}

--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"time"
 
+	subscriptionv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
+
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
-	subscriptionv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 )
 
 func waitSubscriptionPhase(ctx types.Context, namespace, name string, phase subscriptionv1.SubscriptionPhase) error {

--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -18,21 +18,21 @@ func waitSubscriptionPhase(ctx types.Context, namespace, name string, phase subs
 	startTime := time.Now()
 
 	for {
-		sub, err := getSubscription(util.Ctx.Hub, namespace, name)
+		sub, err := getSubscription(ctx.Env().Hub, namespace, name)
 		if err != nil {
 			return err
 		}
 
 		currentPhase := sub.Status.Phase
 		if currentPhase == phase {
-			log.Debugf("Subscription \"%s/%s\" phase is %s in cluster %q", namespace, name, phase, util.Ctx.Hub.Name)
+			log.Debugf("Subscription \"%s/%s\" phase is %s in cluster %q", namespace, name, phase, ctx.Env().Hub.Name)
 
 			return nil
 		}
 
 		if time.Since(startTime) > util.Timeout {
 			return fmt.Errorf("subscription %q status is not %q yet before timeout in cluster %q",
-				name, phase, util.Ctx.Hub.Name)
+				name, phase, ctx.Env().Hub.Name)
 		}
 
 		time.Sleep(util.RetryInterval)

--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -38,7 +38,7 @@ func waitSubscriptionPhase(ctx types.Context, namespace, name string, phase subs
 	}
 }
 
-func WaitWorkloadHealth(ctx types.Context, cluster util.Cluster, namespace string) error {
+func WaitWorkloadHealth(ctx types.Context, cluster types.Cluster, namespace string) error {
 	log := ctx.Logger()
 	w := ctx.Workload()
 	startTime := time.Now()

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -4,11 +4,12 @@
 package deployers
 
 import (
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	subscriptionv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
+
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	subscriptionv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 )
 
 type Subscription struct{}

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -35,7 +35,7 @@ func (s Subscription) Deploy(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub, config.GetDRPolicyName())
+	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, config.GetDRPolicyName())
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func (s Subscription) Deploy(ctx types.Context) error {
 		ctx.AppNamespace(), ctx.Workload().GetAppName(), drpolicy.Spec.DRClusters[0])
 
 	// create subscription namespace
-	err = util.CreateNamespace(util.Ctx.Hub, managementNamespace, log)
+	err = util.CreateNamespace(ctx.Env().Hub, managementNamespace, log)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func (s Subscription) Undeploy(ctx types.Context) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	clusterName, err := util.GetCurrentCluster(util.Ctx.Hub, managementNamespace, name)
+	clusterName, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, name)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
@@ -108,7 +108,7 @@ func (s Subscription) Undeploy(ctx types.Context) error {
 		return err
 	}
 
-	err = util.DeleteNamespace(util.Ctx.Hub, managementNamespace, log)
+	err = util.DeleteNamespace(ctx.Env().Hub, managementNamespace, log)
 	if err != nil {
 		return err
 	}

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -7,7 +7,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	subscriptionv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 
-	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 )
@@ -18,7 +17,7 @@ func (s Subscription) GetName() string {
 	return "subscr"
 }
 
-func (s Subscription) GetNamespace() string {
+func (s Subscription) GetNamespace(_ types.Context) string {
 	// No special namespaces.
 	return ""
 }
@@ -33,9 +32,10 @@ func (s Subscription) Deploy(ctx types.Context) error {
 	// Address namespace/label/suffix as needed for various resources
 	name := ctx.Name()
 	log := ctx.Logger()
+	config := ctx.Config()
 	managementNamespace := ctx.ManagementNamespace()
 
-	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, config.GetDRPolicyName())
+	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, config.DRPolicy)
 	if err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func (s Subscription) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	err = CreateManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
+	err = CreateManagedClusterSetBinding(ctx, config.ClusterSet, managementNamespace)
 	if err != nil {
 		return err
 	}
@@ -78,6 +78,7 @@ func (s Subscription) Deploy(ctx types.Context) error {
 func (s Subscription) Undeploy(ctx types.Context) error {
 	name := ctx.Name()
 	log := ctx.Logger()
+	config := ctx.Config()
 	managementNamespace := ctx.ManagementNamespace()
 
 	clusterName, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, name)
@@ -103,7 +104,7 @@ func (s Subscription) Undeploy(ctx types.Context) error {
 		return err
 	}
 
-	err = DeleteManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
+	err = DeleteManagedClusterSetBinding(ctx, config.ClusterSet, managementNamespace)
 	if err != nil {
 		return err
 	}

--- a/e2e/dr_test.go
+++ b/e2e/dr_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestDR(dt *testing.T) {
-	t := test.WithLog(dt, util.Ctx.Log)
+	t := test.WithLog(dt, log)
 	t.Parallel()
 
 	tests := config.GetTests()
@@ -22,12 +22,12 @@ func TestDR(dt *testing.T) {
 		t.Fatal("No tests found in the configuration file")
 	}
 
-	if err := util.EnsureChannel(); err != nil {
+	if err := util.EnsureChannel(log); err != nil {
 		t.Fatalf("Failed to ensure channel: %s", err)
 	}
 
 	t.Cleanup(func() {
-		if err := util.EnsureChannelDeleted(); err != nil {
+		if err := util.EnsureChannelDeleted(log); err != nil {
 			t.Fatalf("Failed to ensure channel deleted: %s", err)
 		}
 	})
@@ -50,7 +50,7 @@ func TestDR(dt *testing.T) {
 			panic(err)
 		}
 
-		ctx := test.NewContext(workload, deployer, util.Ctx.Log)
+		ctx := test.NewContext(workload, deployer, log)
 		t.Run(ctx.Name(), func(dt *testing.T) {
 			t := test.WithLog(dt, ctx.Logger())
 			t.Parallel()

--- a/e2e/dr_test.go
+++ b/e2e/dr_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestDR(dt *testing.T) {
-	t := test.WithLog(dt, log)
+	t := test.WithLog(dt, Ctx.log)
 	t.Parallel()
 
 	tests := config.GetTests()
@@ -22,12 +22,12 @@ func TestDR(dt *testing.T) {
 		t.Fatal("No tests found in the configuration file")
 	}
 
-	if err := util.EnsureChannel(log); err != nil {
+	if err := util.EnsureChannel(Ctx.env.Hub, Ctx.log); err != nil {
 		t.Fatalf("Failed to ensure channel: %s", err)
 	}
 
 	t.Cleanup(func() {
-		if err := util.EnsureChannelDeleted(log); err != nil {
+		if err := util.EnsureChannelDeleted(Ctx.env.Hub, Ctx.log); err != nil {
 			t.Fatalf("Failed to ensure channel deleted: %s", err)
 		}
 	})
@@ -50,7 +50,7 @@ func TestDR(dt *testing.T) {
 			panic(err)
 		}
 
-		ctx := test.NewContext(workload, deployer, log)
+		ctx := test.NewContext(workload, deployer, Ctx.env, Ctx.log)
 		t.Run(ctx.Name(), func(dt *testing.T) {
 			t := test.WithLog(dt, ctx.Logger())
 			t.Parallel()

--- a/e2e/dr_test.go
+++ b/e2e/dr_test.go
@@ -17,30 +17,29 @@ func TestDR(dt *testing.T) {
 	t := test.WithLog(dt, Ctx.log)
 	t.Parallel()
 
-	tests := config.GetTests()
-	if len(tests) == 0 {
+	if len(Ctx.config.Tests) == 0 {
 		t.Fatal("No tests found in the configuration file")
 	}
 
-	if err := util.EnsureChannel(Ctx.env.Hub, Ctx.log); err != nil {
+	if err := util.EnsureChannel(Ctx.env.Hub, Ctx.config, Ctx.log); err != nil {
 		t.Fatalf("Failed to ensure channel: %s", err)
 	}
 
 	t.Cleanup(func() {
-		if err := util.EnsureChannelDeleted(Ctx.env.Hub, Ctx.log); err != nil {
+		if err := util.EnsureChannelDeleted(Ctx.env.Hub, Ctx.config, Ctx.log); err != nil {
 			t.Fatalf("Failed to ensure channel deleted: %s", err)
 		}
 	})
 
-	pvcSpecs := config.GetPVCSpecs()
+	pvcSpecs := config.PVCSpecsMap(Ctx.config)
 
-	for _, tc := range tests {
+	for _, tc := range Ctx.config.Tests {
 		pvcSpec, ok := pvcSpecs[tc.PVCSpec]
 		if !ok {
 			panic("unknown pvcSpec")
 		}
 
-		workload, err := workloads.New(tc.Workload, config.GetGitBranch(), pvcSpec)
+		workload, err := workloads.New(tc.Workload, Ctx.config.Repo.Branch, pvcSpec)
 		if err != nil {
 			panic(err)
 		}
@@ -50,7 +49,7 @@ func TestDR(dt *testing.T) {
 			panic(err)
 		}
 
-		ctx := test.NewContext(workload, deployer, Ctx.env, Ctx.log)
+		ctx := test.NewContext(workload, deployer, Ctx.env, Ctx.config, Ctx.log)
 		t.Run(ctx.Name(), func(dt *testing.T) {
 			t := test.WithLog(dt, ctx.Logger())
 			t.Parallel()

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -8,7 +8,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 
-	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 )
@@ -35,8 +34,9 @@ func EnableProtection(ctx types.Context) error {
 	managementNamespace := ctx.ManagementNamespace()
 	appNamespace := ctx.AppNamespace()
 	log := ctx.Logger()
+	config := ctx.Config()
 
-	drPolicyName := config.GetDRPolicyName()
+	drPolicyName := config.DRPolicy
 	appname := w.GetAppName()
 	placementName := name
 	drpcName := name
@@ -141,13 +141,14 @@ func Failover(ctx types.Context) error {
 	managementNamespace := ctx.ManagementNamespace()
 	log := ctx.Logger()
 	name := ctx.Name()
+	config := ctx.Config()
 
 	currentCluster, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, name)
 	if err != nil {
 		return err
 	}
 
-	targetCluster, err := getTargetCluster(ctx.Env().Hub, currentCluster)
+	targetCluster, err := getTargetCluster(ctx.Env().Hub, config.DRPolicy, currentCluster)
 	if err != nil {
 		return err
 	}
@@ -172,6 +173,7 @@ func Failover(ctx types.Context) error {
 func Relocate(ctx types.Context) error {
 	managementNamespace := ctx.ManagementNamespace()
 	log := ctx.Logger()
+	config := ctx.Config()
 	name := ctx.Name()
 
 	currentCluster, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, name)
@@ -179,7 +181,7 @@ func Relocate(ctx types.Context) error {
 		return err
 	}
 
-	targetCluster, err := getTargetCluster(ctx.Env().Hub, currentCluster)
+	targetCluster, err := getTargetCluster(ctx.Env().Hub, config.DRPolicy, currentCluster)
 	if err != nil {
 		return err
 	}

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -41,7 +41,7 @@ func EnableProtection(ctx types.Context) error {
 	placementName := name
 	drpcName := name
 
-	clusterName, err := util.GetCurrentCluster(util.Ctx.Hub, managementNamespace, placementName)
+	clusterName, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, placementName)
 	if err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func EnableProtection(ctx types.Context) error {
 	log.Infof("Protecting workload \"%s/%s\" in cluster %q", appNamespace, appname, clusterName)
 
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		placement, err := util.GetPlacement(util.Ctx.Hub, managementNamespace, placementName)
+		placement, err := util.GetPlacement(ctx.Env().Hub, managementNamespace, placementName)
 		if err != nil {
 			return err
 		}
@@ -60,13 +60,13 @@ func EnableProtection(ctx types.Context) error {
 
 		placement.Annotations[OcmSchedulingDisable] = "true"
 
-		if err := updatePlacement(util.Ctx.Hub, placement); err != nil {
+		if err := updatePlacement(ctx.Env().Hub, placement); err != nil {
 			return err
 		}
 
 		log.Debugf("Annotated placement \"%s/%s\" with \"%s: %s\" in cluster %q",
 			managementNamespace, placementName, OcmSchedulingDisable,
-			placement.Annotations[OcmSchedulingDisable], util.Ctx.Hub.Name)
+			placement.Annotations[OcmSchedulingDisable], ctx.Env().Hub.Name)
 
 		return nil
 	})
@@ -75,16 +75,16 @@ func EnableProtection(ctx types.Context) error {
 	}
 
 	drpc := generateDRPC(name, managementNamespace, clusterName, drPolicyName, placementName, appname)
-	if err = createDRPC(ctx, util.Ctx.Hub, drpc); err != nil {
+	if err = createDRPC(ctx, drpc); err != nil {
 		return err
 	}
 
 	// For volsync based replication we must create the cluster namespaces with special annotation.
-	if err := util.CreateNamespaceAndAddAnnotation(ctx.AppNamespace(), log); err != nil {
+	if err := util.CreateNamespaceAndAddAnnotation(ctx.Env(), ctx.AppNamespace(), log); err != nil {
 		return err
 	}
 
-	err = waitDRPCReady(ctx, util.Ctx.Hub, managementNamespace, drpcName)
+	err = waitDRPCReady(ctx, managementNamespace, drpcName)
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ func DisableProtection(ctx types.Context) error {
 	placementName := name
 	log := ctx.Logger()
 
-	clusterName, err := util.GetCurrentCluster(util.Ctx.Hub, managementNamespace, placementName)
+	clusterName, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, placementName)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
@@ -123,11 +123,11 @@ func DisableProtection(ctx types.Context) error {
 
 	drpcName := name
 
-	if err := deleteDRPC(ctx, util.Ctx.Hub, managementNamespace, drpcName); err != nil {
+	if err := deleteDRPC(ctx, managementNamespace, drpcName); err != nil {
 		return err
 	}
 
-	err = waitDRPCDeleted(ctx, util.Ctx.Hub, managementNamespace, drpcName)
+	err = waitDRPCDeleted(ctx, managementNamespace, drpcName)
 	if err != nil {
 		return err
 	}
@@ -142,12 +142,12 @@ func Failover(ctx types.Context) error {
 	log := ctx.Logger()
 	name := ctx.Name()
 
-	currentCluster, err := util.GetCurrentCluster(util.Ctx.Hub, managementNamespace, name)
+	currentCluster, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, name)
 	if err != nil {
 		return err
 	}
 
-	targetCluster, err := getTargetCluster(util.Ctx.Hub, currentCluster)
+	targetCluster, err := getTargetCluster(ctx.Env().Hub, currentCluster)
 	if err != nil {
 		return err
 	}
@@ -174,12 +174,12 @@ func Relocate(ctx types.Context) error {
 	log := ctx.Logger()
 	name := ctx.Name()
 
-	currentCluster, err := util.GetCurrentCluster(util.Ctx.Hub, managementNamespace, name)
+	currentCluster, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, name)
 	if err != nil {
 		return err
 	}
 
-	targetCluster, err := getTargetCluster(util.Ctx.Hub, currentCluster)
+	targetCluster, err := getTargetCluster(ctx.Env().Hub, currentCluster)
 	if err != nil {
 		return err
 	}
@@ -211,33 +211,33 @@ func failoverRelocate(ctx types.Context,
 	drpcName := ctx.Name()
 	managementNamespace := ctx.ManagementNamespace()
 
-	if err := waitAndUpdateDRPC(ctx, util.Ctx.Hub, managementNamespace, drpcName, action, targetCluster); err != nil {
+	if err := waitAndUpdateDRPC(ctx, managementNamespace, drpcName, action, targetCluster); err != nil {
 		return err
 	}
 
-	if err := waitDRPCPhase(ctx, util.Ctx.Hub, managementNamespace, drpcName, state); err != nil {
+	if err := waitDRPCPhase(ctx, managementNamespace, drpcName, state); err != nil {
 		return err
 	}
 
-	return waitDRPCReady(ctx, util.Ctx.Hub, managementNamespace, drpcName)
+	return waitDRPCReady(ctx, managementNamespace, drpcName)
 }
 
 func waitAndUpdateDRPC(
 	ctx types.Context,
-	cluster types.Cluster,
 	namespace, drpcName string,
 	action ramen.DRAction,
 	targetCluster string,
 ) error {
 	log := ctx.Logger()
+	hub := ctx.Env().Hub
 
 	// here we expect drpc should be ready before action
-	if err := waitDRPCReady(ctx, cluster, namespace, drpcName); err != nil {
+	if err := waitDRPCReady(ctx, namespace, drpcName); err != nil {
 		return err
 	}
 
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		drpc, err := getDRPC(cluster, namespace, drpcName)
+		drpc, err := getDRPC(hub, namespace, drpcName)
 		if err != nil {
 			return err
 		}
@@ -249,7 +249,7 @@ func waitAndUpdateDRPC(
 			drpc.Spec.PreferredCluster = targetCluster
 		}
 
-		if err := updateDRPC(cluster, drpc); err != nil {
+		if err := updateDRPC(hub, drpc); err != nil {
 			return err
 		}
 

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -223,7 +223,7 @@ func failoverRelocate(ctx types.Context,
 
 func waitAndUpdateDRPC(
 	ctx types.Context,
-	cluster util.Cluster,
+	cluster types.Cluster,
 	namespace, drpcName string,
 	action ramen.DRAction,
 	targetCluster string,

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -5,11 +5,12 @@ package dractions
 
 import (
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/util/retry"
+
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/util/retry"
 )
 
 const (

--- a/e2e/dractions/crud.go
+++ b/e2e/dractions/crud.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
@@ -39,7 +39,7 @@ func createDRPC(ctx types.Context, cluster util.Cluster, drpc *ramen.DRPlacement
 
 	err := cluster.Client.Create(context.Background(), drpc)
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
+		if !k8serrors.IsAlreadyExists(err) {
 			return err
 		}
 
@@ -69,7 +69,7 @@ func deleteDRPC(ctx types.Context, cluster util.Cluster, namespace, name string)
 
 	err := cluster.Client.Get(context.Background(), key, objDrpc)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 
@@ -141,7 +141,7 @@ func createPlacementManagedByRamen(ctx types.Context, name, namespace string) er
 
 	err := util.Ctx.Hub.Client.Create(context.Background(), placement)
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
+		if !k8serrors.IsAlreadyExists(err) {
 			return err
 		}
 

--- a/e2e/dractions/crud.go
+++ b/e2e/dractions/crud.go
@@ -18,11 +18,11 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-func updatePlacement(cluster util.Cluster, placement *clusterv1beta1.Placement) error {
+func updatePlacement(cluster types.Cluster, placement *clusterv1beta1.Placement) error {
 	return cluster.Client.Update(context.Background(), placement)
 }
 
-func getDRPC(cluster util.Cluster, namespace, name string) (*ramen.DRPlacementControl, error) {
+func getDRPC(cluster types.Cluster, namespace, name string) (*ramen.DRPlacementControl, error) {
 	drpc := &ramen.DRPlacementControl{}
 	key := k8stypes.NamespacedName{Namespace: namespace, Name: name}
 
@@ -34,7 +34,7 @@ func getDRPC(cluster util.Cluster, namespace, name string) (*ramen.DRPlacementCo
 	return drpc, nil
 }
 
-func createDRPC(ctx types.Context, cluster util.Cluster, drpc *ramen.DRPlacementControl) error {
+func createDRPC(ctx types.Context, cluster types.Cluster, drpc *ramen.DRPlacementControl) error {
 	log := ctx.Logger()
 
 	err := cluster.Client.Create(context.Background(), drpc)
@@ -57,11 +57,11 @@ func createDRPC(ctx types.Context, cluster util.Cluster, drpc *ramen.DRPlacement
 	return nil
 }
 
-func updateDRPC(cluster util.Cluster, drpc *ramen.DRPlacementControl) error {
+func updateDRPC(cluster types.Cluster, drpc *ramen.DRPlacementControl) error {
 	return cluster.Client.Update(context.Background(), drpc)
 }
 
-func deleteDRPC(ctx types.Context, cluster util.Cluster, namespace, name string) error {
+func deleteDRPC(ctx types.Context, cluster types.Cluster, namespace, name string) error {
 	log := ctx.Logger()
 
 	objDrpc := &ramen.DRPlacementControl{}

--- a/e2e/dractions/crud.go
+++ b/e2e/dractions/crud.go
@@ -7,15 +7,16 @@ import (
 	"context"
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
-	"github.com/ramendr/ramen/e2e/deployers"
-	"github.com/ramendr/ramen/e2e/types"
-	"github.com/ramendr/ramen/e2e/util"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	"sigs.k8s.io/yaml"
+
+	"github.com/ramendr/ramen/e2e/deployers"
+	"github.com/ramendr/ramen/e2e/types"
+	"github.com/ramendr/ramen/e2e/util"
 )
 
 func updatePlacement(cluster types.Cluster, placement *clusterv1beta1.Placement) error {

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -6,7 +6,6 @@ package dractions
 import (
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 
-	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/deployers"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
@@ -17,16 +16,17 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 	w := ctx.Workload()
 	name := ctx.Name()
 	log := ctx.Logger()
+	config := ctx.Config()
 	managementNamespace := ctx.ManagementNamespace()
 	appNamespace := ctx.AppNamespace()
 
-	drPolicyName := config.GetDRPolicyName()
+	drPolicyName := config.DRPolicy
 	appname := w.GetAppName()
 	placementName := name
 	drpcName := name
 
 	// create mcsb default in ramen-ops ns
-	if err := deployers.CreateManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace); err != nil {
+	if err := deployers.CreateManagedClusterSetBinding(ctx, config.ClusterSet, managementNamespace); err != nil {
 		return err
 	}
 
@@ -67,6 +67,7 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 func DisableProtectionDiscoveredApps(ctx types.Context) error {
 	name := ctx.Name()
 	log := ctx.Logger()
+	config := ctx.Config()
 	managementNamespace := ctx.ManagementNamespace()
 	appNamespace := ctx.AppNamespace()
 
@@ -99,7 +100,7 @@ func DisableProtectionDiscoveredApps(ctx types.Context) error {
 		return err
 	}
 
-	err = deployers.DeleteManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
+	err = deployers.DeleteManagedClusterSetBinding(ctx, config.ClusterSet, managementNamespace)
 	if err != nil {
 		return err
 	}
@@ -118,12 +119,13 @@ func failoverRelocateDiscoveredApps(
 	targetCluster string,
 ) error {
 	name := ctx.Name()
+	config := ctx.Config()
 	managementNamespace := ctx.ManagementNamespace()
 	appNamespace := ctx.AppNamespace()
 
 	drpcName := name
 
-	drPolicyName := config.GetDRPolicyName()
+	drPolicyName := config.DRPolicy
 
 	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, drPolicyName)
 	if err != nil {

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -36,7 +36,7 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 	}
 
 	// create drpc
-	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub, drPolicyName)
+	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, drPolicyName)
 	if err != nil {
 		return err
 	}
@@ -47,12 +47,12 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 
 	drpc := generateDRPCDiscoveredApps(
 		name, managementNamespace, clusterName, drPolicyName, placementName, appname, appNamespace)
-	if err = createDRPC(ctx, util.Ctx.Hub, drpc); err != nil {
+	if err = createDRPC(ctx, drpc); err != nil {
 		return err
 	}
 
 	// wait for drpc ready
-	err = waitDRPCReady(ctx, util.Ctx.Hub, managementNamespace, drpcName)
+	err = waitDRPCReady(ctx, managementNamespace, drpcName)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func DisableProtectionDiscoveredApps(ctx types.Context) error {
 	placementName := name
 	drpcName := name
 
-	clusterName, err := util.GetCurrentCluster(util.Ctx.Hub, managementNamespace, placementName)
+	clusterName, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, placementName)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
@@ -86,11 +86,11 @@ func DisableProtectionDiscoveredApps(ctx types.Context) error {
 			appNamespace, ctx.Workload().GetAppName(), clusterName)
 	}
 
-	if err := deleteDRPC(ctx, util.Ctx.Hub, managementNamespace, drpcName); err != nil {
+	if err := deleteDRPC(ctx, managementNamespace, drpcName); err != nil {
 		return err
 	}
 
-	if err := waitDRPCDeleted(ctx, util.Ctx.Hub, managementNamespace, drpcName); err != nil {
+	if err := waitDRPCDeleted(ctx, managementNamespace, drpcName); err != nil {
 		return err
 	}
 
@@ -125,16 +125,16 @@ func failoverRelocateDiscoveredApps(
 
 	drPolicyName := config.GetDRPolicyName()
 
-	drpolicy, err := util.GetDRPolicy(util.Ctx.Hub, drPolicyName)
+	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, drPolicyName)
 	if err != nil {
 		return err
 	}
 
-	if err := waitAndUpdateDRPC(ctx, util.Ctx.Hub, managementNamespace, drpcName, action, targetCluster); err != nil {
+	if err := waitAndUpdateDRPC(ctx, managementNamespace, drpcName, action, targetCluster); err != nil {
 		return err
 	}
 
-	if err := waitDRPCProgression(ctx, util.Ctx.Hub, managementNamespace, name,
+	if err := waitDRPCProgression(ctx, managementNamespace, name,
 		ramen.ProgressionWaitOnUserToCleanUp); err != nil {
 		return err
 	}
@@ -144,15 +144,15 @@ func failoverRelocateDiscoveredApps(
 		return err
 	}
 
-	if err := waitDRPCPhase(ctx, util.Ctx.Hub, managementNamespace, name, state); err != nil {
+	if err := waitDRPCPhase(ctx, managementNamespace, name, state); err != nil {
 		return err
 	}
 
-	if err := waitDRPCReady(ctx, util.Ctx.Hub, managementNamespace, name); err != nil {
+	if err := waitDRPCReady(ctx, managementNamespace, name); err != nil {
 		return err
 	}
 
-	drCluster := getDRCluster(targetCluster, drpolicy)
+	drCluster := getDRCluster(ctx, targetCluster, drpolicy)
 
 	return deployers.WaitWorkloadHealth(ctx, drCluster, appNamespace)
 }

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -5,6 +5,7 @@ package dractions
 
 import (
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
+
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/deployers"
 	"github.com/ramendr/ramen/e2e/types"

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func waitDRPCReady(ctx types.Context, cluster util.Cluster, namespace string, drpcName string) error {
+func waitDRPCReady(ctx types.Context, cluster types.Cluster, namespace string, drpcName string) error {
 	log := ctx.Logger()
 	startTime := time.Now()
 
@@ -53,7 +53,7 @@ func conditionMet(conditions []metav1.Condition, conditionType string) bool {
 	return condition != nil && condition.Status == "True"
 }
 
-func waitDRPCPhase(ctx types.Context, cluster util.Cluster, namespace, name string, phase ramen.DRState) error {
+func waitDRPCPhase(ctx types.Context, cluster types.Cluster, namespace, name string, phase ramen.DRState) error {
 	log := ctx.Logger()
 	startTime := time.Now()
 
@@ -81,7 +81,7 @@ func waitDRPCPhase(ctx types.Context, cluster util.Cluster, namespace, name stri
 }
 
 // return dr cluster
-func getDRCluster(clusterName string, drpolicy *ramen.DRPolicy) util.Cluster {
+func getDRCluster(clusterName string, drpolicy *ramen.DRPolicy) types.Cluster {
 	if clusterName == drpolicy.Spec.DRClusters[0] {
 		return util.Ctx.C1
 	}
@@ -89,7 +89,7 @@ func getDRCluster(clusterName string, drpolicy *ramen.DRPolicy) util.Cluster {
 	return util.Ctx.C2
 }
 
-func getTargetCluster(cluster util.Cluster, currentCluster string) (string, error) {
+func getTargetCluster(cluster types.Cluster, currentCluster string) (string, error) {
 	drpolicy, err := util.GetDRPolicy(cluster, config.GetDRPolicyName())
 	if err != nil {
 		return "", err
@@ -105,7 +105,7 @@ func getTargetCluster(cluster util.Cluster, currentCluster string) (string, erro
 	return targetCluster, nil
 }
 
-func waitDRPCDeleted(ctx types.Context, cluster util.Cluster, namespace string, name string) error {
+func waitDRPCDeleted(ctx types.Context, cluster types.Cluster, namespace string, name string) error {
 	log := ctx.Logger()
 	startTime := time.Now()
 
@@ -134,7 +134,7 @@ func waitDRPCDeleted(ctx types.Context, cluster util.Cluster, namespace string, 
 // nolint:unparam
 func waitDRPCProgression(
 	ctx types.Context,
-	cluster util.Cluster,
+	cluster types.Cluster,
 	namespace, name string,
 	progression ramen.ProgressionStatus,
 ) error {

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -114,7 +114,7 @@ func waitDRPCDeleted(ctx types.Context, cluster util.Cluster, namespace string, 
 	for {
 		_, err := getDRPC(cluster, namespace, name)
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if k8serrors.IsNotFound(err) {
 				log.Debugf("drpc \"%s/%s\" is deleted in cluster %q", namespace, name, cluster.Name)
 
 				return nil

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -8,12 +8,13 @@ import (
 	"time"
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
-	"github.com/ramendr/ramen/e2e/config"
-	"github.com/ramendr/ramen/e2e/types"
-	"github.com/ramendr/ramen/e2e/util"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ramendr/ramen/e2e/config"
+	"github.com/ramendr/ramen/e2e/types"
+	"github.com/ramendr/ramen/e2e/util"
 )
 
 func waitDRPCReady(ctx types.Context, cluster types.Cluster, namespace string, drpcName string) error {

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 )
@@ -92,8 +91,8 @@ func getDRCluster(ctx types.Context, clusterName string, drpolicy *ramen.DRPolic
 	return ctx.Env().C2
 }
 
-func getTargetCluster(cluster types.Cluster, currentCluster string) (string, error) {
-	drpolicy, err := util.GetDRPolicy(cluster, config.GetDRPolicyName())
+func getTargetCluster(cluster types.Cluster, drPolicyName, currentCluster string) (string, error) {
+	drpolicy, err := util.GetDRPolicy(cluster, drPolicyName)
 	if err != nil {
 		return "", err
 	}

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -23,7 +23,6 @@ import (
 	subscription "open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
 	placementrule "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 
-	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 )
 
@@ -86,42 +85,40 @@ func setupClient(kubeconfigPath string) (client.Client, error) {
 	return client, nil
 }
 
-func New(log *zap.SugaredLogger) (*types.Env, error) {
+func New(config *types.Config, log *zap.SugaredLogger) (*types.Env, error) {
 	var err error
 
 	env := &types.Env{}
 
-	clusters := config.GetClusters()
-
-	env.Hub.Name = clusters["hub"].Name
+	env.Hub.Name = config.Clusters["hub"].Name
 	if env.Hub.Name == "" {
 		env.Hub.Name = defaultHubClusterName
 		log.Infof("Cluster \"hub\" name not set, using default name %q", defaultHubClusterName)
 	}
 
-	env.Hub.Client, err = setupClient(clusters["hub"].KubeconfigPath)
+	env.Hub.Client, err = setupClient(config.Clusters["hub"].KubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clients for hub cluster: %w", err)
 	}
 
-	env.C1.Name = clusters["c1"].Name
+	env.C1.Name = config.Clusters["c1"].Name
 	if env.C1.Name == "" {
 		env.C1.Name = defaultC1ClusterName
 		log.Infof("Cluster \"c1\" name not set, using default name %q", defaultC1ClusterName)
 	}
 
-	env.C1.Client, err = setupClient(clusters["c1"].KubeconfigPath)
+	env.C1.Client, err = setupClient(config.Clusters["c1"].KubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clients for c1 cluster: %w", err)
 	}
 
-	env.C2.Name = clusters["c2"].Name
+	env.C2.Name = config.Clusters["c2"].Name
 	if env.C2.Name == "" {
 		env.C2.Name = defaultC2ClusterName
 		log.Infof("Cluster \"c2\" name not set, using default name %q", defaultC2ClusterName)
 	}
 
-	env.C2.Client, err = setupClient(clusters["c2"].KubeconfigPath)
+	env.C2.Client, err = setupClient(config.Clusters["c2"].KubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clients for c2 cluster: %w", err)
 	}

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: The RamenDR authors
 // SPDX-License-Identifier: Apache-2.0
 
-package util
+package env
 
 import (
 	"fmt"
@@ -26,14 +26,6 @@ import (
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 )
-
-type Context struct {
-	Hub types.Cluster
-	C1  types.Cluster
-	C2  types.Cluster
-}
-
-var Ctx *Context
 
 const (
 	defaultHubClusterName = "hub"
@@ -94,45 +86,45 @@ func setupClient(kubeconfigPath string) (client.Client, error) {
 	return client, nil
 }
 
-func NewContext(log *zap.SugaredLogger) (*Context, error) {
+func New(log *zap.SugaredLogger) (*types.Env, error) {
 	var err error
 
-	ctx := new(Context)
+	env := &types.Env{}
 
 	clusters := config.GetClusters()
 
-	ctx.Hub.Name = clusters["hub"].Name
-	if ctx.Hub.Name == "" {
-		ctx.Hub.Name = defaultHubClusterName
+	env.Hub.Name = clusters["hub"].Name
+	if env.Hub.Name == "" {
+		env.Hub.Name = defaultHubClusterName
 		log.Infof("Cluster \"hub\" name not set, using default name %q", defaultHubClusterName)
 	}
 
-	ctx.Hub.Client, err = setupClient(clusters["hub"].KubeconfigPath)
+	env.Hub.Client, err = setupClient(clusters["hub"].KubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clients for hub cluster: %w", err)
 	}
 
-	ctx.C1.Name = clusters["c1"].Name
-	if ctx.C1.Name == "" {
-		ctx.C1.Name = defaultC1ClusterName
+	env.C1.Name = clusters["c1"].Name
+	if env.C1.Name == "" {
+		env.C1.Name = defaultC1ClusterName
 		log.Infof("Cluster \"c1\" name not set, using default name %q", defaultC1ClusterName)
 	}
 
-	ctx.C1.Client, err = setupClient(clusters["c1"].KubeconfigPath)
+	env.C1.Client, err = setupClient(clusters["c1"].KubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clients for c1 cluster: %w", err)
 	}
 
-	ctx.C2.Name = clusters["c2"].Name
-	if ctx.C2.Name == "" {
-		ctx.C2.Name = defaultC2ClusterName
+	env.C2.Name = clusters["c2"].Name
+	if env.C2.Name == "" {
+		env.C2.Name = defaultC2ClusterName
 		log.Infof("Cluster \"c2\" name not set, using default name %q", defaultC2ClusterName)
 	}
 
-	ctx.C2.Client, err = setupClient(clusters["c2"].KubeconfigPath)
+	env.C2.Client, err = setupClient(clusters["c2"].KubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clients for c2 cluster: %w", err)
 	}
 
-	return ctx, nil
+	return env, nil
 }

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -20,8 +20,9 @@ import (
 )
 
 type Context struct {
-	log *zap.SugaredLogger
-	env *types.Env
+	log    *zap.SugaredLogger
+	env    *types.Env
+	config *types.Config
 }
 
 // The global test context
@@ -53,11 +54,13 @@ func TestMain(m *testing.M) {
 		Deployers: deployers.AvailableNames(),
 		Workloads: workloads.AvailableNames(),
 	}
-	if err := config.ReadConfig(configFile, options); err != nil {
+
+	Ctx.config, err = config.ReadConfig(configFile, options)
+	if err != nil {
 		log.Fatalf("Failed to read config: %s", err)
 	}
 
-	Ctx.env, err = env.New(log)
+	Ctx.env, err = env.New(Ctx.config, Ctx.log)
 	if err != nil {
 		log.Fatalf("Failed to create testing context: %s", err)
 	}

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -8,16 +8,20 @@ import (
 	"os"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/deployers"
+	"github.com/ramendr/ramen/e2e/env"
 	"github.com/ramendr/ramen/e2e/test"
+	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 	"github.com/ramendr/ramen/e2e/workloads"
-	"go.uber.org/zap"
 )
 
 type Context struct {
 	log *zap.SugaredLogger
+	env *types.Env
 }
 
 // The global test context
@@ -53,7 +57,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Failed to read config: %s", err)
 	}
 
-	util.Ctx, err = util.NewContext(log)
+	Ctx.env, err = env.New(log)
 	if err != nil {
 		log.Fatalf("Failed to create testing context: %s", err)
 	}

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -13,7 +13,15 @@ import (
 	"github.com/ramendr/ramen/e2e/test"
 	"github.com/ramendr/ramen/e2e/util"
 	"github.com/ramendr/ramen/e2e/workloads"
+	"go.uber.org/zap"
 )
+
+type Context struct {
+	log *zap.SugaredLogger
+}
+
+// The global test context
+var Ctx Context
 
 func TestMain(m *testing.M) {
 	var (
@@ -26,11 +34,13 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&logFile, "logfile", "ramen-e2e.log", "e2e log file")
 	flag.Parse()
 
-	log, err := test.CreateLogger(logFile)
+	Ctx.log, err = test.CreateLogger(logFile)
 	if err != nil {
 		panic(err)
 	}
 	// TODO: Sync the log on exit
+
+	log := Ctx.log
 
 	log.Infof("Using config file %q", configFile)
 	log.Infof("Using log file %q", logFile)

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -15,19 +15,15 @@ import (
 	"github.com/ramendr/ramen/e2e/workloads"
 )
 
-var (
-	configFile string
-	logFile    string
-)
+func TestMain(m *testing.M) {
+	var (
+		err        error
+		configFile string
+		logFile    string
+	)
 
-func init() {
 	flag.StringVar(&configFile, "config", "config.yaml", "e2e configuration file")
 	flag.StringVar(&logFile, "logfile", "ramen-e2e.log", "e2e log file")
-}
-
-func TestMain(m *testing.M) {
-	var err error
-
 	flag.Parse()
 
 	log, err := test.CreateLogger(logFile)

--- a/e2e/test/context.go
+++ b/e2e/test/context.go
@@ -22,16 +22,18 @@ type Context struct {
 	workload types.Workload
 	deployer types.Deployer
 	name     string
+	env      *types.Env
 	logger   *zap.SugaredLogger
 }
 
-func NewContext(w types.Workload, d types.Deployer, log *zap.SugaredLogger) Context {
+func NewContext(w types.Workload, d types.Deployer, env *types.Env, log *zap.SugaredLogger) Context {
 	name := strings.ToLower(d.GetName() + "-" + w.GetName() + "-" + w.GetAppName())
 
 	return Context{
 		workload: w,
 		deployer: d,
 		name:     name,
+		env:      env,
 		logger:   log.Named(name),
 	}
 }
@@ -62,6 +64,10 @@ func (c *Context) AppNamespace() string {
 
 func (c *Context) Logger() *zap.SugaredLogger {
 	return c.logger
+}
+
+func (c *Context) Env() *types.Env {
+	return c.env
 }
 
 // Validated return an error if the combination of deployer and workload is not supported.

--- a/e2e/test/context.go
+++ b/e2e/test/context.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"github.com/ramendr/ramen/e2e/dractions"
 	"github.com/ramendr/ramen/e2e/types"
-	"go.uber.org/zap"
 )
 
 // Make it easier to manage namespaces created by the tests.

--- a/e2e/test/context.go
+++ b/e2e/test/context.go
@@ -23,10 +23,17 @@ type Context struct {
 	deployer types.Deployer
 	name     string
 	env      *types.Env
+	config   *types.Config
 	logger   *zap.SugaredLogger
 }
 
-func NewContext(w types.Workload, d types.Deployer, env *types.Env, log *zap.SugaredLogger) Context {
+func NewContext(
+	w types.Workload,
+	d types.Deployer,
+	env *types.Env,
+	config *types.Config,
+	log *zap.SugaredLogger,
+) Context {
 	name := strings.ToLower(d.GetName() + "-" + w.GetName() + "-" + w.GetAppName())
 
 	return Context{
@@ -34,6 +41,7 @@ func NewContext(w types.Workload, d types.Deployer, env *types.Env, log *zap.Sug
 		deployer: d,
 		name:     name,
 		env:      env,
+		config:   config,
 		logger:   log.Named(name),
 	}
 }
@@ -51,7 +59,7 @@ func (c *Context) Name() string {
 }
 
 func (c *Context) ManagementNamespace() string {
-	if ns := c.deployer.GetNamespace(); ns != "" {
+	if ns := c.deployer.GetNamespace(c); ns != "" {
 		return ns
 	}
 
@@ -68,6 +76,10 @@ func (c *Context) Logger() *zap.SugaredLogger {
 
 func (c *Context) Env() *types.Env {
 	return c.env
+}
+
+func (c *Context) Config() *types.Config {
+	return c.config
 }
 
 // Validated return an error if the combination of deployer and workload is not supported.

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -14,6 +14,12 @@ type Cluster struct {
 	Client client.Client
 }
 
+type Env struct {
+	Hub Cluster
+	C1  Cluster
+	C2  Cluster
+}
+
 // Deployer interface has methods to deploy a workload to a cluster
 type Deployer interface {
 	Deploy(Context) error
@@ -55,4 +61,5 @@ type Context interface {
 	AppNamespace() string
 
 	Logger() *zap.SugaredLogger
+	Env() *Env
 }

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -4,9 +4,15 @@
 package types
 
 import (
-	"github.com/ramendr/ramen/e2e/util"
 	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// Clsuter can be a hub cluster or a managed cluster.
+type Cluster struct {
+	Name   string
+	Client client.Client
+}
 
 // Deployer interface has methods to deploy a workload to a cluster
 type Deployer interface {
@@ -31,7 +37,7 @@ type Workload interface {
 	// SupportsDeployer returns tue if this workload is compatible with deployer.
 	SupportsDeployer(Deployer) bool
 
-	Health(ctx Context, cluster util.Cluster, namespace string) error
+	Health(ctx Context, cluster Cluster, namespace string) error
 }
 
 // Context combines workload, deployer and logger used in the content of one test.

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -81,7 +81,7 @@ type Deployer interface {
 	Undeploy(Context) error
 	GetName() string
 	// GetNamespace return the namespace for the ramen resources, or empty string if not using a special namespace.
-	GetNamespace() string
+	GetNamespace(Context) string
 	// Return true for OCM discovered application, false for OCM managed applications.
 	IsDiscovered() bool
 }
@@ -117,4 +117,5 @@ type Context interface {
 
 	Logger() *zap.SugaredLogger
 	Env() *Env
+	Config() *Config
 }

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -8,6 +8,61 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ChannelConfig defines the name and namespace for the channel CR.
+// This is not user-configurable and always uses default values.
+type ChannelConfig struct {
+	Name      string
+	Namespace string
+}
+
+// NamespacesConfig are determined by distro and are not user-configurable.
+type NamespacesConfig struct {
+	RamenHubNamespace       string
+	RamenDRClusterNamespace string
+	RamenOpsNamespace       string
+	ArgocdNamespace         string
+}
+
+// RepoConfig represents the user-configurable git repository settings.
+// It includes the repository url and branch to be used for deploying workload.
+type RepoConfig struct {
+	URL    string
+	Branch string
+}
+
+type PVCSpecConfig struct {
+	Name                 string
+	StorageClassName     string
+	AccessModes          string
+	UnsupportedDeployers []string
+}
+
+type ClusterConfig struct {
+	Name           string
+	KubeconfigPath string
+}
+
+type TestConfig struct {
+	Workload string
+	Deployer string
+	PVCSpec  string
+}
+
+type Config struct {
+	// User configurable values.
+	Distro     string
+	Repo       RepoConfig
+	DRPolicy   string
+	ClusterSet string
+	Clusters   map[string]ClusterConfig
+	PVCSpecs   []PVCSpecConfig
+	Tests      []TestConfig
+
+	// Generated values
+	Channel    ChannelConfig
+	Namespaces NamespacesConfig
+}
+
 // Clsuter can be a hub cluster or a managed cluster.
 type Cluster struct {
 	Name   string

--- a/e2e/util/channel.go
+++ b/e2e/util/channel.go
@@ -6,12 +6,12 @@ package util
 import (
 	"context"
 
-	"github.com/ramendr/ramen/e2e/config"
 	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	channelv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
+
+	"github.com/ramendr/ramen/e2e/config"
 )
 
 func EnsureChannel(log *zap.SugaredLogger) error {

--- a/e2e/util/channel.go
+++ b/e2e/util/channel.go
@@ -12,27 +12,28 @@ import (
 	channelv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 
 	"github.com/ramendr/ramen/e2e/config"
+	"github.com/ramendr/ramen/e2e/types"
 )
 
-func EnsureChannel(log *zap.SugaredLogger) error {
+func EnsureChannel(hub types.Cluster, log *zap.SugaredLogger) error {
 	// create channel namespace
-	err := CreateNamespace(Ctx.Hub, config.GetChannelNamespace(), log)
+	err := CreateNamespace(hub, config.GetChannelNamespace(), log)
 	if err != nil {
 		return err
 	}
 
-	return createChannel(log)
+	return createChannel(hub, log)
 }
 
-func EnsureChannelDeleted(log *zap.SugaredLogger) error {
-	if err := deleteChannel(log); err != nil {
+func EnsureChannelDeleted(hub types.Cluster, log *zap.SugaredLogger) error {
+	if err := deleteChannel(hub, log); err != nil {
 		return err
 	}
 
-	return DeleteNamespace(Ctx.Hub, config.GetChannelNamespace(), log)
+	return DeleteNamespace(hub, config.GetChannelNamespace(), log)
 }
 
-func createChannel(log *zap.SugaredLogger) error {
+func createChannel(hub types.Cluster, log *zap.SugaredLogger) error {
 	objChannel := &channelv1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.GetChannelName(),
@@ -44,23 +45,23 @@ func createChannel(log *zap.SugaredLogger) error {
 		},
 	}
 
-	err := Ctx.Hub.Client.Create(context.Background(), objChannel)
+	err := hub.Client.Create(context.Background(), objChannel)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
 		}
 
 		log.Debugf("Channel \"%s/%s\" already exists in cluster %q",
-			config.GetChannelNamespace(), config.GetChannelName(), Ctx.Hub.Name)
+			config.GetChannelNamespace(), config.GetChannelName(), hub.Name)
 	} else {
 		log.Infof("Created channel \"%s/%s\" in cluster %q",
-			config.GetChannelNamespace(), config.GetChannelName(), Ctx.Hub.Name)
+			config.GetChannelNamespace(), config.GetChannelName(), hub.Name)
 	}
 
 	return nil
 }
 
-func deleteChannel(log *zap.SugaredLogger) error {
+func deleteChannel(hub types.Cluster, log *zap.SugaredLogger) error {
 	channel := &channelv1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.GetChannelName(),
@@ -68,17 +69,17 @@ func deleteChannel(log *zap.SugaredLogger) error {
 		},
 	}
 
-	err := Ctx.Hub.Client.Delete(context.Background(), channel)
+	err := hub.Client.Delete(context.Background(), channel)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 
 		log.Debugf("Channel \"%s/%s\" not found in cluster %q",
-			config.GetChannelNamespace(), config.GetChannelName(), Ctx.Hub.Name)
+			config.GetChannelNamespace(), config.GetChannelName(), hub.Name)
 	} else {
 		log.Infof("Deleted channel \"%s/%s\" in cluster %q",
-			config.GetChannelNamespace(), config.GetChannelName(), Ctx.Hub.Name)
+			config.GetChannelNamespace(), config.GetChannelName(), hub.Name)
 	}
 
 	return nil

--- a/e2e/util/channel.go
+++ b/e2e/util/channel.go
@@ -7,31 +7,32 @@ import (
 	"context"
 
 	"github.com/ramendr/ramen/e2e/config"
+	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	channelv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 )
 
-func EnsureChannel() error {
+func EnsureChannel(log *zap.SugaredLogger) error {
 	// create channel namespace
-	err := CreateNamespace(Ctx.Hub, config.GetChannelNamespace(), Ctx.Log)
+	err := CreateNamespace(Ctx.Hub, config.GetChannelNamespace(), log)
 	if err != nil {
 		return err
 	}
 
-	return createChannel()
+	return createChannel(log)
 }
 
-func EnsureChannelDeleted() error {
-	if err := deleteChannel(); err != nil {
+func EnsureChannelDeleted(log *zap.SugaredLogger) error {
+	if err := deleteChannel(log); err != nil {
 		return err
 	}
 
-	return DeleteNamespace(Ctx.Hub, config.GetChannelNamespace(), Ctx.Log)
+	return DeleteNamespace(Ctx.Hub, config.GetChannelNamespace(), log)
 }
 
-func createChannel() error {
+func createChannel(log *zap.SugaredLogger) error {
 	objChannel := &channelv1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.GetChannelName(),
@@ -49,17 +50,17 @@ func createChannel() error {
 			return err
 		}
 
-		Ctx.Log.Debugf("Channel \"%s/%s\" already exists in cluster %q",
+		log.Debugf("Channel \"%s/%s\" already exists in cluster %q",
 			config.GetChannelNamespace(), config.GetChannelName(), Ctx.Hub.Name)
 	} else {
-		Ctx.Log.Infof("Created channel \"%s/%s\" in cluster %q",
+		log.Infof("Created channel \"%s/%s\" in cluster %q",
 			config.GetChannelNamespace(), config.GetChannelName(), Ctx.Hub.Name)
 	}
 
 	return nil
 }
 
-func deleteChannel() error {
+func deleteChannel(log *zap.SugaredLogger) error {
 	channel := &channelv1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.GetChannelName(),
@@ -73,10 +74,10 @@ func deleteChannel() error {
 			return err
 		}
 
-		Ctx.Log.Debugf("Channel \"%s/%s\" not found in cluster %q",
+		log.Debugf("Channel \"%s/%s\" not found in cluster %q",
 			config.GetChannelNamespace(), config.GetChannelName(), Ctx.Hub.Name)
 	} else {
-		Ctx.Log.Infof("Deleted channel \"%s/%s\" in cluster %q",
+		log.Infof("Deleted channel \"%s/%s\" in cluster %q",
 			config.GetChannelNamespace(), config.GetChannelName(), Ctx.Hub.Name)
 	}
 

--- a/e2e/util/channel.go
+++ b/e2e/util/channel.go
@@ -11,36 +11,35 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	channelv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
 
-	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 )
 
-func EnsureChannel(hub types.Cluster, log *zap.SugaredLogger) error {
+func EnsureChannel(hub types.Cluster, config *types.Config, log *zap.SugaredLogger) error {
 	// create channel namespace
-	err := CreateNamespace(hub, config.GetChannelNamespace(), log)
+	err := CreateNamespace(hub, config.Channel.Namespace, log)
 	if err != nil {
 		return err
 	}
 
-	return createChannel(hub, log)
+	return createChannel(hub, config, log)
 }
 
-func EnsureChannelDeleted(hub types.Cluster, log *zap.SugaredLogger) error {
-	if err := deleteChannel(hub, log); err != nil {
+func EnsureChannelDeleted(hub types.Cluster, config *types.Config, log *zap.SugaredLogger) error {
+	if err := deleteChannel(hub, config, log); err != nil {
 		return err
 	}
 
-	return DeleteNamespace(hub, config.GetChannelNamespace(), log)
+	return DeleteNamespace(hub, config.Channel.Namespace, log)
 }
 
-func createChannel(hub types.Cluster, log *zap.SugaredLogger) error {
+func createChannel(hub types.Cluster, config *types.Config, log *zap.SugaredLogger) error {
 	objChannel := &channelv1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.GetChannelName(),
-			Namespace: config.GetChannelNamespace(),
+			Name:      config.Channel.Name,
+			Namespace: config.Channel.Namespace,
 		},
 		Spec: channelv1.ChannelSpec{
-			Pathname: config.GetGitURL(),
+			Pathname: config.Repo.URL,
 			Type:     channelv1.ChannelTypeGitHub,
 		},
 	}
@@ -52,20 +51,20 @@ func createChannel(hub types.Cluster, log *zap.SugaredLogger) error {
 		}
 
 		log.Debugf("Channel \"%s/%s\" already exists in cluster %q",
-			config.GetChannelNamespace(), config.GetChannelName(), hub.Name)
+			config.Channel.Namespace, config.Channel.Name, hub.Name)
 	} else {
 		log.Infof("Created channel \"%s/%s\" in cluster %q",
-			config.GetChannelNamespace(), config.GetChannelName(), hub.Name)
+			config.Channel.Namespace, config.Channel.Name, hub.Name)
 	}
 
 	return nil
 }
 
-func deleteChannel(hub types.Cluster, log *zap.SugaredLogger) error {
+func deleteChannel(hub types.Cluster, config *types.Config, log *zap.SugaredLogger) error {
 	channel := &channelv1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      config.GetChannelName(),
-			Namespace: config.GetChannelNamespace(),
+			Name:      config.Channel.Name,
+			Namespace: config.Channel.Namespace,
 		},
 	}
 
@@ -76,10 +75,10 @@ func deleteChannel(hub types.Cluster, log *zap.SugaredLogger) error {
 		}
 
 		log.Debugf("Channel \"%s/%s\" not found in cluster %q",
-			config.GetChannelNamespace(), config.GetChannelName(), hub.Name)
+			config.Channel.Namespace, config.Channel.Name, hub.Name)
 	} else {
 		log.Infof("Deleted channel \"%s/%s\" in cluster %q",
-			config.GetChannelNamespace(), config.GetChannelName(), hub.Name)
+			config.Channel.Namespace, config.Channel.Name, hub.Name)
 	}
 
 	return nil

--- a/e2e/util/channel.go
+++ b/e2e/util/channel.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/ramendr/ramen/e2e/config"
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	channelv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
@@ -46,7 +46,7 @@ func createChannel(log *zap.SugaredLogger) error {
 
 	err := Ctx.Hub.Client.Create(context.Background(), objChannel)
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
+		if !k8serrors.IsAlreadyExists(err) {
 			return err
 		}
 
@@ -70,7 +70,7 @@ func deleteChannel(log *zap.SugaredLogger) error {
 
 	err := Ctx.Hub.Client.Delete(context.Background(), channel)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 

--- a/e2e/util/context.go
+++ b/e2e/util/context.go
@@ -31,7 +31,6 @@ type Cluster struct {
 }
 
 type Context struct {
-	Log *zap.SugaredLogger
 	Hub Cluster
 	C1  Cluster
 	C2  Cluster
@@ -102,7 +101,6 @@ func NewContext(log *zap.SugaredLogger) (*Context, error) {
 	var err error
 
 	ctx := new(Context)
-	ctx.Log = log
 
 	clusters := config.GetClusters()
 

--- a/e2e/util/context.go
+++ b/e2e/util/context.go
@@ -20,20 +20,17 @@ import (
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	argocdv1alpha1hack "github.com/ramendr/ramen/e2e/argocd"
-	"github.com/ramendr/ramen/e2e/config"
 	subscription "open-cluster-management.io/multicloud-operators-subscription/pkg/apis"
 	placementrule "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
+
+	"github.com/ramendr/ramen/e2e/config"
+	"github.com/ramendr/ramen/e2e/types"
 )
 
-type Cluster struct {
-	Name   string
-	Client client.Client
-}
-
 type Context struct {
-	Hub Cluster
-	C1  Cluster
-	C2  Cluster
+	Hub types.Cluster
+	C1  types.Cluster
+	C2  types.Cluster
 }
 
 var Ctx *Context

--- a/e2e/util/drpolicy.go
+++ b/e2e/util/drpolicy.go
@@ -7,13 +7,13 @@ import (
 	"context"
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
-	"k8s.io/apimachinery/pkg/types"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 )
 
 // nolint:unparam
 func GetDRPolicy(cluster Cluster, name string) (*ramen.DRPolicy, error) {
 	drpolicy := &ramen.DRPolicy{}
-	key := types.NamespacedName{Name: name}
+	key := k8stypes.NamespacedName{Name: name}
 
 	err := cluster.Client.Get(context.Background(), key, drpolicy)
 	if err != nil {

--- a/e2e/util/drpolicy.go
+++ b/e2e/util/drpolicy.go
@@ -8,10 +8,12 @@ import (
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/ramendr/ramen/e2e/types"
 )
 
 // nolint:unparam
-func GetDRPolicy(cluster Cluster, name string) (*ramen.DRPolicy, error) {
+func GetDRPolicy(cluster types.Cluster, name string) (*ramen.DRPolicy, error) {
 	drpolicy := &ramen.DRPolicy{}
 	key := k8stypes.NamespacedName{Name: name}
 

--- a/e2e/util/namespace.go
+++ b/e2e/util/namespace.go
@@ -87,20 +87,20 @@ func DeleteNamespace(cluster types.Cluster, namespace string, log *zap.SugaredLo
 // Problem: currently we must manually add an annotation to application’s namespace to make volsync work.
 // See this link https://volsync.readthedocs.io/en/stable/usage/permissionmodel.html#controlling-mover-permissions
 // Workaround: create ns in both drclusters and add annotation
-func CreateNamespaceAndAddAnnotation(namespace string, log *zap.SugaredLogger) error {
-	if err := CreateNamespace(Ctx.C1, namespace, log); err != nil {
+func CreateNamespaceAndAddAnnotation(env *types.Env, namespace string, log *zap.SugaredLogger) error {
+	if err := CreateNamespace(env.C1, namespace, log); err != nil {
 		return err
 	}
 
-	if err := addNamespaceAnnotationForVolSync(Ctx.C1, namespace, log); err != nil {
+	if err := addNamespaceAnnotationForVolSync(env.C1, namespace, log); err != nil {
 		return err
 	}
 
-	if err := CreateNamespace(Ctx.C2, namespace, log); err != nil {
+	if err := CreateNamespace(env.C2, namespace, log); err != nil {
 		return err
 	}
 
-	return addNamespaceAnnotationForVolSync(Ctx.C2, namespace, log)
+	return addNamespaceAnnotationForVolSync(env.C2, namespace, log)
 }
 
 func addNamespaceAnnotationForVolSync(cluster types.Cluster, namespace string, log *zap.SugaredLogger) error {

--- a/e2e/util/namespace.go
+++ b/e2e/util/namespace.go
@@ -9,18 +9,19 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/ramendr/ramen/e2e/types"
 )
 
 // Namespace annotation for volsync to grant elevated permissions for mover pods
 // More info: https://volsync.readthedocs.io/en/stable/usage/permissionmodel.html#controlling-mover-permissions
 const volsyncPrivilegedMovers = "volsync.backube/privileged-movers"
 
-func CreateNamespace(cluster Cluster, namespace string, log *zap.SugaredLogger) error {
+func CreateNamespace(cluster types.Cluster, namespace string, log *zap.SugaredLogger) error {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
@@ -41,7 +42,7 @@ func CreateNamespace(cluster Cluster, namespace string, log *zap.SugaredLogger) 
 	return nil
 }
 
-func DeleteNamespace(cluster Cluster, namespace string, log *zap.SugaredLogger) error {
+func DeleteNamespace(cluster types.Cluster, namespace string, log *zap.SugaredLogger) error {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
@@ -102,7 +103,7 @@ func CreateNamespaceAndAddAnnotation(namespace string, log *zap.SugaredLogger) e
 	return addNamespaceAnnotationForVolSync(Ctx.C2, namespace, log)
 }
 
-func addNamespaceAnnotationForVolSync(cluster Cluster, namespace string, log *zap.SugaredLogger) error {
+func addNamespaceAnnotationForVolSync(cluster types.Cluster, namespace string, log *zap.SugaredLogger) error {
 	key := k8stypes.NamespacedName{Name: namespace}
 	objNs := &corev1.Namespace{}
 

--- a/e2e/util/namespace.go
+++ b/e2e/util/namespace.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +29,7 @@ func CreateNamespace(cluster Cluster, namespace string, log *zap.SugaredLogger) 
 
 	err := cluster.Client.Create(context.Background(), ns)
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
+		if !k8serrors.IsAlreadyExists(err) {
 			return err
 		}
 
@@ -50,7 +50,7 @@ func DeleteNamespace(cluster Cluster, namespace string, log *zap.SugaredLogger) 
 
 	err := cluster.Client.Delete(context.Background(), ns)
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 
@@ -62,11 +62,11 @@ func DeleteNamespace(cluster Cluster, namespace string, log *zap.SugaredLogger) 
 	log.Debugf("Waiting until namespace %q is deleted in cluster %q", namespace, cluster.Name)
 
 	startTime := time.Now()
-	key := types.NamespacedName{Name: namespace}
+	key := k8stypes.NamespacedName{Name: namespace}
 
 	for {
 		if err := cluster.Client.Get(context.Background(), key, ns); err != nil {
-			if !errors.IsNotFound(err) {
+			if !k8serrors.IsNotFound(err) {
 				return err
 			}
 
@@ -103,7 +103,7 @@ func CreateNamespaceAndAddAnnotation(namespace string, log *zap.SugaredLogger) e
 }
 
 func addNamespaceAnnotationForVolSync(cluster Cluster, namespace string, log *zap.SugaredLogger) error {
-	key := types.NamespacedName{Name: namespace}
+	key := k8stypes.NamespacedName{Name: namespace}
 	objNs := &corev1.Namespace{}
 
 	if err := cluster.Client.Get(context.Background(), key, objNs); err != nil {

--- a/e2e/util/placement.go
+++ b/e2e/util/placement.go
@@ -11,13 +11,15 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"open-cluster-management.io/api/cluster/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ramendr/ramen/e2e/types"
 )
 
 // GetCurrentCluster returns the name of the cluster where the workload is currently placed,
 // based on the PlacementDecision for the given Placement resource.
 // Assumes the PlacementDecision exists with a Decision.
 // Not applicable for discovered apps before enabling protection, as no Placement exists.
-func GetCurrentCluster(cluster Cluster, namespace string, placementName string) (string, error) {
+func GetCurrentCluster(cluster types.Cluster, namespace string, placementName string) (string, error) {
 	placementDecision, err := waitPlacementDecision(cluster, namespace, placementName)
 	if err != nil {
 		return "", err
@@ -26,7 +28,7 @@ func GetCurrentCluster(cluster Cluster, namespace string, placementName string) 
 	return placementDecision.Status.Decisions[0].ClusterName, nil
 }
 
-func GetPlacement(cluster Cluster, namespace, name string) (*v1beta1.Placement, error) {
+func GetPlacement(cluster types.Cluster, namespace, name string) (*v1beta1.Placement, error) {
 	placement := &v1beta1.Placement{}
 	key := k8stypes.NamespacedName{Namespace: namespace, Name: name}
 
@@ -39,7 +41,7 @@ func GetPlacement(cluster Cluster, namespace, name string) (*v1beta1.Placement, 
 }
 
 // waitPlacementDecision waits until we have a placement decision and returns the placement decision object.
-func waitPlacementDecision(cluster Cluster, namespace string, placementName string,
+func waitPlacementDecision(cluster types.Cluster, namespace string, placementName string,
 ) (*v1beta1.PlacementDecision, error) {
 	startTime := time.Now()
 
@@ -66,7 +68,7 @@ func waitPlacementDecision(cluster Cluster, namespace string, placementName stri
 	}
 }
 
-func getPlacementDecisionFromPlacement(cluster Cluster, placement *v1beta1.Placement,
+func getPlacementDecisionFromPlacement(cluster types.Cluster, placement *v1beta1.Placement,
 ) (*v1beta1.PlacementDecision, error) {
 	matchLabels := map[string]string{
 		v1beta1.PlacementLabel: placement.GetName(),

--- a/e2e/util/validation.go
+++ b/e2e/util/validation.go
@@ -16,15 +16,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 )
 
-func ValidateRamenHubOperator(cluster types.Cluster, log *zap.SugaredLogger) error {
+func ValidateRamenHubOperator(cluster types.Cluster, config *types.Config, log *zap.SugaredLogger) error {
 	labelSelector := "app=ramen-hub"
 	podIdentifier := "ramen-hub-operator"
 
-	pod, err := FindPod(cluster, config.GetNamespaces().RamenHubNamespace, labelSelector, podIdentifier)
+	pod, err := FindPod(cluster, config.Namespaces.RamenHubNamespace, labelSelector, podIdentifier)
 	if err != nil {
 		return err
 	}
@@ -39,11 +38,11 @@ func ValidateRamenHubOperator(cluster types.Cluster, log *zap.SugaredLogger) err
 	return nil
 }
 
-func ValidateRamenDRClusterOperator(cluster types.Cluster, log *zap.SugaredLogger) error {
+func ValidateRamenDRClusterOperator(cluster types.Cluster, config *types.Config, log *zap.SugaredLogger) error {
 	labelSelector := "app=ramen-dr-cluster"
 	podIdentifier := "ramen-dr-cluster-operator"
 
-	pod, err := FindPod(cluster, config.GetNamespaces().RamenDRClusterNamespace, labelSelector, podIdentifier)
+	pod, err := FindPod(cluster, config.Namespaces.RamenDRClusterNamespace, labelSelector, podIdentifier)
 	if err != nil {
 		return err
 	}

--- a/e2e/util/validation.go
+++ b/e2e/util/validation.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ramendr/ramen/e2e/config"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -16,9 +15,12 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ramendr/ramen/e2e/config"
+	"github.com/ramendr/ramen/e2e/types"
 )
 
-func ValidateRamenHubOperator(cluster Cluster, log *zap.SugaredLogger) error {
+func ValidateRamenHubOperator(cluster types.Cluster, log *zap.SugaredLogger) error {
 	labelSelector := "app=ramen-hub"
 	podIdentifier := "ramen-hub-operator"
 
@@ -37,7 +39,7 @@ func ValidateRamenHubOperator(cluster Cluster, log *zap.SugaredLogger) error {
 	return nil
 }
 
-func ValidateRamenDRClusterOperator(cluster Cluster, log *zap.SugaredLogger) error {
+func ValidateRamenDRClusterOperator(cluster types.Cluster, log *zap.SugaredLogger) error {
 	labelSelector := "app=ramen-dr-cluster"
 	podIdentifier := "ramen-dr-cluster-operator"
 
@@ -58,7 +60,7 @@ func ValidateRamenDRClusterOperator(cluster Cluster, log *zap.SugaredLogger) err
 
 // IsOpenShiftCluster checks if the given Kubernetes cluster is an OpenShift cluster.
 // It returns true if the cluster is OpenShift, false otherwise, along with any error encountered.
-func IsOpenShiftCluster(cluster Cluster) (bool, error) {
+func IsOpenShiftCluster(cluster types.Cluster) (bool, error) {
 	configList := &unstructured.Unstructured{}
 	configList.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "config.openshift.io",
@@ -83,7 +85,7 @@ func IsOpenShiftCluster(cluster Cluster) (bool, error) {
 }
 
 // FindPod returns the first pod matching the label selector including the pod identifier in the namespace.
-func FindPod(cluster Cluster, namespace, labelSelector, podIdentifier string) (
+func FindPod(cluster types.Cluster, namespace, labelSelector, podIdentifier string) (
 	*v1.Pod, error,
 ) {
 	ls, err := labels.Parse(labelSelector)

--- a/e2e/util/validation.go
+++ b/e2e/util/validation.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/ramendr/ramen/e2e/config"
+	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -17,7 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func ValidateRamenHubOperator(cluster Cluster) error {
+func ValidateRamenHubOperator(cluster Cluster, log *zap.SugaredLogger) error {
 	labelSelector := "app=ramen-hub"
 	podIdentifier := "ramen-hub-operator"
 
@@ -31,12 +32,12 @@ func ValidateRamenHubOperator(cluster Cluster) error {
 			pod.Name, pod.Status.Phase, cluster.Name)
 	}
 
-	Ctx.Log.Infof("Ramen hub operator pod %q is running in cluster %q", pod.Name, cluster.Name)
+	log.Infof("Ramen hub operator pod %q is running in cluster %q", pod.Name, cluster.Name)
 
 	return nil
 }
 
-func ValidateRamenDRClusterOperator(cluster Cluster) error {
+func ValidateRamenDRClusterOperator(cluster Cluster, log *zap.SugaredLogger) error {
 	labelSelector := "app=ramen-dr-cluster"
 	podIdentifier := "ramen-dr-cluster-operator"
 
@@ -50,7 +51,7 @@ func ValidateRamenDRClusterOperator(cluster Cluster) error {
 			pod.Name, pod.Status.Phase, cluster.Name)
 	}
 
-	Ctx.Log.Infof("Ramen dr cluster operator pod %q is running in cluster %q", pod.Name, cluster.Name)
+	log.Infof("Ramen dr cluster operator pod %q is running in cluster %q", pod.Name, cluster.Name)
 
 	return nil
 }

--- a/e2e/validation_test.go
+++ b/e2e/validation_test.go
@@ -18,7 +18,7 @@ func TestValidation(dt *testing.T) {
 		t := test.WithLog(dt, Ctx.log)
 		t.Parallel()
 
-		err := util.ValidateRamenHubOperator(Ctx.env.Hub, Ctx.log)
+		err := util.ValidateRamenHubOperator(Ctx.env.Hub, Ctx.config, Ctx.log)
 		if err != nil {
 			t.Fatalf("Failed to validate hub cluster %q: %s", Ctx.env.Hub.Name, err)
 		}
@@ -27,7 +27,7 @@ func TestValidation(dt *testing.T) {
 		t := test.WithLog(dt, Ctx.log)
 		t.Parallel()
 
-		err := util.ValidateRamenDRClusterOperator(Ctx.env.C1, Ctx.log)
+		err := util.ValidateRamenDRClusterOperator(Ctx.env.C1, Ctx.config, Ctx.log)
 		if err != nil {
 			t.Fatalf("Failed to validate dr cluster %q: %s", Ctx.env.C1.Name, err)
 		}
@@ -36,7 +36,7 @@ func TestValidation(dt *testing.T) {
 		t := test.WithLog(dt, Ctx.log)
 		t.Parallel()
 
-		err := util.ValidateRamenDRClusterOperator(Ctx.env.C2, Ctx.log)
+		err := util.ValidateRamenDRClusterOperator(Ctx.env.C2, Ctx.config, Ctx.log)
 		if err != nil {
 			t.Fatalf("Failed to validate dr cluster %q: %s", Ctx.env.C2.Name, err)
 		}

--- a/e2e/validation_test.go
+++ b/e2e/validation_test.go
@@ -18,27 +18,27 @@ func TestValidation(dt *testing.T) {
 		t := test.WithLog(dt, Ctx.log)
 		t.Parallel()
 
-		err := util.ValidateRamenHubOperator(util.Ctx.Hub, Ctx.log)
+		err := util.ValidateRamenHubOperator(Ctx.env.Hub, Ctx.log)
 		if err != nil {
-			t.Fatalf("Failed to validate hub cluster %q: %s", util.Ctx.Hub.Name, err)
+			t.Fatalf("Failed to validate hub cluster %q: %s", Ctx.env.Hub.Name, err)
 		}
 	})
 	t.Run("c1", func(dt *testing.T) {
 		t := test.WithLog(dt, Ctx.log)
 		t.Parallel()
 
-		err := util.ValidateRamenDRClusterOperator(util.Ctx.C1, Ctx.log)
+		err := util.ValidateRamenDRClusterOperator(Ctx.env.C1, Ctx.log)
 		if err != nil {
-			t.Fatalf("Failed to validate dr cluster %q: %s", util.Ctx.C1.Name, err)
+			t.Fatalf("Failed to validate dr cluster %q: %s", Ctx.env.C1.Name, err)
 		}
 	})
 	t.Run("c2", func(dt *testing.T) {
 		t := test.WithLog(dt, Ctx.log)
 		t.Parallel()
 
-		err := util.ValidateRamenDRClusterOperator(util.Ctx.C2, Ctx.log)
+		err := util.ValidateRamenDRClusterOperator(Ctx.env.C2, Ctx.log)
 		if err != nil {
-			t.Fatalf("Failed to validate dr cluster %q: %s", util.Ctx.C2.Name, err)
+			t.Fatalf("Failed to validate dr cluster %q: %s", Ctx.env.C2.Name, err)
 		}
 	})
 }

--- a/e2e/validation_test.go
+++ b/e2e/validation_test.go
@@ -11,32 +11,32 @@ import (
 )
 
 func TestValidation(dt *testing.T) {
-	t := test.WithLog(dt, util.Ctx.Log)
+	t := test.WithLog(dt, Ctx.log)
 	t.Parallel()
 
 	t.Run("hub", func(dt *testing.T) {
-		t := test.WithLog(dt, util.Ctx.Log)
+		t := test.WithLog(dt, Ctx.log)
 		t.Parallel()
 
-		err := util.ValidateRamenHubOperator(util.Ctx.Hub)
+		err := util.ValidateRamenHubOperator(util.Ctx.Hub, Ctx.log)
 		if err != nil {
 			t.Fatalf("Failed to validate hub cluster %q: %s", util.Ctx.Hub.Name, err)
 		}
 	})
 	t.Run("c1", func(dt *testing.T) {
-		t := test.WithLog(dt, util.Ctx.Log)
+		t := test.WithLog(dt, Ctx.log)
 		t.Parallel()
 
-		err := util.ValidateRamenDRClusterOperator(util.Ctx.C1)
+		err := util.ValidateRamenDRClusterOperator(util.Ctx.C1, Ctx.log)
 		if err != nil {
 			t.Fatalf("Failed to validate dr cluster %q: %s", util.Ctx.C1.Name, err)
 		}
 	})
 	t.Run("c2", func(dt *testing.T) {
-		t := test.WithLog(dt, util.Ctx.Log)
+		t := test.WithLog(dt, Ctx.log)
 		t.Parallel()
 
-		err := util.ValidateRamenDRClusterOperator(util.Ctx.C2)
+		err := util.ValidateRamenDRClusterOperator(util.Ctx.C2, Ctx.log)
 		if err != nil {
 			t.Fatalf("Failed to validate dr cluster %q: %s", util.Ctx.C2.Name, err)
 		}

--- a/e2e/workloads/deploy.go
+++ b/e2e/workloads/deploy.go
@@ -9,10 +9,11 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/ramendr/ramen/e2e/config"
-	"github.com/ramendr/ramen/e2e/types"
 	appsv1 "k8s.io/api/apps/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/ramendr/ramen/e2e/config"
+	"github.com/ramendr/ramen/e2e/types"
 )
 
 const (

--- a/e2e/workloads/deploy.go
+++ b/e2e/workloads/deploy.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
-	"github.com/ramendr/ramen/e2e/util"
 	appsv1 "k8s.io/api/apps/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 )
@@ -91,7 +90,7 @@ func (w Deployment) GetResources() error {
 }
 
 // Check the workload health deployed in a cluster namespace
-func (w Deployment) Health(ctx types.Context, cluster util.Cluster, namespace string) error {
+func (w Deployment) Health(ctx types.Context, cluster types.Cluster, namespace string) error {
 	log := ctx.Logger()
 
 	deploy, err := getDeployment(cluster, namespace, w.GetAppName())
@@ -108,7 +107,7 @@ func (w Deployment) Health(ctx types.Context, cluster util.Cluster, namespace st
 	return nil
 }
 
-func getDeployment(cluster util.Cluster, namespace, name string) (*appsv1.Deployment, error) {
+func getDeployment(cluster types.Cluster, namespace, name string) (*appsv1.Deployment, error) {
 	deploy := &appsv1.Deployment{}
 	key := k8stypes.NamespacedName{Name: name, Namespace: namespace}
 

--- a/e2e/workloads/deploy.go
+++ b/e2e/workloads/deploy.go
@@ -12,7 +12,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
-	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 )
 
@@ -25,10 +24,10 @@ const (
 type Deployment struct {
 	Name    string
 	Branch  string
-	PVCSpec config.PVCSpec
+	PVCSpec types.PVCSpecConfig
 }
 
-func NewDeployment(branch string, pvcSpec config.PVCSpec) types.Workload {
+func NewDeployment(branch string, pvcSpec types.PVCSpecConfig) types.Workload {
 	return &Deployment{
 		Name:    fmt.Sprintf("%s-%s", deploymentName, pvcSpec.Name),
 		Branch:  branch,

--- a/e2e/workloads/workloads.go
+++ b/e2e/workloads/workloads.go
@@ -6,17 +6,16 @@ package workloads
 import (
 	"fmt"
 
-	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 )
 
-type factory func(revision string, pvcSpec config.PVCSpec) types.Workload
+type factory func(revision string, pvcSpec types.PVCSpecConfig) types.Workload
 
 var registry = map[string]factory{
 	deploymentName: NewDeployment,
 }
 
-func New(name, branch string, pvcSpec config.PVCSpec) (types.Workload, error) {
+func New(name, branch string, pvcSpec types.PVCSpecConfig) (types.Workload, error) {
 	fac := registry[name]
 	if fac == nil {
 		return nil, fmt.Errorf("unknown deployment: %q (choose from %q)", name, AvailableNames())


### PR DESCRIPTION
Currently the config is stored in the config package, and accessed using package accessors. This is needed since we don't have a way to pass the config from TestMain() to other tests, but it does not work for ramenctl, that want to parse the config and pass it as parameter.

Currently we access the clusters via utils.Ctx global. This will not work for ramenctl that need to create the clusters for all commands and pass them as parameters.

Currently we access the main logger via utils.Ctx global. This wil not work for ramenctl that need to create a logger and pass it to the test context.

Changes:

- [x] Keep the main logger in test package global. The test pass the log the log to the test context or to utils functions that need the main logger.

- [x] Extract e2e/env package providing the Env type, holding the clusters. We create an Env in TestMain() and pass it to the test using test package global. Tests pass the env to the test context. e2e code access the cluster via the context.

- [x] config.ReadConfig() returns a config object. The config is passed to the tests using test package global. The tests will pass the config to the text context, and all e2e code access the config via the context.

In ramenctl we will create a Config and Env and pass them as parameters.

Example ramenctl usage:
https://github.com/RamenDR/ramenctl/pull/33