### PR TITLE
e2e: move validation to validate package and refactor calls

### DIFF
--- a/e2e/dr_test.go
+++ b/e2e/dr_test.go
@@ -22,8 +22,8 @@ func TestDR(dt *testing.T) {
 		t.Fatal("No tests found in the configuration file")
 	}
 
-	if err := validate.ClustersInDRPolicy(Ctx.env, Ctx.config, Ctx.log); err != nil {
-		t.Fatalf("Failed to validate clusters with DRPolicy: %s", err)
+	if err := validate.TestConfig(Ctx.env, Ctx.config, Ctx.log); err != nil {
+		t.Fatal(err.Error())
 	}
 
 	if err := util.EnsureChannel(Ctx.env.Hub, Ctx.config, Ctx.log); err != nil {

--- a/e2e/dr_test.go
+++ b/e2e/dr_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ramendr/ramen/e2e/deployers"
 	"github.com/ramendr/ramen/e2e/test"
 	"github.com/ramendr/ramen/e2e/util"
+	"github.com/ramendr/ramen/e2e/validate"
 	"github.com/ramendr/ramen/e2e/workloads"
 )
 
@@ -21,7 +22,7 @@ func TestDR(dt *testing.T) {
 		t.Fatal("No tests found in the configuration file")
 	}
 
-	if err := util.ValidateClustersInDRPolicy(Ctx.env, Ctx.config, Ctx.log); err != nil {
+	if err := validate.ClustersInDRPolicy(Ctx.env, Ctx.config, Ctx.log); err != nil {
 		t.Fatalf("Failed to validate clusters with DRPolicy: %s", err)
 	}
 

--- a/e2e/validate/validation.go
+++ b/e2e/validate/validation.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: The RamenDR authors
 // SPDX-License-Identifier: Apache-2.0
 
-package util
+package validate
 
 import (
 	"context"
@@ -18,9 +18,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ramendr/ramen/e2e/types"
+	"github.com/ramendr/ramen/e2e/util"
 )
 
-func ValidateRamenHubOperator(cluster types.Cluster, config *types.Config, log *zap.SugaredLogger) error {
+func RamenHubOperator(cluster types.Cluster, config *types.Config, log *zap.SugaredLogger) error {
 	labelSelector := "app=ramen-hub"
 	podIdentifier := "ramen-hub-operator"
 
@@ -39,7 +40,7 @@ func ValidateRamenHubOperator(cluster types.Cluster, config *types.Config, log *
 	return nil
 }
 
-func ValidateRamenDRClusterOperator(cluster types.Cluster, config *types.Config, log *zap.SugaredLogger) error {
+func RamenDRClusterOperator(cluster types.Cluster, config *types.Config, log *zap.SugaredLogger) error {
 	labelSelector := "app=ramen-dr-cluster"
 	podIdentifier := "ramen-dr-cluster-operator"
 
@@ -121,8 +122,8 @@ func FindPod(cluster types.Cluster, namespace, labelSelector, podIdentifier stri
 // drpolicy. Returns an error if cluster names are not the same as drpolicy
 // drclusters. The reason for a failure may be wrong cluster name or wrong
 // drpolicy.
-func ValidateClustersInDRPolicy(env *types.Env, config *types.Config, log *zap.SugaredLogger) error {
-	drpolicy, err := GetDRPolicy(env.Hub, config.DRPolicy)
+func ClustersInDRPolicy(env *types.Env, config *types.Config, log *zap.SugaredLogger) error {
+	drpolicy, err := util.GetDRPolicy(env.Hub, config.DRPolicy)
 	if err != nil {
 		return err
 	}

--- a/e2e/validate/validation.go
+++ b/e2e/validate/validation.go
@@ -118,14 +118,25 @@ func FindPod(cluster types.Cluster, namespace, labelSelector, podIdentifier stri
 		labelSelector, podIdentifier, namespace, cluster.Name)
 }
 
-// ValidateClustersInDRPolicy checks if configured clusters match the configured
+// TestConfig is a wrapper function which performs validation checks on
+// the test environment configurations with the DR resources on the clusters.
+// Returns an error if any validation fails.
+func TestConfig(env *types.Env, config *types.Config, log *zap.SugaredLogger) error {
+	if err := clustersInDRPolicy(env, config, log); err != nil {
+		return fmt.Errorf("failed to validate test config: %w", err)
+	}
+
+	return nil
+}
+
+// clustersInDRPolicy checks if configured clusters match the configured
 // drpolicy. Returns an error if cluster names are not the same as drpolicy
 // drclusters. The reason for a failure may be wrong cluster name or wrong
 // drpolicy.
-func ClustersInDRPolicy(env *types.Env, config *types.Config, log *zap.SugaredLogger) error {
+func clustersInDRPolicy(env *types.Env, config *types.Config, log *zap.SugaredLogger) error {
 	drpolicy, err := util.GetDRPolicy(env.Hub, config.DRPolicy)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get DRPolicy %q: %w", config.DRPolicy, err)
 	}
 
 	clusters := []types.Cluster{env.C1, env.C2}

--- a/e2e/validation_test.go
+++ b/e2e/validation_test.go
@@ -14,6 +14,10 @@ func TestValidation(dt *testing.T) {
 	t := test.WithLog(dt, Ctx.log)
 	t.Parallel()
 
+	if err := validate.TestConfig(Ctx.env, Ctx.config, Ctx.log); err != nil {
+		t.Fatal(err.Error())
+	}
+
 	t.Run("hub", func(dt *testing.T) {
 		t := test.WithLog(dt, Ctx.log)
 		t.Parallel()

--- a/e2e/validation_test.go
+++ b/e2e/validation_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/ramendr/ramen/e2e/test"
-	"github.com/ramendr/ramen/e2e/util"
+	"github.com/ramendr/ramen/e2e/validate"
 )
 
 func TestValidation(dt *testing.T) {
@@ -18,7 +18,7 @@ func TestValidation(dt *testing.T) {
 		t := test.WithLog(dt, Ctx.log)
 		t.Parallel()
 
-		err := util.ValidateRamenHubOperator(Ctx.env.Hub, Ctx.config, Ctx.log)
+		err := validate.RamenHubOperator(Ctx.env.Hub, Ctx.config, Ctx.log)
 		if err != nil {
 			t.Fatalf("Failed to validate hub cluster %q: %s", Ctx.env.Hub.Name, err)
 		}
@@ -27,7 +27,7 @@ func TestValidation(dt *testing.T) {
 		t := test.WithLog(dt, Ctx.log)
 		t.Parallel()
 
-		err := util.ValidateRamenDRClusterOperator(Ctx.env.C1, Ctx.config, Ctx.log)
+		err := validate.RamenDRClusterOperator(Ctx.env.C1, Ctx.config, Ctx.log)
 		if err != nil {
 			t.Fatalf("Failed to validate dr cluster %q: %s", Ctx.env.C1.Name, err)
 		}
@@ -36,7 +36,7 @@ func TestValidation(dt *testing.T) {
 		t := test.WithLog(dt, Ctx.log)
 		t.Parallel()
 
-		err := util.ValidateRamenDRClusterOperator(Ctx.env.C2, Ctx.config, Ctx.log)
+		err := validate.RamenDRClusterOperator(Ctx.env.C2, Ctx.config, Ctx.log)
 		if err != nil {
 			t.Fatalf("Failed to validate dr cluster %q: %s", Ctx.env.C2.Name, err)
 		}


### PR DESCRIPTION
With this change util/validations.go is moved separate package under validate/validation.go, which will be also used in ramenctl. Also added a wrapper called TestConfig() which holds different validation helpers.

Ran TestValidation and TestDR separately, o/p of validate.TestConfig call:

1. when success:
```
INFO	Validated clusters ["dr1", "dr2"] in DRPolicy "dr-policy"
```
2. when there is no drpolicy:
```
ERROR	failed to validate test config: failed to get DRPolicy "dr-test": drpolicies.ramendr.openshift.io "dr-policysda" not found
```
4. when user provide incorrect clustername:
```
ERROR	failed to validate test config: cluster "test" is not defined in drpolicy "dr-policy", clusters in drpolicy: ["dr1" "dr2"]
```

Fixes #1938 