### PR TITLE
Add group related API support across peer classes

### DIFF
--- a/api/v1alpha1/drclusterconfig_types.go
+++ b/api/v1alpha1/drclusterconfig_types.go
@@ -47,9 +47,17 @@ type DRClusterConfigStatus struct {
 	// storageid label
 	VolumeSnapshotClasses []string `json:"volumeSnapshotClasses,omitempty"`
 
+	// VolumeGroupSnapshotClasses lists the detected volume group snapshot classes on the cluster that carry the ramen
+	// storageid label
+	VolumeGroupSnapshotClasses []string `json:"volumeGroupSnapshotClasses,omitempty"`
+
 	// VolumeReplicationClasses lists the detected volume replication classes on the cluster that carry the ramen
 	// replicationid label
 	VolumeReplicationClasses []string `json:"volumeReplicationClasses,omitempty"`
+
+	// VolumeGroupReplicationClasses lists the detected volume group replication classes on the cluster that carry the
+	// ramen replicationid label
+	VolumeGroupReplicationClasses []string `json:"volumeGroupReplicationClasses,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/drpolicy_types.go
+++ b/api/v1alpha1/drpolicy_types.go
@@ -101,6 +101,12 @@ type PeerClass struct {
 	// ClusterIDs is a list of two clusterIDs that represent this peer relationship for a common StorageClassName
 	// The IDs are based on the value of the metadata.uid of the kube-system namespace
 	ClusterIDs []string `json:"clusterIDs,omitempty"`
+
+	// Grouping reflects if PVCs using the StorageClassName can be grouped for replication, via VolumeGroupSnapshotClass
+	// if ReplicationID is empty, or via VolumeGroupReplicationClass otherwise. This is true only when grouping can be
+	// supported across the clusters in the ClusterIDs list.
+	//+optional
+	Grouping bool `json:"grouping,omitempty"`
 }
 
 const (

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -214,8 +214,18 @@ func (in *DRClusterConfigStatus) DeepCopyInto(out *DRClusterConfigStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.VolumeGroupSnapshotClasses != nil {
+		in, out := &in.VolumeGroupSnapshotClasses, &out.VolumeGroupSnapshotClasses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.VolumeReplicationClasses != nil {
 		in, out := &in.VolumeReplicationClasses, &out.VolumeReplicationClasses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.VolumeGroupReplicationClasses != nil {
+		in, out := &in.VolumeGroupReplicationClasses, &out.VolumeGroupReplicationClasses
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/config/crd/bases/ramendr.openshift.io_drclusterconfigs.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drclusterconfigs.yaml
@@ -132,6 +132,20 @@ spec:
                 items:
                   type: string
                 type: array
+              volumeGroupReplicationClasses:
+                description: |-
+                  VolumeGroupReplicationClasses lists the detected volume group replication classes on the cluster that carry the
+                  ramen replicationid label
+                items:
+                  type: string
+                type: array
+              volumeGroupSnapshotClasses:
+                description: |-
+                  VolumeGroupSnapshotClasses lists the detected volume group snapshot classes on the cluster that carry the ramen
+                  storageid label
+                items:
+                  type: string
+                type: array
               volumeReplicationClasses:
                 description: |-
                   VolumeReplicationClasses lists the detected volume replication classes on the cluster that carry the ramen

--- a/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
@@ -246,6 +246,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        grouping:
+                          description: |-
+                            Grouping reflects if PVCs using the StorageClassName can be grouped for replication, via VolumeGroupSnapshotClass
+                            if ReplicationID is empty, or via VolumeGroupReplicationClass otherwise. This is true only when grouping can be
+                            supported across the clusters in the ClusterIDs list.
+                          type: boolean
                         replicationID:
                           description: |-
                             ReplicationID is the common value for the label "ramendr.openshift.io/replicationID" on the corresponding
@@ -340,6 +346,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        grouping:
+                          description: |-
+                            Grouping reflects if PVCs using the StorageClassName can be grouped for replication, via VolumeGroupSnapshotClass
+                            if ReplicationID is empty, or via VolumeGroupReplicationClass otherwise. This is true only when grouping can be
+                            supported across the clusters in the ClusterIDs list.
+                          type: boolean
                         replicationID:
                           description: |-
                             ReplicationID is the common value for the label "ramendr.openshift.io/replicationID" on the corresponding

--- a/config/crd/bases/ramendr.openshift.io_protectedvolumereplicationgrouplists.yaml
+++ b/config/crd/bases/ramendr.openshift.io_protectedvolumereplicationgrouplists.yaml
@@ -134,6 +134,12 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  grouping:
+                                    description: |-
+                                      Grouping reflects if PVCs using the StorageClassName can be grouped for replication, via VolumeGroupSnapshotClass
+                                      if ReplicationID is empty, or via VolumeGroupReplicationClass otherwise. This is true only when grouping can be
+                                      supported across the clusters in the ClusterIDs list.
+                                    type: boolean
                                   replicationID:
                                     description: |-
                                       ReplicationID is the common value for the label "ramendr.openshift.io/replicationID" on the corresponding
@@ -481,6 +487,12 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  grouping:
+                                    description: |-
+                                      Grouping reflects if PVCs using the StorageClassName can be grouped for replication, via VolumeGroupSnapshotClass
+                                      if ReplicationID is empty, or via VolumeGroupReplicationClass otherwise. This is true only when grouping can be
+                                      supported across the clusters in the ClusterIDs list.
+                                    type: boolean
                                   replicationID:
                                     description: |-
                                       ReplicationID is the common value for the label "ramendr.openshift.io/replicationID" on the corresponding

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -84,6 +84,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        grouping:
+                          description: |-
+                            Grouping reflects if PVCs using the StorageClassName can be grouped for replication, via VolumeGroupSnapshotClass
+                            if ReplicationID is empty, or via VolumeGroupReplicationClass otherwise. This is true only when grouping can be
+                            supported across the clusters in the ClusterIDs list.
+                          type: boolean
                         replicationID:
                           description: |-
                             ReplicationID is the common value for the label "ramendr.openshift.io/replicationID" on the corresponding
@@ -430,6 +436,12 @@ spec:
                           items:
                             type: string
                           type: array
+                        grouping:
+                          description: |-
+                            Grouping reflects if PVCs using the StorageClassName can be grouped for replication, via VolumeGroupSnapshotClass
+                            if ReplicationID is empty, or via VolumeGroupReplicationClass otherwise. This is true only when grouping can be
+                            supported across the clusters in the ClusterIDs list.
+                          type: boolean
                         replicationID:
                           description: |-
                             ReplicationID is the common value for the label "ramendr.openshift.io/replicationID" on the corresponding


### PR DESCRIPTION
DRClusterConfig API is updated to report group related classes in status.

PeerClass is updated to carry "Grouping" bool to denote if group based operations are supported across a pair of cluster peers.

-------------------------
NOTES:
This is an initial PR to start the discussion on representing grouping ability across a pair of peer clusters.

This PR would address #1753 and #1754 as well once compete

This PR does not change how a DRPC would opt into grouping, but intends to collect and reflect the related grouping data in peer classes.

Consumption of this grouping value from peerClasses when grouping PVCs for replication support in VRG reconciliation is not intended as part of this PR as well.