### PR TITLE
e2e: auto detect and set distro

### DIFF
--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -1,9 +1,6 @@
 # Configuration for RamenDR End to End testing.
 
 ---
-# Kubernetes distribution (possible distro values: k8s, ocp)
-distro: k8s
-
 # Git repository url and branch containing application manifests
 # to be deployed on the clusters.
 repo:

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -40,7 +40,7 @@ type Options struct {
 }
 
 // Default namespace mappings for Kubernetes (k8s) clusters.
-var k8sNamespaces = types.NamespacesConfig{
+var K8sNamespaces = types.NamespacesConfig{
 	RamenHubNamespace:       "ramen-system",
 	RamenDRClusterNamespace: "ramen-system",
 	RamenOpsNamespace:       "ramen-ops",
@@ -48,7 +48,7 @@ var k8sNamespaces = types.NamespacesConfig{
 }
 
 // Default namespace mappings for OpenShift (ocp) clusters.
-var ocpNamespaces = types.NamespacesConfig{
+var OcpNamespaces = types.NamespacesConfig{
 	RamenHubNamespace:       "openshift-operators",
 	RamenDRClusterNamespace: "openshift-dr-system",
 	RamenOpsNamespace:       "openshift-dr-ops",
@@ -108,9 +108,9 @@ func readConfig(configFile string, config *types.Config) error {
 func validateDistro(config *types.Config) error {
 	switch config.Distro {
 	case DistroK8s:
-		config.Namespaces = k8sNamespaces
+		config.Namespaces = K8sNamespaces
 	case DistroOcp:
-		config.Namespaces = ocpNamespaces
+		config.Namespaces = OcpNamespaces
 	default:
 		return fmt.Errorf("invalid distro %q: (choose one of %q, %q)",
 			config.Distro, DistroK8s, DistroOcp)

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -106,6 +106,11 @@ func readConfig(configFile string, config *types.Config) error {
 }
 
 func validateDistro(config *types.Config) error {
+	// Discover distro during validation if the distro is not configured
+	if config.Distro == "" {
+		return nil
+	}
+
 	switch config.Distro {
 	case DistroK8s:
 		config.Namespaces = K8sNamespaces


### PR DESCRIPTION
This change adds distro detection if distro is not explicitly provided by the user in the config.yaml. Based on detected
distribution, we set `config.Distro` and `config.Namespaces`.

Testing:
1. on ocp without config.distro , manually skipped disapp cephfs test. (Passed)
[ramen-e2e.log](https://github.com/user-attachments/files/19482894/ramen-e2e.log)
2. on k8s without config.distro (Passed)
[ramen-e2e.log](https://github.com/user-attachments/files/19464848/ramen-e2e.log)
4. on k8s with config distro=k8s (Passed)
[ramen-e2e.log](https://github.com/user-attachments/files/19465268/ramen-e2e.log)
5. fail if config.distro is set to invalid value
```
FATAL	Failed to read config: invalid distro "test": (choose one of "k8s", "ocp")
```

info log on success:
```
INFO Detected kubernetes distribution: "ocp"
INFO Using namespaces: {RamenHubNamespace:openshift-operators RamenDRClusterNamespace:openshift-dr-system RamenOpsNamespace:openshift-dr-ops ArgocdNamespace:openshift-gitops}
```

Fixes #1907 