### PR TITLE
e2e: Check if mscb deletion is related to flaky runs

### DIFF
--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -98,11 +98,6 @@ func DisableProtectionDiscoveredApps(ctx types.Context) error {
 		return err
 	}
 
-	err = deployers.DeleteManagedClusterSetBinding(ctx, config.GetClusterSetName(), managementNamespace)
-	if err != nil {
-		return err
-	}
-
 	log.Info("Workload unprotected")
 
 	return nil


### PR DESCRIPTION
We don't manage the managedclustersetbinding resource properly. We create a resource for the ramen-ops namespace when enabling protection for a disapp test, and delete it when disabling protection. The resource is used by both tests so deleting it while an app is in the middle of relocate may break the relocate.

Change to never delete the managedclustersetbinding resource to see if this affects the random failures.

The real fix is probably to stop creating this resource and move it to ramendev config step, but lets see first if this is the root cause for the random failures.

We still see the random failure with disapp, so this issue is not the root cause.