### PR TITLE
e2e: Wait for resource deletion during undeploy and unprotect

### DIFF
--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -77,6 +77,18 @@ func (a ApplicationSet) Undeploy(ctx types.TestContext) error {
 		return err
 	}
 
+	if err := util.WaitForApplicationSetDelete(ctx, ctx.Env().Hub, name, managementNamespace); err != nil {
+		return err
+	}
+
+	if err := util.WaitForConfigMapDelete(ctx, ctx.Env().Hub, name, managementNamespace); err != nil {
+		return err
+	}
+
+	if err := util.WaitForPlacementDelete(ctx, ctx.Env().Hub, name, managementNamespace); err != nil {
+		return err
+	}
+
 	log.Info("Workload undeployed")
 
 	return nil

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -431,7 +431,7 @@ func DeleteDiscoveredApps(ctx types.TestContext, cluster types.Cluster, namespac
 	}
 
 	cmd := exec.Command("kubectl", "delete", "-k", tempDir, "-n", namespace,
-		"--kubeconfig", cluster.Kubeconfig, "--timeout=5m", "--ignore-not-found=true")
+		"--kubeconfig", cluster.Kubeconfig, "--wait=false", "--ignore-not-found=true")
 
 	if out, err := cmd.Output(); err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -80,6 +80,7 @@ func (d DiscoveredApp) Undeploy(ctx types.TestContext) error {
 		appNamespace, ctx.Workload().GetAppName(), ctx.Env().C1.Name, ctx.Env().C2.Name)
 
 	// delete app on both clusters
+
 	if err := DeleteDiscoveredApps(ctx, ctx.Env().C1, appNamespace); err != nil {
 		return err
 	}
@@ -89,6 +90,7 @@ func (d DiscoveredApp) Undeploy(ctx types.TestContext) error {
 	}
 
 	// delete namespace on both clusters
+
 	if err := util.DeleteNamespace(ctx, ctx.Env().C1, appNamespace); err != nil {
 		return err
 	}

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -97,6 +97,16 @@ func (d DiscoveredApp) Undeploy(ctx types.TestContext) error {
 		return err
 	}
 
+	// wait for namespace to be deleted on both clusters
+
+	if err := util.WaitForNamespaceDelete(ctx, ctx.Env().C1, appNamespace); err != nil {
+		return err
+	}
+
+	if err := util.WaitForNamespaceDelete(ctx, ctx.Env().C2, appNamespace); err != nil {
+		return err
+	}
+
 	log.Info("Workload undeployed")
 
 	return nil

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -112,6 +112,10 @@ func (s Subscription) Undeploy(ctx types.TestContext) error {
 		return err
 	}
 
+	if err := util.WaitForNamespaceDelete(ctx, ctx.Env().Hub, managementNamespace); err != nil {
+		return err
+	}
+
 	log.Info("Workload undeployed")
 
 	return nil

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -127,8 +127,7 @@ func DisableProtection(ctx types.TestContext) error {
 		return err
 	}
 
