### PR TITLE
controllers: standardize log names and init procedure

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -153,6 +153,7 @@ func setupReconcilersCluster(mgr ctrl.Manager, ramenConfig *ramendrv1alpha1.Rame
 		Scheme:         mgr.GetScheme(),
 		APIReader:      mgr.GetAPIReader(),
 		ObjStoreGetter: controllers.S3ObjectStoreGetter(),
+		Log:            ctrl.Log.WithName("pvrgl"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ProtectedVolumeReplicationGroupList")
 		os.Exit(1)
@@ -167,7 +168,7 @@ func setupReconcilersCluster(mgr ctrl.Manager, ramenConfig *ramendrv1alpha1.Rame
 	if err := (&controllers.VolumeReplicationGroupReconciler{
 		Client:         mgr.GetClient(),
 		APIReader:      mgr.GetAPIReader(),
-		Log:            ctrl.Log.WithName("controllers").WithName("VolumeReplicationGroup"),
+		Log:            ctrl.Log.WithName("vrg"),
 		ObjStoreGetter: controllers.S3ObjectStoreGetter(),
 		Scheme:         mgr.GetScheme(),
 	}).SetupWithManager(mgr, ramenConfig); err != nil {
@@ -178,7 +179,7 @@ func setupReconcilersCluster(mgr ctrl.Manager, ramenConfig *ramendrv1alpha1.Rame
 	if err := (&controllers.DRClusterConfigReconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("DRClusterConfig"),
+		Log:    ctrl.Log.WithName("drcc"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DRClusterConfig")
 		os.Exit(1)
@@ -190,6 +191,7 @@ func setupReconcilersCluster(mgr ctrl.Manager, ramenConfig *ramendrv1alpha1.Rame
 		if err := (&controllers.ReplicationGroupDestinationReconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),
+			Log:    ctrl.Log.WithName("rgd"),
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ReplicationGroupDestination")
 			os.Exit(1)
@@ -199,6 +201,7 @@ func setupReconcilersCluster(mgr ctrl.Manager, ramenConfig *ramendrv1alpha1.Rame
 			Client:    mgr.GetClient(),
 			APIReader: mgr.GetAPIReader(),
 			Scheme:    mgr.GetScheme(),
+			Log:       ctrl.Log.WithName("rgs"),
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "ReplicationGroupSource")
 			os.Exit(1)
@@ -210,7 +213,7 @@ func setupReconcilersHub(mgr ctrl.Manager) {
 	if err := (&controllers.DRPolicyReconciler{
 		Client:    mgr.GetClient(),
 		APIReader: mgr.GetAPIReader(),
-		Log:       ctrl.Log.WithName("controllers").WithName("DRPolicy"),
+		Log:       ctrl.Log.WithName("drp"),
 		Scheme:    mgr.GetScheme(),
 		MCVGetter: rmnutil.ManagedClusterViewGetterImpl{
 			Client:    mgr.GetClient(),
@@ -225,7 +228,7 @@ func setupReconcilersHub(mgr ctrl.Manager) {
 	if err := (&controllers.DRClusterReconciler{
 		Client:    mgr.GetClient(),
 		APIReader: mgr.GetAPIReader(),
-		Log:       ctrl.Log.WithName("controllers").WithName("DRCluster"),
+		Log:       ctrl.Log.WithName("drc"),
 		Scheme:    mgr.GetScheme(),
 		MCVGetter: rmnutil.ManagedClusterViewGetterImpl{
 			Client:    mgr.GetClient(),
@@ -240,7 +243,7 @@ func setupReconcilersHub(mgr ctrl.Manager) {
 	if err := (&controllers.DRPlacementControlReconciler{
 		Client:    mgr.GetClient(),
 		APIReader: mgr.GetAPIReader(),
-		Log:       ctrl.Log.WithName("controllers").WithName("DRPlacementControl"),
+		Log:       ctrl.Log.WithName("drpc"),
 		MCVGetter: rmnutil.ManagedClusterViewGetterImpl{
 			Client:    mgr.GetClient(),
 			APIReader: mgr.GetAPIReader(),

--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -357,7 +356,7 @@ func filterDRClusterSecret(ctx context.Context, reader client.Reader, secret *co
 func (r *DRClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// TODO: Validate managedCluster name? and also ensure it is not deleted!
 	// TODO: Setup views for storage class and VRClass to read and report IDs
-	log := r.Log.WithValues("name", req.NamespacedName.Name, "rid", uuid.New())
+	log := r.Log.WithValues("drc", req.NamespacedName.Name, "rid", util.GetRID())
 	log.Info("reconcile enter")
 
 	defer log.Info("reconcile exit")

--- a/internal/controller/drclusterconfig_controller.go
+++ b/internal/controller/drclusterconfig_controller.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/go-logr/logr"
-	"github.com/google/uuid"
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/internal/controller/core"
 	"github.com/ramendr/ramen/internal/controller/util"
@@ -59,7 +58,7 @@ type DRClusterConfigReconciler struct {
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=get;list;watch;create;update;delete
 
 func (r *DRClusterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("name", req.NamespacedName.Name, "rid", uuid.New())
+	log := r.Log.WithValues("drcc", req.NamespacedName.Name, "rid", util.GetRID())
 	log.Info("reconcile enter")
 
 	defer log.Info("reconcile exit")

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -13,7 +13,6 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/go-logr/logr"
-	"github.com/google/uuid"
 	recipecore "github.com/ramendr/ramen/internal/controller/core"
 	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -122,7 +121,7 @@ func (r *DRPlacementControlReconciler) SetupWithManager(mgr ctrl.Manager) error 
 //
 //nolint:funlen,gocognit,gocyclo,cyclop
 func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := r.Log.WithValues("DRPC", req.NamespacedName, "rid", uuid.New())
+	logger := r.Log.WithValues("drpc", req.NamespacedName, "rid", rmnutil.GetRID())
 
 	logger.Info("Entering reconcile loop")
 	defer logger.Info("Exiting reconcile loop")

--- a/internal/controller/drpolicy_controller.go
+++ b/internal/controller/drpolicy_controller.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -82,7 +81,7 @@ const AllDRPolicyAnnotation = "drpolicy.ramendr.openshift.io"
 //
 //nolint:cyclop,funlen
 func (r *DRPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("DRPolicy", req.NamespacedName.Name, "rid", uuid.New())
+	log := r.Log.WithValues("drp", req.NamespacedName.Name, "rid", util.GetRID())
 	log.Info("reconcile enter")
 
 	defer log.Info("reconcile exit")

--- a/internal/controller/protectedvolumereplicationgrouplist_controller.go
+++ b/internal/controller/protectedvolumereplicationgrouplist_controller.go
@@ -30,6 +30,7 @@ type ProtectedVolumeReplicationGroupListReconciler struct {
 	ObjStoreGetter ObjectStoreGetter
 	Scheme         *runtime.Scheme
 	RateLimiter    *workqueue.TypedRateLimiter[reconcile.Request]
+	Log            logr.Logger
 }
 
 type ProtectedVolumeReplicationGroupListInstance struct {
@@ -60,7 +61,7 @@ func (r *ProtectedVolumeReplicationGroupListReconciler) Reconcile(ctx context.Co
 	s := ProtectedVolumeReplicationGroupListInstance{
 		reconciler: r,
 		ctx:        ctx,
-		log:        ctrl.Log.WithName("pvrgl").WithValues("name", req.NamespacedName.Name),
+		log:        r.Log.WithValues("pvrgl", req.NamespacedName.Name, "rid", util.GetRID()),
 		instance:   &ramendrv1alpha1.ProtectedVolumeReplicationGroupList{},
 	}
 

--- a/internal/controller/replicationgroupdestination_controller.go
+++ b/internal/controller/replicationgroupdestination_controller.go
@@ -8,6 +8,7 @@ import (
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 	"github.com/backube/volsync/controllers/statemachine"
+	"github.com/go-logr/logr"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/internal/controller/cephfscg"
@@ -21,7 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -30,6 +30,7 @@ import (
 type ReplicationGroupDestinationReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+	Log    logr.Logger
 }
 
 //+kubebuilder:rbac:groups=ramendr.openshift.io,resources=replicationgroupdestinations,verbs=get;list;watch;create;update;patch;delete
@@ -39,7 +40,7 @@ type ReplicationGroupDestinationReconciler struct {
 //+kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;list;watch;delete
 
 func (r *ReplicationGroupDestinationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
+	logger := r.Log.WithValues("rgd", req.NamespacedName, "rid", util.GetRID())
 	logger.Info("Get ReplicationGroupDestination")
 
 	rgd := &ramendrv1alpha1.ReplicationGroupDestination{}

--- a/internal/controller/replicationgroupsource_controller.go
+++ b/internal/controller/replicationgroupsource_controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	vgsv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -16,11 +17,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/internal/controller/cephfscg"
+	"github.com/ramendr/ramen/internal/controller/util"
 	"github.com/ramendr/ramen/internal/controller/volsync"
 
 	"github.com/backube/volsync/controllers/statemachine"
@@ -58,6 +59,7 @@ type ReplicationGroupSourceReconciler struct {
 	APIReader                        client.Reader
 	Scheme                           *runtime.Scheme
 	volumeGroupSnapshotCRsAreWatched bool
+	Log                              logr.Logger
 }
 
 // +kubebuilder:rbac:groups=ramendr.openshift.io,resources=replicationgroupsources,verbs=get;list;watch;create;update;patch;delete
@@ -73,7 +75,7 @@ type ReplicationGroupSourceReconciler struct {
 
 //nolint:funlen
 func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
+	logger := r.Log.WithValues("rgs", req.NamespacedName, "rid", util.GetRID())
 	logger.Info("Get ReplicationGroupSource")
 
 	if !r.volumeGroupSnapshotCRsAreWatched {

--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -9,6 +9,7 @@ import (
 	"hash/crc32"
 	"reflect"
 
+	"github.com/google/uuid"
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/internal/controller/core"
 	corev1 "k8s.io/api/core/v1"
@@ -286,4 +287,8 @@ func getShortenedResourceName(namePrefix string, ownerName string, maxLength int
 // https://github.com/backube/volsync/pull/1519
 func GetHashedName(name string) string {
 	return fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(name)))
+}
+
+func GetRID() string {
+	return GetHashedName(uuid.New().String())
 }

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -15,7 +15,6 @@ import (
 	"golang.org/x/time/rate"
 
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
-	"github.com/google/uuid"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"github.com/ramendr/ramen/internal/controller/kubeobjects"
 	"github.com/ramendr/ramen/internal/controller/kubeobjects/velero"
@@ -405,7 +404,7 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 //
 //nolint:funlen
 func (r *VolumeReplicationGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := r.Log.WithValues("VolumeReplicationGroup", req.NamespacedName, "rid", uuid.New())
+	log := r.Log.WithValues("vrg", req.NamespacedName, "rid", util.GetRID())
 
 	log.Info("Entering reconcile loop")
 


### PR DESCRIPTION
With this change, all the 8 controllers in Ramen
- will have the logger name set to the abbreviated name of the controller
- have a rid(reconcile ID) set to a UUID generated at the start of the reconcile
- log the namespacedName of the resource under the key of the resource type