### PR TITLE
drenv/kubevirt: Use our own private key for the test

### DIFF
--- a/test/addons/kubevirt/test
+++ b/test/addons/kubevirt/test
@@ -8,6 +8,7 @@ import shutil
 import sys
 import time
 
+from drenv import ssh
 from drenv import kubectl
 from drenv import virtctl
 
@@ -23,10 +24,9 @@ def test(cluster):
 
 
 def copy_public_key():
-    src = os.path.expanduser("~/.ssh/id_rsa.pub")
     dst = "vm/id_rsa.pub"
-    print(f"Copying public key from {src} to {dst}")
-    shutil.copyfile(src, dst)
+    print(f"Copying public key from {ssh.PUBLIC_KEY} to {dst}")
+    shutil.copyfile(ssh.PUBLIC_KEY, dst)
 
 
 def create_vm(cluster):
@@ -69,6 +69,7 @@ def verify_ssh(cluster):
                 "tail -6 /var/log/ramen.log",
                 username="cirros",
                 namespace=NAMESPACE,
+                identity_file=ssh.PRIVATE_KEY,
                 local_ssh=True,
                 local_ssh_opts=(
                     "-o UserKnownHostsFile=/dev/null",

--- a/test/addons/kubevirt/test
+++ b/test/addons/kubevirt/test
@@ -69,7 +69,12 @@ def verify_ssh(cluster):
                 "tail -6 /var/log/ramen.log",
                 username="cirros",
                 namespace=NAMESPACE,
-                known_hosts="",  # Skip host key verification.
+                local_ssh=True,
+                local_ssh_opts=(
+                    "-o UserKnownHostsFile=/dev/null",
+                    "-o StrictHostKeyChecking=no",
+                    "-o LogLevel=DEBUG",
+                ),
                 context=cluster,
             )
         except Exception as e:

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -23,6 +23,7 @@ from . import providers
 from . import ramen
 from . import shutdown
 from . import yaml
+from . import ssh
 
 ADDONS_DIR = "addons"
 
@@ -194,6 +195,8 @@ def handle_termination_signal(signo, frame):
 
 def do_setup(args):
     env = load_env(args)
+    logging.info("[main] Setting up drenv")
+    ssh.setup()
     for name in set(p["provider"] for p in env["profiles"]):
         logging.info("[main] Setting up '%s' for drenv", name)
         provider = providers.get(name)
@@ -202,10 +205,12 @@ def do_setup(args):
 
 def do_cleanup(args):
     env = load_env(args)
+    logging.info("[main] Cleaning up drenv")
     for name in set(p["provider"] for p in env["profiles"]):
         logging.info("[main] Cleaning up '%s' for drenv", name)
         provider = providers.get(name)
         provider.cleanup()
+    ssh.cleanup()
 
 
 def do_clear(args):

--- a/test/drenv/ssh.py
+++ b/test/drenv/ssh.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+import shutil
+
+import drenv
+from drenv import commands
+
+SSH_DIR = drenv.config_dir("ssh")
+PRIVATE_KEY = os.path.join(SSH_DIR, "id_rsa")
+PUBLIC_KEY = PRIVATE_KEY + ".pub"
+
+
+def setup():
+    """
+    Called during drenv steup.
+    """
+    if os.path.exists(PRIVATE_KEY):
+        logging.debug("[ssh] Using existing private key '%s'", PRIVATE_KEY)
+        return
+
+    logging.debug("[ssh] Generating private key '%s'", PRIVATE_KEY)
+    os.makedirs(SSH_DIR, mode=0o700, exist_ok=True)
+    commands.run("ssh-keygen", "-f", PRIVATE_KEY, "-N", "", "-t", "rsa", "-q")
+
+
+def cleanup():
+    """
+    Called during drenv cleanup.
+    """
+    logging.debug("[ssh] Removing '%s'", SSH_DIR)
+    shutil.rmtree(SSH_DIR, ignore_errors=True)

--- a/test/drenv/virtctl.py
+++ b/test/drenv/virtctl.py
@@ -4,7 +4,17 @@
 from . import commands
 
 
-def ssh(vm, command, username=None, namespace=None, known_hosts=None, context=None):
+def ssh(
+    vm,
+    command,
+    username=None,
+    namespace=None,
+    known_hosts=None,
+    identity_file=None,
+    local_ssh=True,
+    local_ssh_opts=(),
+    context=None,
+):
     """
     Run ssh command via virtctl.
     """
