### PR TITLE
e2e: Rename kubeconfigpath to kubeconfig

### DIFF
--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -57,10 +57,10 @@ tests:
 # clusters:
 #   hub:
 #     name: hub
-#     kubeconfigpath: /path/to/kubeconfig/hub
+#     kubeconfig: hub/config
 #   c1:
 #     name: dr1
-#     kubeconfigpath: /path/to/kubeconfig/dr1
+#     kubeconfig: dr1/config
 #   c2:
 #     name: dr2
-#     kubeconfigpath: /path/to/kubeconfig/dr2
+#     kubeconfig: dr2/config

--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -54,7 +54,7 @@ tests:
 # Sample cluster configurations:
 # Uncomment and edit the following lines to set cluster names
 # and their kubeconfig paths for the hub and managed clusters.
-# Clusters:
+# clusters:
 #   hub:
 #     name: hub
 #     kubeconfigpath: /path/to/kubeconfig/hub

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -120,15 +120,15 @@ func validateDistro(config *types.Config) error {
 }
 
 func validateClusters(config *types.Config) error {
-	if config.Clusters["hub"].KubeconfigPath == "" {
+	if config.Clusters["hub"].Kubeconfig == "" {
 		return fmt.Errorf("failed to find hub cluster in configuration")
 	}
 
-	if config.Clusters["c1"].KubeconfigPath == "" {
+	if config.Clusters["c1"].Kubeconfig == "" {
 		return fmt.Errorf("failed to find c1 cluster in configuration")
 	}
 
-	if config.Clusters["c2"].KubeconfigPath == "" {
+	if config.Clusters["c2"].Kubeconfig == "" {
 		return fmt.Errorf("failed to find c2 cluster in configuration")
 	}
 

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -96,7 +96,7 @@ func New(config *types.Config, log *zap.SugaredLogger) (*types.Env, error) {
 		log.Infof("Cluster \"hub\" name not set, using default name %q", defaultHubClusterName)
 	}
 
-	env.Hub.Client, err = setupClient(config.Clusters["hub"].KubeconfigPath)
+	env.Hub.Client, err = setupClient(config.Clusters["hub"].Kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clients for hub cluster: %w", err)
 	}
@@ -107,7 +107,7 @@ func New(config *types.Config, log *zap.SugaredLogger) (*types.Env, error) {
 		log.Infof("Cluster \"c1\" name not set, using default name %q", defaultC1ClusterName)
 	}
 
-	env.C1.Client, err = setupClient(config.Clusters["c1"].KubeconfigPath)
+	env.C1.Client, err = setupClient(config.Clusters["c1"].Kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clients for c1 cluster: %w", err)
 	}
@@ -118,7 +118,7 @@ func New(config *types.Config, log *zap.SugaredLogger) (*types.Env, error) {
 		log.Infof("Cluster \"c2\" name not set, using default name %q", defaultC2ClusterName)
 	}
 
-	env.C2.Client, err = setupClient(config.Clusters["c2"].KubeconfigPath)
+	env.C2.Client, err = setupClient(config.Clusters["c2"].Kubeconfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clients for c2 cluster: %w", err)
 	}

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -38,8 +38,8 @@ type PVCSpecConfig struct {
 }
 
 type ClusterConfig struct {
-	Name           string
-	KubeconfigPath string
+	Name       string
+	Kubeconfig string
 }
 
 type TestConfig struct {

--- a/test/drenv/ramen.py
+++ b/test/drenv/ramen.py
@@ -35,29 +35,29 @@ def dump_e2e_config(env):
     kubeconfigs_dir = os.path.join(base, "kubeconfigs")
     os.makedirs(kubeconfigs_dir, exist_ok=True)
 
-    e2e_config = {"clusters": {}}
-
     # Map e2e cluster names to actual cluster names.
     clusters = zip(
         [env["ramen"]["hub"], *env["ramen"]["clusters"]],
         ["hub", "c1", "c2"],
     )
 
+    e2e_clusters = {}
     for cluster_name, e2e_name in clusters:
         if cluster_name is None:
             continue
 
         # Create standlone config file for this cluster.
         data = kubectl.config("view", "--flatten", "--minify", context=cluster_name)
-        path = os.path.join(kubeconfigs_dir, cluster_name)
-        with open(path, "w") as f:
+        kubeconfig = os.path.join(kubeconfigs_dir, cluster_name)
+        with open(kubeconfig, "w") as f:
             f.write(data)
 
-        e2e_config["clusters"][e2e_name] = {
+        e2e_clusters[e2e_name] = {
             "name": cluster_name,
-            "kubeconfigpath": path,
+            "kubeconfigpath": kubeconfig,
         }
 
+    e2e_config = {"clusters": e2e_clusters}
     path = os.path.join(base, "config.yaml")
     with open(path, "w") as f:
         yaml.dump(e2e_config, f)

--- a/test/drenv/ramen.py
+++ b/test/drenv/ramen.py
@@ -35,7 +35,7 @@ def dump_e2e_config(env):
     kubeconfigs_dir = os.path.join(base, "kubeconfigs")
     os.makedirs(kubeconfigs_dir, exist_ok=True)
 
-    e2e_config = {"Clusters": {}}
+    e2e_config = {"clusters": {}}
 
     # Map e2e cluster names to actual cluster names.
     clusters = zip(
@@ -53,7 +53,7 @@ def dump_e2e_config(env):
         with open(path, "w") as f:
             f.write(data)
 
-        e2e_config["Clusters"][e2e_name] = {
+        e2e_config["clusters"][e2e_name] = {
             "name": cluster_name,
             "kubeconfigpath": path,
         }

--- a/test/drenv/ramen.py
+++ b/test/drenv/ramen.py
@@ -46,7 +46,7 @@ def dump_e2e_config(env):
         if cluster_name is None:
             continue
 
-        # Create standlone config file for this cluster.
+        # Create a self-contained config file for this cluster.
         data = kubectl.config("view", "--flatten", "--minify", context=cluster_name)
         kubeconfig = os.path.join(kubeconfigs_dir, cluster_name)
         with open(kubeconfig, "w") as f:

--- a/test/drenv/ramen.py
+++ b/test/drenv/ramen.py
@@ -54,7 +54,7 @@ def dump_e2e_config(env):
 
         e2e_clusters[e2e_name] = {
             "name": cluster_name,
-            "kubeconfigpath": kubeconfig,
+            "kubeconfig": kubeconfig,
         }
 
     e2e_config = {"clusters": e2e_clusters}


### PR DESCRIPTION
Use the common term when referring to kubeconfig file to make it easier
to use and nicer. This is also the documented config format in ramenctl.
    
Also shorten the sample configuration to avoid repeating the term
"kubeconfig" and match the default kubeconfig (~/.kube/config).