### PR TITLE
Check for PVC(provisioned by RBD/CEPHFS) label selector conflicts against the secondary cluster

### DIFF
--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -1514,7 +1514,6 @@ func setConflictStatusCondition(existingConditions *[]metav1.Condition,
 	// TODO: Why not update lastTranTime if the above change?
 
 	if existingCondition.ObservedGeneration != newCondition.ObservedGeneration {
-		existingCondition.ObservedGeneration = newCondition.ObservedGeneration
 		existingCondition.LastTransitionTime = metav1.NewTime(time.Now())
 	}
 

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -40,14 +40,16 @@ const (
 	// protected from a disaster by uploading it to the required S3 store(s).
 	VRGConditionTypeClusterDataProtected = "ClusterDataProtected"
 
-	VRGConditionTypeNoClusterDataConflict = "NoClusterDataConflict"
-
 	// VolSync related conditions. These conditions are only applicable
 	// at individual PVCs and not generic VRG conditions.
 	VRGConditionTypeVolSyncRepSourceSetup      = "ReplicationSourceSetup"
 	VRGConditionTypeVolSyncFinalSyncInProgress = "FinalSyncInProgress"
 	VRGConditionTypeVolSyncRepDestinationSetup = "ReplicationDestinationSetup"
 	VRGConditionTypeVolSyncPVsRestored         = "PVsRestored"
+
+	// Indicates no conflict in PVC and Kubernetes resource data
+	// between primary and secondary clusters.
+	VRGConditionTypeNoClusterDataConflict = "NoClusterDataConflict"
 )
 
 // VRG condition reasons
@@ -76,9 +78,14 @@ const (
 	VRGConditionReasonClusterDataAnnotationFailed = "AnnotationFailed"
 	VRGConditionReasonPeerClassNotFound           = "PeerClassNotFound"
 	VRGConditionReasonStorageIDNotFound           = "StorageIDNotFound"
-	VRGConditionReasonDataConflictPrimary         = "ClusterDataConflictPrimary"
-	VRGConditionReasonDataConflictSecondary       = "ClusterDataConflictSecondary"
-	VRGConditionReasonConflictResolved            = "ConflictResolved"
+	// Indicates a conflict in cluster data detected on the primary cluster.
+	VRGConditionReasonClusterDataConflictPrimary = "ClusterDataConflictPrimary"
+
+	// Indicates a conflict in cluster data detected on the secondary cluster.
+	VRGConditionReasonClusterDataConflictSecondary = "ClusterDataConflictSecondary"
+
+	// Indicates no conflict in cluster data detected on both the primary and secondary cluster.
+	VRGConditionReasonNoConflictDetected = "NoConflictDetected"
 )
 
 const (


### PR DESCRIPTION
**Applying PVC Label Conflict Check on the Secondary Cluster**

The PR introduces a mechanism in vrg_volrep.go and vrg_volsync.go that applies the **PVCLabelSelector** from the **secondary VRG** and checks whether any PVCs are selected.

**Expected behavior:**

A **secondary VRG** should not match any PVCs using the **PVCLabelSelector**.
    If a PVC is selected on the secondary cluster, it indicates a conflict because the label selector should not apply to unintended PVCs after failover/relocation.
    In case of a conflict, the reconciliation process will be required, and the VRG will log the issue.
    For VolSync, the behavior is slightly different, if the label selector matches any PVC that is not part of RDSpec, it is considered a conflict.

Fix for : [#1861](https://github.com/RamenDR/ramen/issues/1861)
Fix for : [#2022](https://github.com/RamenDR/ramen/issues/2022)