### PR TITLE
Improvements in evaluation of json expression

### DIFF
--- a/internal/controller/hooks/check_hook.go
+++ b/internal/controller/hooks/check_hook.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -311,10 +312,15 @@ func EvaluateCheckHookExp(booleanExpression string, jsonData interface{}) (bool,
 	}
 
 	operand := make([]reflect.Value, len(jsonPaths))
+
 	for i, jsonPath := range jsonPaths {
-		operand[i], err = QueryJSONPath(jsonData, jsonPath)
-		if err != nil {
-			return false, fmt.Errorf("failed to get value for %v: %w", jsonPath, err)
+		if strings.HasPrefix(jsonPath, "$") {
+			operand[i], err = QueryJSONPath(jsonData, jsonPath)
+			if err != nil {
+				return false, fmt.Errorf("failed to get value for %v: %w", jsonPath, err)
+			}
+		} else {
+			operand[i] = reflect.ValueOf(jsonPath)
 		}
 	}
 

--- a/internal/controller/hooks/check_hook.go
+++ b/internal/controller/hooks/check_hook.go
@@ -7,9 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -306,23 +304,5 @@ func getMatchingStatefulSets(ssList *appsv1.StatefulSetList, re *regexp.Regexp) 
 }
 
 func EvaluateCheckHookExp(booleanExpression string, jsonData interface{}) (bool, error) {
-	op, jsonPaths, err := parseBooleanExpression(booleanExpression)
-	if err != nil {
-		return false, fmt.Errorf("failed to parse boolean expression: %w", err)
-	}
-
-	operand := make([]reflect.Value, len(jsonPaths))
-
-	for i, jsonPath := range jsonPaths {
-		if strings.HasPrefix(jsonPath, "$") {
-			operand[i], err = QueryJSONPath(jsonData, jsonPath)
-			if err != nil {
-				return false, fmt.Errorf("failed to get value for %v: %w", jsonPath, err)
-			}
-		} else {
-			operand[i] = reflect.ValueOf(jsonPath)
-		}
-	}
-
-	return compare(operand[0], operand[1], op)
+	return evaluateBooleanExpression(booleanExpression, jsonData)
 }

--- a/internal/controller/hooks/check_hook_test.go
+++ b/internal/controller/hooks/check_hook_test.go
@@ -157,6 +157,18 @@ var testCasesData = []testCases{
 		result:   true,
 		jsonText: jsonPod,
 	},
