### PR TITLE
e2e: Support cancellation

### DIFF
--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -49,7 +49,7 @@ func (a ApplicationSet) Undeploy(ctx types.TestContext) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	clusterName, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, name)
+	clusterName, err := util.GetCurrentCluster(ctx, managementNamespace, name)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err

--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -12,7 +12,7 @@ import (
 type ApplicationSet struct{}
 
 // Deploy creates an ApplicationSet on the hub cluster, creating the workload on one of the managed clusters.
-func (a ApplicationSet) Deploy(ctx types.Context) error {
+func (a ApplicationSet) Deploy(ctx types.TestContext) error {
 	name := ctx.Name()
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
@@ -44,7 +44,7 @@ func (a ApplicationSet) Deploy(ctx types.Context) error {
 }
 
 // Undeploy deletes an ApplicationSet from the hub cluster, deleting the workload from the managed clusters.
-func (a ApplicationSet) Undeploy(ctx types.Context) error {
+func (a ApplicationSet) Undeploy(ctx types.TestContext) error {
 	name := ctx.Name()
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
@@ -86,7 +86,7 @@ func (a ApplicationSet) GetName() string {
 	return "appset"
 }
 
-func (a ApplicationSet) GetNamespace(ctx types.Context) string {
+func (a ApplicationSet) GetNamespace(ctx types.TestContext) string {
 	return ctx.Config().Namespaces.ArgocdNamespace
 }
 

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -31,7 +31,7 @@ const (
 	fMode = 0o600
 )
 
-func CreateManagedClusterSetBinding(ctx types.Context, name, namespace string) error {
+func CreateManagedClusterSetBinding(ctx types.TestContext, name, namespace string) error {
 	log := ctx.Logger()
 	config := ctx.Config()
 	labels := make(map[string]string)
@@ -61,7 +61,7 @@ func CreateManagedClusterSetBinding(ctx types.Context, name, namespace string) e
 	return nil
 }
 
-func DeleteManagedClusterSetBinding(ctx types.Context, name, namespace string) error {
+func DeleteManagedClusterSetBinding(ctx types.TestContext, name, namespace string) error {
 	log := ctx.Logger()
 	mcsb := &ocmv1b2.ManagedClusterSetBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -84,7 +84,7 @@ func DeleteManagedClusterSetBinding(ctx types.Context, name, namespace string) e
 	return nil
 }
 
-func CreatePlacement(ctx types.Context, name, namespace string, clusterName string) error {
+func CreatePlacement(ctx types.TestContext, name, namespace string, clusterName string) error {
 	log := ctx.Logger()
 	config := ctx.Config()
 	labels := make(map[string]string)
@@ -134,7 +134,7 @@ func CreatePlacement(ctx types.Context, name, namespace string, clusterName stri
 	return nil
 }
 
-func DeletePlacement(ctx types.Context, name, namespace string) error {
+func DeletePlacement(ctx types.TestContext, name, namespace string) error {
 	log := ctx.Logger()
 	placement := &ocmv1b1.Placement{
 		ObjectMeta: metav1.ObjectMeta{
@@ -157,7 +157,7 @@ func DeletePlacement(ctx types.Context, name, namespace string) error {
 	return nil
 }
 
-func CreateSubscription(ctx types.Context, s Subscription) error {
+func CreateSubscription(ctx types.TestContext, s Subscription) error {
 	name := ctx.Name()
 	log := ctx.Logger()
 	config := ctx.Config()
@@ -216,7 +216,7 @@ func CreateSubscription(ctx types.Context, s Subscription) error {
 	return nil
 }
 
-func DeleteSubscription(ctx types.Context, s Subscription) error {
+func DeleteSubscription(ctx types.TestContext, s Subscription) error {
 	name := ctx.Name()
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
@@ -254,7 +254,7 @@ func getSubscription(cluster types.Cluster, namespace, name string) (*subscripti
 	return subscription, nil
 }
 
-func CreatePlacementDecisionConfigMap(ctx types.Context, cmName string, cmNamespace string) error {
+func CreatePlacementDecisionConfigMap(ctx types.TestContext, cmName string, cmNamespace string) error {
 	log := ctx.Logger()
 	object := metav1.ObjectMeta{Name: cmName, Namespace: cmNamespace}
 
@@ -281,7 +281,7 @@ func CreatePlacementDecisionConfigMap(ctx types.Context, cmName string, cmNamesp
 	return nil
 }
 
-func DeleteConfigMap(ctx types.Context, cmName string, cmNamespace string) error {
+func DeleteConfigMap(ctx types.TestContext, cmName string, cmNamespace string) error {
 	log := ctx.Logger()
 	object := metav1.ObjectMeta{Name: cmName, Namespace: cmNamespace}
 
@@ -304,7 +304,7 @@ func DeleteConfigMap(ctx types.Context, cmName string, cmNamespace string) error
 }
 
 // nolint:funlen
-func CreateApplicationSet(ctx types.Context, a ApplicationSet) error {
+func CreateApplicationSet(ctx types.TestContext, a ApplicationSet) error {
 	var requeueSeconds int64 = 180
 
 	name := ctx.Name()
@@ -388,7 +388,7 @@ func CreateApplicationSet(ctx types.Context, a ApplicationSet) error {
 	return nil
 }
 
-func DeleteApplicationSet(ctx types.Context, a ApplicationSet) error {
+func DeleteApplicationSet(ctx types.TestContext, a ApplicationSet) error {
 	name := ctx.Name()
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
@@ -414,7 +414,7 @@ func DeleteApplicationSet(ctx types.Context, a ApplicationSet) error {
 	return nil
 }
 
-func DeleteDiscoveredApps(ctx types.Context, cluster types.Cluster, namespace string) error {
+func DeleteDiscoveredApps(ctx types.TestContext, cluster types.Cluster, namespace string) error {
 	log := ctx.Logger()
 
 	tempDir, err := os.MkdirTemp("", "ramen-")
@@ -448,7 +448,7 @@ func DeleteDiscoveredApps(ctx types.Context, cluster types.Cluster, namespace st
 
 type CombinedData map[string]interface{}
 
-func CreateKustomizationFile(ctx types.Context, dir string) error {
+func CreateKustomizationFile(ctx types.TestContext, dir string) error {
 	w := ctx.Workload()
 	config := ctx.Config()
 	yamlData := `resources:

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -4,7 +4,6 @@
 package deployers
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -47,7 +46,7 @@ func CreateManagedClusterSetBinding(ctx types.TestContext, name, namespace strin
 		},
 	}
 
-	err := ctx.Env().Hub.Client.Create(context.Background(), mcsb)
+	err := ctx.Env().Hub.Client.Create(ctx.Context(), mcsb)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
@@ -70,7 +69,7 @@ func DeleteManagedClusterSetBinding(ctx types.TestContext, name, namespace strin
 		},
 	}
 
-	err := ctx.Env().Hub.Client.Delete(context.Background(), mcsb)
+	err := ctx.Env().Hub.Client.Delete(ctx.Context(), mcsb)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
@@ -120,7 +119,7 @@ func CreatePlacement(ctx types.TestContext, name, namespace string, clusterName 
 		},
 	}
 
-	err := ctx.Env().Hub.Client.Create(context.Background(), placement)
+	err := ctx.Env().Hub.Client.Create(ctx.Context(), placement)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
@@ -143,7 +142,7 @@ func DeletePlacement(ctx types.TestContext, name, namespace string) error {
 		},
 	}
 
-	err := ctx.Env().Hub.Client.Delete(context.Background(), placement)
+	err := ctx.Env().Hub.Client.Delete(ctx.Context(), placement)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
@@ -202,7 +201,7 @@ func CreateSubscription(ctx types.TestContext, s Subscription) error {
 		})
 	}
 
-	err := ctx.Env().Hub.Client.Create(context.Background(), subscription)
+	err := ctx.Env().Hub.Client.Create(ctx.Context(), subscription)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
@@ -228,7 +227,7 @@ func DeleteSubscription(ctx types.TestContext, s Subscription) error {
 		},
 	}
 
-	err := ctx.Env().Hub.Client.Delete(context.Background(), subscription)
+	err := ctx.Env().Hub.Client.Delete(ctx.Context(), subscription)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
@@ -242,11 +241,13 @@ func DeleteSubscription(ctx types.TestContext, s Subscription) error {
 	return nil
 }
 
-func getSubscription(cluster types.Cluster, namespace, name string) (*subscriptionv1.Subscription, error) {
+func getSubscription(ctx types.TestContext, namespace, name string) (*subscriptionv1.Subscription, error) {
+	hub := ctx.Env().Hub
+
 	subscription := &subscriptionv1.Subscription{}
 	key := k8stypes.NamespacedName{Name: name, Namespace: namespace}
 
-	err := cluster.Client.Get(context.Background(), key, subscription)
+	err := hub.Client.Get(ctx.Context(), key, subscription)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +268,7 @@ func CreatePlacementDecisionConfigMap(ctx types.TestContext, cmName string, cmNa
 
 	configMap := &corev1.ConfigMap{ObjectMeta: object, Data: data}
 
-	err := ctx.Env().Hub.Client.Create(context.Background(), configMap)
+	err := ctx.Env().Hub.Client.Create(ctx.Context(), configMap)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return fmt.Errorf("could not create configMap %q", cmName)
@@ -289,7 +290,7 @@ func DeleteConfigMap(ctx types.TestContext, cmName string, cmNamespace string) e
 		ObjectMeta: object,
 	}
 
-	err := ctx.Env().Hub.Client.Delete(context.Background(), configMap)
+	err := ctx.Env().Hub.Client.Delete(ctx.Context(), configMap)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return fmt.Errorf("could not delete configMap %q in cluster %q", cmName, ctx.Env().Hub.Name)
@@ -374,7 +375,7 @@ func CreateApplicationSet(ctx types.TestContext, a ApplicationSet) error {
 		appset.Spec.Template.Spec.Source.Kustomize = patches
 	}
 
-	err := ctx.Env().Hub.Client.Create(context.Background(), appset)
+	err := ctx.Env().Hub.Client.Create(ctx.Context(), appset)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
@@ -400,7 +401,7 @@ func DeleteApplicationSet(ctx types.TestContext, a ApplicationSet) error {
 		},
 	}
 
-	err := ctx.Env().Hub.Client.Delete(context.Background(), appset)
+	err := ctx.Env().Hub.Client.Delete(ctx.Context(), appset)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -31,7 +31,7 @@ func (d DiscoveredApp) Deploy(ctx types.TestContext) error {
 	cluster := ctx.Env().C1
 
 	// Create namespace on the first DR cluster (c1)
-	err := util.CreateNamespace(cluster, appNamespace, log)
+	err := util.CreateNamespace(ctx, cluster, appNamespace)
 	if err != nil {
 		return err
 	}
@@ -89,11 +89,11 @@ func (d DiscoveredApp) Undeploy(ctx types.TestContext) error {
 	}
 
 	// delete namespace on both clusters
-	if err := util.DeleteNamespace(ctx.Env().C1, appNamespace, log); err != nil {
+	if err := util.DeleteNamespace(ctx, ctx.Env().C1, appNamespace); err != nil {
 		return err
 	}
 
-	if err := util.DeleteNamespace(ctx.Env().C2, appNamespace, log); err != nil {
+	if err := util.DeleteNamespace(ctx, ctx.Env().C2, appNamespace); err != nil {
 		return err
 	}
 

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -18,12 +18,12 @@ func (d DiscoveredApp) GetName() string {
 	return "disapp"
 }
 
-func (d DiscoveredApp) GetNamespace(ctx types.Context) string {
+func (d DiscoveredApp) GetNamespace(ctx types.TestContext) string {
 	return ctx.Config().Namespaces.RamenOpsNamespace
 }
 
 // Deploy creates a workload on the first managed cluster.
-func (d DiscoveredApp) Deploy(ctx types.Context) error {
+func (d DiscoveredApp) Deploy(ctx types.TestContext) error {
 	log := ctx.Logger()
 	appNamespace := ctx.AppNamespace()
 
@@ -72,7 +72,7 @@ func (d DiscoveredApp) Deploy(ctx types.Context) error {
 }
 
 // Undeploy deletes the workload from the managed clusters.
-func (d DiscoveredApp) Undeploy(ctx types.Context) error {
+func (d DiscoveredApp) Undeploy(ctx types.TestContext) error {
 	log := ctx.Logger()
 	appNamespace := ctx.AppNamespace()
 

--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -22,7 +22,7 @@ func waitSubscriptionPhase(
 	startTime := time.Now()
 
 	for {
-		sub, err := getSubscription(ctx.Env().Hub, namespace, name)
+		sub, err := getSubscription(ctx, namespace, name)
 		if err != nil {
 			return err
 		}

--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -13,7 +13,11 @@ import (
 	"github.com/ramendr/ramen/e2e/util"
 )
 
-func waitSubscriptionPhase(ctx types.Context, namespace, name string, phase subscriptionv1.SubscriptionPhase) error {
+func waitSubscriptionPhase(
+	ctx types.TestContext,
+	namespace, name string,
+	phase subscriptionv1.SubscriptionPhase,
+) error {
 	log := ctx.Logger()
 	startTime := time.Now()
 
@@ -39,7 +43,7 @@ func waitSubscriptionPhase(ctx types.Context, namespace, name string, phase subs
 	}
 }
 
-func WaitWorkloadHealth(ctx types.Context, cluster types.Cluster, namespace string) error {
+func WaitWorkloadHealth(ctx types.TestContext, cluster types.Cluster, namespace string) error {
 	log := ctx.Logger()
 	w := ctx.Workload()
 	startTime := time.Now()

--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -39,7 +39,9 @@ func waitSubscriptionPhase(
 				name, phase, ctx.Env().Hub.Name)
 		}
 
-		time.Sleep(util.RetryInterval)
+		if err := util.Sleep(ctx.Context(), util.RetryInterval); err != nil {
+			return err
+		}
 	}
 }
 
@@ -61,6 +63,8 @@ func WaitWorkloadHealth(ctx types.TestContext, cluster types.Cluster, namespace 
 				w.GetName(), util.Timeout, cluster.Name)
 		}
 
-		time.Sleep(util.RetryInterval)
+		if err := util.Sleep(ctx.Context(), util.RetryInterval); err != nil {
+			return err
+		}
 	}
 }

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -79,7 +79,7 @@ func (s Subscription) Undeploy(ctx types.TestContext) error {
 	config := ctx.Config()
 	managementNamespace := ctx.ManagementNamespace()
 
-	clusterName, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, name)
+	clusterName, err := util.GetCurrentCluster(ctx, managementNamespace, name)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -42,7 +42,7 @@ func (s Subscription) Deploy(ctx types.TestContext) error {
 		ctx.AppNamespace(), ctx.Workload().GetAppName(), cluster.Name)
 
 	// create subscription namespace
-	err := util.CreateNamespace(ctx.Env().Hub, managementNamespace, log)
+	err := util.CreateNamespace(ctx, ctx.Env().Hub, managementNamespace)
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func (s Subscription) Undeploy(ctx types.TestContext) error {
 		return err
 	}
 
-	err = util.DeleteNamespace(ctx.Env().Hub, managementNamespace, log)
+	err = util.DeleteNamespace(ctx, ctx.Env().Hub, managementNamespace)
 	if err != nil {
 		return err
 	}

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -17,13 +17,13 @@ func (s Subscription) GetName() string {
 	return "subscr"
 }
 
-func (s Subscription) GetNamespace(_ types.Context) string {
+func (s Subscription) GetNamespace(_ types.TestContext) string {
 	// No special namespaces.
 	return ""
 }
 
 // Deploy creates a Subscription on the hub cluster, creating the workload on one of the managed clusters.
-func (s Subscription) Deploy(ctx types.Context) error {
+func (s Subscription) Deploy(ctx types.TestContext) error {
 	// Generate a Placement for the Workload
 	// Use the global Channel
 	// Generate a Binding for the namespace (does this need clusters?)
@@ -73,7 +73,7 @@ func (s Subscription) Deploy(ctx types.Context) error {
 }
 
 // Undeploy deletes a subscription from the hub cluster, deleting the workload from the managed clusters.
-func (s Subscription) Undeploy(ctx types.Context) error {
+func (s Subscription) Undeploy(ctx types.TestContext) error {
 	name := ctx.Name()
 	log := ctx.Logger()
 	config := ctx.Config()

--- a/e2e/dr_test.go
+++ b/e2e/dr_test.go
@@ -54,7 +54,7 @@ func TestDR(dt *testing.T) {
 			panic(err)
 		}
 
-		ctx := test.NewContext(workload, deployer, Ctx.env, Ctx.config, Ctx.log)
+		ctx := test.NewContext(&Ctx, workload, deployer)
 		t.Run(ctx.Name(), func(dt *testing.T) {
 			t := test.WithLog(dt, ctx.Logger())
 			t.Parallel()

--- a/e2e/dr_test.go
+++ b/e2e/dr_test.go
@@ -22,7 +22,7 @@ func TestDR(dt *testing.T) {
 		t.Fatal("No tests found in the configuration file")
 	}
 
-	if err := validate.TestConfig(Ctx.env, Ctx.config, Ctx.log); err != nil {
+	if err := validate.TestConfig(&Ctx); err != nil {
 		t.Fatal(err.Error())
 	}
 

--- a/e2e/dr_test.go
+++ b/e2e/dr_test.go
@@ -26,12 +26,12 @@ func TestDR(dt *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	if err := util.EnsureChannel(Ctx.env.Hub, Ctx.config, Ctx.log); err != nil {
+	if err := util.EnsureChannel(&Ctx); err != nil {
 		t.Fatalf("Failed to ensure channel: %s", err)
 	}
 
 	t.Cleanup(func() {
-		if err := util.EnsureChannelDeleted(Ctx.env.Hub, Ctx.config, Ctx.log); err != nil {
+		if err := util.EnsureChannelDeleted(&Ctx); err != nil {
 			t.Fatalf("Failed to ensure channel deleted: %s", err)
 		}
 	})

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -61,7 +61,7 @@ func EnableProtection(ctx types.TestContext) error {
 
 		placement.Annotations[OcmSchedulingDisable] = "true"
 
-		if err := updatePlacement(ctx.Env().Hub, placement); err != nil {
+		if err := updatePlacement(ctx, placement); err != nil {
 			return err
 		}
 
@@ -199,7 +199,8 @@ func Relocate(ctx types.TestContext) error {
 	return nil
 }
 
-func failoverRelocate(ctx types.TestContext,
+func failoverRelocate(
+	ctx types.TestContext,
 	action ramen.DRAction,
 	state ramen.DRState,
 	currentCluster string,
@@ -231,7 +232,6 @@ func waitAndUpdateDRPC(
 	targetCluster string,
 ) error {
 	log := ctx.Logger()
-	hub := ctx.Env().Hub
 
 	// here we expect drpc should be ready before action
 	if err := waitDRPCReady(ctx, namespace, drpcName); err != nil {
@@ -239,7 +239,7 @@ func waitAndUpdateDRPC(
 	}
 
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		drpc, err := getDRPC(hub, namespace, drpcName)
+		drpc, err := getDRPC(ctx, namespace, drpcName)
 		if err != nil {
 			return err
 		}
@@ -251,7 +251,7 @@ func waitAndUpdateDRPC(
 			drpc.Spec.PreferredCluster = targetCluster
 		}
 
-		if err := updateDRPC(hub, drpc); err != nil {
+		if err := updateDRPC(ctx, drpc); err != nil {
 			return err
 		}
 

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -148,7 +148,7 @@ func Failover(ctx types.TestContext) error {
 		return err
 	}
 
-	targetCluster, err := getTargetCluster(ctx.Env().Hub, config.DRPolicy, currentCluster)
+	targetCluster, err := getTargetCluster(ctx, ctx.Env().Hub, config.DRPolicy, currentCluster)
 	if err != nil {
 		return err
 	}
@@ -181,7 +181,7 @@ func Relocate(ctx types.TestContext) error {
 		return err
 	}
 
-	targetCluster, err := getTargetCluster(ctx.Env().Hub, config.DRPolicy, currentCluster)
+	targetCluster, err := getTargetCluster(ctx, ctx.Env().Hub, config.DRPolicy, currentCluster)
 	if err != nil {
 		return err
 	}

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -25,7 +25,7 @@ const (
 // Determine KubeObjectProtection requirements if Imperative (?)
 // Create DRPC, in desired namespace
 // nolint:funlen
-func EnableProtection(ctx types.Context) error {
+func EnableProtection(ctx types.TestContext) error {
 	d := ctx.Deployer()
 	if d.IsDiscovered() {
 		return EnableProtectionDiscoveredApps(ctx)
@@ -97,7 +97,7 @@ func EnableProtection(ctx types.Context) error {
 
 // remove DRPC
 // update placement annotation
-func DisableProtection(ctx types.Context) error {
+func DisableProtection(ctx types.TestContext) error {
 	d := ctx.Deployer()
 	if d.IsDiscovered() {
 		return DisableProtectionDiscoveredApps(ctx)
@@ -138,7 +138,7 @@ func DisableProtection(ctx types.Context) error {
 	return nil
 }
 
-func Failover(ctx types.Context) error {
+func Failover(ctx types.TestContext) error {
 	managementNamespace := ctx.ManagementNamespace()
 	log := ctx.Logger()
 	name := ctx.Name()
@@ -171,7 +171,7 @@ func Failover(ctx types.Context) error {
 // Check Placement
 // Relocate to Primary in DRPolicy as the PrimaryCluster
 // Update DRPC
-func Relocate(ctx types.Context) error {
+func Relocate(ctx types.TestContext) error {
 	managementNamespace := ctx.ManagementNamespace()
 	log := ctx.Logger()
 	config := ctx.Config()
@@ -200,7 +200,7 @@ func Relocate(ctx types.Context) error {
 	return nil
 }
 
-func failoverRelocate(ctx types.Context,
+func failoverRelocate(ctx types.TestContext,
 	action ramen.DRAction,
 	state ramen.DRState,
 	currentCluster string,
@@ -226,7 +226,7 @@ func failoverRelocate(ctx types.Context,
 }
 
 func waitAndUpdateDRPC(
-	ctx types.Context,
+	ctx types.TestContext,
 	namespace, drpcName string,
 	action ramen.DRAction,
 	targetCluster string,
@@ -266,7 +266,7 @@ func waitAndUpdateDRPC(
 // createNamespaces creates namespaces and annotations for managed app protection on
 // both DR clusters for Volsync based replication if the distribution is Kubernetes.
 // Returns an error if namespace creation or annotation fails.
-func createNamespaces(ctx types.Context, appNamespace string, log *zap.SugaredLogger) error {
+func createNamespaces(ctx types.TestContext, appNamespace string, log *zap.SugaredLogger) error {
 	if ctx.Config().Distro == config.DistroK8s {
 		return util.CreateNamespaceAndAddAnnotation(ctx.Env(), appNamespace, log)
 	}

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -42,7 +42,7 @@ func EnableProtection(ctx types.TestContext) error {
 	placementName := name
 	drpcName := name
 
-	clusterName, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, placementName)
+	clusterName, err := util.GetCurrentCluster(ctx, managementNamespace, placementName)
 	if err != nil {
 		return err
 	}
@@ -50,7 +50,7 @@ func EnableProtection(ctx types.TestContext) error {
 	log.Infof("Protecting workload \"%s/%s\" in cluster %q", appNamespace, appname, clusterName)
 
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		placement, err := util.GetPlacement(ctx.Env().Hub, managementNamespace, placementName)
+		placement, err := util.GetPlacement(ctx, managementNamespace, placementName)
 		if err != nil {
 			return err
 		}
@@ -108,7 +108,7 @@ func DisableProtection(ctx types.TestContext) error {
 	placementName := name
 	log := ctx.Logger()
 
-	clusterName, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, placementName)
+	clusterName, err := util.GetCurrentCluster(ctx, managementNamespace, placementName)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
@@ -143,7 +143,7 @@ func Failover(ctx types.TestContext) error {
 	name := ctx.Name()
 	config := ctx.Config()
 
-	currentCluster, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, name)
+	currentCluster, err := util.GetCurrentCluster(ctx, managementNamespace, name)
 	if err != nil {
 		return err
 	}
@@ -176,7 +176,7 @@ func Relocate(ctx types.TestContext) error {
 	config := ctx.Config()
 	name := ctx.Name()
 
-	currentCluster, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, name)
+	currentCluster, err := util.GetCurrentCluster(ctx, managementNamespace, name)
 	if err != nil {
 		return err
 	}

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -5,7 +5,6 @@ package dractions
 
 import (
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
-	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 
@@ -81,7 +80,7 @@ func EnableProtection(ctx types.TestContext) error {
 		return err
 	}
 
-	if err := createNamespaces(ctx, appNamespace, log); err != nil {
+	if err := createNamespaces(ctx, appNamespace); err != nil {
 		return err
 	}
 
@@ -266,9 +265,9 @@ func waitAndUpdateDRPC(
 // createNamespaces creates namespaces and annotations for managed app protection on
 // both DR clusters for Volsync based replication if the distribution is Kubernetes.
 // Returns an error if namespace creation or annotation fails.
-func createNamespaces(ctx types.TestContext, appNamespace string, log *zap.SugaredLogger) error {
+func createNamespaces(ctx types.TestContext, appNamespace string) error {
 	if ctx.Config().Distro == config.DistroK8s {
-		return util.CreateNamespaceAndAddAnnotation(ctx.Env(), appNamespace, log)
+		return util.CreateNamespaceAndAddAnnotation(ctx, appNamespace)
 	}
 
 	return nil

--- a/e2e/dractions/crud.go
+++ b/e2e/dractions/crud.go
@@ -34,7 +34,7 @@ func getDRPC(cluster types.Cluster, namespace, name string) (*ramen.DRPlacementC
 	return drpc, nil
 }
 
-func createDRPC(ctx types.Context, drpc *ramen.DRPlacementControl) error {
+func createDRPC(ctx types.TestContext, drpc *ramen.DRPlacementControl) error {
 	log := ctx.Logger()
 	hub := ctx.Env().Hub
 
@@ -62,7 +62,7 @@ func updateDRPC(cluster types.Cluster, drpc *ramen.DRPlacementControl) error {
 	return cluster.Client.Update(context.Background(), drpc)
 }
 
-func deleteDRPC(ctx types.Context, namespace, name string) error {
+func deleteDRPC(ctx types.TestContext, namespace, name string) error {
 	log := ctx.Logger()
 	hub := ctx.Env().Hub
 
@@ -119,7 +119,7 @@ func generateDRPC(name, namespace, clusterName, drPolicyName, placementName, app
 	return drpc
 }
 
-func createPlacementManagedByRamen(ctx types.Context, name, namespace string) error {
+func createPlacementManagedByRamen(ctx types.TestContext, name, namespace string) error {
 	log := ctx.Logger()
 	labels := make(map[string]string)
 	labels[deployers.AppLabelKey] = name

--- a/e2e/dractions/crud.go
+++ b/e2e/dractions/crud.go
@@ -4,8 +4,6 @@
 package dractions
 
 import (
-	"context"
-
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -18,15 +16,19 @@ import (
 	"github.com/ramendr/ramen/e2e/types"
 )
 
-func updatePlacement(cluster types.Cluster, placement *clusterv1beta1.Placement) error {
-	return cluster.Client.Update(context.Background(), placement)
+func updatePlacement(ctx types.TestContext, placement *clusterv1beta1.Placement) error {
+	hub := ctx.Env().Hub
+
+	return hub.Client.Update(ctx.Context(), placement)
 }
 
-func getDRPC(cluster types.Cluster, namespace, name string) (*ramen.DRPlacementControl, error) {
+func getDRPC(ctx types.TestContext, namespace, name string) (*ramen.DRPlacementControl, error) {
+	hub := ctx.Env().Hub
+
 	drpc := &ramen.DRPlacementControl{}
 	key := k8stypes.NamespacedName{Namespace: namespace, Name: name}
 
-	err := cluster.Client.Get(context.Background(), key, drpc)
+	err := hub.Client.Get(ctx.Context(), key, drpc)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +40,7 @@ func createDRPC(ctx types.TestContext, drpc *ramen.DRPlacementControl) error {
 	log := ctx.Logger()
 	hub := ctx.Env().Hub
 
-	err := hub.Client.Create(context.Background(), drpc)
+	err := hub.Client.Create(ctx.Context(), drpc)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
@@ -58,8 +60,10 @@ func createDRPC(ctx types.TestContext, drpc *ramen.DRPlacementControl) error {
 	return nil
 }
 
-func updateDRPC(cluster types.Cluster, drpc *ramen.DRPlacementControl) error {
-	return cluster.Client.Update(context.Background(), drpc)
+func updateDRPC(ctx types.TestContext, drpc *ramen.DRPlacementControl) error {
+	hub := ctx.Env().Hub
+
+	return hub.Client.Update(ctx.Context(), drpc)
 }
 
 func deleteDRPC(ctx types.TestContext, namespace, name string) error {
@@ -69,7 +73,7 @@ func deleteDRPC(ctx types.TestContext, namespace, name string) error {
 	objDrpc := &ramen.DRPlacementControl{}
 	key := k8stypes.NamespacedName{Namespace: namespace, Name: name}
 
-	err := hub.Client.Get(context.Background(), key, objDrpc)
+	err := hub.Client.Get(ctx.Context(), key, objDrpc)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
@@ -80,7 +84,7 @@ func deleteDRPC(ctx types.TestContext, namespace, name string) error {
 		return nil
 	}
 
-	if err := hub.Client.Delete(context.Background(), objDrpc); err != nil {
+	if err := hub.Client.Delete(ctx.Context(), objDrpc); err != nil {
 		return err
 	}
 
@@ -141,7 +145,7 @@ func createPlacementManagedByRamen(ctx types.TestContext, name, namespace string
 		},
 	}
 
-	err := ctx.Env().Hub.Client.Create(context.Background(), placement)
+	err := ctx.Env().Hub.Client.Create(ctx.Context(), placement)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
-	"go.uber.org/zap"
 
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/deployers"
@@ -53,7 +52,7 @@ func EnableProtectionDiscoveredApps(ctx types.TestContext) error {
 		return err
 	}
 
-	if err := createNamespacesDiscoveredApps(ctx, appNamespace, log); err != nil {
+	if err := createNamespacesDiscoveredApps(ctx, appNamespace); err != nil {
 		return err
 	}
 
@@ -170,12 +169,12 @@ func failoverRelocateDiscoveredApps(
 // For Kubernetes, creates namespaces and adds annotation on both DR clusters for volsync based replication.
 // For OpenShift, creates namespace only on the target DR cluster (c2) before failover.
 // Returns an error if the distribution is unknown, and if namespace creation or annotation fails.
-func createNamespacesDiscoveredApps(ctx types.TestContext, namespace string, log *zap.SugaredLogger) error {
+func createNamespacesDiscoveredApps(ctx types.TestContext, namespace string) error {
 	switch ctx.Config().Distro {
 	case config.DistroK8s:
-		return util.CreateNamespaceAndAddAnnotation(ctx.Env(), namespace, log)
+		return util.CreateNamespaceAndAddAnnotation(ctx, namespace)
 	case config.DistroOcp:
-		return util.CreateNamespace(ctx.Env().C2, namespace, log)
+		return util.CreateNamespace(ctx, ctx.Env().C2, namespace)
 	default:
 		return fmt.Errorf("unknown distro: %s", ctx.Config().Distro)
 	}

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -17,7 +17,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-func EnableProtectionDiscoveredApps(ctx types.Context) error {
+func EnableProtectionDiscoveredApps(ctx types.TestContext) error {
 	w := ctx.Workload()
 	name := ctx.Name()
 	log := ctx.Logger()
@@ -70,7 +70,7 @@ func EnableProtectionDiscoveredApps(ctx types.Context) error {
 
 // remove DRPC
 // update placement annotation
-func DisableProtectionDiscoveredApps(ctx types.Context) error {
+func DisableProtectionDiscoveredApps(ctx types.TestContext) error {
 	name := ctx.Name()
 	log := ctx.Logger()
 	config := ctx.Config()
@@ -118,7 +118,7 @@ func DisableProtectionDiscoveredApps(ctx types.Context) error {
 
 // nolint:funlen,cyclop
 func failoverRelocateDiscoveredApps(
-	ctx types.Context,
+	ctx types.TestContext,
 	action ramen.DRAction,
 	state ramen.DRState,
 	currentClusterName string,
@@ -170,7 +170,7 @@ func failoverRelocateDiscoveredApps(
 // For Kubernetes, creates namespaces and adds annotation on both DR clusters for volsync based replication.
 // For OpenShift, creates namespace only on the target DR cluster (c2) before failover.
 // Returns an error if the distribution is unknown, and if namespace creation or annotation fails.
-func createNamespacesDiscoveredApps(ctx types.Context, namespace string, log *zap.SugaredLogger) error {
+func createNamespacesDiscoveredApps(ctx types.TestContext, namespace string, log *zap.SugaredLogger) error {
 	switch ctx.Config().Distro {
 	case config.DistroK8s:
 		return util.CreateNamespaceAndAddAnnotation(ctx.Env(), namespace, log)

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -79,7 +79,7 @@ func DisableProtectionDiscoveredApps(ctx types.TestContext) error {
 	placementName := name
 	drpcName := name
 
-	clusterName, err := util.GetCurrentCluster(ctx.Env().Hub, managementNamespace, placementName)
+	clusterName, err := util.GetCurrentCluster(ctx, managementNamespace, placementName)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -90,8 +90,12 @@ func waitDRPCPhase(ctx types.TestContext, namespace, name string, phase ramen.DR
 	}
 }
 
-func getTargetCluster(cluster types.Cluster, drPolicyName, currentCluster string) (string, error) {
-	drpolicy, err := util.GetDRPolicy(cluster, drPolicyName)
+func getTargetCluster(
+	ctx types.TestContext,
+	cluster types.Cluster,
+	drPolicyName, currentCluster string,
+) (string, error) {
+	drpolicy, err := util.GetDRPolicy(ctx, cluster, drPolicyName)
 	if err != nil {
 		return "", err
 	}

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -24,7 +24,7 @@ func waitDRPCReady(ctx types.TestContext, namespace string, drpcName string) err
 	log.Debugf("Waiting until drpc \"%s/%s\" is ready in cluster %q", namespace, drpcName, hub.Name)
 
 	for {
-		drpc, err := getDRPC(hub, namespace, drpcName)
+		drpc, err := getDRPC(ctx, namespace, drpcName)
 		if err != nil {
 			return err
 		}
@@ -70,7 +70,7 @@ func waitDRPCPhase(ctx types.TestContext, namespace, name string, phase ramen.DR
 	log.Debugf("Waiting until drpc \"%s/%s\" reach phase %q in cluster %q", namespace, name, phase, hub.Name)
 
 	for {
-		drpc, err := getDRPC(hub, namespace, name)
+		drpc, err := getDRPC(ctx, namespace, name)
 		if err != nil {
 			return err
 		}
@@ -118,7 +118,7 @@ func waitDRPCDeleted(ctx types.TestContext, namespace string, name string) error
 	log.Debugf("Waiting until drpc \"%s/%s\" is deleted in cluster %q", namespace, name, hub.Name)
 
 	for {
-		_, err := getDRPC(hub, namespace, name)
+		_, err := getDRPC(ctx, namespace, name)
 		if err != nil {
 			if k8serrors.IsNotFound(err) {
 				log.Debugf("drpc \"%s/%s\" is deleted in cluster %q", namespace, name, hub.Name)
@@ -151,7 +151,7 @@ func waitDRPCProgression(
 		namespace, name, progression, hub.Name)
 
 	for {
-		drpc, err := getDRPC(hub, namespace, name)
+		drpc, err := getDRPC(ctx, namespace, name)
 		if err != nil {
 			return err
 		}

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -52,7 +52,9 @@ func waitDRPCReady(ctx types.TestContext, namespace string, drpcName string) err
 				hub.Name, available, peerReady, progressionCompleted, drpc.Status.LastGroupSyncTime)
 		}
 
-		time.Sleep(util.RetryInterval)
+		if err := util.Sleep(ctx.Context(), util.RetryInterval); err != nil {
+			return err
+		}
 	}
 }
 
@@ -86,7 +88,9 @@ func waitDRPCPhase(ctx types.TestContext, namespace, name string, phase ramen.DR
 			return fmt.Errorf("drpc %q status is not %q yet before timeout in cluster %q, fail", name, phase, hub.Name)
 		}
 
-		time.Sleep(util.RetryInterval)
+		if err := util.Sleep(ctx.Context(), util.RetryInterval); err != nil {
+			return err
+		}
 	}
 }
 
@@ -133,7 +137,9 @@ func waitDRPCDeleted(ctx types.TestContext, namespace string, name string) error
 			return fmt.Errorf("drpc %q is not deleted yet before timeout in cluster %q, fail", name, hub.Name)
 		}
 
-		time.Sleep(util.RetryInterval)
+		if err := util.Sleep(ctx.Context(), util.RetryInterval); err != nil {
+			return err
+		}
 	}
 }
 
@@ -168,6 +174,8 @@ func waitDRPCProgression(
 				name, progression, util.Timeout, hub.Name)
 		}
 
-		time.Sleep(util.RetryInterval)
+		if err := util.Sleep(ctx.Context(), util.RetryInterval); err != nil {
+			return err
+		}
 	}
 }

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -16,7 +16,7 @@ import (
 	"github.com/ramendr/ramen/e2e/util"
 )
 
-func waitDRPCReady(ctx types.Context, namespace string, drpcName string) error {
+func waitDRPCReady(ctx types.TestContext, namespace string, drpcName string) error {
 	log := ctx.Logger()
 	hub := ctx.Env().Hub
 	startTime := time.Now()
@@ -62,7 +62,7 @@ func conditionMet(conditions []metav1.Condition, conditionType string) bool {
 	return condition != nil && condition.Status == "True"
 }
 
-func waitDRPCPhase(ctx types.Context, namespace, name string, phase ramen.DRState) error {
+func waitDRPCPhase(ctx types.TestContext, namespace, name string, phase ramen.DRState) error {
 	log := ctx.Logger()
 	hub := ctx.Env().Hub
 	startTime := time.Now()
@@ -106,7 +106,7 @@ func getTargetCluster(cluster types.Cluster, drPolicyName, currentCluster string
 	return targetCluster, nil
 }
 
-func waitDRPCDeleted(ctx types.Context, namespace string, name string) error {
+func waitDRPCDeleted(ctx types.TestContext, namespace string, name string) error {
 	log := ctx.Logger()
 	hub := ctx.Env().Hub
 	startTime := time.Now()
@@ -135,7 +135,7 @@ func waitDRPCDeleted(ctx types.Context, namespace string, name string) error {
 
 // nolint:unparam
 func waitDRPCProgression(
-	ctx types.Context,
+	ctx types.TestContext,
 	namespace, name string,
 	progression ramen.ProgressionStatus,
 ) error {

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -19,10 +19,23 @@ import (
 	"github.com/ramendr/ramen/e2e/workloads"
 )
 
+// Context implements types.Context for sharing the log, env, and config with all code.
 type Context struct {
 	log    *zap.SugaredLogger
 	env    *types.Env
 	config *types.Config
+}
+
+func (c *Context) Logger() *zap.SugaredLogger {
+	return c.log
+}
+
+func (c *Context) Config() *types.Config {
+	return c.config
+}
+
+func (c *Context) Env() *types.Env {
+	return c.env
 }
 
 // The global test context

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -78,7 +78,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Failed to read config: %s", err)
 	}
 
-	Ctx.env, err = env.New(Ctx.config, Ctx.log)
+	Ctx.env, err = env.New(Ctx.Context(), Ctx.config, Ctx.log)
 	if err != nil {
 		log.Fatalf("Failed to create testing context: %s", err)
 	}

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -4,6 +4,7 @@
 package e2e_test
 
 import (
+	"context"
 	"flag"
 	"os"
 	"testing"
@@ -38,7 +39,11 @@ func (c *Context) Env() *types.Env {
 	return c.env
 }
 
-// The global test context
+func (c *Context) Context() context.Context {
+	return context.Background()
+}
+
+// The global test context.
 var Ctx Context
 
 func TestMain(m *testing.M) {

--- a/e2e/test/context.go
+++ b/e2e/test/context.go
@@ -18,30 +18,26 @@ import (
 const appNamespacePrefix = "e2e-"
 
 type Context struct {
+	ctx      types.Context
 	workload types.Workload
 	deployer types.Deployer
 	name     string
-	env      *types.Env
-	config   *types.Config
 	logger   *zap.SugaredLogger
 }
 
 func NewContext(
+	ctx types.Context,
 	w types.Workload,
 	d types.Deployer,
-	env *types.Env,
-	config *types.Config,
-	log *zap.SugaredLogger,
 ) Context {
 	name := strings.ToLower(d.GetName() + "-" + w.GetName() + "-" + w.GetAppName())
 
 	return Context{
+		ctx:      ctx,
 		workload: w,
 		deployer: d,
 		name:     name,
-		env:      env,
-		config:   config,
-		logger:   log.Named(name),
+		logger:   ctx.Logger().Named(name),
 	}
 }
 
@@ -74,11 +70,12 @@ func (c *Context) Logger() *zap.SugaredLogger {
 }
 
 func (c *Context) Env() *types.Env {
-	return c.env
+	return c.ctx.Env()
 }
 
 func (c *Context) Config() *types.Config {
-	return c.config
+	return c.ctx.Config()
+}
 }
 
 // Validated return an error if the combination of deployer and workload is not supported.

--- a/e2e/test/context.go
+++ b/e2e/test/context.go
@@ -5,6 +5,7 @@
 package test
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -76,6 +77,9 @@ func (c *Context) Env() *types.Env {
 func (c *Context) Config() *types.Config {
 	return c.ctx.Config()
 }
+
+func (c *Context) Context() context.Context {
+	return c.ctx.Context()
 }
 
 // Validated return an error if the combination of deployer and workload is not supported.

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -76,11 +76,11 @@ type Env struct {
 
 // Deployer interface has methods to deploy a workload to a cluster
 type Deployer interface {
-	Deploy(Context) error
-	Undeploy(Context) error
+	Deploy(TestContext) error
+	Undeploy(TestContext) error
 	GetName() string
 	// GetNamespace return the namespace for the ramen resources, or empty string if not using a special namespace.
-	GetNamespace(Context) string
+	GetNamespace(TestContext) string
 	// Return true for OCM discovered application, false for OCM managed applications.
 	IsDiscovered() bool
 }
@@ -93,13 +93,12 @@ type Workload interface {
 	GetAppName() string
 	GetPath() string
 	GetBranch() string
-
-	Health(ctx Context, cluster Cluster, namespace string) error
+	Health(ctx TestContext, cluster Cluster, namespace string) error
 }
 
-// Context combines workload, deployer and logger used in the content of one test.
+// TestContext combines workload, deployer and logger used in the content of one test.
 // The context name is used for logging and resource names.
-type Context interface {
+type TestContext interface {
 	Deployer() Deployer
 	Workload() Workload
 	Name() string

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -4,6 +4,8 @@
 package types
 
 import (
+	"context"
+
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -96,15 +98,16 @@ type Workload interface {
 	Health(ctx TestContext, cluster Cluster, namespace string) error
 }
 
-// Context keeps the Logger, Env, and Config shared by all code in the e2e package.
+// Context keeps the Logger, Env, Config, and Context shared by all code in the e2e package.
 type Context interface {
 	Logger() *zap.SugaredLogger
 	Env() *Env
 	Config() *Config
+	Context() context.Context
 }
 
 // TestContext is a more specific Context for a single test; a combination of Deployer, Workload, and namespaces. A test
-// has a unique Name and Logger, and it shares the global Env and Config.
+// has a unique Name and Logger, and it shares the global Env, Config and Context.
 type TestContext interface {
 	Context
 	Deployer() Deployer

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -96,9 +96,17 @@ type Workload interface {
 	Health(ctx TestContext, cluster Cluster, namespace string) error
 }
 
-// TestContext combines workload, deployer and logger used in the content of one test.
-// The context name is used for logging and resource names.
+// Context keeps the Logger, Env, and Config shared by all code in the e2e package.
+type Context interface {
+	Logger() *zap.SugaredLogger
+	Env() *Env
+	Config() *Config
+}
+
+// TestContext is a more specific Context for a single test; a combination of Deployer, Workload, and namespaces. A test
+// has a unique Name and Logger, and it shares the global Env and Config.
 type TestContext interface {
+	Context
 	Deployer() Deployer
 	Workload() Workload
 	Name() string
@@ -109,8 +117,4 @@ type TestContext interface {
 
 	// Namespace for application resources on the managed clusters.
 	AppNamespace() string
-
-	Logger() *zap.SugaredLogger
-	Env() *Env
-	Config() *Config
 }

--- a/e2e/util/channel.go
+++ b/e2e/util/channel.go
@@ -15,7 +15,7 @@ import (
 
 func EnsureChannel(ctx types.Context) error {
 	// create channel namespace
-	err := CreateNamespace(ctx.Env().Hub, ctx.Config().Channel.Namespace, ctx.Logger())
+	err := CreateNamespace(ctx, ctx.Env().Hub, ctx.Config().Channel.Namespace)
 	if err != nil {
 		return err
 	}
@@ -28,7 +28,7 @@ func EnsureChannelDeleted(ctx types.Context) error {
 		return err
 	}
 
-	return DeleteNamespace(ctx.Env().Hub, ctx.Config().Channel.Namespace, ctx.Logger())
+	return DeleteNamespace(ctx, ctx.Env().Hub, ctx.Config().Channel.Namespace)
 }
 
 func createChannel(ctx types.Context) error {

--- a/e2e/util/channel.go
+++ b/e2e/util/channel.go
@@ -4,8 +4,6 @@
 package util
 
 import (
-	"context"
-
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	channelv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
@@ -47,7 +45,7 @@ func createChannel(ctx types.Context) error {
 		},
 	}
 
-	err := hub.Client.Create(context.Background(), objChannel)
+	err := hub.Client.Create(ctx.Context(), objChannel)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
@@ -75,7 +73,7 @@ func deleteChannel(ctx types.Context) error {
 		},
 	}
 
-	err := hub.Client.Delete(context.Background(), channel)
+	err := hub.Client.Delete(ctx.Context(), channel)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err

--- a/e2e/util/channel.go
+++ b/e2e/util/channel.go
@@ -6,7 +6,6 @@ package util
 import (
 	"context"
 
-	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	channelv1 "open-cluster-management.io/multicloud-operators-channel/pkg/apis/apps/v1"
@@ -14,25 +13,29 @@ import (
 	"github.com/ramendr/ramen/e2e/types"
 )
 
-func EnsureChannel(hub types.Cluster, config *types.Config, log *zap.SugaredLogger) error {
+func EnsureChannel(ctx types.Context) error {
 	// create channel namespace
-	err := CreateNamespace(hub, config.Channel.Namespace, log)
+	err := CreateNamespace(ctx.Env().Hub, ctx.Config().Channel.Namespace, ctx.Logger())
 	if err != nil {
 		return err
 	}
 
-	return createChannel(hub, config, log)
+	return createChannel(ctx)
 }
 
-func EnsureChannelDeleted(hub types.Cluster, config *types.Config, log *zap.SugaredLogger) error {
-	if err := deleteChannel(hub, config, log); err != nil {
+func EnsureChannelDeleted(ctx types.Context) error {
+	if err := deleteChannel(ctx); err != nil {
 		return err
 	}
 
-	return DeleteNamespace(hub, config.Channel.Namespace, log)
+	return DeleteNamespace(ctx.Env().Hub, ctx.Config().Channel.Namespace, ctx.Logger())
 }
 
-func createChannel(hub types.Cluster, config *types.Config, log *zap.SugaredLogger) error {
+func createChannel(ctx types.Context) error {
+	hub := ctx.Env().Hub
+	config := ctx.Config()
+	log := ctx.Logger()
+
 	objChannel := &channelv1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.Channel.Name,
@@ -60,7 +63,11 @@ func createChannel(hub types.Cluster, config *types.Config, log *zap.SugaredLogg
 	return nil
 }
 
-func deleteChannel(hub types.Cluster, config *types.Config, log *zap.SugaredLogger) error {
+func deleteChannel(ctx types.Context) error {
+	hub := ctx.Env().Hub
+	config := ctx.Config()
+	log := ctx.Logger()
+
 	channel := &channelv1.Channel{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.Channel.Name,

--- a/e2e/util/drpolicy.go
+++ b/e2e/util/drpolicy.go
@@ -4,8 +4,6 @@
 package util
 
 import (
-	"context"
-
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
@@ -13,11 +11,11 @@ import (
 )
 
 // nolint:unparam
-func GetDRPolicy(cluster types.Cluster, name string) (*ramen.DRPolicy, error) {
+func GetDRPolicy(ctx types.Context, cluster types.Cluster, name string) (*ramen.DRPolicy, error) {
 	drpolicy := &ramen.DRPolicy{}
 	key := k8stypes.NamespacedName{Name: name}
 
-	err := cluster.Client.Get(context.Background(), key, drpolicy)
+	err := cluster.Client.Get(ctx.Context(), key, drpolicy)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/util/namespace.go
+++ b/e2e/util/namespace.go
@@ -4,7 +4,6 @@
 package util
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -30,7 +29,7 @@ func CreateNamespace(ctx types.Context, cluster types.Cluster, namespace string)
 		},
 	}
 
-	err := cluster.Client.Create(context.Background(), ns)
+	err := cluster.Client.Create(ctx.Context(), ns)
 	if err != nil {
 		if !k8serrors.IsAlreadyExists(err) {
 			return err
@@ -53,7 +52,7 @@ func DeleteNamespace(ctx types.Context, cluster types.Cluster, namespace string)
 		},
 	}
 
-	err := cluster.Client.Delete(context.Background(), ns)
+	err := cluster.Client.Delete(ctx.Context(), ns)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
@@ -70,7 +69,7 @@ func DeleteNamespace(ctx types.Context, cluster types.Cluster, namespace string)
 	key := k8stypes.NamespacedName{Name: namespace}
 
 	for {
-		if err := cluster.Client.Get(context.Background(), key, ns); err != nil {
+		if err := cluster.Client.Get(ctx.Context(), key, ns); err != nil {
 			if !k8serrors.IsNotFound(err) {
 				return err
 			}
@@ -117,7 +116,7 @@ func addNamespaceAnnotationForVolSync(ctx types.Context, cluster types.Cluster, 
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		objNs := &corev1.Namespace{}
 
-		if err := cluster.Client.Get(context.Background(), key, objNs); err != nil {
+		if err := cluster.Client.Get(ctx.Context(), key, objNs); err != nil {
 			return err
 		}
 
@@ -129,7 +128,7 @@ func addNamespaceAnnotationForVolSync(ctx types.Context, cluster types.Cluster, 
 		annotations[volsyncPrivilegedMovers] = "true"
 		objNs.SetAnnotations(annotations)
 
-		if err := cluster.Client.Update(context.Background(), objNs); err != nil {
+		if err := cluster.Client.Update(ctx.Context(), objNs); err != nil {
 			return err
 		}
 

--- a/e2e/util/namespace.go
+++ b/e2e/util/namespace.go
@@ -83,7 +83,9 @@ func DeleteNamespace(ctx types.Context, cluster types.Cluster, namespace string)
 			return fmt.Errorf("timeout deleting namespace %q in cluster %q", namespace, cluster.Name)
 		}
 
-		time.Sleep(time.Second)
+		if err := Sleep(ctx.Context(), time.Second); err != nil {
+			return err
+		}
 	}
 }
 

--- a/e2e/util/placement.go
+++ b/e2e/util/placement.go
@@ -66,7 +66,9 @@ func waitPlacementDecision(ctx types.Context, namespace string, placementName st
 			return nil, fmt.Errorf("timeout waiting for placement decisions for %q in cluster %q", placementName, cluster.Name)
 		}
 
-		time.Sleep(RetryInterval)
+		if err := Sleep(ctx.Context(), RetryInterval); err != nil {
+			return nil, err
+		}
 	}
 }
 

--- a/e2e/util/timeout.go
+++ b/e2e/util/timeout.go
@@ -3,9 +3,23 @@
 
 package util
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 const (
 	Timeout       = 600 * time.Second
 	RetryInterval = 5 * time.Second
 )
+
+// Sleep pauses the current goroutine for at least the duration d. If the context was canceled or its deadline has
+// exceeded it will return early with a context.Canceled or a context.DeadlineExceeded error.
+func Sleep(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}

--- a/e2e/validate/clusterset.go
+++ b/e2e/validate/clusterset.go
@@ -4,7 +4,6 @@
 package validate
 
 import (
-	"context"
 	"fmt"
 
 	ocmv1 "open-cluster-management.io/api/cluster/v1"
@@ -14,22 +13,26 @@ import (
 	"github.com/ramendr/ramen/e2e/types"
 )
 
-func getClusterSet(hub types.Cluster, clusterSetName string) (*ocmv1b2.ManagedClusterSet, error) {
+func getClusterSet(ctx types.Context, clusterSetName string) (*ocmv1b2.ManagedClusterSet, error) {
+	hub := ctx.Env().Hub
+
 	clusterSet := &ocmv1b2.ManagedClusterSet{}
 	key := client.ObjectKey{Name: clusterSetName}
 
-	if err := hub.Client.Get(context.TODO(), key, clusterSet); err != nil {
+	if err := hub.Client.Get(ctx.Context(), key, clusterSet); err != nil {
 		return nil, fmt.Errorf("failed to get ClusterSet %q: %w", clusterSetName, err)
 	}
 
 	return clusterSet, nil
 }
 
-func getManagedClustersFromClusterSet(hub types.Cluster, clusterSetName string) ([]string, error) {
+func getManagedClustersFromClusterSet(ctx types.Context, clusterSetName string) ([]string, error) {
+	hub := ctx.Env().Hub
+
 	clusterList := &ocmv1.ManagedClusterList{}
 	labelSelector := client.MatchingLabels{"cluster.open-cluster-management.io/clusterset": clusterSetName}
 
-	if err := hub.Client.List(context.TODO(), clusterList, labelSelector); err != nil {
+	if err := hub.Client.List(ctx.Context(), clusterList, labelSelector); err != nil {
 		return nil, fmt.Errorf("failed to list ManagedClusters for ClusterSet %q: %w", clusterSetName, err)
 	}
 

--- a/e2e/validation_test.go
+++ b/e2e/validation_test.go
@@ -11,38 +11,40 @@ import (
 )
 
 func TestValidation(dt *testing.T) {
-	t := test.WithLog(dt, Ctx.log)
+	t := test.WithLog(dt, Ctx.Logger())
 	t.Parallel()
 
-	if err := validate.TestConfig(Ctx.env, Ctx.config, Ctx.log); err != nil {
+	if err := validate.TestConfig(&Ctx); err != nil {
 		t.Fatal(err.Error())
 	}
 
+	env := Ctx.Env()
+
 	t.Run("hub", func(dt *testing.T) {
-		t := test.WithLog(dt, Ctx.log)
+		t := test.WithLog(dt, Ctx.Logger())
 		t.Parallel()
 
-		err := validate.RamenHubOperator(Ctx.env.Hub, Ctx.config, Ctx.log)
+		err := validate.RamenHubOperator(&Ctx, env.Hub)
 		if err != nil {
-			t.Fatalf("Failed to validate hub cluster %q: %s", Ctx.env.Hub.Name, err)
+			t.Fatalf("Failed to validate hub cluster %q: %s", env.Hub.Name, err)
 		}
 	})
 	t.Run("c1", func(dt *testing.T) {
-		t := test.WithLog(dt, Ctx.log)
+		t := test.WithLog(dt, Ctx.Logger())
 		t.Parallel()
 
-		err := validate.RamenDRClusterOperator(Ctx.env.C1, Ctx.config, Ctx.log)
+		err := validate.RamenDRClusterOperator(&Ctx, env.C1)
 		if err != nil {
-			t.Fatalf("Failed to validate dr cluster %q: %s", Ctx.env.C1.Name, err)
+			t.Fatalf("Failed to validate dr cluster %q: %s", env.C1.Name, err)
 		}
 	})
 	t.Run("c2", func(dt *testing.T) {
-		t := test.WithLog(dt, Ctx.log)
+		t := test.WithLog(dt, Ctx.Logger())
 		t.Parallel()
 
-		err := validate.RamenDRClusterOperator(Ctx.env.C2, Ctx.config, Ctx.log)
+		err := validate.RamenDRClusterOperator(&Ctx, env.C2)
 		if err != nil {
-			t.Fatalf("Failed to validate dr cluster %q: %s", Ctx.env.C2.Name, err)
+			t.Fatalf("Failed to validate dr cluster %q: %s", env.C2.Name, err)
 		}
 	})
 }

--- a/e2e/workloads/deploy.go
+++ b/e2e/workloads/deploy.go
@@ -4,7 +4,6 @@
 package workloads
 
 import (
-	"context"
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -87,7 +86,7 @@ func (w Deployment) GetResources() error {
 func (w Deployment) Health(ctx types.TestContext, cluster types.Cluster, namespace string) error {
 	log := ctx.Logger()
 
-	deploy, err := getDeployment(cluster, namespace, w.GetAppName())
+	deploy, err := getDeployment(ctx, cluster, namespace, w.GetAppName())
 	if err != nil {
 		return err
 	}
@@ -101,11 +100,11 @@ func (w Deployment) Health(ctx types.TestContext, cluster types.Cluster, namespa
 	return nil
 }
 
-func getDeployment(cluster types.Cluster, namespace, name string) (*appsv1.Deployment, error) {
+func getDeployment(ctx types.TestContext, cluster types.Cluster, namespace, name string) (*appsv1.Deployment, error) {
 	deploy := &appsv1.Deployment{}
 	key := k8stypes.NamespacedName{Name: name, Namespace: namespace}
 
-	err := cluster.Client.Get(context.Background(), key, deploy)
+	err := cluster.Client.Get(ctx.Context(), key, deploy)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/workloads/deploy.go
+++ b/e2e/workloads/deploy.go
@@ -84,7 +84,7 @@ func (w Deployment) GetResources() error {
 }
 
 // Check the workload health deployed in a cluster namespace
-func (w Deployment) Health(ctx types.Context, cluster types.Cluster, namespace string) error {
+func (w Deployment) Health(ctx types.TestContext, cluster types.Cluster, namespace string) error {
 	log := ctx.Logger()
 
 	deploy, err := getDeployment(cluster, namespace, w.GetAppName())


### PR DESCRIPTION
When user run or clean tests in ramenctl, the command can block for 10 minutes
before it fails. Users are likely to interrupt the block command and report
bugs with the test report[1]. However if ramenctl is interrupted, it exits
without writing a test report, and we don't have enough info about the failure.

We cannot educate users to wait until commands completes, so we should handle
interruption gracefully. The best way to do this is to support cancellation in
e2e using context.Context. The k8s client already support cancellation, if we
pass a cancellable context.Context instead of context.TODO() or
context.Background().

Passing context.Context to all functions so we can pass it to the client
function does not make sense. We already pass types.Context() to most of the
code to accessing test related state. This change use our context to make
cancellation possible.

This change renames the types.Context interface to types.TestContext, and add a
new types.Context interface for code running in global context. The
types.Context interface includes Context() function returning the shared
context.Context. This context is used now in the client calls using
context.Context. When we wait during retires we fail early if the context was
canceled.

With these changes, ramenctl can pass a cancellable context to ramen/e2e
functions, and cancel the context when receiving a termination signal. This
avoids making entire ramenctl thread safe which will make it harder to
contribute to.

[1] https://github.com/RamenDR/ramenctl/issues/112

Blocks https://github.com/RamenDR/ramenctl/issues/43