### PR TITLE
e2e: add Equal method for Config and related tests

### DIFF
--- a/e2e/types/config.go
+++ b/e2e/types/config.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import (
+	"maps"
+	"slices"
+)
+
+// Equal return true if config is equal to other config.
+//
+//nolint:cyclop
+func (c *Config) Equal(o *Config) bool {
+	if c == o {
+		return true
+	}
+
+	if c.Distro != o.Distro {
+		return false
+	}
+
+	if c.Repo != o.Repo {
+		return false
+	}
+
+	if c.DRPolicy != o.DRPolicy {
+		return false
+	}
+
+	if c.ClusterSet != o.ClusterSet {
+		return false
+	}
+
+	if !maps.Equal(c.Clusters, o.Clusters) {
+		return false
+	}
+
+	if !slices.Equal(c.PVCSpecs, o.PVCSpecs) {
+		return false
+	}
+
+	if !slices.Equal(c.Tests, o.Tests) {
+		return false
+	}
+
+	if c.Channel != o.Channel {
+		return false
+	}
+
+	if c.Namespaces != o.Namespaces {
+		return false
+	}
+
+	return true
+}

--- a/e2e/types/config_test.go
+++ b/e2e/types/config_test.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package types_test
+
+import (
+	"testing"
+
+	"github.com/ramendr/ramen/e2e/types"
+)
+
+func baseConfig() *types.Config {
+	return &types.Config{
+		Distro:     "ocp",
+		Repo:       types.RepoConfig{URL: "https://github.com/org/repo", Branch: "main"},
+		DRPolicy:   "dr-policy",
+		ClusterSet: "clusterset",
+		Clusters: map[string]types.ClusterConfig{
+			"hub": {Kubeconfig: "hub-kubeconfig"},
+			"c1":  {Kubeconfig: "c1-kubeconfig"},
+			"c2":  {Kubeconfig: "c2-kubeconfig"},
+		},
+		PVCSpecs: []types.PVCSpecConfig{
+			{Name: "pvc-a", StorageClassName: "standard", AccessModes: "ReadWriteOnce"},
+		},
+		Tests: []types.TestConfig{
+			{Workload: "wl1", Deployer: "ocm-hub", PVCSpec: "pvc-a"},
+		},
+		Channel: types.ChannelConfig{
+			Name:      "my-channel",
+			Namespace: "ramen-system",
+		},
+		Namespaces: types.NamespacesConfig{
+			RamenHubNamespace:       "ramen-hub",
+			RamenDRClusterNamespace: "ramen-dr-cluster",
+			RamenOpsNamespace:       "ramen-ops",
+			ArgocdNamespace:         "argocd",
+		},
+	}
+}
+
+func TestConfigEqual(t *testing.T) {
+	c1 := baseConfig()
+	c2 := baseConfig()
+
+	// intentionally comparing config to itself
+	// nolint:gocritic
+	t.Run("equal to itself", func(t *testing.T) {
+		if !c1.Equal(c1) {
+			t.Errorf("config %+v is not equal to itself", c1)
+		}
+	})
+
+	t.Run("equal to other identical config", func(t *testing.T) {
+		if !c1.Equal(c2) {
+			t.Errorf("config %+v is not equal to other identical config %+v", c1, c2)
+		}
+	})
+}
+
+func TestConfigNotEqual(t *testing.T) {
+	type test struct {
+		Name   string
+		Modify func(c *types.Config)
+	}
+
+	tests := []test{
+		{
+			Name: "empty config",
+			Modify: func(c *types.Config) {
+				*c = types.Config{}
+			},
+		},
+		{
+			Name:   "different distro",
+			Modify: func(c *types.Config) { c.Distro = "modified-distro" },
+		},
+		{
+			Name: "different repo url",
+			Modify: func(c *types.Config) {
+				c.Repo.URL = "https://github.com/org/modified"
+			},
+		},
+		{
+			Name: "different drpolicy",
+			Modify: func(c *types.Config) {
+				c.DRPolicy = "modified-policy"
+			},
+		},
+		{
+			Name: "different clusterSet",
+			Modify: func(c *types.Config) {
+				c.ClusterSet = "modified-clusterset"
+			},
+		},
+		{
+			Name: "different cluster kubeconfig",
+			Modify: func(c *types.Config) {
+				c.Clusters["c1"] = types.ClusterConfig{Kubeconfig: "modified-kubeconfig"}
+			},
+		},
+		{
+			Name: "different pvcspec",
+			Modify: func(c *types.Config) {
+				c.PVCSpecs[0].StorageClassName = "modified-sc"
+			},
+		},
+		{
+			Name: "different test workload",
+			Modify: func(c *types.Config) {
+				c.Tests[0].Workload = "modified-workload"
+			},
+		},
+		{
+			Name: "different channel name",
+			Modify: func(c *types.Config) {
+				c.Channel.Name = "modified-channel"
+			},
+		},
+		{
+			Name: "different ramen hub namespace",
+			Modify: func(c *types.Config) {
+				c.Namespaces.RamenHubNamespace = "modified-ns"
+			},
+		},
+	}
+
+	c1 := baseConfig()
+
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			c2 := baseConfig()
+			tt.Modify(c2)
+
+			if c1.Equal(c2) {
+				t.Errorf("config %+v is equal to non-equal config %+v", c1, c2)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The Equal method is added to the Config struct to allow comparison of two Config objects. This method checks for equality across various fields of the Config struct. The Equal method is necessary for ensuring accurate comparison and validation of configuration objects, particularly for use in reporting configurations and its testing within the ramenctl.

- Testing the Equal method. The tests verify all config fields:
```
--- PASS: TestConfigEqual (0.00s)
    --- PASS: TestConfigEqual/equal_to_itself (0.00s)
    --- PASS: TestConfigEqual/equal_to_other_identical_config (0.00s)
--- PASS: TestConfigNotEqual (0.00s)
    --- PASS: TestConfigNotEqual/empty_config (0.00s)
    --- PASS: TestConfigNotEqual/different_distro (0.00s)
    --- PASS: TestConfigNotEqual/different_repo_url (0.00s)
    --- PASS: TestConfigNotEqual/different_drpolicy (0.00s)
    --- PASS: TestConfigNotEqual/different_clusterSet (0.00s)
    --- PASS: TestConfigNotEqual/different_cluster_kubeconfig (0.00s)
    --- PASS: TestConfigNotEqual/different_pvcspec (0.00s)
    --- PASS: TestConfigNotEqual/different_test_workload (0.00s)
    --- PASS: TestConfigNotEqual/different_channel_name (0.00s)
    --- PASS: TestConfigNotEqual/different_ramen_hub_namespace (0.00s)
PASS
ok  	github.com/ramendr/ramen/e2e/types	1.184s
```