### PR TITLE
drenv: create mcsb for "argocd" ns during installation

### DIFF
--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -15,7 +15,6 @@ type ApplicationSet struct{}
 func (a ApplicationSet) Deploy(ctx types.Context) error {
 	name := ctx.Name()
 	log := ctx.Logger()
-	config := ctx.Config()
 	managementNamespace := ctx.ManagementNamespace()
 
 	// Deploys the application on the first DR cluster (c1).
@@ -24,12 +23,7 @@ func (a ApplicationSet) Deploy(ctx types.Context) error {
 	log.Infof("Deploying applicationset app \"%s/%s\" in cluster %q",
 		ctx.AppNamespace(), ctx.Workload().GetAppName(), cluster.Name)
 
-	err := CreateManagedClusterSetBinding(ctx, config.ClusterSet, managementNamespace)
-	if err != nil {
-		return err
-	}
-
-	err = CreatePlacement(ctx, name, managementNamespace, cluster.Name)
+	err := CreatePlacement(ctx, name, managementNamespace, cluster.Name)
 	if err != nil {
 		return err
 	}
@@ -53,7 +47,6 @@ func (a ApplicationSet) Deploy(ctx types.Context) error {
 func (a ApplicationSet) Undeploy(ctx types.Context) error {
 	name := ctx.Name()
 	log := ctx.Logger()
-	config := ctx.Config()
 	managementNamespace := ctx.ManagementNamespace()
 
 	clusterName, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, name)
@@ -82,20 +75,6 @@ func (a ApplicationSet) Undeploy(ctx types.Context) error {
 	err = DeletePlacement(ctx, name, managementNamespace)
 	if err != nil {
 		return err
-	}
-
-	// multiple appsets could use the same mcsb in argocd ns.
-	// so delete mcsb if only 1 appset is in argocd ns
-	lastAppset, err := isLastAppsetInArgocdNs(ctx, managementNamespace)
-	if err != nil {
-		return err
-	}
-
-	if lastAppset {
-		err = DeleteManagedClusterSetBinding(ctx, config.ClusterSet, managementNamespace)
-		if err != nil {
-			return err
-		}
 	}
 
 	log.Info("Workload undeployed")

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -19,7 +19,6 @@ import (
 	ocmv1b2 "open-cluster-management.io/api/cluster/v1beta2"
 	placementrulev1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/placementrule/v1"
 	subscriptionv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	argocdv1alpha1hack "github.com/ramendr/ramen/e2e/argocd"
@@ -413,19 +412,6 @@ func DeleteApplicationSet(ctx types.Context, a ApplicationSet) error {
 	log.Debugf("Deleted applicationset \"%s/%s\" in cluster %q", managementNamespace, name, ctx.Env().Hub.Name)
 
 	return nil
-}
-
-// check if only the last appset is in the argocd namespace
-func isLastAppsetInArgocdNs(ctx types.Context, namespace string) (bool, error) {
-	appsetList := &argocdv1alpha1hack.ApplicationSetList{}
-
-	err := ctx.Env().Hub.Client.List(
-		context.Background(), appsetList, client.InNamespace(namespace))
-	if err != nil {
-		return false, fmt.Errorf("failed to list applicationsets in cluster %q: %w", ctx.Env().Hub.Name, err)
-	}
-
-	return len(appsetList.Items) == 1, nil
 }
 
 func DeleteDiscoveredApps(ctx types.Context, namespace, cluster string) error {

--- a/test/addons/argocd/argocd-mcsb.yaml
+++ b/test/addons/argocd/argocd-mcsb.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: cluster.open-cluster-management.io/v1beta2
+kind: ManagedClusterSetBinding
+metadata:
+  name: default
+  namespace: argocd
+spec:
+  clusterSet: default

--- a/test/addons/argocd/cache
+++ b/test/addons/argocd/cache
@@ -7,4 +7,4 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh(".", "addons/argocd-2.11.yaml")
+cache.refresh(".", "addons/argocd-2.11-1.yaml")

--- a/test/addons/argocd/kustomization.yaml
+++ b/test/addons/argocd/kustomization.yaml
@@ -5,6 +5,7 @@
 ---
 resources:
   - argocd-ns.yaml
+  - argocd-mcsb.yaml
   - https://raw.githubusercontent.com/argoproj/argo-cd/release-2.11/manifests/install.yaml
 
 # In argocd appset DR e2e test, an appset CR will be created that uses placementdecision

--- a/test/addons/argocd/start
+++ b/test/addons/argocd/start
@@ -21,7 +21,7 @@ def wait_for_clusters(clusters):
 
 def deploy_argocd(cluster):
     print("Deploying argocd")
-    path = cache.get(".", "addons/argocd-2.11.yaml")
+    path = cache.get(".", "addons/argocd-2.11-1.yaml")
     kubectl.apply("--filename", path, "--namespace", "argocd", context=cluster)
 
 


### PR DESCRIPTION
This change handles mcsb creation for "argocd" namespace for default clusterset during drenv cluster installation similar to how it is configured by users for "openshift-gitops" namespace in openshift env. With this change we do not need to handle create/delete mcsb in e2e for appset apps.

tested locally, mcsb got created:
```
- apiVersion: cluster.open-cluster-management.io/v1beta2
  kind: ManagedClusterSetBinding
  metadata:
    creationTimestamp: "2025-03-18T11:04:35Z"
    generation: 1
    name: default
    namespace: argocd
    resourceVersion: "1778"
    uid: 3a6cd4b6-a6ab-4883-8af5-ce4bb7510500
  spec:
    clusterSet: default
  status:
    conditions:
    - lastTransitionTime: "2025-03-18T11:04:35Z"
      message: ""
      reason: ClusterSetBound
      status: "True"
      type: Bound
```

Fixes #1921