### PR TITLE
Enable and process GroupClass based replication

### DIFF
--- a/internal/controller/drclusterconfig_controller.go
+++ b/internal/controller/drclusterconfig_controller.go
@@ -375,7 +375,7 @@ func (r *DRClusterConfigReconciler) listDRSupportedVRCs(ctx context.Context) ([]
 	}
 
 	for i := range vrClasses.Items {
-		if !util.HasLabel(&vrClasses.Items[i], VolumeReplicationIDLabel) {
+		if !util.HasLabel(&vrClasses.Items[i], ReplicationIDLabel) {
 			continue
 		}
 
@@ -395,7 +395,7 @@ func (r *DRClusterConfigReconciler) listDRSupportedVGRCs(ctx context.Context) ([
 	}
 
 	for i := range vgrClasses.Items {
-		if !util.HasLabel(&vgrClasses.Items[i], VolumeReplicationIDLabel) {
+		if !util.HasLabel(&vgrClasses.Items[i], ReplicationIDLabel) {
 			continue
 		}
 

--- a/internal/controller/drclusterconfig_controller.go
+++ b/internal/controller/drclusterconfig_controller.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
+	groupsnapv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"golang.org/x/time/rate"
 	storagev1 "k8s.io/api/storage/v1"
@@ -305,6 +306,22 @@ func (r *DRClusterConfigReconciler) UpdateSupportedClasses(
 	drCConfig.Status.VolumeReplicationClasses = vrClasses
 	slices.Sort(drCConfig.Status.VolumeReplicationClasses)
 
+	vgrClasses, err := r.listDRSupportedVGRCs(ctx)
+	if err != nil {
+		return err
+	}
+
+	drCConfig.Status.VolumeGroupReplicationClasses = vgrClasses
+	slices.Sort(drCConfig.Status.VolumeGroupReplicationClasses)
+
+	vgsClasses, err := r.listDRSupportedVGSCs(ctx)
+	if err != nil {
+		return err
+	}
+
+	drCConfig.Status.VolumeGroupSnapshotClasses = vgsClasses
+	slices.Sort(drCConfig.Status.VolumeGroupSnapshotClasses)
+
 	return nil
 }
 
@@ -368,6 +385,46 @@ func (r *DRClusterConfigReconciler) listDRSupportedVRCs(ctx context.Context) ([]
 	return vrcs, nil
 }
 
+// listDRSupportedVGRCs returns a list of VolumeGroupReplicationClasses that are marked as DR supported
+func (r *DRClusterConfigReconciler) listDRSupportedVGRCs(ctx context.Context) ([]string, error) {
+	vgrcs := []string{}
+
+	vgrClasses := &volrep.VolumeGroupReplicationClassList{}
+	if err := r.Client.List(ctx, vgrClasses); err != nil {
+		return nil, fmt.Errorf("failed to list VolumeGroupReplicationClasses, %w", err)
+	}
+
+	for i := range vgrClasses.Items {
+		if !util.HasLabel(&vgrClasses.Items[i], VolumeReplicationIDLabel) {
+			continue
+		}
+
+		vgrcs = append(vgrcs, vgrClasses.Items[i].Name)
+	}
+
+	return vgrcs, nil
+}
+
+// listDRSupportedVGSCs returns a list of VolumeGroupSnapshotClasses that are marked as DR supported
+func (r *DRClusterConfigReconciler) listDRSupportedVGSCs(ctx context.Context) ([]string, error) {
+	vgscs := []string{}
+
+	vgsClasses := &groupsnapv1beta1.VolumeGroupSnapshotClassList{}
+	if err := r.Client.List(ctx, vgsClasses); err != nil {
+		return nil, fmt.Errorf("failed to list VolumeGroupSnapshotClasses, %w", err)
+	}
+
+	for i := range vgsClasses.Items {
+		if !util.HasLabel(&vgsClasses.Items[i], StorageIDLabel) {
+			continue
+		}
+
+		vgscs = append(vgscs, vgsClasses.Items[i].Name)
+	}
+
+	return vgscs, nil
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *DRClusterConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	drccMapFn := handler.EnqueueRequestsFromMapFunc(handler.MapFunc(
@@ -414,5 +471,7 @@ func (r *DRClusterConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&storagev1.StorageClass{}, drccMapFn, drccPredFn).
 		Watches(&snapv1.VolumeSnapshotClass{}, drccMapFn, drccPredFn).
 		Watches(&volrep.VolumeReplicationClass{}, drccMapFn, drccPredFn).
+		Watches(&volrep.VolumeGroupReplicationClass{}, drccMapFn, drccPredFn).
+		Watches(&groupsnapv1beta1.VolumeGroupSnapshotClass{}, drccMapFn, drccPredFn).
 		Complete(r)
 }

--- a/internal/controller/drclusterconfig_controller.go
+++ b/internal/controller/drclusterconfig_controller.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
-	groupsnapv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	groupsnapv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	"golang.org/x/time/rate"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controller/drclusterconfig_controller_test.go
+++ b/internal/controller/drclusterconfig_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
+	groupsnapv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -32,7 +33,9 @@ import (
 	ramencontrollers "github.com/ramendr/ramen/internal/controller"
 )
 
-func ensureClassStatus(apiReader client.Reader, drCConfig *ramen.DRClusterConfig, scs, vscs, vrcs []string) {
+func ensureClassStatus(apiReader client.Reader, drCConfig *ramen.DRClusterConfig,
+	scs, vscs, vrcs, vgrcs, vgscs []string,
+) {
 	Eventually(func(g Gomega) {
 		drClusterConfig := &ramen.DRClusterConfig{}
 
@@ -43,22 +46,26 @@ func ensureClassStatus(apiReader client.Reader, drCConfig *ramen.DRClusterConfig
 		g.Expect(drClusterConfig.Status.StorageClasses).To(ConsistOf(scs))
 		g.Expect(drClusterConfig.Status.VolumeSnapshotClasses).To(ConsistOf(vscs))
 		g.Expect(drClusterConfig.Status.VolumeReplicationClasses).To(ConsistOf(vrcs))
+		g.Expect(drClusterConfig.Status.VolumeGroupReplicationClasses).To(ConsistOf(vgrcs))
+		g.Expect(drClusterConfig.Status.VolumeGroupSnapshotClasses).To(ConsistOf(vgscs))
 	}, timeout, interval).Should(Succeed())
 }
 
 var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 	var (
-		ctx                 context.Context
-		cancel              context.CancelFunc
-		cfg                 *rest.Config
-		testEnv             *envtest.Environment
-		k8sClient           client.Client
-		apiReader           client.Reader
-		drCConfig           *ramen.DRClusterConfig
-		baseSC, sc1, sc2    *storagev1.StorageClass
-		baseVSC, vsc1, vsc2 *snapv1.VolumeSnapshotClass
-		baseVRC, vrc1, vrc2 *volrep.VolumeReplicationClass
-		scs, vscs, vrcs     []string
+		ctx                           context.Context
+		cancel                        context.CancelFunc
+		cfg                           *rest.Config
+		testEnv                       *envtest.Environment
+		k8sClient                     client.Client
+		apiReader                     client.Reader
+		drCConfig                     *ramen.DRClusterConfig
+		baseSC, sc1, sc2              *storagev1.StorageClass
+		baseVSC, vsc1, vsc2           *snapv1.VolumeSnapshotClass
+		baseVRC, vrc1, vrc2           *volrep.VolumeReplicationClass
+		baseVGRC, vgrc1, vgrc2        *volrep.VolumeGroupReplicationClass
+		baseVGSC, vgsc1, vgsc2        *groupsnapv1beta1.VolumeGroupSnapshotClass
+		scs, vscs, vrcs, vgrcs, vgscs []string
 	)
 
 	BeforeAll(func() {
@@ -184,6 +191,28 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 				Provisioner: "fake.ramen.com",
 			},
 		}
+
+		baseVGRC = &volrep.VolumeGroupReplicationClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "baseVGRC",
+				Labels: map[string]string{
+					ramencontrollers.VolumeReplicationIDLabel: "fake",
+				},
+			},
+			Spec: volrep.VolumeGroupReplicationClassSpec{
+				Provisioner: "fake.ramen.com",
+			},
+		}
+		baseVGSC = &groupsnapv1beta1.VolumeGroupSnapshotClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "baseVGSC",
+				Labels: map[string]string{
+					ramencontrollers.StorageIDLabel: "fake",
+				},
+			},
+			Driver:         "fake.ramen.com",
+			DeletionPolicy: snapv1.VolumeSnapshotContentDelete,
+		}
 	})
 
 	AfterAll(func() {
@@ -235,7 +264,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 					scs = append(scs, "sc1")
 					slices.Sort(scs)
 
-					ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs)
+					ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
 					objectConditionExpectEventually(
 						apiReader,
 						drCConfig,
@@ -254,7 +283,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 
 					scs = []string{}
 
-					ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs)
+					ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
 					objectConditionExpectEventually(
 						apiReader,
 						drCConfig,
@@ -281,7 +310,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 					scs = append(scs, "sc2")
 					slices.Sort(scs)
 
-					ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs)
+					ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
 					objectConditionExpectEventually(
 						apiReader,
 						drCConfig,
@@ -301,7 +330,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 
 					scs = []string{"sc2"}
 
-					ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs)
+					ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
 					objectConditionExpectEventually(
 						apiReader,
 						drCConfig,
@@ -324,7 +353,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 				vscs = append(vscs, "vsc1")
 				slices.Sort(vscs)
 
-				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs)
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
 				objectConditionExpectEventually(
 					apiReader,
 					drCConfig,
@@ -343,7 +372,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 
 				vscs = []string{}
 
-				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs)
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
 				objectConditionExpectEventually(
 					apiReader,
 					drCConfig,
@@ -369,7 +398,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 				vscs = append(vscs, "vsc1")
 				vscs = append(vscs, "vsc2")
 
-				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs)
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
 				objectConditionExpectEventually(
 					apiReader,
 					drCConfig,
@@ -389,7 +418,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 
 				vscs = []string{"vsc1"}
 
-				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs)
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
 				objectConditionExpectEventually(
 					apiReader,
 					drCConfig,
@@ -411,7 +440,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 				vrcs = append(vrcs, "vrc1")
 				slices.Sort(vrcs)
 
-				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs)
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
 				objectConditionExpectEventually(
 					apiReader,
 					drCConfig,
@@ -430,7 +459,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 
 				vrcs = []string{}
 
-				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs)
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
 				objectConditionExpectEventually(
 					apiReader,
 					drCConfig,
@@ -456,7 +485,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 				vrcs = append(vrcs, "vrc1")
 				vrcs = append(vrcs, "vrc2")
 
-				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs)
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
 				objectConditionExpectEventually(
 					apiReader,
 					drCConfig,
@@ -476,7 +505,181 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 
 				vrcs = []string{"vrc1"}
 
-				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs)
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
+				objectConditionExpectEventually(
+					apiReader,
+					drCConfig,
+					metav1.ConditionTrue,
+					Equal("Succeeded"),
+					Equal("Configuration processed and validated"),
+					ramen.DRClusterConfigConfigurationProcessed,
+				)
+			})
+		})
+		When("there is a VolumeGroupReplicationCLass created with required labels", func() {
+			It("creates a ClusterClaim", func() {
+				By("creating a VolumeGroupReplicationClass")
+
+				vgrc1 = baseVGRC.DeepCopy()
+				vgrc1.Name = "vgrc1"
+				Expect(k8sClient.Create(context.TODO(), vgrc1)).To(Succeed())
+
+				vgrcs = append(vgrcs, "vgrc1")
+				slices.Sort(vgrcs)
+
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
+				objectConditionExpectEventually(
+					apiReader,
+					drCConfig,
+					metav1.ConditionTrue,
+					Equal("Succeeded"),
+					Equal("Configuration processed and validated"),
+					ramen.DRClusterConfigConfigurationProcessed,
+				)
+			})
+		})
+		When("a VolumeGroupReplicationClass with required labels is deleted", func() {
+			It("deletes the associated ClusterClaim", func() {
+				By("deleting a VolumeGroupReplicationClass")
+
+				Expect(k8sClient.Delete(context.TODO(), vgrc1)).To(Succeed())
+
+				vgrcs = []string{}
+
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
+				objectConditionExpectEventually(
+					apiReader,
+					drCConfig,
+					metav1.ConditionTrue,
+					Equal("Succeeded"),
+					Equal("Configuration processed and validated"),
+					ramen.DRClusterConfigConfigurationProcessed,
+				)
+			})
+		})
+		When("there are multiple VolumeGroupReplicationClass created with required labels", func() {
+			It("creates ClusterClaims", func() {
+				By("creating a VolumeGroupReplicationClass")
+
+				vgrc1 = baseVGRC.DeepCopy()
+				vgrc1.Name = "vgrc1"
+				Expect(k8sClient.Create(context.TODO(), vgrc1)).To(Succeed())
+
+				vgrc2 = baseVGRC.DeepCopy()
+				vgrc2.Name = "vgrc2"
+				Expect(k8sClient.Create(context.TODO(), vgrc2)).To(Succeed())
+
+				vgrcs = append(vgrcs, "vgrc1")
+				vgrcs = append(vgrcs, "vgrc2")
+
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
+				objectConditionExpectEventually(
+					apiReader,
+					drCConfig,
+					metav1.ConditionTrue,
+					Equal("Succeeded"),
+					Equal("Configuration processed and validated"),
+					ramen.DRClusterConfigConfigurationProcessed,
+				)
+			})
+		})
+		When("a VolumeGroupReplicationClass label is deleted", func() {
+			It("deletes the associated ClusterClaim", func() {
+				By("deleting a VolumeGroupReplicationClass label")
+
+				vgrc2.Labels = map[string]string{}
+				Expect(k8sClient.Update(context.TODO(), vgrc2)).To(Succeed())
+
+				vgrcs = []string{"vgrc1"}
+
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
+				objectConditionExpectEventually(
+					apiReader,
+					drCConfig,
+					metav1.ConditionTrue,
+					Equal("Succeeded"),
+					Equal("Configuration processed and validated"),
+					ramen.DRClusterConfigConfigurationProcessed,
+				)
+			})
+		})
+		When("there is a GroupSnapshotCLass created with required labels", func() {
+			It("creates a ClusterClaim", func() {
+				By("creating a GroupSnapshotClass")
+
+				vgsc1 = baseVGSC.DeepCopy()
+				vgsc1.Name = "vgsc1"
+				Expect(k8sClient.Create(context.TODO(), vgsc1)).To(Succeed())
+
+				vgscs = append(vgscs, "vgsc1")
+				slices.Sort(vgscs)
+
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
+				objectConditionExpectEventually(
+					apiReader,
+					drCConfig,
+					metav1.ConditionTrue,
+					Equal("Succeeded"),
+					Equal("Configuration processed and validated"),
+					ramen.DRClusterConfigConfigurationProcessed,
+				)
+			})
+		})
+		When("a GroupSnapshotClass with required labels is deleted", func() {
+			It("deletes the associated ClusterClaim", func() {
+				By("deleting a GroupSnapshotClass")
+
+				Expect(k8sClient.Delete(context.TODO(), vgsc1)).To(Succeed())
+
+				vgscs = []string{}
+
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
+				objectConditionExpectEventually(
+					apiReader,
+					drCConfig,
+					metav1.ConditionTrue,
+					Equal("Succeeded"),
+					Equal("Configuration processed and validated"),
+					ramen.DRClusterConfigConfigurationProcessed,
+				)
+			})
+		})
+		When("there are multiple SnapshotClass created with required labels", func() {
+			It("creates ClusterClaims", func() {
+				By("creating a SnapshotClass")
+
+				vgsc1 = baseVGSC.DeepCopy()
+				vgsc1.Name = "vgsc1"
+				Expect(k8sClient.Create(context.TODO(), vgsc1)).To(Succeed())
+
+				vgsc2 = baseVGSC.DeepCopy()
+				vgsc2.Name = "vgsc2"
+				Expect(k8sClient.Create(context.TODO(), vgsc2)).To(Succeed())
+
+				vgscs = append(vgscs, "vgsc1")
+				vgscs = append(vgscs, "vgsc2")
+
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
+				objectConditionExpectEventually(
+					apiReader,
+					drCConfig,
+					metav1.ConditionTrue,
+					Equal("Succeeded"),
+					Equal("Configuration processed and validated"),
+					ramen.DRClusterConfigConfigurationProcessed,
+				)
+			})
+		})
+		When("a GroupSnapshotClass label is deleted", func() {
+			It("deletes the associated ClusterClaim", func() {
+				By("deleting a GroupSnapshotClass label")
+
+				vgsc2.Labels = map[string]string{}
+				Expect(k8sClient.Update(context.TODO(), vgsc2)).To(Succeed())
+
+				vgscs = []string{"vgsc1"}
+
+				ensureClassStatus(apiReader, drCConfig, scs, vscs, vrcs, vgrcs, vgscs)
 				objectConditionExpectEventually(
 					apiReader,
 					drCConfig,

--- a/internal/controller/drclusterconfig_controller_test.go
+++ b/internal/controller/drclusterconfig_controller_test.go
@@ -51,7 +51,7 @@ func ensureClassStatus(apiReader client.Reader, drCConfig *ramen.DRClusterConfig
 	}, timeout, interval).Should(Succeed())
 }
 
-var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
+var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 	var (
 		ctx                           context.Context
 		cancel                        context.CancelFunc
@@ -251,10 +251,10 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 	})
-	Describe("ClusterClaims", Ordered, func() {
+	Describe("DRClusterConfig", Ordered, func() {
 		Context("Given DRClusterConfig resource", func() {
 			When("there is a StorageClass created with required labels", func() {
-				It("creates a ClusterClaim", func() {
+				It("updates DRClusterConfig Status", func() {
 					By("creating a StorageClass")
 
 					sc1 = baseSC.DeepCopy()
@@ -276,7 +276,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 				})
 			})
 			When("a StorageClass with required labels is deleted", func() {
-				It("deletes the associated ClusterClaim", func() {
+				It("removes the associated StorageClass from DRClusterConfig Status", func() {
 					By("deleting a StorageClass")
 
 					Expect(k8sClient.Delete(context.TODO(), sc1)).To(Succeed())
@@ -295,7 +295,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 				})
 			})
 			When("there are multiple StorageClass created with required labels", func() {
-				It("creates ClusterClaims", func() {
+				It("updates DRClusterConfig Status", func() {
 					By("creating a StorageClass")
 
 					sc1 = baseSC.DeepCopy()
@@ -322,7 +322,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 				})
 			})
 			When("a StorageClass label is deleted", func() {
-				It("deletes the associated ClusterClaim", func() {
+				It("removes the associated StorageClass from DRClusterConfig Status", func() {
 					By("deleting a StorageClass label")
 
 					sc1.Labels = map[string]string{}
@@ -343,7 +343,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("there is a SnapshotCLass created with required labels", func() {
-			It("creates a ClusterClaim", func() {
+			It("updates DRClusterConfig Status", func() {
 				By("creating a SnapshotClass")
 
 				vsc1 = baseVSC.DeepCopy()
@@ -365,7 +365,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("a SnapshotClass with required labels is deleted", func() {
-			It("deletes the associated ClusterClaim", func() {
+			It("removes the associated SnapshotClass from DRClusterConfig Status", func() {
 				By("deleting a SnapshotClass")
 
 				Expect(k8sClient.Delete(context.TODO(), vsc1)).To(Succeed())
@@ -384,7 +384,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("there are multiple SnapshotClass created with required labels", func() {
-			It("creates ClusterClaims", func() {
+			It("updates DRClusterConfig Status", func() {
 				By("creating a SnapshotClass")
 
 				vsc1 = baseVSC.DeepCopy()
@@ -410,7 +410,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("a SnapshotClass label is deleted", func() {
-			It("deletes the associated ClusterClaim", func() {
+			It("removes the associated SnapshotClass from DRClusterConfig Status", func() {
 				By("deleting a SnapshotClass label")
 
 				vsc2.Labels = map[string]string{}
@@ -430,7 +430,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("there is a VolumeReplicationCLass created with required labels", func() {
-			It("creates a ClusterClaim", func() {
+			It("updates DRClusterConfig Status", func() {
 				By("creating a VolumeReplicationClass")
 
 				vrc1 = baseVRC.DeepCopy()
@@ -452,7 +452,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("a VolumeReplicationClass with required labels is deleted", func() {
-			It("deletes the associated ClusterClaim", func() {
+			It("removes the associated VolumeReplicationClass from DRClusterConfig Status", func() {
 				By("deleting a VolumeReplicationClass")
 
 				Expect(k8sClient.Delete(context.TODO(), vrc1)).To(Succeed())
@@ -471,7 +471,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("there are multiple VolumeReplicationClass created with required labels", func() {
-			It("creates ClusterClaims", func() {
+			It("updates DRClusterConfig Status", func() {
 				By("creating a VolumeReplicationClass")
 
 				vrc1 = baseVRC.DeepCopy()
@@ -497,7 +497,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("a VolumeReplicationClass label is deleted", func() {
-			It("deletes the associated ClusterClaim", func() {
+			It("removes the associated VolumeReplicationClass from DRClusterConfig Status", func() {
 				By("deleting a VolumeReplicationClass label")
 
 				vrc2.Labels = map[string]string{}
@@ -517,7 +517,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("there is a VolumeGroupReplicationCLass created with required labels", func() {
-			It("creates a ClusterClaim", func() {
+			It("updates DRClusterConfig Status", func() {
 				By("creating a VolumeGroupReplicationClass")
 
 				vgrc1 = baseVGRC.DeepCopy()
@@ -539,7 +539,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("a VolumeGroupReplicationClass with required labels is deleted", func() {
-			It("deletes the associated ClusterClaim", func() {
+			It("removes the associated VolumeGroupReplicationClass from DRClusterConfig Status", func() {
 				By("deleting a VolumeGroupReplicationClass")
 
 				Expect(k8sClient.Delete(context.TODO(), vgrc1)).To(Succeed())
@@ -558,7 +558,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("there are multiple VolumeGroupReplicationClass created with required labels", func() {
-			It("creates ClusterClaims", func() {
+			It("updates DRClusterConfig Status", func() {
 				By("creating a VolumeGroupReplicationClass")
 
 				vgrc1 = baseVGRC.DeepCopy()
@@ -584,7 +584,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("a VolumeGroupReplicationClass label is deleted", func() {
-			It("deletes the associated ClusterClaim", func() {
+			It("removes the associated VolumeGroupReplicationClass from DRClusterConfig Status", func() {
 				By("deleting a VolumeGroupReplicationClass label")
 
 				vgrc2.Labels = map[string]string{}
@@ -604,7 +604,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("there is a GroupSnapshotCLass created with required labels", func() {
-			It("creates a ClusterClaim", func() {
+			It("updates DRClusterConfig Status", func() {
 				By("creating a GroupSnapshotClass")
 
 				vgsc1 = baseVGSC.DeepCopy()
@@ -626,7 +626,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("a GroupSnapshotClass with required labels is deleted", func() {
-			It("deletes the associated ClusterClaim", func() {
+			It("removes the associated GroupSnapshotClass from DRClusterConfig Status", func() {
 				By("deleting a GroupSnapshotClass")
 
 				Expect(k8sClient.Delete(context.TODO(), vgsc1)).To(Succeed())
@@ -645,7 +645,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("there are multiple SnapshotClass created with required labels", func() {
-			It("creates ClusterClaims", func() {
+			It("updates DRClusterConfig Status", func() {
 				By("creating a SnapshotClass")
 
 				vgsc1 = baseVGSC.DeepCopy()
@@ -671,7 +671,7 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 			})
 		})
 		When("a GroupSnapshotClass label is deleted", func() {
-			It("deletes the associated ClusterClaim", func() {
+			It("removes the associated GroupSnapshotClass from DRClusterConfig Status", func() {
 				By("deleting a GroupSnapshotClass label")
 
 				vgsc2.Labels = map[string]string{}

--- a/internal/controller/drclusterconfig_controller_test.go
+++ b/internal/controller/drclusterconfig_controller_test.go
@@ -184,7 +184,7 @@ var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "baseVRC",
 				Labels: map[string]string{
-					ramencontrollers.VolumeReplicationIDLabel: "fake",
+					ramencontrollers.ReplicationIDLabel: "fake",
 				},
 			},
 			Spec: volrep.VolumeReplicationClassSpec{
@@ -196,7 +196,7 @@ var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "baseVGRC",
 				Labels: map[string]string{
-					ramencontrollers.VolumeReplicationIDLabel: "fake",
+					ramencontrollers.ReplicationIDLabel: "fake",
 				},
 			},
 			Spec: volrep.VolumeGroupReplicationClassSpec{

--- a/internal/controller/drclusterconfig_controller_test.go
+++ b/internal/controller/drclusterconfig_controller_test.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
-	groupsnapv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	groupsnapv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -1613,13 +1613,13 @@ func updatePeerClass(log logr.Logger, to []rmn.PeerClass, from rmn.PeerClass, sc
 			continue
 		}
 
-		if to[toIdx].ReplicationID == "" && from.ReplicationID == "" {
+		if to[toIdx].ReplicationID == "" && from.ReplicationID == "" && to[toIdx].Grouping == from.Grouping {
 			to[toIdx] = from
 
 			break
 		}
 
-		if to[toIdx].ReplicationID != "" && from.ReplicationID != "" {
+		if to[toIdx].ReplicationID != "" && from.ReplicationID != "" && to[toIdx].Grouping == from.Grouping {
 			to[toIdx] = from
 
 			break

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -1816,7 +1816,6 @@ func (d *DRPCInstance) updateVRGOptionalFields(vrg, vrgFromView *rmn.VolumeRepli
 		DestinationClusterAnnotationKey: homeCluster,
 		DoNotDeletePVCAnnotation:        d.instance.GetAnnotations()[DoNotDeletePVCAnnotation],
 		DRPCUIDAnnotation:               string(d.instance.UID),
-		rmnutil.IsCGEnabledAnnotation:   d.instance.GetAnnotations()[rmnutil.IsCGEnabledAnnotation],
 		rmnutil.UseVolSyncAnnotation:    d.instance.GetAnnotations()[rmnutil.UseVolSyncAnnotation],
 	}
 

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -1605,8 +1605,11 @@ func equalClusterIDSlices(a, b []string) bool {
 
 // updatePeerClass conditionally updates an existing peerClass in to, with values from. If existing peerClass claims
 // a replicationID then the from should also claim a replicationID, else both should not. This ensures that a peerClass
-// is updated with latest storage/replication IDs, but only if the underlying replication scheme remains unchanged.
-func updatePeerClass(log logr.Logger, to []rmn.PeerClass, from rmn.PeerClass, scName string) {
+// is updated with latest storage/replication IDs but only if the underlying replication scheme remains unchanged.
+// If DRPC is annotated with CG values, then grouping is also updated to true.
+
+//nolint:gocognit,cyclop
+func updatePeerClass(log logr.Logger, to []rmn.PeerClass, from rmn.PeerClass, scName string, cgAnnotationExists bool) {
 	for toIdx := range to {
 		if (to[toIdx].StorageClassName != scName) ||
 			(!equalClusterIDSlices(to[toIdx].ClusterIDs, from.ClusterIDs)) {
@@ -1616,11 +1619,19 @@ func updatePeerClass(log logr.Logger, to []rmn.PeerClass, from rmn.PeerClass, sc
 		if to[toIdx].ReplicationID == "" && from.ReplicationID == "" && to[toIdx].Grouping == from.Grouping {
 			to[toIdx] = from
 
+			if cgAnnotationExists {
+				to[toIdx].Grouping = true
+			}
+
 			break
 		}
 
 		if to[toIdx].ReplicationID != "" && from.ReplicationID != "" && to[toIdx].Grouping == from.Grouping {
 			to[toIdx] = from
+
+			if cgAnnotationExists {
+				to[toIdx].Grouping = true
+			}
 
 			break
 		}
@@ -1650,6 +1661,7 @@ func updatePeers(
 	log logr.Logger,
 	vrgFromView *rmn.VolumeReplicationGroup,
 	vrgPeerClasses, policyPeerClasses []rmn.PeerClass,
+	cgAnnotationExists bool,
 ) []rmn.PeerClass {
 	peerClasses := vrgPeerClasses
 
@@ -1675,6 +1687,7 @@ func updatePeers(
 					peerClasses,
 					policyPeerClasses[policyPeerClassIdx],
 					*vrgFromView.Status.ProtectedPVCs[pvcIdx].StorageClassName,
+					cgAnnotationExists,
 				)
 
 				break
@@ -1721,11 +1734,14 @@ func (d *DRPCInstance) updateVRGAsyncSpec(vrgFromView, vrg *rmn.VolumeReplicatio
 		return
 	}
 
+	cgAnnotationExists := d.instance.GetAnnotations()[rmnutil.IsCGEnabledAnnotation] == "true"
+
 	asyncSpec.PeerClasses = updatePeers(
 		d.log,
 		vrgFromView,
 		vrg.Spec.Async.PeerClasses,
 		d.drPolicy.Status.Async.PeerClasses,
+		cgAnnotationExists,
 	)
 
 	// TODO: prune peerClasses not in policy and not in use by VRG
@@ -1756,7 +1772,9 @@ func (d *DRPCInstance) updateVRGSyncSpec(vrgFromView, vrg *rmn.VolumeReplication
 		return
 	}
 
-	syncSpec.PeerClasses = updatePeers(d.log, vrgFromView, vrg.Spec.Sync.PeerClasses, d.drPolicy.Status.Sync.PeerClasses)
+	syncSpec.PeerClasses = updatePeers(d.log, vrgFromView, vrg.Spec.Sync.PeerClasses,
+		d.drPolicy.Status.Sync.PeerClasses,
+		false)
 
 	// TODO: prune peerClasses not in policy and not in use by VRG
 

--- a/internal/controller/drpolicy_peerclass.go
+++ b/internal/controller/drpolicy_peerclass.go
@@ -195,7 +195,7 @@ func getVRID(scName string, cl classLists, vrcIdx int, inSID string, schedule st
 		return ""
 	}
 
-	if cl.vrClasses[vrcIdx].Spec.Parameters[VRClassScheduleKey] != schedule {
+	if cl.vrClasses[vrcIdx].Spec.Parameters[ReplicationClassScheduleKey] != schedule {
 		return ""
 	}
 
@@ -217,7 +217,7 @@ func getVGRID(scName string, cl classLists, vgrcIdx int, inSID string, schedule 
 		return ""
 	}
 
-	if cl.vgrClasses[vgrcIdx].Spec.Parameters[VRClassScheduleKey] != schedule {
+	if cl.vgrClasses[vgrcIdx].Spec.Parameters[ReplicationClassScheduleKey] != schedule {
 		return ""
 	}
 

--- a/internal/controller/drpolicy_peerclass.go
+++ b/internal/controller/drpolicy_peerclass.go
@@ -196,7 +196,7 @@ func getVRID(scName string, cl classLists, vrcIdx int, inSID string, schedule st
 		return ""
 	}
 
-	rID := cl.vrClasses[vrcIdx].GetLabels()[VolumeReplicationIDLabel]
+	rID := cl.vrClasses[vrcIdx].GetLabels()[ReplicationIDLabel]
 
 	return rID
 }

--- a/internal/controller/drpolicy_peerclass_internal_test.go
+++ b/internal/controller/drpolicy_peerclass_internal_test.go
@@ -210,8 +210,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-1-sID-mismatch",
-									VolumeReplicationIDLabel: "cl-1-2-rID",
+									StorageIDLabel:     "cl-1-sID-mismatch",
+									ReplicationIDLabel: "cl-1-2-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -241,8 +241,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-2-sID-mismatch",
-									VolumeReplicationIDLabel: "cl-1-2-rID",
+									StorageIDLabel:     "cl-2-sID-mismatch",
+									ReplicationIDLabel: "cl-1-2-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -336,8 +336,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-1-sID-mismatch",
-									VolumeReplicationIDLabel: "cl-1-2-rID",
+									StorageIDLabel:     "cl-1-sID-mismatch",
+									ReplicationIDLabel: "cl-1-2-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -378,8 +378,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-2-sID-mismatch",
-									VolumeReplicationIDLabel: "cl-1-2-rID",
+									StorageIDLabel:     "cl-2-sID-mismatch",
+									ReplicationIDLabel: "cl-1-2-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -427,8 +427,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-1-sID",
-									VolumeReplicationIDLabel: "cl-1-2-rID",
+									StorageIDLabel:     "cl-1-sID",
+									ReplicationIDLabel: "cl-1-2-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -458,8 +458,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-2-sID",
-									VolumeReplicationIDLabel: "cl-1-2-rID",
+									StorageIDLabel:     "cl-2-sID",
+									ReplicationIDLabel: "cl-1-2-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -654,8 +654,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-2-sID",
-									VolumeReplicationIDLabel: "cl-1-2-rID",
+									StorageIDLabel:     "cl-2-sID",
+									ReplicationIDLabel: "cl-1-2-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -692,8 +692,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-1-sID",
-									VolumeReplicationIDLabel: "cl-1-2-rID",
+									StorageIDLabel:     "cl-1-sID",
+									ReplicationIDLabel: "cl-1-2-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -723,8 +723,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-2-sID",
-									VolumeReplicationIDLabel: "cl-1-2-rID",
+									StorageIDLabel:     "cl-2-sID",
+									ReplicationIDLabel: "cl-1-2-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -761,8 +761,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-1-sID",
-									VolumeReplicationIDLabel: "cl-1-2-rID",
+									StorageIDLabel:     "cl-1-sID",
+									ReplicationIDLabel: "cl-1-2-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -792,8 +792,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-2-sID",
-									VolumeReplicationIDLabel: "cl-1-2-rID-mismatch",
+									StorageIDLabel:     "cl-2-sID",
+									ReplicationIDLabel: "cl-1-2-rID-mismatch",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -850,8 +850,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-1-sID2",
-									VolumeReplicationIDLabel: "cl-1-2-rID",
+									StorageIDLabel:     "cl-1-sID2",
+									ReplicationIDLabel: "cl-1-2-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -901,8 +901,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-2-sID2",
-									VolumeReplicationIDLabel: "cl-1-2-rID",
+									StorageIDLabel:     "cl-2-sID2",
+									ReplicationIDLabel: "cl-1-2-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -952,8 +952,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-[1|2]-sID1",
-									VolumeReplicationIDLabel: "cl-[1|2]-[3|4]-rID",
+									StorageIDLabel:     "cl-[1|2]-sID1",
+									ReplicationIDLabel: "cl-[1|2]-[3|4]-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -983,8 +983,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-[1|2]-sID1",
-									VolumeReplicationIDLabel: "cl-[1|2]-[3|4]-rID",
+									StorageIDLabel:     "cl-[1|2]-sID1",
+									ReplicationIDLabel: "cl-[1|2]-[3|4]-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -1014,8 +1014,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-[3|4]-sID1",
-									VolumeReplicationIDLabel: "cl-[1|2]-[3|4]-rID",
+									StorageIDLabel:     "cl-[3|4]-sID1",
+									ReplicationIDLabel: "cl-[1|2]-[3|4]-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -1045,8 +1045,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-[3|4]-sID1",
-									VolumeReplicationIDLabel: "cl-[1|2]-[3|4]-rID",
+									StorageIDLabel:     "cl-[3|4]-sID1",
+									ReplicationIDLabel: "cl-[1|2]-[3|4]-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -1141,8 +1141,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-1-sID1",
-									VolumeReplicationIDLabel: "cl-1-2-rID",
+									StorageIDLabel:     "cl-1-sID1",
+									ReplicationIDLabel: "cl-1-2-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{
@@ -1192,8 +1192,8 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "vrc1",
 								Labels: map[string]string{
-									StorageIDLabel:           "cl-2-sID1",
-									VolumeReplicationIDLabel: "cl-1-2-rID",
+									StorageIDLabel:     "cl-2-sID1",
+									ReplicationIDLabel: "cl-1-2-rID",
 								},
 							},
 							Spec: volrep.VolumeReplicationClassSpec{

--- a/internal/controller/drpolicy_peerclass_internal_test.go
+++ b/internal/controller/drpolicy_peerclass_internal_test.go
@@ -217,7 +217,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -248,7 +248,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -343,7 +343,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -385,7 +385,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -434,7 +434,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -465,7 +465,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -630,7 +630,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -661,7 +661,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -699,7 +699,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "2m",
+									ReplicationClassScheduleKey: "2m",
 								},
 							},
 						},
@@ -730,7 +730,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -768,7 +768,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -799,7 +799,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -857,7 +857,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -908,7 +908,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -959,7 +959,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -990,7 +990,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -1021,7 +1021,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -1052,7 +1052,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -1148,7 +1148,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample2.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},
@@ -1199,7 +1199,7 @@ var _ = Describe("updatePeerClassesInternal", func() {
 							Spec: volrep.VolumeReplicationClassSpec{
 								Provisioner: "sample2.csi.com",
 								Parameters: map[string]string{
-									VRClassScheduleKey: "1m",
+									ReplicationClassScheduleKey: "1m",
 								},
 							},
 						},

--- a/internal/controller/fake_mcv_test.go
+++ b/internal/controller/fake_mcv_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-logr/logr"
 
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
+	groupsnapv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 
 	storagev1 "k8s.io/api/storage/v1"
@@ -61,12 +62,30 @@ func (f FakeMCVGetter) ListVSClassMCVs(managedCluster string) (*viewv1beta1.Mana
 	return &viewv1beta1.ManagedClusterViewList{}, nil
 }
 
+func (f FakeMCVGetter) GetVGSClassFromManagedCluster(resourceName, managedCluster string, annotations map[string]string,
+) (*groupsnapv1beta1.VolumeGroupSnapshotClass, error) {
+	return nil, nil
+}
+
+func (f FakeMCVGetter) ListVGSClassMCVs(managedCluster string) (*viewv1beta1.ManagedClusterViewList, error) {
+	return &viewv1beta1.ManagedClusterViewList{}, nil
+}
+
 func (f FakeMCVGetter) GetVRClassFromManagedCluster(resourceName, managedCluster string, annotations map[string]string,
 ) (*volrep.VolumeReplicationClass, error) {
 	return nil, nil
 }
 
 func (f FakeMCVGetter) ListVRClassMCVs(managedCluster string) (*viewv1beta1.ManagedClusterViewList, error) {
+	return &viewv1beta1.ManagedClusterViewList{}, nil
+}
+
+func (f FakeMCVGetter) GetVGRClassFromManagedCluster(resourceName, managedCluster string, annotations map[string]string,
+) (*volrep.VolumeGroupReplicationClass, error) {
+	return nil, nil
+}
+
+func (f FakeMCVGetter) ListVGRClassMCVs(managedCluster string) (*viewv1beta1.ManagedClusterViewList, error) {
 	return &viewv1beta1.ManagedClusterViewList{}, nil
 }
 

--- a/internal/controller/fake_mcv_test.go
+++ b/internal/controller/fake_mcv_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/go-logr/logr"
 
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
-	groupsnapv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	groupsnapv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"

--- a/internal/controller/util/labels.go
+++ b/internal/controller/util/labels.go
@@ -15,7 +15,9 @@ const (
 	MModesLabel                           = "ramendr.openshift.io/maintenancemodes"
 	SClassLabel                           = "ramendr.openshift.io/storageclass"
 	VSClassLabel                          = "ramendr.openshift.io/volumesnapshotclass"
+	VGSClassLabel                         = "ramendr.openshift.io/volumegroupsnapshotclass"
 	VRClassLabel                          = "ramendr.openshift.io/volumereplicationclass"
+	VGRClassLabel                         = "ramendr.openshift.io/volumegroupreplicationclass"
 	ExcludeFromVeleroBackup               = "velero.io/exclude-from-backup"
 	VeleroKubevirtMetadataOnlyBackupLabel = "velero.kubevirt.io/metadataBackup"
 )

--- a/internal/controller/util/mcv_util.go
+++ b/internal/controller/util/mcv_util.go
@@ -11,6 +11,7 @@ import (
 
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
 	"github.com/go-logr/logr"
+	groupsnapv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -64,6 +65,18 @@ type ManagedClusterViewGetter interface {
 		annotations map[string]string) (*volrep.VolumeReplicationClass, error)
 
 	ListVRClassMCVs(managedCluster string) (*viewv1beta1.ManagedClusterViewList, error)
+
+	GetVGSClassFromManagedCluster(
+		resourceName, managedCluster string,
+		annotations map[string]string) (*groupsnapv1beta1.VolumeGroupSnapshotClass, error)
+
+	ListVGSClassMCVs(managedCluster string) (*viewv1beta1.ManagedClusterViewList, error)
+
+	GetVGRClassFromManagedCluster(
+		resourceName, managedCluster string,
+		annotations map[string]string) (*volrep.VolumeGroupReplicationClass, error)
+
+	ListVGRClassMCVs(managedCluster string) (*viewv1beta1.ManagedClusterViewList, error)
 
 	GetResource(mcv *viewv1beta1.ManagedClusterView, resource interface{}) error
 
@@ -269,6 +282,56 @@ func (m ManagedClusterViewGetterImpl) GetVSClassFromManagedCluster(resourceName,
 
 func (m ManagedClusterViewGetterImpl) ListVSClassMCVs(cluster string) (*viewv1beta1.ManagedClusterViewList, error) {
 	return m.listMCVsWithLabel(cluster, map[string]string{VSClassLabel: ""})
+}
+
+func (m ManagedClusterViewGetterImpl) GetVGSClassFromManagedCluster(resourceName, managedCluster string,
+	annotations map[string]string,
+) (*groupsnapv1beta1.VolumeGroupSnapshotClass, error) {
+	vgsc := &groupsnapv1beta1.VolumeGroupSnapshotClass{}
+
+	err := m.getResourceFromManagedCluster(
+		resourceName,
+		"",
+		managedCluster,
+		annotations,
+		map[string]string{VGSClassLabel: ""},
+		BuildManagedClusterViewName(resourceName, "", MWTypeVGSClass),
+		"VolumeGroupSnapshotClass",
+		groupsnapv1beta1.SchemeGroupVersion.Group,
+		groupsnapv1beta1.SchemeGroupVersion.Version,
+		vgsc,
+	)
+
+	return vgsc, err
+}
+
+func (m ManagedClusterViewGetterImpl) ListVGSClassMCVs(cluster string) (*viewv1beta1.ManagedClusterViewList, error) {
+	return m.listMCVsWithLabel(cluster, map[string]string{VGSClassLabel: ""})
+}
+
+func (m ManagedClusterViewGetterImpl) GetVGRClassFromManagedCluster(resourceName, managedCluster string,
+	annotations map[string]string,
+) (*volrep.VolumeGroupReplicationClass, error) {
+	vgrc := &volrep.VolumeGroupReplicationClass{}
+
+	err := m.getResourceFromManagedCluster(
+		resourceName,
+		"",
+		managedCluster,
+		annotations,
+		map[string]string{VGRClassLabel: ""},
+		BuildManagedClusterViewName(resourceName, "", MWTypeVGRClass),
+		"VolumeGroupReplicationClass",
+		volrep.GroupVersion.Group,
+		volrep.GroupVersion.Version,
+		vgrc,
+	)
+
+	return vgrc, err
+}
+
+func (m ManagedClusterViewGetterImpl) ListVGRClassMCVs(cluster string) (*viewv1beta1.ManagedClusterViewList, error) {
+	return m.listMCVsWithLabel(cluster, map[string]string{VGRClassLabel: ""})
 }
 
 func (m ManagedClusterViewGetterImpl) GetVRClassFromManagedCluster(resourceName, managedCluster string,

--- a/internal/controller/util/mcv_util.go
+++ b/internal/controller/util/mcv_util.go
@@ -11,8 +11,8 @@ import (
 
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
 	"github.com/go-logr/logr"
-	groupsnapv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	groupsnapv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/controller/util/mw_util.go
+++ b/internal/controller/util/mw_util.go
@@ -48,7 +48,9 @@ const (
 	MWTypeMMode     string = "mmode"
 	MWTypeSClass    string = "sc"
 	MWTypeVSClass   string = "vsc"
+	MWTypeVGSClass  string = "vgsc"
 	MWTypeVRClass   string = "vrc"
+	MWTypeVGRClass  string = "vgrc"
 	MWTypeDRCConfig string = "drcconfig"
 )
 

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -539,8 +539,8 @@ const (
 	// Maintenance mode label
 	MModesLabel = "ramendr.openshift.io/maintenancemodes"
 
-	// VolumeReplicationClass schedule parameter key
-	VRClassScheduleKey = "schedulingInterval"
+	// VolumeReplicationClass and VolumeGroupReplicationClass schedule parameter key
+	ReplicationClassScheduleKey = "schedulingInterval"
 )
 
 func (v *VRGInstance) requeue() {

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -533,8 +533,8 @@ const (
 	// Consistency group label
 	ConsistencyGroupLabel = "ramendr.openshift.io/consistency-group"
 
-	// VolumeReplicationClass label
-	VolumeReplicationIDLabel = "ramendr.openshift.io/replicationid"
+	// VolumeReplicationClass and VolumeGroupReplicationClass label
+	ReplicationIDLabel = "ramendr.openshift.io/replicationid"
 
 	// Maintenance mode label
 	MModesLabel = "ramendr.openshift.io/maintenancemodes"
@@ -1034,7 +1034,7 @@ func (v *VRGInstance) findReplicationClassUsingPeerClass(
 	storageClass *storagev1.StorageClass,
 ) client.Object {
 	findMatchingReplicationClass := func(replicationClass client.Object, provisioner string) client.Object {
-		rIDFromReplicationClass := replicationClass.GetLabels()[VolumeReplicationIDLabel]
+		rIDFromReplicationClass := replicationClass.GetLabels()[ReplicationIDLabel]
 		sIDfromReplicationClass := replicationClass.GetLabels()[StorageIDLabel]
 
 		matched := sIDfromReplicationClass == storageClass.GetLabels()[StorageIDLabel] &&

--- a/internal/controller/vrg_recipe_test.go
+++ b/internal/controller/vrg_recipe_test.go
@@ -57,8 +57,8 @@ var _ = Describe("VolumeReplicationGroupRecipe", func() {
 		}
 		vrcLabels = func() map[string]string {
 			return map[string]string{
-				controllers.VolumeReplicationIDLabel: replicationIDs[0],
-				controllers.StorageIDLabel:           storageIDs[0],
+				controllers.ReplicationIDLabel: replicationIDs[0],
+				controllers.StorageIDLabel:     storageIDs[0],
 			}
 		}
 		peerClass = func(replicationID, storageClassName string, sIDs []string) ramen.PeerClass {

--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -428,7 +428,7 @@ func (v *VRGInstance) getVGRClassReplicationID(pvc *corev1.PersistentVolumeClaim
 		return "", err
 	}
 
-	replicationID, ok := vgrClass.GetLabels()[VolumeReplicationIDLabel]
+	replicationID, ok := vgrClass.GetLabels()[ReplicationIDLabel]
 	if !ok {
 		v.log.Info(fmt.Sprintf("VolumeGroupReplicationClass %s is missing replicationID for PVC %s/%s",
 			vgrClass.GetName(), pvc.GetNamespace(), pvc.GetName()))

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -1389,7 +1389,7 @@ func (v *VRGInstance) selectVolumeReplicationClass(
 	filterMatchingReplicationClass := func(replicationClass client.Object, parameters map[string]string,
 		provisioner string,
 	) {
-		schedulingInterval, found := parameters[VRClassScheduleKey]
+		schedulingInterval, found := parameters[ReplicationClassScheduleKey]
 
 		if storageClass.Provisioner != provisioner || !found {
 			// skip this replication class if provisioner does not match or if schedule not found

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -344,7 +344,7 @@ func setPVCStorageIdentifiers(
 		}
 	}
 
-	if value, ok := volumeReplicationClass.GetLabels()[VolumeReplicationIDLabel]; ok {
+	if value, ok := volumeReplicationClass.GetLabels()[ReplicationIDLabel]; ok {
 		protectedPVC.StorageIdentifiers.ReplicationID.ID = value
 		if modes, ok := volumeReplicationClass.GetLabels()[MModesLabel]; ok {
 			protectedPVC.StorageIdentifiers.ReplicationID.Modes = MModesFromCSV(modes)

--- a/internal/controller/vrg_volrep_test.go
+++ b/internal/controller/vrg_volrep_test.go
@@ -272,7 +272,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			restoreTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
 			numPVs := 3
 			vtest := newVRGTestCaseCreate(0, restoreTestTemplate, true, false)
-			replicationID := restoreTestTemplate.replicationClassLabels[vrgController.VolumeReplicationIDLabel]
+			replicationID := restoreTestTemplate.replicationClassLabels[vrgController.ReplicationIDLabel]
 			asyncPeerClass := genPeerClass(replicationID, restoreTestTemplate.storageClassName, []string{storageID})
 			vtest.asyncPeerClasses = []ramendrv1alpha1.PeerClass{asyncPeerClass}
 			vtest.skipCreationPVandPVC = true
@@ -316,7 +316,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			restoreTestTemplate.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
 			numPVs := pvcCount
 			vrgTestBoundPV = newVRGTestCaseCreate(numPVs, restoreTestTemplate, true, false)
-			replicationID := restoreTestTemplate.replicationClassLabels[vrgController.VolumeReplicationIDLabel]
+			replicationID := restoreTestTemplate.replicationClassLabels[vrgController.ReplicationIDLabel]
 			asyncPeerClass := genPeerClass(replicationID, restoreTestTemplate.storageClassName, []string{storageID})
 			vrgTestBoundPV.asyncPeerClasses = []ramendrv1alpha1.PeerClass{asyncPeerClass}
 			pvList := vrgTestBoundPV.generateFakePVs("pv", numPVs)
@@ -1575,8 +1575,8 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			storageIDLabel := genStorageIDLabel(storageIDs[0])
 			storageID := storageIDLabel[vrgController.StorageIDLabel]
 			vrgScheduleTest6Template.replicationClassLabels = map[string]string{
-				vrgController.VolumeReplicationIDLabel: replicationIDs[0],
-				vrgController.StorageIDLabel:           storageID,
+				vrgController.ReplicationIDLabel: replicationIDs[0],
+				vrgController.StorageIDLabel:     storageID,
 			}
 			vrgScheduleTest6Template.additionalVRCInfoList[0].replicationClassLabels = genVRCLabels(
 				replicationIDs[0], storageID, "ramen")
@@ -1815,7 +1815,7 @@ func newVRGTestCaseCreateAndStart(pvcCount int, testTemplate *template, checkBin
 	if len(testTemplate.replicationClassLabels) == 0 {
 		replicationID = replicationIDs[0]
 	} else {
-		replicationID = testTemplate.replicationClassLabels[vrgController.VolumeReplicationIDLabel]
+		replicationID = testTemplate.replicationClassLabels[vrgController.ReplicationIDLabel]
 	}
 
 	storageID := testTemplate.storageIDLabels[vrgController.StorageIDLabel]
@@ -3422,7 +3422,7 @@ func genVRCLabels(replicationID, storageID, protectionKey string) map[string]str
 	}
 
 	if replicationID != "" {
-		vrcLabel[vrgController.VolumeReplicationIDLabel] = replicationID
+		vrcLabel[vrgController.ReplicationIDLabel] = replicationID
 	}
 
 	return vrcLabel


### PR DESCRIPTION
Following up on https://github.com/RamenDR/ramen/pull/2015,  this changes includes 

- [x] The updation of DRClusterConfig with VolumeGroupReplicationClasses and VolumeGroupSnapshotClasses.
- [x] Update PeerClass.grouping based on VGRC
- [x] Update PeerClass.grouping based on VGSC 