+	{
+		jsonPathExprs: "({$.spec.replicas} == {$.status.readyReplicas}) && (({$.spec.replicas} ==" +
+			" {$.status.updatedReplicas}) || ({$.spec.revisionHistoryLimit} != {11}))",
+		result:   true,
+		jsonText: jsonPod,
+	},
+	{
+		jsonPathExprs: "(({$.spec.replicas} == {$.status.readyReplicas}) && ({$.spec.replicas} ==" +
+			" {$.status.updatedReplicas})) || ({$.spec.revisionHistoryLimit} != {11})",
+		result:   true,
+		jsonText: jsonPod,
+	},
 }
 
 var testCasesObjectData = []testCasesObject{

--- a/internal/controller/hooks/check_hook_test.go
+++ b/internal/controller/hooks/check_hook_test.go
@@ -141,16 +141,22 @@ var testCasesData = []testCases{
 		result:        true,
 		jsonText:      jsonPod,
 	},
-	// {
-	// 	jsonPathExprs: "{$.spec.replicas} == {1} || $.status.conditions[0].status == {True}",
-	// 	result:        true,
-	// 	jsonText:      jsonPod,
-	// },
-	// {
-	// 	jsonPathExprs: "{$.spec.replicas} == {1} && $.status.conditions[0].status == {True}",
-	// 	result:        true,
-	// 	jsonText:      jsonPod,
-	// },
+	{
+		jsonPathExprs: "{$.spec.replicas} == {1} || {$.status.conditions[0].status} == {True}",
+		result:        true,
+		jsonText:      jsonPod,
+	},
+	{
+		jsonPathExprs: "{$.spec.replicas} == {1} && {$.status.conditions[0].status} == {True}",
+		result:        true,
+		jsonText:      jsonPod,
+	},
+	{
+		jsonPathExprs: "{$.spec.replicas} == {$.status.readyReplicas} || {$.spec.replicas} == {$.status.updatedReplicas}" +
+			" && {$.spec.revisionHistoryLimit} == {10}",
+		result:   true,
+		jsonText: jsonPod,
+	},
 }
 
 var testCasesObjectData = []testCasesObject{

--- a/internal/controller/hooks/check_hook_test.go
+++ b/internal/controller/hooks/check_hook_test.go
@@ -136,11 +136,11 @@ var testCasesData = []testCases{
 		result:        true,
 		jsonText:      jsonStatefulset,
 	},
-	// {
-	// 	jsonPathExprs: "{$.status.conditions[?(@type.==\"Progressing\")].status} == {True}",
-	// 	result:        true,
-	// 	jsonText:      jsonPod,
-	// },
+	{
+		jsonPathExprs: "{$.status.conditions[?(@type.==\"Progressing\")].status} == {True}",
+		result:        true,
+		jsonText:      jsonPod,
+	},
 	// {
 	// 	jsonPathExprs: "{$.spec.replicas} == {1} || $.status.conditions[0].status == {True}",
 	// 	result:        true,
@@ -165,8 +165,13 @@ var testCasesObjectData = []testCasesObject{
 		jsonObj: getPodContent(),
 	},
 	{
-		hook:    getHookSpec("Pod", "{$.status.containerStatuses[0].restartCount} == 2"),
+		hook:    getHookSpec("Pod", "{$.status.containerStatuses[0].restartCount} == {2}"),
 		result:  true,
+		jsonObj: getPodContent(),
+	},
+	{
+		hook:    getHookSpec("Pod", "{$.status.containerStatuses[0].restartCount} == 2"),
+		result:  false,
 		jsonObj: getPodContent(),
 	},
 	{
@@ -239,40 +244,47 @@ func Test_isValidJsonPathExpression(t *testing.T) {
 		want bool
 	}{
 		/* Same comments as above */
-		// {
-		// 	name: "String expression",
-		// 	args: args{
-		// 		expr: "{True}",
-		// 	},
-		// 	want: true,
-		// },
-		// {
-		// 	name: "String expression 1",
-		// 	args: args{
-		// 		expr: "{\"Ready\"}",
-		// 	},
-		// 	want: true,
-		// },
-		// {
-		// 	name: "Number expression",
-		// 	args: args{
-		// 		expr: "{10}",
-		// 	},
-		// 	want: true,
-		// },
+		{
+			name: "String expression",
+			args: args{
+				expr: "{True}",
+			},
+			want: true,
+		},
+		{
+			name: "String expression 1",
+			args: args{
+				expr: "{\"Ready\"}",
+			},
+			want: true,
+		},
+		{
+			name: "Number expression",
+			args: args{
+				expr: "{10}",
+			},
+			want: true,
+		},
+		{
+			name: "Number expression",
+			args: args{
+				expr: "10",
+			},
+			want: false,
+		},
 		{
 			name: "Simple expression",
 			args: args{
 				expr: "$.spec.replicas",
 			},
-			want: true,
+			want: false,
 		},
 		{
 			name: "no $ at the start",
 			args: args{
 				expr: "{.spec.replicas}",
 			},
-			want: true,
+			want: false,
 		},
 		{
 			name: "element in array",
@@ -300,14 +312,14 @@ func Test_isValidJsonPathExpression(t *testing.T) {
 			args: args{
 				expr: "{True}",
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "spec 3b",
 			args: args{
 				expr: "{False}",
 			},
-			want: false,
+			want: true,
 		},
 		{
 			name: "spec 3c",
@@ -333,42 +345,42 @@ func Test_isValidJsonPathExpression(t *testing.T) {
 		{
 			name: "expression with == operator",
 			args: args{
-				expr: "$.store.book[?(@.price > 10)].title==$.store.book[0].title",
+				expr: "{$.store.book[?(@.price > 10)].title==$.store.book[0].title}",
 			},
 			want: true,
 		},
 		{
 			name: "expression with > operator",
 			args: args{
-				expr: "$.store.book[?(@.author CONTAINS 'Smith')].price>20",
+				expr: "{$.store.book[?(@.author CONTAINS 'Smith')].price>20}",
 			},
 			want: true,
 		},
 		{
 			name: "expression with >= operator",
 			args: args{
-				expr: "$.user.age>=$.minimum.age",
+				expr: "{$.user.age>=$.minimum.age}",
 			},
 			want: true,
 		},
 		{
 			name: "expression with < operator",
 			args: args{
-				expr: "$.user.age<$.maximum.age",
+				expr: "{$.user.age<$.maximum.age}",
 			},
 			want: true,
 		},
 		{
 			name: "expression with <= operator",
 			args: args{
-				expr: "$.user.age<=$.maximum.age",
+				expr: "{$.user.age<=$.maximum.age}",
 			},
 			want: true,
 		},
 		{
 			name: "expression with != operator",
 			args: args{
-				expr: "$.user.age!=$.maximum.age",
+				expr: "{$.user.age!=$.maximum.age}",
 			},
 			want: true,
 		},

--- a/internal/controller/hooks/check_hook_test.go
+++ b/internal/controller/hooks/check_hook_test.go
@@ -99,19 +99,14 @@ var rep int32 = 1
 
 var testCasesData = []testCases{
 	{
-		jsonPathExprs: "{$.status.conditions[0].status} == True",
+		jsonPathExprs: "{$.status.conditions[0].status} == {True}",
 		result:        true,
 		jsonText:      jsonDeployment,
 	},
 	{
 		jsonPathExprs: "{$.spec.replicas} == 1",
-		result:        true,
-		jsonText:      jsonPod,
-	},
-	{
-		jsonPathExprs: "{$.status.conditions[0].status} == {True}",
 		result:        false,
-		jsonText:      jsonStatefulset,
+		jsonText:      jsonPod,
 	},
 	/* The json expression that can be provided as a condition in the check hook spec follows the format
 
@@ -126,21 +121,21 @@ var testCasesData = []testCases{
 
 	Adding the commented TCs which are to pass when the improvements are done.
 	*/
-	// {
-	// 	jsonPathExprs: "{$.status.conditions[0].status} == {True}",
-	// 	result:        true,
-	// 	jsonText:      jsonStatefulset,
-	// },
-	// {
-	// 	jsonPathExprs: "{$.spec.replicas} == {1}",
-	// 	result:        true,
-	// 	jsonText:      jsonPod,
-	// },
-	// {
-	// 	jsonPathExprs: "{$.status.conditions[0].status} == {\"True\"}",
-	// 	result:        true,
-	// 	jsonText:      jsonStatefulset,
-	// },
+	{
+		jsonPathExprs: "{$.status.conditions[0].status} == True",
+		result:        false,
+		jsonText:      jsonStatefulset,
+	},
+	{
+		jsonPathExprs: "{$.spec.replicas} == {1}",
+		result:        true,
+		jsonText:      jsonPod,
+	},
+	{
+		jsonPathExprs: "{$.status.conditions[0].status} == {\"True\"}",
+		result:        true,
+		jsonText:      jsonStatefulset,
+	},
 	// {
 	// 	jsonPathExprs: "{$.status.conditions[?(@type.==\"Progressing\")].status} == {True}",
 	// 	result:        true,


### PR DESCRIPTION
The PR addresses 3 issues related to json expression evaluation:

1. Json expression to be treated as literal when it doesn't start with $
> Expressions like {True}, {"Ready"}, {10} will be treated as literals.

2. Handle complex expression that contains operators
complex expression can contain operators like '==', '!=', '>', '<', '>=', '<=' in between which needs to be handled.

Example of expressions: 
> ({$.status.conditions[?(@.type=="Progressing")].status} == {"True"})

3. Handle usage of logical operators in the json expression
A condition provided in the check hook can have multiple boolean expressions which can be separated by logical operators "||" or "&&". Currently only one expression is being handled. Also support nested parenthesis within the expression.

Example of expressions:
> {$.spec.replicas} == {$.status.readyReplicas} || {$.spec.replicas} == {$.status.updatedReplicas}

> {$.spec.replicas} == {$.status.readyReplicas} && {$.spec.replicas} == {$.status.updatedReplicas}

> ({$.spec.replicas} == {$.status.readyReplicas}) && (({$.spec.replicas} == {$.status.updatedReplicas}) || ({$.spec.revisionHistoryLimit} != {11}))

Fixes: #1906 #1908 #1909 #1910 