### PR TITLE
e2e: Use context deadline per action

### DIFF
--- a/e2e/dr_test.go
+++ b/e2e/dr_test.go
@@ -5,6 +5,7 @@ package e2e_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/deployers"
@@ -31,7 +32,10 @@ func TestDR(dt *testing.T) {
 	}
 
 	t.Cleanup(func() {
-		if err := util.EnsureChannelDeleted(&Ctx); err != nil {
+		timedCtx, cancel := Ctx.WithTimeout(1 * time.Minute)
+		defer cancel()
+
+		if err := util.EnsureChannelDeleted(timedCtx); err != nil {
 			t.Fatalf("Failed to ensure channel deleted: %s", err)
 		}
 	})

--- a/e2e/test/context.go
+++ b/e2e/test/context.go
@@ -19,7 +19,8 @@ import (
 const appNamespacePrefix = "e2e-"
 
 type Context struct {
-	ctx      types.Context
+	parent   types.Context
+	context  context.Context
 	workload types.Workload
 	deployer types.Deployer
 	name     string
@@ -27,18 +28,19 @@ type Context struct {
 }
 
 func NewContext(
-	ctx types.Context,
+	parent types.Context,
 	w types.Workload,
 	d types.Deployer,
 ) Context {
 	name := strings.ToLower(d.GetName() + "-" + w.GetName() + "-" + w.GetAppName())
 
 	return Context{
-		ctx:      ctx,
+		parent:   parent,
+		context:  parent.Context(),
 		workload: w,
 		deployer: d,
 		name:     name,
-		logger:   ctx.Logger().Named(name),
+		logger:   parent.Logger().Named(name),
 	}
 }
 
@@ -71,15 +73,15 @@ func (c *Context) Logger() *zap.SugaredLogger {
 }
 
 func (c *Context) Env() *types.Env {
-	return c.ctx.Env()
+	return c.parent.Env()
 }
 
 func (c *Context) Config() *types.Config {
-	return c.ctx.Config()
+	return c.parent.Config()
 }
 
 func (c *Context) Context() context.Context {
-	return c.ctx.Context()
+	return c.context
 }
 
 // Validated return an error if the combination of deployer and workload is not supported.

--- a/e2e/test/context.go
+++ b/e2e/test/context.go
@@ -8,11 +8,13 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/ramendr/ramen/e2e/dractions"
 	"github.com/ramendr/ramen/e2e/types"
+	"github.com/ramendr/ramen/e2e/util"
 )
 
 // Make it easier to manage namespaces created by the tests.
@@ -84,6 +86,15 @@ func (c *Context) Context() context.Context {
 	return c.context
 }
 
+// WithTimeout returns a derived context with a deadline. Call cancel to release resources associated with the context
+// as soon as the operation running in the context complete.
+func (c Context) WithTimeout(d time.Duration) (*Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(c.context, d)
+	c.context = ctx //nolint:revive
+
+	return &c, cancel
+}
+
 // Validated return an error if the combination of deployer and workload is not supported.
 // TODO: validate that the deployer/workload is compatible with the clusters.
 func (c *Context) Validate() error {
@@ -94,7 +105,10 @@ func (c *Context) Deploy(dt *testing.T) {
 	t := WithLog(dt, c.logger)
 	t.Helper()
 
-	if err := c.deployer.Deploy(c); err != nil {
+	timedCtx, cancel := c.WithTimeout(util.Timeout)
+	defer cancel()
+
+	if err := timedCtx.deployer.Deploy(timedCtx); err != nil {
 		t.Fatalf("Failed to deploy workload: %s", err)
 	}
 }
@@ -103,7 +117,10 @@ func (c *Context) Undeploy(dt *testing.T) {
 	t := WithLog(dt, c.logger)
 	t.Helper()
 
-	if err := c.deployer.Undeploy(c); err != nil {
+	timedCtx, cancel := c.WithTimeout(util.Timeout)
+	defer cancel()
+
+	if err := timedCtx.deployer.Undeploy(timedCtx); err != nil {
 		t.Fatalf("Failed to undeploy workload: %s", err)
 	}
 }
@@ -112,7 +129,10 @@ func (c *Context) Enable(dt *testing.T) {
 	t := WithLog(dt, c.logger)
 	t.Helper()
 
-	if err := dractions.EnableProtection(c); err != nil {
+	timedCtx, cancel := c.WithTimeout(util.Timeout)
+	defer cancel()
+
+	if err := dractions.EnableProtection(timedCtx); err != nil {
 		t.Fatalf("Failed to enable protection for workload: %s", err)
 	}
 }
@@ -121,7 +141,10 @@ func (c *Context) Disable(dt *testing.T) {
 	t := WithLog(dt, c.logger)
 	t.Helper()
 
-	if err := dractions.DisableProtection(c); err != nil {
+	timedCtx, cancel := c.WithTimeout(util.Timeout)
+	defer cancel()
+
+	if err := dractions.DisableProtection(timedCtx); err != nil {
 		t.Fatalf("Failed to disable protection for workload: %s", err)
 	}
 }
@@ -130,7 +153,10 @@ func (c *Context) Failover(dt *testing.T) {
 	t := WithLog(dt, c.logger)
 	t.Helper()
 
-	if err := dractions.Failover(c); err != nil {
+	timedCtx, cancel := c.WithTimeout(util.Timeout)
+	defer cancel()
+
+	if err := dractions.Failover(timedCtx); err != nil {
 		t.Fatalf("Failed to failover workload: %s", err)
 	}
 }
@@ -139,7 +165,10 @@ func (c *Context) Relocate(dt *testing.T) {
 	t := WithLog(dt, c.logger)
 	t.Helper()
 
-	if err := dractions.Relocate(c); err != nil {
+	timedCtx, cancel := c.WithTimeout(util.Timeout)
+	defer cancel()
+
+	if err := dractions.Relocate(timedCtx); err != nil {
 		t.Fatalf("Failed to relocate workload: %s", err)
 	}
 }

--- a/e2e/util/namespace.go
+++ b/e2e/util/namespace.go
@@ -65,7 +65,6 @@ func DeleteNamespace(ctx types.Context, cluster types.Cluster, namespace string)
 
 	log.Debugf("Waiting until namespace %q is deleted in cluster %q", namespace, cluster.Name)
 
-	startTime := time.Now()
 	key := k8stypes.NamespacedName{Name: namespace}
 
 	for {
@@ -79,12 +78,8 @@ func DeleteNamespace(ctx types.Context, cluster types.Cluster, namespace string)
 			return nil
 		}
 
-		if time.Since(startTime) > 60*time.Second {
-			return fmt.Errorf("timeout deleting namespace %q in cluster %q", namespace, cluster.Name)
-		}
-
 		if err := Sleep(ctx.Context(), time.Second); err != nil {
-			return err
+			return fmt.Errorf("namespace %q not deleted in cluster %q: %w", namespace, cluster.Name, err)
 		}
 	}
 }

--- a/e2e/util/placement.go
+++ b/e2e/util/placement.go
@@ -5,7 +5,6 @@ package util
 
 import (
 	"fmt"
-	"time"
 
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"open-cluster-management.io/api/cluster/v1beta1"
@@ -45,7 +44,6 @@ func GetPlacement(ctx types.Context, namespace, name string) (*v1beta1.Placement
 func waitPlacementDecision(ctx types.Context, namespace string, placementName string,
 ) (*v1beta1.PlacementDecision, error) {
 	cluster := ctx.Env().Hub
-	startTime := time.Now()
 
 	for {
 		placement, err := GetPlacement(ctx, namespace, placementName)
@@ -62,12 +60,9 @@ func waitPlacementDecision(ctx types.Context, namespace string, placementName st
 			return placementDecision, nil
 		}
 
-		if time.Since(startTime) > Timeout {
-			return nil, fmt.Errorf("timeout waiting for placement decisions for %q in cluster %q", placementName, cluster.Name)
-		}
-
 		if err := Sleep(ctx.Context(), RetryInterval); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("no placement decisions for %q in cluster %q: %w",
+				placementName, cluster.Name, err)
 		}
 	}
 }


### PR DESCRIPTION
Previously we used util.Timeout when waiting for resources. In flow when
we have multiple waits, we could wait 10 minutes for each change before
failing, which is way too much.

This change adds a deadline to the underlying context.Context returned
by TestContext.Context() and Context.Context(). We set the deadline before
calling one of the e2e operations (deploy, undeploy, enable, disable,
failover, relocate, or before cleaning up (EnsureChannelDeleted). Since we
wait using util.Sleep(), the call will fail with context.DaadlineExceeded on
timeouts.

Advantages of using context based deadline:

- Limiting the timeout for flows including multiple waits, getting more
  predictable test time.
- Simplify waiting for multiple objects with same deadline, added in
  https://github.com/RamenDR/ramen/pull/2035
- Allows ramenctl to control the deadline when running multiple
  operations in parallel
- Enforcing the deadline in external calls using a context
- Simplify wait loops

This change requires a change in ramenctl:
https://github.com/RamenDR/ramenctl/pull/185