### PR TITLE
E2E fix to keep the tests compatible with the ODF-DR console.

### DIFF
--- a/e2e/dractions/crud.go
+++ b/e2e/dractions/crud.go
@@ -106,8 +106,9 @@ func generateDRPC(name, namespace, clusterName, drPolicyName, placementName, app
 				Name: drPolicyName,
 			},
 			PlacementRef: v1.ObjectReference{
-				Kind: "placement",
-				Name: placementName,
+				Kind:      "placement",
+				Name:      placementName,
+				Namespace: namespace,
 			},
 			PVCSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"appname": appname},
@@ -184,8 +185,9 @@ func generateDRPCDiscoveredApps(name, namespace, clusterName, drPolicyName, plac
 				Name: drPolicyName,
 			},
 			PlacementRef: v1.ObjectReference{
-				Kind: "placement",
-				Name: placementName,
+				Kind:      "placement",
+				Name:      placementName,
+				Namespace: namespace,
 			},
 			PVCSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"appname": appname},


### PR DESCRIPTION
When running the E2E tests against OpenShift, the tests execute within an OpenShift cluster, while cleanup can be managed via the console. This setup allows users to trigger E2E testing easily downstream while simultaneously tracking progress and results in the ODF console.  

To ensure E2E testing remains compatible with the ODF console, minor adjustments are necessary. Specifically, the console requires the **name**, **kind**, and **namespace** of the `placementRef` to locate the `DRPlacementControl (DRPC)` object associated with a placement. However, the namespace was previously missing in the E2E test implementation, preventing the console from properly retrieving the **protected DR details**. This PR addresses the issue by adding the missing namespace to `placementRef`.  

#### **Before Fix** (Missing Namespace in PlacementRef)  
```go
PlacementRef: v1.ObjectReference{
    Kind: "placement",
    Name: placementName,
},
```
#### **After Fix** (Namespace Added)  
```go
PlacementRef: v1.ObjectReference{
    Kind:      "placement",
    Name:      placementName,
    Namespace: namespace, // Added namespace
},
```