### PR TITLE
ramendev: match the config to the default ones

### DIFF
--- a/ramendev/ramendev/resources/configmap.yaml
+++ b/ramendev/ramendev/resources/configmap.yaml
@@ -36,6 +36,7 @@ data:
       veleroNamespaceName: velero
     volSync:
       disabled: $volsync_disabled
+      destinationCopyMethod: Direct
     multiNamespace:
       FeatureEnabled: true
       volsyncSupported: true


### PR DESCRIPTION
The default destinationCopyMethod in our config files is Direct but in ramendev we had left it empty. Therefore, the code was defaulting to snapshot method.