### PR TITLE
Update to ocm 0.16.0

### DIFF
--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -150,6 +150,7 @@ enough resources:
    For more info see
    [Install clusteradm CLI tool](https://open-cluster-management.io/docs/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool).
    Version v0.8.1 or later is required.
+   Tested with version v0.11.0-0-g73281f6.
 
 1. Install the `subctl` tool
 

--- a/test/README.md
+++ b/test/README.md
@@ -59,6 +59,7 @@ environment.
    For more info see
    [Install clusteradm CLI tool](https://open-cluster-management.io/docs/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool).
    Version v0.8.1 or later is required.
+   Tested with version v0.11.0-0-g73281f6.
 
 1. Install the `subctl` tool
 
@@ -180,6 +181,7 @@ environment.
    For more info see
    [Install clusteradm CLI tool](https://open-cluster-management.io/docs/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool).
    Version v0.8.1 or later is required.
+   Tested with version v0.11.0-0-g73281f6.
 
 1. Install the `subctl` tool
 


### PR DESCRIPTION
Recommend installing clusteradm v0.11.0, installing ocm 0.16.0. When we automated clusteadm tool installation, we will also enforce the version.

Tested with:
- [x] ocm.yaml
- [x] regional-dr.yaml