### PR TITLE
e2e: add drcluster validation with clusters in DRPolicy

### DIFF
--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -18,20 +18,18 @@ func (a ApplicationSet) Deploy(ctx types.Context) error {
 	config := ctx.Config()
 	managementNamespace := ctx.ManagementNamespace()
 
-	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, config.DRPolicy)
-	if err != nil {
-		return err
-	}
+	// Deploys the application on the first DR cluster (c1).
+	cluster := ctx.Env().C1
 
 	log.Infof("Deploying applicationset app \"%s/%s\" in cluster %q",
-		ctx.AppNamespace(), ctx.Workload().GetAppName(), drpolicy.Spec.DRClusters[0])
+		ctx.AppNamespace(), ctx.Workload().GetAppName(), cluster.Name)
 
-	err = CreateManagedClusterSetBinding(ctx, config.ClusterSet, managementNamespace)
+	err := CreateManagedClusterSetBinding(ctx, config.ClusterSet, managementNamespace)
 	if err != nil {
 		return err
 	}
 
-	err = CreatePlacement(ctx, name, managementNamespace, drpolicy.Spec.DRClusters[0])
+	err = CreatePlacement(ctx, name, managementNamespace, cluster.Name)
 	if err != nil {
 		return err
 	}

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -35,16 +35,14 @@ func (s Subscription) Deploy(ctx types.Context) error {
 	config := ctx.Config()
 	managementNamespace := ctx.ManagementNamespace()
 
-	drpolicy, err := util.GetDRPolicy(ctx.Env().Hub, config.DRPolicy)
-	if err != nil {
-		return err
-	}
+	// Deploys the application on the first DR cluster (c1).
+	cluster := ctx.Env().C1
 
 	log.Infof("Deploying subscription app \"%s/%s\" in cluster %q",
-		ctx.AppNamespace(), ctx.Workload().GetAppName(), drpolicy.Spec.DRClusters[0])
+		ctx.AppNamespace(), ctx.Workload().GetAppName(), cluster.Name)
 
 	// create subscription namespace
-	err = util.CreateNamespace(ctx.Env().Hub, managementNamespace, log)
+	err := util.CreateNamespace(ctx.Env().Hub, managementNamespace, log)
 	if err != nil {
 		return err
 	}
@@ -54,7 +52,7 @@ func (s Subscription) Deploy(ctx types.Context) error {
 		return err
 	}
 
-	err = CreatePlacement(ctx, name, managementNamespace, drpolicy.Spec.DRClusters[0])
+	err = CreatePlacement(ctx, name, managementNamespace, cluster.Name)
 	if err != nil {
 		return err
 	}

--- a/e2e/dr_test.go
+++ b/e2e/dr_test.go
@@ -21,6 +21,10 @@ func TestDR(dt *testing.T) {
 		t.Fatal("No tests found in the configuration file")
 	}
 
+	if err := util.ValidateClustersInDRPolicy(Ctx.env, Ctx.config, Ctx.log); err != nil {
+		t.Fatalf("Failed to validate clusters with DRPolicy: %s", err)
+	}
+
 	if err := util.EnsureChannel(Ctx.env.Hub, Ctx.config, Ctx.log); err != nil {
 		t.Fatalf("Failed to ensure channel: %s", err)
 	}

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -82,15 +82,6 @@ func waitDRPCPhase(ctx types.Context, namespace, name string, phase ramen.DRStat
 	}
 }
 
-// return dr cluster
-func getDRCluster(ctx types.Context, clusterName string, drpolicy *ramen.DRPolicy) types.Cluster {
-	if clusterName == drpolicy.Spec.DRClusters[0] {
-		return ctx.Env().C1
-	}
-
-	return ctx.Env().C2
-}
-
 func getTargetCluster(cluster types.Cluster, drPolicyName, currentCluster string) (string, error) {
 	drpolicy, err := util.GetDRPolicy(cluster, drPolicyName)
 	if err != nil {

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -125,3 +125,18 @@ func New(config *types.Config, log *zap.SugaredLogger) (*types.Env, error) {
 
 	return env, nil
 }
+
+// GetCluster returns the cluster from the env that matches clusterName.
+// If not found, it returns an empty Cluster and an error.
+func GetCluster(env *types.Env, clusterName string) (types.Cluster, error) {
+	switch clusterName {
+	case env.C1.Name:
+		return env.C1, nil
+	case env.C2.Name:
+		return env.C2, nil
+	case env.Hub.Name:
+		return env.Hub, nil
+	default:
+		return types.Cluster{}, fmt.Errorf("cluster %q not found in environment", clusterName)
+	}
+}


### PR DESCRIPTION
Changes:

- Added validation to ensure c1 and c2 exist in DRPolicy before proceeding with tests.
- Replaced drpolicy.Spec.DRClusters[0] with ctx.Env().C1 so that drcluster order in drpolicy.Spec.DRClusters does not matter and we always pick c1 to deploy apps.
- Moved log messages before resource creation in discovered app deployment and protection.

Fixes #1937