### PR TITLE
drenv: Use profile name in envfile debug logs

### DIFF
--- a/test/drenv/envfile.py
+++ b/test/drenv/envfile.py
@@ -202,9 +202,9 @@ def _validate_platform_defaults(profile):
     if profile["network"] == SHARED_NETWORK:
         profile["network"] = platform[SHARED_NETWORK][info.machine]
 
-    logging.debug("[envfile] Using provider: '%s'", profile["provider"])
-    logging.debug("[envfile] Using driver: '%s'", profile["driver"])
-    logging.debug("[envfile] Using network: '%s'", profile["network"])
+    logging.debug("[%s] Using provider: '%s'", profile["name"], profile["provider"])
+    logging.debug("[%s] Using driver: '%s'", profile["name"], profile["driver"])
+    logging.debug("[%s] Using network: '%s'", profile["name"], profile["network"])
 
 
 def _validate_worker(worker, env, addons_root, index):


### PR DESCRIPTION
We use to log [envfile] for logs about a single profile, leading to confusing logs:

    % drenv dump envs/regional-dr.yaml -v
    2025-05-11 19:39:51,549 DEBUG   [envfile] Detected os: 'darwin'
    2025-05-11 19:39:51,549 DEBUG   [envfile] Detected machine: 'arm64'
    2025-05-11 19:39:51,549 DEBUG   [envfile] Using provider: 'lima'
    2025-05-11 19:39:51,549 DEBUG   [envfile] Using driver: ''
    2025-05-11 19:39:51,549 DEBUG   [envfile] Using network: ''
    2025-05-11 19:39:51,549 DEBUG   [envfile] Using provider: 'lima'
    2025-05-11 19:39:51,549 DEBUG   [envfile] Using driver: ''
    2025-05-11 19:39:51,549 DEBUG   [envfile] Using network: ''
    2025-05-11 19:39:51,549 DEBUG   [envfile] Using provider: 'lima'
    2025-05-11 19:39:51,549 DEBUG   [envfile] Using driver: ''
    2025-05-11 19:39:51,549 DEBUG   [envfile] Using network: ''
    ...

Now we log the relevant profile name:

    % drenv dump envs/regional-dr.yaml -v
    2025-05-11 19:36:25,724 DEBUG   [envfile] Detected os: 'darwin'
    2025-05-11 19:36:25,724 DEBUG   [envfile] Detected machine: 'arm64'
    2025-05-11 19:36:25,724 DEBUG   [dr1] Using provider: 'lima'
    2025-05-11 19:36:25,724 DEBUG   [dr1] Using driver: ''
    2025-05-11 19:36:25,724 DEBUG   [dr1] Using network: ''
    2025-05-11 19:36:25,724 DEBUG   [dr2] Using provider: 'lima'
    2025-05-11 19:36:25,724 DEBUG   [dr2] Using driver: ''
    2025-05-11 19:36:25,724 DEBUG   [dr2] Using network: ''
    2025-05-11 19:36:25,724 DEBUG   [hub] Using provider: 'lima'
    2025-05-11 19:36:25,724 DEBUG   [hub] Using driver: ''
    2025-05-11 19:36:25,724 DEBUG   [hub] Using network: ''
    ...