### PR TITLE
e2e: create namespace and annotate based on distro

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -16,8 +16,8 @@ import (
 
 const (
 	// Kubernetes distributions
-	distroK8s = "k8s"
-	distroOcp = "ocp"
+	DistroK8s = "k8s"
+	DistroOcp = "ocp"
 
 	// Channel
 	defaultChannelNamespace = "e2e-gitops"
@@ -107,13 +107,13 @@ func readConfig(configFile string, config *types.Config) error {
 
 func validateDistro(config *types.Config) error {
 	switch config.Distro {
-	case distroK8s:
+	case DistroK8s:
 		config.Namespaces = k8sNamespaces
-	case distroOcp:
+	case DistroOcp:
 		config.Namespaces = ocpNamespaces
 	default:
 		return fmt.Errorf("invalid distro %q: (choose one of %q, %q)",
-			config.Distro, distroK8s, distroOcp)
+			config.Distro, DistroK8s, DistroOcp)
 	}
 
 	return nil

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -30,8 +30,9 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 	// Deploys the application on the first DR cluster (c1).
 	cluster := ctx.Env().C1
 
-	// create namespace in both dr clusters
-	if err := util.CreateNamespaceAndAddAnnotation(ctx.Env(), appNamespace, log); err != nil {
+	// Create namespace on the first DR cluster (c1)
+	err := util.CreateNamespace(cluster, appNamespace, log)
+	if err != nil {
 		return err
 	}
 

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -5,9 +5,11 @@ package dractions
 
 import (
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
+	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 )
@@ -34,9 +36,9 @@ func EnableProtection(ctx types.Context) error {
 	managementNamespace := ctx.ManagementNamespace()
 	appNamespace := ctx.AppNamespace()
 	log := ctx.Logger()
-	config := ctx.Config()
+	cfg := ctx.Config()
 
-	drPolicyName := config.DRPolicy
+	drPolicyName := cfg.DRPolicy
 	appname := w.GetAppName()
 	placementName := name
 	drpcName := name
@@ -79,8 +81,8 @@ func EnableProtection(ctx types.Context) error {
 		return err
 	}
 
-	// For volsync based replication we must create the cluster namespaces with special annotation.
-	if err := util.CreateNamespaceAndAddAnnotation(ctx.Env(), ctx.AppNamespace(), log); err != nil {
+	err = createNamespaceAndAnnotation(ctx, appNamespace, log)
+	if err != nil {
 		return err
 	}
 
@@ -260,4 +262,16 @@ func waitAndUpdateDRPC(
 
 		return nil
 	})
+}
+
+// createNamespaceAndAnnotation is a helper function used during the protection of managed apps
+// to create namespaces and add annotations for VolSync based replication on both DR clusters
+// if the distribution is Kubernetes.
+// Returns an error if namespace creation or annotation fails.
+func createNamespaceAndAnnotation(ctx types.Context, appNamespace string, log *zap.SugaredLogger) error {
+	if ctx.Config().Distro == config.DistroK8s {
+		return util.CreateNamespaceAndAddAnnotation(ctx.Env(), appNamespace, log)
+	}
+
+	return nil
 }

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -4,8 +4,12 @@
 package dractions
 
 import (
-	ramen "github.com/ramendr/ramen/api/v1alpha1"
+	"fmt"
 
+	ramen "github.com/ramendr/ramen/api/v1alpha1"
+	"go.uber.org/zap"
+
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/deployers"
 	"github.com/ramendr/ramen/e2e/env"
 	"github.com/ramendr/ramen/e2e/types"
@@ -46,6 +50,10 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 	drpc := generateDRPCDiscoveredApps(
 		name, managementNamespace, cluster.Name, drPolicyName, placementName, appname, appNamespace)
 	if err := createDRPC(ctx, drpc); err != nil {
+		return err
+	}
+
+	if err := createNamespaces(ctx, appNamespace, log); err != nil {
 		return err
 	}
 
@@ -150,4 +158,19 @@ func failoverRelocateDiscoveredApps(
 	}
 
 	return deployers.WaitWorkloadHealth(ctx, drCluster, appNamespace)
+}
+
+// createNamespaces sets up namespaces for discovered app protection based on the Kubernetes distribution.
+// For Kubernetes, creates namespaces and adds annotation on both DR clusters for volsync based replication.
+// For OpenShift, creates namespace only on the target DR cluster (c2) before failover.
+// Returns an error if the distribution is unknown, and if namespace creation or annotation fails.
+func createNamespaces(ctx types.Context, namespace string, log *zap.SugaredLogger) error {
+	switch ctx.Config().Distro {
+	case config.DistroK8s:
+		return util.CreateNamespaceAndAddAnnotation(ctx.Env(), namespace, log)
+	case config.DistroOcp:
+		return util.CreateNamespace(ctx.Env().C2, namespace, log)
+	default:
+		return fmt.Errorf("unknown distro: %s", ctx.Config().Distro)
+	}
 }


### PR DESCRIPTION
This change exports distro constants in config package and based on distro creates namespace/annotates during deploy and protection.

Fixes #1919 