### PR TITLE
e2e: Add ClusterSet validation

### DIFF
--- a/e2e/validate/clusterset.go
+++ b/e2e/validate/clusterset.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"context"
+	"fmt"
+
+	ocmv1 "open-cluster-management.io/api/cluster/v1"
+	ocmv1b2 "open-cluster-management.io/api/cluster/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ramendr/ramen/e2e/types"
+)
+
+func getClusterSet(hub types.Cluster, clusterSetName string) (*ocmv1b2.ManagedClusterSet, error) {
+	clusterSet := &ocmv1b2.ManagedClusterSet{}
+	key := client.ObjectKey{Name: clusterSetName}
+
+	if err := hub.Client.Get(context.TODO(), key, clusterSet); err != nil {
+		return nil, fmt.Errorf("failed to get ClusterSet %q: %w", clusterSetName, err)
+	}
+
+	return clusterSet, nil
+}
+
+func getManagedClustersFromClusterSet(hub types.Cluster, clusterSetName string) ([]string, error) {
+	clusterList := &ocmv1.ManagedClusterList{}
+	labelSelector := client.MatchingLabels{"cluster.open-cluster-management.io/clusterset": clusterSetName}
+
+	if err := hub.Client.List(context.TODO(), clusterList, labelSelector); err != nil {
+		return nil, fmt.Errorf("failed to list ManagedClusters for ClusterSet %q: %w", clusterSetName, err)
+	}
+
+	if len(clusterList.Items) == 0 {
+		return nil, fmt.Errorf("no clusters found for ClusterSet %q", clusterSetName)
+	}
+
+	clusterNames := make([]string, 0, len(clusterList.Items))
+	for _, cluster := range clusterList.Items {
+		clusterNames = append(clusterNames, cluster.Name)
+	}
+
+	return clusterNames, nil
+}


### PR DESCRIPTION
Added clustersInClusterSet function to validate that the configured clusters exist in the specified ClusterSet. Ensures test config validation fails early if the ClusterSet is misconfigured or the clusters are not part of it.

Testing:
1. on success:
```
INFO	Validated clusters ["dr1", "dr2"] in ClusterSet "default"
```
2. when clusterset does not exist:
```
ERROR	failed to validate test config: failed to get ClusterSet "test": managedclustersets.cluster.open-cluster-management.io "test" not found
```
3. when clusters provided is not part of the clusterset:
```
ERROR	failed to validate test config: cluster "dr-test" is not defined in ClusterSet "default", clusters in ClusterSet: ["dr1" "dr2"]
```

Fixes #1904 