-	err = waitDRPCDeleted(ctx, managementNamespace, drpcName)
-	if err != nil {
+	if err := util.WaitForDRPCDelete(ctx, ctx.Env().Hub, drpcName, managementNamespace); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -96,10 +96,6 @@ func DisableProtectionDiscoveredApps(ctx types.TestContext) error {
 		return err
 	}
 
-	if err := util.WaitForDRPCDelete(ctx, ctx.Env().Hub, drpcName, managementNamespace); err != nil {
-		return err
-	}
-
 	// delete placement
 	if err := deployers.DeletePlacement(ctx, placementName, managementNamespace); err != nil {
 		return err
@@ -107,6 +103,10 @@ func DisableProtectionDiscoveredApps(ctx types.TestContext) error {
 
 	err = deployers.DeleteManagedClusterSetBinding(ctx, config.ClusterSet, managementNamespace)
 	if err != nil {
+		return err
+	}
+
+	if err := util.WaitForDRPCDelete(ctx, ctx.Env().Hub, drpcName, managementNamespace); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -96,7 +96,7 @@ func DisableProtectionDiscoveredApps(ctx types.TestContext) error {
 		return err
 	}
 
-	if err := waitDRPCDeleted(ctx, managementNamespace, drpcName); err != nil {
+	if err := util.WaitForDRPCDelete(ctx, ctx.Env().Hub, drpcName, managementNamespace); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -110,6 +110,15 @@ func DisableProtectionDiscoveredApps(ctx types.TestContext) error {
 		return err
 	}
 
+	if err := util.WaitForPlacementDelete(ctx, ctx.Env().Hub, placementName, managementNamespace); err != nil {
+		return err
+	}
+
+	if err := util.WaitForManagedClusterSetBindingDelete(ctx, ctx.Env().Hub, config.ClusterSet,
+		managementNamespace); err != nil {
+		return err
+	}
+
 	log.Info("Workload unprotected")
 
 	return nil

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -101,30 +100,6 @@ func getTargetCluster(
 	}
 
 	return targetCluster, nil
-}
-
-func waitDRPCDeleted(ctx types.TestContext, namespace string, name string) error {
-	log := ctx.Logger()
-	hub := ctx.Env().Hub
-
-	log.Debugf("Waiting until drpc \"%s/%s\" is deleted in cluster %q", namespace, name, hub.Name)
-
-	for {
-		_, err := getDRPC(ctx, namespace, name)
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				log.Debugf("drpc \"%s/%s\" is deleted in cluster %q", namespace, name, hub.Name)
-
-				return nil
-			}
-
-			log.Debugf("Failed to get drpc \"%s/%s\" in cluster %q: %s", namespace, name, hub.Name, err)
-		}
-
-		if err := util.Sleep(ctx.Context(), util.RetryInterval); err != nil {
-			return fmt.Errorf("drpc %q is not deleted in cluster %q: %w", name, hub.Name, err)
-		}
-	}
 }
 
 // nolint:unparam

--- a/e2e/util/channel.go
+++ b/e2e/util/channel.go
@@ -26,7 +26,11 @@ func EnsureChannelDeleted(ctx types.Context) error {
 		return err
 	}
 
-	return DeleteNamespace(ctx, ctx.Env().Hub, ctx.Config().Channel.Namespace)
+	if err := DeleteNamespace(ctx, ctx.Env().Hub, ctx.Config().Channel.Namespace); err != nil {
+		return err
+	}
+
+	return WaitForNamespaceDelete(ctx, ctx.Env().Hub, ctx.Config().Channel.Namespace)
 }
 
 func createChannel(ctx types.Context) error {

--- a/e2e/util/namespace.go
+++ b/e2e/util/namespace.go
@@ -4,9 +4,6 @@
 package util
 
 import (
-	"fmt"
-	"time"
-
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,25 +60,7 @@ func DeleteNamespace(ctx types.Context, cluster types.Cluster, namespace string)
 		return nil
 	}
 
-	log.Debugf("Waiting until namespace %q is deleted in cluster %q", namespace, cluster.Name)
-
-	key := k8stypes.NamespacedName{Name: namespace}
-
-	for {
-		if err := cluster.Client.Get(ctx.Context(), key, ns); err != nil {
-			if !k8serrors.IsNotFound(err) {
-				return err
-			}
-
-			log.Debugf("Namespace %q deleted in cluster %q", namespace, cluster.Name)
-
-			return nil
-		}
-
-		if err := Sleep(ctx.Context(), time.Second); err != nil {
-			return fmt.Errorf("namespace %q not deleted in cluster %q: %w", namespace, cluster.Name, err)
-		}
-	}
+	return nil
 }
 
 // Problem: currently we must manually add an annotation to application’s namespace to make volsync work.

--- a/e2e/util/namespace.go
+++ b/e2e/util/namespace.go
@@ -17,12 +17,12 @@ import (
 // More info: https://volsync.readthedocs.io/en/stable/usage/permissionmodel.html#controlling-mover-permissions
 const volsyncPrivilegedMovers = "volsync.backube/privileged-movers"
 
-func CreateNamespace(ctx types.Context, cluster types.Cluster, namespace string) error {
+func CreateNamespace(ctx types.Context, cluster types.Cluster, name string) error {
 	log := ctx.Logger()
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
+			Name: name,
 		},
 	}
 
@@ -32,20 +32,20 @@ func CreateNamespace(ctx types.Context, cluster types.Cluster, namespace string)
 			return err
 		}
 
-		log.Debugf("Namespace %q already exist in cluster %q", namespace, cluster.Name)
+		log.Debugf("Namespace %q already exist in cluster %q", name, cluster.Name)
 	}
 
-	log.Debugf("Created namespace %q in cluster %q", namespace, cluster.Name)
+	log.Debugf("Created namespace %q in cluster %q", name, cluster.Name)
 
 	return nil
 }
 
-func DeleteNamespace(ctx types.Context, cluster types.Cluster, namespace string) error {
+func DeleteNamespace(ctx types.Context, cluster types.Cluster, name string) error {
 	log := ctx.Logger()
 
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
+			Name: name,
 		},
 	}
 
@@ -55,7 +55,7 @@ func DeleteNamespace(ctx types.Context, cluster types.Cluster, namespace string)
 			return err
 		}
 
-		log.Debugf("Namespace %q not found in cluster %q", namespace, cluster.Name)
+		log.Debugf("Namespace %q not found in cluster %q", name, cluster.Name)
 
 		return nil
 	}

