### PR TITLE
Require go 1.23.5 fixing CVE-2024-45336

### DIFF
--- a/.github/workflows/ramen.yaml
+++ b/.github/workflows/ramen.yaml
@@ -22,7 +22,7 @@ env:
   IMAGE_NAME: ${{ vars.IMAGE_NAME || 'ramen' }}
   OPERATOR_SUGGESTED_NAMESPACE: ${{ vars.OPERATOR_SUGGESTED_NAMESPACE || 'ramen-system' }}
   # Constants
-  GO_VERSION: "1.22"
+  GO_VERSION: "1.23"
   IMAGE_REGISTRY: "quay.io"
   IMAGE_TAG: "ci"
   DOCKERCMD: "podman"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the manager binary
-FROM docker.io/library/golang:1.22 as builder
+FROM docker.io/library/golang:1.23 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,8 +1,10 @@
 module github.com/ramendr/ramen/api
 
-go 1.22.5
+// Required minimum version, must be available in downstream builders.
+go 1.23.5
 
-toolchain go1.22.7
+// Recommended version: latest go 1.23 release.
+toolchain go1.23.7
 
 require (
 	k8s.io/api v0.31.1

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,8 +1,10 @@
 module github.com/ramendr/ramen/e2e
 
-go 1.22.5
+// Required minimum version, must be available in downstream builders.
+go 1.23.5
 
-toolchain go1.22.7
+// Recommended version: latest go 1.23 release.
+toolchain go1.23.7
 
 require (
 	github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/ramendr/ramen
 
-go 1.22.8
+// Required minimum version, must be available in downstream builders.
+go 1.23.5
 
-toolchain go1.22.9
+// Recommended version: latest go 1.23 release.
+toolchain go1.23.7
 
 // This replace should always be here for ease of development.
 replace github.com/ramendr/ramen/api => ./api


### PR DESCRIPTION
Fixing [CVE-2024-45336](https://access.redhat.com/security/cve/CVE-2024-45336):
golang net/http: net/http: sensitive headers incorrectly sent after
cross-domain redirect

Based on https://github.com/red-hat-storage/odf-cli/pull/113.

We could require go 1.22.11 which also include the fix[1], but it is
time to move to go 1.23 like other odf components.

We require go 1.23.5 to ensure so ramen cannot be built with older
version that does not include the fix to this CVE.

For toolchain version we can use the latest go release (1.24.1), but 
currently we use old golangci-lint version built with go 1.23, and it
fails with this error when using go 1.24.1:

    Failed executing command with error: can't load config: the Go
    language version (go1.23) used to build golangci-lint is lower than
    the targeted Go version (1.24.1)

So we keep tool chain version to as go1.23.7, using the latest go 1.23
release at this time. It would be nice to find a way to use the latest
release without modifying the toolchain manually.

All the go.mod file document now the purpose of the version requirements
to avoid confusion and broken builds.

The latest go version in the downstream builders is: 

    go1.23.6 (Red Hat 1.23.6-2.el9_6)

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2341751#c3
