### PR TITLE
e2e: refactor cluster setup in env

### DIFF
--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -85,49 +85,44 @@ func setupClient(kubeconfigPath string) (client.Client, error) {
 	return client, nil
 }
 
-func New(config *types.Config, log *zap.SugaredLogger) (*types.Env, error) {
-	var err error
+func setupCluster(
+	cluster *types.Cluster,
+	key string,
+	clusterConfig types.ClusterConfig,
+	defaultName string,
+	log *zap.SugaredLogger,
+) error {
+	client, err := setupClient(clusterConfig.Kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to setup cluster %q: %w", key, err)
+	}
 
+	cluster.Client = client
+	cluster.Kubeconfig = clusterConfig.Kubeconfig
+
+	cluster.Name = clusterConfig.Name
+	if cluster.Name == "" {
+		cluster.Name = defaultName
+		log.Infof("Cluster %q name not provided, using default name %q", key, defaultName)
+	}
+
+	return nil
+}
+
+func New(config *types.Config, log *zap.SugaredLogger) (*types.Env, error) {
 	env := &types.Env{}
 
-	env.Hub.Name = config.Clusters["hub"].Name
-	if env.Hub.Name == "" {
-		env.Hub.Name = defaultHubClusterName
-		log.Infof("Cluster \"hub\" name not set, using default name %q", defaultHubClusterName)
+	if err := setupCluster(&env.Hub, "hub", config.Clusters["hub"], defaultHubClusterName, log); err != nil {
+		return nil, fmt.Errorf("failed to create env: %w", err)
 	}
 
-	env.Hub.Client, err = setupClient(config.Clusters["hub"].Kubeconfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create clients for hub cluster: %w", err)
+	if err := setupCluster(&env.C1, "c1", config.Clusters["c1"], defaultC1ClusterName, log); err != nil {
+		return nil, fmt.Errorf("failed to create env: %w", err)
 	}
 
-	env.Hub.Kubeconfig = config.Clusters["hub"].Kubeconfig
-
-	env.C1.Name = config.Clusters["c1"].Name
-	if env.C1.Name == "" {
-		env.C1.Name = defaultC1ClusterName
-		log.Infof("Cluster \"c1\" name not set, using default name %q", defaultC1ClusterName)
+	if err := setupCluster(&env.C2, "c2", config.Clusters["c2"], defaultC2ClusterName, log); err != nil {
+		return nil, fmt.Errorf("failed to create env: %w", err)
 	}
-
-	env.C1.Client, err = setupClient(config.Clusters["c1"].Kubeconfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create clients for c1 cluster: %w", err)
-	}
-
-	env.C1.Kubeconfig = config.Clusters["c1"].Kubeconfig
-
-	env.C2.Name = config.Clusters["c2"].Name
-	if env.C2.Name == "" {
-		env.C2.Name = defaultC2ClusterName
-		log.Infof("Cluster \"c2\" name not set, using default name %q", defaultC2ClusterName)
-	}
-
-	env.C2.Client, err = setupClient(config.Clusters["c2"].Kubeconfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create clients for c2 cluster: %w", err)
-	}
-
-	env.C2.Kubeconfig = config.Clusters["c2"].Kubeconfig
 
 	return env, nil
 }


### PR DESCRIPTION
This change improves structure and reduces code duplication for c1 and c2 by refactoring the New function in env by adding separate helper functions:
- `setupHub` to initialize the hub cluster.
- `setupManagedClusters` to initialize managed clusters (c1 and c2).

Testing:
1. error during setup_client(incorrect kubeconfig path):
```
FATAL Failed to create testing context: failed to create env: failed to setup cluster "c1": failed to build config from kubeconfig (/Users/pari/.config/drenv/rdr/kubeconfigs/dr): stat /Users/pari/.config/drenv/rdr/kubeconfigs/dr: no such file or directory
```
2. When default cluster name is used:
```
INFO Cluster "c1" name not provided, using default name "c1"
```


Fixes #1950 