@@ -17,5 +27,11 @@ def ssh(vm, command, username=None, namespace=None, known_hosts=None, context=No
         cmd.extend(("--known-hosts", known_hosts))
     if namespace:
         cmd.extend(("--namespace", namespace))
+    if identity_file:
+        cmd.extend(("--identity-file", identity_file))
+    if local_ssh:
+        cmd.append("--local-ssh")
+        for opt in local_ssh_opts:
+            cmd.extend(("--local-ssh-opts", opt))
     cmd.extend((vm, "--command", command))
     return commands.run(*cmd)


### PR DESCRIPTION
We use the default private key (~/.ssh/id_rsa) which may not work on some systems when using non-standard configuration. Now we use our own key:

    ~/.config/drenv/ssh/id_rsa
    ~/.config/drenv/ssh/id_rsa.pub

We create the private key in `drenv setup`, and remove it in `drenv cleanup`. The kubevirt addon use this key for running commands in the vm.

Debugging this required enabling ssh debug logs, and using local ssh command. Using local ssh command is the default in virtctl 1.5.0 so we want to keep it anway. The debug level little bit too verbose but is good enough for --verbose mode.

We also add UserKnownHostsFile=/dev/null and StrictHostKeyChecking=no to disable host key checking which is not useful for testing local vm.

## Example log with this change

```console
$ addons/kubevirt/test kubevirt
Copying public key from /home/nsoffer/.config/drenv/ssh/id_rsa.pub to vm/id_rsa.pub
Deploying test vm in namespace 'kubevirt-test'
namespace/kubevirt-test created
secret/my-public-key created
virtualmachine.kubevirt.io/testvm created
Waiting until test vm is ready
virtualmachine.kubevirt.io/testvm condition met
Last entries in /var/log/ramen.log (attempt 1/30)
Command failed:
   command: ('virtctl', 'ssh', '--context', 'kubevirt', '--username', 'cirros', '--namespace', 'kubevirt-test', '--identity-file', '/home/nsoffer/.config/drenv/ssh/id_rsa', '--local-ssh', '--local-ssh-opts', '-o UserKnownHostsFile=/dev/null', '--local-ssh-opts', '-o StrictHostKeyChecking=no', '--local-ssh-opts', '-o LogLevel=DEBUG', 'testvm', '--command', 'tail -6 /var/log/ramen.log')
   exitcode: 1
   output:
      You are using a client virtctl version that is different from the KubeVirt version running in the cluster
      Client Version: v1.4.0
      Server Version: v1.3.1
   error:
      debug1: Reading configuration data /etc/ssh/ssh_config
      debug1: Reading configuration data /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf
      debug1: Reading configuration data /etc/ssh/ssh_config.d/30-libvirt-ssh-proxy.conf
      debug1: Reading configuration data /etc/ssh/ssh_config.d/50-redhat.conf
      debug1: Reading configuration data /etc/crypto-policies/back-ends/openssh.config
      debug1: configuration requests final Match pass
      debug1: re-parsing configuration
      debug1: Reading configuration data /etc/ssh/ssh_config
      debug1: Reading configuration data /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf
      debug1: Reading configuration data /etc/ssh/ssh_config.d/30-libvirt-ssh-proxy.conf
      debug1: Reading configuration data /etc/ssh/ssh_config.d/50-redhat.conf
      debug1: Reading configuration data /etc/crypto-policies/back-ends/openssh.config
      debug1: Executing proxy command: exec virtctl port-forward --stdio=true vmi/testvm.kubevirt-test 22
      debug1: identity file /home/nsoffer/.config/drenv/ssh/id_rsa type 0
      debug1: identity file /home/nsoffer/.config/drenv/ssh/id_rsa-cert type -1
      debug1: Local version string SSH-2.0-OpenSSH_9.9
      You are using a client virtctl version that is different from the KubeVirt version running in the cluster
      Client Version: v1.4.0
      Server Version: v1.3.1
      Internal error occurred: dialing VM: dial tcp 10.244.0.25:22: connect: no route to host
      kex_exchange_identification: Connection closed by remote host
      Connection closed by UNKNOWN port 65535
      exit status 255

Retrying in 5 seconds...
...

Retrying in 5 seconds...
Last entries in /var/log/ramen.log (attempt 7/30)
Wed May 14 19:01:41 UTC 2025 START uptime=31.90

Deleting test vm in namespace 'kubevirt-test'
namespace "kubevirt-test" deleted
secret "my-public-key" deleted
virtualmachine.kubevirt.io "testvm" deleted
```