--- a/e2e/util/wait.go
+++ b/e2e/util/wait.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"time"
 
+	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	argocdv1alpha1hack "github.com/ramendr/ramen/e2e/argocd"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -55,6 +56,17 @@ func WaitForPlacementDelete(ctx types.Context, cluster types.Cluster, name, name
 
 func WaitForManagedClusterSetBindingDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
 	obj := &ocmv1b2.ManagedClusterSetBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	return waitForResourceDelete(ctx, cluster, obj)
+}
+
+func WaitForDRPCDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
+	obj := &ramen.DRPlacementControl{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,

--- a/e2e/util/wait.go
+++ b/e2e/util/wait.go
@@ -76,10 +76,10 @@ func WaitForDRPCDelete(ctx types.Context, cluster types.Cluster, name, namespace
 	return waitForResourceDelete(ctx, cluster, obj)
 }
 
-func WaitForNamespaceDelete(ctx types.Context, cluster types.Cluster, namespace string) error {
+func WaitForNamespaceDelete(ctx types.Context, cluster types.Cluster, name string) error {
 	obj := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
+			Name: name,
 		},
 	}
 

--- a/e2e/util/wait.go
+++ b/e2e/util/wait.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	argocdv1alpha1hack "github.com/ramendr/ramen/e2e/argocd"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	ocmv1b1 "open-cluster-management.io/api/cluster/v1beta1"
+	ocmv1b2 "open-cluster-management.io/api/cluster/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ramendr/ramen/e2e/types"
+)
+
+func WaitForApplicationSetDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
+	obj := &argocdv1alpha1hack.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	return waitForResourceDelete(ctx, cluster, obj)
+}
+
+func WaitForConfigMapDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
+	obj := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	return waitForResourceDelete(ctx, cluster, obj)
+}
+
+func WaitForPlacementDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
+	obj := &ocmv1b1.Placement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	return waitForResourceDelete(ctx, cluster, obj)
+}
+
+func WaitForManagedClusterSetBindingDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
+	obj := &ocmv1b2.ManagedClusterSetBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	return waitForResourceDelete(ctx, cluster, obj)
+}
+
+// waitForResourceDelete waits until a resource is deleted or deadline is reached
+func waitForResourceDelete(ctx types.Context, cluster types.Cluster, obj client.Object) error {
+	log := ctx.Logger()
+	kind := getKind(obj)
+	key := k8stypes.NamespacedName{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+	resourceName := logName(obj)
+
+	log.Debugf("Waiting until %s %q is deleted in cluster %q", kind, resourceName, cluster.Name)
+
+	for {
+		if err := cluster.Client.Get(ctx.Context(), key, obj); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				return err
+			}
+
+			log.Debugf("%s %q deleted in cluster %q", kind, resourceName, cluster.Name)
+
+			return nil
+		}
+
+		if err := Sleep(ctx.Context(), time.Second); err != nil {
+			return fmt.Errorf("%s %q not deleted in cluster %q: %w", kind, resourceName, cluster.Name, err)
+		}
+	}
+}
+
+// getKind extracts resource type name from the object
+func getKind(obj client.Object) string {
+	t := reflect.TypeOf(obj)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	return t.Name()
+}
+
+// logName returns the resource name for logging (namespace/name or just name)
+func logName(obj client.Object) string {
+	if obj.GetNamespace() != "" {
+		return obj.GetNamespace() + "/" + obj.GetName()
+	}
+
+	return obj.GetName()
+}

--- a/e2e/util/wait.go
+++ b/e2e/util/wait.go
@@ -64,6 +64,16 @@ func WaitForManagedClusterSetBindingDelete(ctx types.Context, cluster types.Clus
 	return waitForResourceDelete(ctx, cluster, obj)
 }
 
