### PR TITLE
Ensure the right VolumeSnapshot (VS) linked to the owner (VGS) is selected

### DIFF
--- a/internal/controller/util/cephfs_cg.go
+++ b/internal/controller/util/cephfs_cg.go
@@ -327,7 +327,7 @@ func GetVolumeSnapshotsOwnedByVolumeGroupSnapshot(
 
 	for _, snapshot := range volumeSnapshotList.Items {
 		for _, owner := range snapshot.ObjectMeta.OwnerReferences {
-			if owner.Kind == "VolumeGroupSnapshot" && owner.Name == vgs.Name {
+			if owner.Kind == "VolumeGroupSnapshot" && owner.Name == vgs.Name && owner.UID == vgs.UID {
 				volumeSnapshots = append(volumeSnapshots, snapshot)
 
 				break


### PR DESCRIPTION
It is possible for a VS to be associated with an outdated VGS. Using the UID when verifying the owner ensures the correct VS for the correct VGS is picked.