### PR TITLE
Revert "drenv: Use private ocm-controller image"

### DIFF
--- a/test/addons/ocm-controller/cache
+++ b/test/addons/ocm-controller/cache
@@ -7,4 +7,4 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh(".", "addons/ocm-controller-1.yaml")
+cache.refresh(".", "addons/ocm-controller-2.yaml")

--- a/test/addons/ocm-controller/kustomization.yaml
+++ b/test/addons/ocm-controller/kustomization.yaml
@@ -11,8 +11,7 @@ resources:
 - https://github.com/stolostron/multicloud-operators-foundation.git/deploy/foundation/hub/overlays/ocm-controller?ref=main&timeout=300s
 images:
 - name: quay.io/stolostron/multicloud-manager
-  newName: quay.io/nirsof/multicloud-manager
-  newTag: 2025-03-24
+  newTag: latest
 patches:
 # Ammend upstream kustomization since it does not add an image tag. We want an
 # image tag to pin to specific version.
@@ -25,4 +24,4 @@ patches:
       value: "--agent-addon-image=quay.io/stolostron/multicloud-manager"
     - op: replace
       path: /spec/template/spec/containers/0/args/2
-      value: "--agent-addon-image=quay.io/nirsof/multicloud-manager:2025-03-24"
+      value: "--agent-addon-image=quay.io/stolostron/multicloud-manager:latest"

--- a/test/addons/ocm-controller/start
+++ b/test/addons/ocm-controller/start
@@ -12,7 +12,7 @@ from drenv import cache
 
 def deploy(cluster):
     print("Deploying ocm controller")
-    path = cache.get(".", "addons/ocm-controller-1.yaml")
+    path = cache.get(".", "addons/ocm-controller-2.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
 


### PR DESCRIPTION
The issue was fixed upstream[1] so we can use again upstream image. In quay.io we have now multiarch image with amd64 and arm64 manifests[2].

This reverts commit 8d3c48d326cd4b4c30d78406e35a1ce651bc6b14.

We also bump the version of the ocm-controller addon cache to ensure that CI picks up current upstream content. This should be done for every change in the kustomization.

[1] https://github.com/openshift/release/pull/63183
[2] https://quay.io/repository/stolostron/multicloud-manager?tab=tags&tag=latest