+func WaitForNamespaceDelete(ctx types.Context, cluster types.Cluster, namespace string) error {
+	obj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+
+	return waitForResourceDelete(ctx, cluster, obj)
+}
+
 // waitForResourceDelete waits until a resource is deleted or deadline is reached
 func waitForResourceDelete(ctx types.Context, cluster types.Cluster, obj client.Object) error {
 	log := ctx.Logger()


### PR DESCRIPTION
Improves how resources are cleaned up and waited. It implements a more consistent separation between resource deletion initiation and wait/verification of complete deletion of the resource with deadline.

Changes:

- Deadline-based resource deletion:
Implement a generic waitForResourceDelete function that accepts and replace individual timeouts with a shared deadline approach provided in the context for all deletion operations.
Add resource-specific wait functions for ApplicationSets, ConfigMaps, Placements, DRPCs, namespace and mcsb.

- Separation of deletion and waiting
Refactor namespace deletion to separate the deletion request from the wait for delete.
Change kubectl commands to use --wait=false to return immediately and handle waiting ourselves.

- Update deployers and actions to use new wait functions with deadline

Example wait logs of different resources added:
- appset undeploy
```
2025-05-21T15:13:45.282+0530	DEBUG	appset-deploy-rbd-busybox	util/wait.go:99	Waiting until ApplicationSet "argocd/appset-deploy-rbd-busybox" is deleted in cluster "hub"
2025-05-21T15:13:45.284+0530	DEBUG	appset-deploy-rbd-busybox	util/wait.go:107	ApplicationSet "argocd/appset-deploy-rbd-busybox" deleted in cluster "hub"
2025-05-21T15:13:45.284+0530	DEBUG	appset-deploy-rbd-busybox	util/wait.go:99	Waiting until ConfigMap "argocd/appset-deploy-rbd-busybox" is deleted in cluster "hub"
2025-05-21T15:13:45.287+0530	DEBUG	appset-deploy-rbd-busybox	util/wait.go:107	ConfigMap "argocd/appset-deploy-rbd-busybox" deleted in cluster "hub"
2025-05-21T15:13:45.287+0530	DEBUG	appset-deploy-rbd-busybox	util/wait.go:99	Waiting until Placement "argocd/appset-deploy-rbd-busybox" is deleted in cluster "hub"
2025-05-21T15:13:45.289+0530	DEBUG	appset-deploy-rbd-busybox	util/wait.go:107	Placement "argocd/appset-deploy-rbd-busybox" deleted in cluster "hub"
```
- dissapp undeploy:
```
2025-05-21T15:11:45.721+0530	DEBUG	disapp-deploy-cephfs-busybox	util/wait.go:99	Waiting until Namespace "e2e-disapp-deploy-cephfs-busybox" is deleted in cluster "dr1"
2025-05-21T15:11:51.734+0530	DEBUG	disapp-deploy-cephfs-busybox	util/wait.go:107	Namespace "e2e-disapp-deploy-cephfs-busybox" deleted in cluster "dr1"
2025-05-21T15:11:51.734+0530	DEBUG	disapp-deploy-cephfs-busybox	util/wait.go:99	Waiting until Namespace "e2e-disapp-deploy-cephfs-busybox" is deleted in cluster "dr2"
2025-05-21T15:11:51.735+0530	DEBUG	disapp-deploy-cephfs-busybox	util/wait.go:107	Namespace "e2e-disapp-deploy-cephfs-busybox" deleted in cluster "dr2"

```
- subscription undeploy:
```
2025-05-21T15:13:16.455+0530	DEBUG	subscr-deploy-cephfs-busybox	util/wait.go:99	Waiting until Namespace "e2e-subscr-deploy-cephfs-busybox" is deleted in cluster "hub"
2025-05-21T15:13:22.472+0530	DEBUG	subscr-deploy-cephfs-busybox	util/wait.go:107	Namespace "e2e-subscr-deploy-cephfs-busybox" deleted in cluster "hub"
```
- disapp unprotect:
```
2025-05-21T15:10:42.483+0530	DEBUG	disapp-deploy-cephfs-busybox	util/wait.go:99	Waiting until DRPlacementControl "ramen-ops/disapp-deploy-cephfs-busybox" is deleted in cluster "hub"
2025-05-21T15:11:42.682+0530	DEBUG	disapp-deploy-cephfs-busybox	util/wait.go:107	DRPlacementControl "ramen-ops/disapp-deploy-cephfs-busybox" deleted in cluster "hub"
2025-05-21T15:11:42.682+0530	DEBUG	disapp-deploy-cephfs-busybox	util/wait.go:99	Waiting until Placement "ramen-ops/disapp-deploy-cephfs-busybox" is deleted in cluster "hub"
2025-05-21T15:11:42.683+0530	DEBUG	disapp-deploy-cephfs-busybox	util/wait.go:107	Placement "ramen-ops/disapp-deploy-cephfs-busybox" deleted in cluster "hub"
2025-05-21T15:11:42.683+0530	DEBUG	disapp-deploy-cephfs-busybox	util/wait.go:99	Waiting until ManagedClusterSetBinding "ramen-ops/default" is deleted in cluster "hub"
2025-05-21T15:11:42.683+0530	DEBUG	disapp-deploy-cephfs-busybox	util/wait.go:107	ManagedClusterSetBinding "ramen-ops/default" deleted in cluster "hub"
```
- channel:
```
2025-05-21T15:13:45.291+0530	INFO	util/channel.go:89	Deleted channel "e2e-gitops/https-github-com-ramendr-ocm-ramen-samples-git" in cluster "hub"
2025-05-21T15:13:45.295+0530	DEBUG	util/wait.go:99	Waiting until Namespace "e2e-gitops" is deleted in cluster "hub"
```

Fixes #2019 