### PR TITLE
e2e: auto detect managed cluster name

### DIFF
--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -32,19 +32,16 @@ Create a `config.yaml` file by copying the `config.yaml.sample` template:
 cp config.yaml.sample config.yaml
 ```
 
-Update `config.yaml` by uncommenting and adding cluster names and kubeconfig paths
+Update `config.yaml` by uncommenting and adding cluster kubeconfig paths
 for the hub and managed clusters.
 
 ```yaml
 Clusters:
   hub:
-    name: hub
     kubeconfigpath: /path/to/kubeconfig/hub
   c1:
-    name: dr1
     kubeconfigpath: /path/to/kubeconfig/c1
   c2:
-    name: dr2
     kubeconfigpath: /path/to/kubeconfig/c2
 ```
 

--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -49,15 +49,12 @@ tests:
     pvcspec: cephfs
 
 # Sample cluster configurations:
-# Uncomment and edit the following lines to set cluster names
-# and their kubeconfig paths for the hub and managed clusters.
+# Uncomment and edit the following lines to set the cluster
+# kubeconfig paths for the hub and managed clusters.
 # clusters:
 #   hub:
-#     name: hub
 #     kubeconfig: hub/config
 #   c1:
-#     name: dr1
 #     kubeconfig: dr1/config
 #   c2:
-#     name: dr2
 #     kubeconfig: dr2/config

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -38,7 +38,6 @@ type PVCSpecConfig struct {
 }
 
 type ClusterConfig struct {
-	Name       string
 	Kubeconfig string
 }
 

--- a/test/drenv/ramen.py
+++ b/test/drenv/ramen.py
@@ -53,7 +53,6 @@ def dump_e2e_config(env):
             f.write(data)
 
         e2e_clusters[e2e_name] = {
-            "name": cluster_name,
             "kubeconfig": kubeconfig,
         }
 


### PR DESCRIPTION
This change to auto detect managed cluster names instead of taking input from user from the config file. For hub clusters we always set "hub" as cluster name. 

Needs testing on OCP and drenv. Tests passed.
drenv:
```
INFO	Using "hub" cluster name: "hub"
INFO	Detected "c1" managed cluster name: "dr1"
INFO	Detected "c2" managed cluster name: "dr2"
```
ocp:
```
2025-03-28T13:55:34.196+0530	INFO	Using "hub" cluster name: "hub"
2025-03-28T13:55:35.183+0530	INFO	Detected "c1" managed cluster name: "prsurve-ibm-c1"
2025-03-28T13:55:36.288+0530	INFO	Detected "c2" managed cluster name: "prsurve-ibm-c2"
```

Fixes #1866 