### PR TITLE
e2e: add kubeconfig to env and replace with context

### DIFF
--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -414,7 +414,7 @@ func DeleteApplicationSet(ctx types.Context, a ApplicationSet) error {
 	return nil
 }
 
-func DeleteDiscoveredApps(ctx types.Context, namespace, cluster string) error {
+func DeleteDiscoveredApps(ctx types.Context, cluster types.Cluster, namespace string) error {
 	log := ctx.Logger()
 
 	tempDir, err := os.MkdirTemp("", "ramen-")
@@ -430,7 +430,7 @@ func DeleteDiscoveredApps(ctx types.Context, namespace, cluster string) error {
 	}
 
 	cmd := exec.Command("kubectl", "delete", "-k", tempDir, "-n", namespace,
-		"--context", cluster, "--timeout=5m", "--ignore-not-found=true")
+		"--kubeconfig", cluster.Kubeconfig, "--timeout=5m", "--ignore-not-found=true")
 
 	if out, err := cmd.Output(); err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
@@ -441,7 +441,7 @@ func DeleteDiscoveredApps(ctx types.Context, namespace, cluster string) error {
 	}
 
 	log.Debugf("Deleted discovered app \"%s/%s\" in cluster %q",
-		namespace, ctx.Workload().GetAppName(), cluster)
+		namespace, ctx.Workload().GetAppName(), cluster.Name)
 
 	return nil
 }

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -101,6 +101,8 @@ func New(config *types.Config, log *zap.SugaredLogger) (*types.Env, error) {
 		return nil, fmt.Errorf("failed to create clients for hub cluster: %w", err)
 	}
 
+	env.Hub.Kubeconfig = config.Clusters["hub"].Kubeconfig
+
 	env.C1.Name = config.Clusters["c1"].Name
 	if env.C1.Name == "" {
 		env.C1.Name = defaultC1ClusterName
@@ -112,6 +114,8 @@ func New(config *types.Config, log *zap.SugaredLogger) (*types.Env, error) {
 		return nil, fmt.Errorf("failed to create clients for c1 cluster: %w", err)
 	}
 
+	env.C1.Kubeconfig = config.Clusters["c1"].Kubeconfig
+
 	env.C2.Name = config.Clusters["c2"].Name
 	if env.C2.Name == "" {
 		env.C2.Name = defaultC2ClusterName
@@ -122,6 +126,8 @@ func New(config *types.Config, log *zap.SugaredLogger) (*types.Env, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create clients for c2 cluster: %w", err)
 	}
+
+	env.C2.Kubeconfig = config.Clusters["c2"].Kubeconfig
 
 	return env, nil
 }

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -65,8 +65,9 @@ type Config struct {
 
 // Clsuter can be a hub cluster or a managed cluster.
 type Cluster struct {
-	Name   string
-	Client client.Client
+	Name       string
+	Client     client.Client
+	Kubeconfig string
 }
 
 type Env struct {


### PR DESCRIPTION
This change adds kubeconfig field to Cluster enabling access from env. Using the kubeconfig from env, replaced --context with --kubeconfig for kubectl commands in discovered app created and delete since cluster contexts does not exist by default on openshift clusters.

Tested disapp-rbd on openshift qe cluster:
[ramen-e2e.log](https://github.com/user-attachments/files/19248161/ramen-e2e.log)

Fixes #1920 