### PR TITLE
Refactor haveOverlappingMetroZones to return a list of cluster lists

### DIFF
--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -406,7 +406,7 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 
 	d.drType = DRTypeAsync
 
-	isMetro, _ := dRPolicySupportsMetro(drPolicy, drClusters)
+	isMetro, _ := dRPolicySupportsMetro(drPolicy, drClusters, nil)
 	if isMetro {
 		d.volSyncDisabled = true
 		d.drType = DRTypeSync
@@ -1466,7 +1466,7 @@ func (r *DRPlacementControlReconciler) setDRPCMetrics(ctx context.Context,
 	}
 
 	// do not set sync metrics if metro-dr
-	isMetro, _ := dRPolicySupportsMetro(drPolicy, drClusters)
+	isMetro, _ := dRPolicySupportsMetro(drPolicy, drClusters, nil)
 	if isMetro {
 		return nil
 	}

--- a/internal/controller/drplacementcontrol_watcher.go
+++ b/internal/controller/drplacementcontrol_watcher.go
@@ -478,7 +478,7 @@ func DRPCsFailingOverToCluster(k8sclient client.Client, log logr.Logger, drclust
 			}
 
 			// Skip if policy is of type metro, fake the from and to cluster
-			if metro, _ := dRPolicySupportsMetro(drpolicy, drClusters); metro {
+			if metro, _ := dRPolicySupportsMetro(drpolicy, drClusters, nil); metro {
 				log.Info("Sync DRPolicy detected, skipping!")
 
 				break


### PR DESCRIPTION
As a part of deprecating spec.Region from DRCluster, the way to process overlapping metro DRPolicies was amended to return different maps from the corresponsing region based or peerClass based policies.

This is now refactored to return only a list of list of clusters as required to detect overlapping metro zones.