### PR TITLE
drenv: Use private ocm-controller image

### DIFF
--- a/test/addons/ocm-controller/cache
+++ b/test/addons/ocm-controller/cache
@@ -7,4 +7,4 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh(".", "addons/ocm-controller.yaml")
+cache.refresh(".", "addons/ocm-controller-1.yaml")

--- a/test/addons/ocm-controller/kustomization.yaml
+++ b/test/addons/ocm-controller/kustomization.yaml
@@ -11,7 +11,8 @@ resources:
 - https://github.com/stolostron/multicloud-operators-foundation.git/deploy/foundation/hub/overlays/ocm-controller?ref=main&timeout=300s
 images:
 - name: quay.io/stolostron/multicloud-manager
-  newTag: latest
+  newName: quay.io/nirsof/multicloud-manager
+  newTag: 2025-03-24
 patches:
 # Ammend upstream kustomization since it does not add an image tag. We want an
 # image tag to pin to specific version.
@@ -24,4 +25,4 @@ patches:
       value: "--agent-addon-image=quay.io/stolostron/multicloud-manager"
     - op: replace
       path: /spec/template/spec/containers/0/args/2
-      value: "--agent-addon-image=quay.io/stolostron/multicloud-manager:latest"
+      value: "--agent-addon-image=quay.io/nirsof/multicloud-manager:2025-03-24"

--- a/test/addons/ocm-controller/start
+++ b/test/addons/ocm-controller/start
@@ -12,7 +12,7 @@ from drenv import cache
 
 def deploy(cluster):
     print("Deploying ocm controller")
-    path = cache.get(".", "addons/ocm-controller.yaml")
+    path = cache.get(".", "addons/ocm-controller-1.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
 


### PR DESCRIPTION
quay.io/stolostron/multicloud-manager:latest cannot work now for macOS[1].  This is now a multiatch image with one manifest, and pulling the image fails with:

    Warning  Failed     54s (x5 over 3m58s)  kubelet  Failed to pull image
    "quay.io/stolostron/multicloud-manager:latest": rpc error: code = NotFound
    desc = failed to pull and unpack image "quay.io/stolostron/multicloud-manager:latest":
    no match for platform in manifest: not found

I pushed the image to my private repo to create a flat amd64 image that we can consume. This should be good enough until we get a fix.

Example run with private image:

    % drenv start envs/ocm.yaml
    2025-03-24 23:01:34,854 INFO    [ocm] Starting environment
    2025-03-24 23:01:34,872 INFO    [hub] Starting lima cluster
    2025-03-24 23:01:34,872 INFO    [dr1] Starting lima cluster
    2025-03-24 23:01:34,872 INFO    [dr2] Starting lima cluster
    2025-03-24 23:03:17,896 INFO    [hub] Cluster started in 103.02 seconds
    2025-03-24 23:03:17,897 INFO    [hub/0] Running addons/ocm-hub/start
    2025-03-24 23:03:23,917 INFO    [dr2] Cluster started in 109.05 seconds
    2025-03-24 23:03:23,920 INFO    [dr2/0] Running addons/ocm-cluster/start
    2025-03-24 23:03:29,392 INFO    [dr1] Cluster started in 114.52 seconds
    2025-03-24 23:03:29,393 INFO    [dr1/0] Running addons/ocm-cluster/start
    2025-03-24 23:04:02,303 INFO    [hub/0] addons/ocm-hub/start completed in 44.41 seconds
    2025-03-24 23:04:02,303 INFO    [hub/0] Running addons/ocm-controller/start
    2025-03-24 23:04:13,775 INFO    [hub/0] addons/ocm-controller/start completed in 11.47 seconds
    2025-03-24 23:05:19,422 INFO    [dr2/0] addons/ocm-cluster/start completed in 115.50 seconds
    2025-03-24 23:05:19,422 INFO    [dr2/0] Running addons/ocm-cluster/test
    2025-03-24 23:05:21,654 INFO    [dr1/0] addons/ocm-cluster/start completed in 112.26 seconds
    2025-03-24 23:05:21,654 INFO    [dr1/0] Running addons/ocm-cluster/test
    2025-03-24 23:05:24,461 INFO    [dr2/0] addons/ocm-cluster/test completed in 5.04 seconds
    2025-03-24 23:05:24,694 INFO    [dr1/0] addons/ocm-cluster/test completed in 3.04 seconds
    2025-03-24 23:05:24,694 INFO    [ocm] Environment started in 229.84 seconds

[1] https://issues.redhat.com/browse/HYPBLD-620

Fixes: #1960