### PR TITLE
Update instructions to install subctl to refer to path at HOME

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -64,8 +64,8 @@ environment.
 
    ```
    curl -Ls https://get.submariner.io | bash
-   sudo install .local/bin/subctl /usr/local/bin/
-   rm .local/bin/subctl
+   sudo install ~/.local/bin/subctl /usr/local/bin/
+   rm ~/.local/bin/subctl
    ```
 
    For more info see
@@ -185,8 +185,8 @@ environment.
 
    ```
    curl -Ls https://get.submariner.io | bash
-   sudo install .local/bin/subctl /usr/local/bin/
-   rm .local/bin/subctl
+   sudo install ~/.local/bin/subctl /usr/local/bin/
+   rm ~/.local/bin/subctl
    ```
 
    For more info see


### PR DESCRIPTION
subctl installs its tool in ~/.local/bin/ and the instructions refer to .local/bin which would be correct if pwd is at $HOME.

Change the command to refer the full path, in case it is executed from within another pwd than from $HOME.