### PR TITLE
UpdateProtectedCGs function must filter list of volumegroupreplications by owner name and namespace

### DIFF
--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1796,7 +1796,12 @@ func getStatusStateFromSpecState(state ramendrv1alpha1.ReplicationState) ramendr
 
 func (v *VRGInstance) updateProtectedCGs() error {
 	var vgrs volrep.VolumeGroupReplicationList
-	if err := v.reconciler.List(v.ctx, &vgrs); err != nil {
+
+	listOptions := []client.ListOption{
+		client.MatchingLabels(util.OwnerLabels(v.instance)),
+	}
+
+	if err := v.reconciler.List(v.ctx, &vgrs, listOptions...); err != nil {
 		return fmt.Errorf("failed to list Volume Group Replications, %w", err)
 	}
 
@@ -1804,11 +1809,6 @@ func (v *VRGInstance) updateProtectedCGs() error {
 
 	for idx := range vgrs.Items {
 		vgr := &vgrs.Items[idx]
-
-		ownerNamespaceName, ownerName, _ := util.OwnerNamespaceNameAndName(vgr.GetLabels())
-		if ownerNamespaceName != v.instance.Namespace || ownerName != v.instance.Name {
-			continue
-		}
 
 		group := ramendrv1alpha1.Groups{Grouped: []string{}}
 


### PR DESCRIPTION
Initially, the updateProtectedCGs function listed all VGRs and filtered them by the owning VRG's name and namespace in loop. During the PR review, it was suggested to optimize this by applying the filter directly during listing. This PR addresses that feedback.

This PR is addressing the following comment: https://github.com/RamenDR/ramen/pull/1472#discussion_r1974325239