### PR TITLE
DRCluster mirrors S3 health reported via DRClusterConfig

### DIFF
--- a/api/v1alpha1/drcluster_types.go
+++ b/api/v1alpha1/drcluster_types.go
@@ -59,6 +59,10 @@ const (
 	// Fencing CR to fence off this cluster
 	// has been created
 	DRClusterConditionTypeFenced = "Fenced"
+
+	DRClusterConditionS3UpdateFailed = "S3ConditionUpdateFailed"
+
+	DRClusterConditionS3Healthy = "S3Healthy"
 )
 
 type DRClusterPhase string

--- a/api/v1alpha1/drcluster_types.go
+++ b/api/v1alpha1/drcluster_types.go
@@ -60,6 +60,10 @@ const (
 	// has been created
 	DRClusterConditionTypeFenced = "Fenced"
 
+	DRClusterConditionS3UpdateFailed = "S3ConditionUpdateFailed"
+
+	DRClusterConditionS3Healthy = "S3Healthy"
+
 	// CIDRsValidated indicates the validation state of CIDRs configured in the DRCluster
 	// against CIDRs detected by the storage provisioner in DRClusterConfig StorageAccessDetails.
 	DRClusterConditionTypeCIDRsValidated = "CIDRsValidated"

--- a/api/v1alpha1/drclusterconfig_types.go
+++ b/api/v1alpha1/drclusterconfig_types.go
@@ -33,7 +33,7 @@ type DRClusterConfigSpec struct {
 
 const (
 	DRClusterConfigConfigurationProcessed string = "Processed"
-	DRClusterConfigS3Reachable            string = "Reachable"
+	DRClusterConfigS3Healthy              string = "MetaDataStoresHealthy"
 )
 
 // DRClusterConfigStatus defines the observed state of DRClusterConfig

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -181,9 +181,10 @@ func setupReconcilersCluster(mgr ctrl.Manager, ramenConfig *ramendrv1alpha1.Rame
 	}
 
 	if err := (&controllers.DRClusterConfigReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("drcc"),
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Log:               ctrl.Log.WithName("drcc"),
+		ObjectStoreGetter: controllers.S3ObjectStoreGetter(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DRClusterConfig")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -191,10 +191,11 @@ func setupReconcilersCluster(mgr ctrl.Manager, ramenConfig *ramendrv1alpha1.Rame
 	}
 
 	if err := (&controllers.DRClusterConfigReconciler{
-		Client:    mgr.GetClient(),
-		Scheme:    mgr.GetScheme(),
-		Log:       ctrl.Log.WithName("drcc"),
-		APIReader: mgr.GetAPIReader(),
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Log:               ctrl.Log.WithName("drcc"),
+		APIReader:         mgr.GetAPIReader(),
+		ObjectStoreGetter: controllers.S3ObjectStoreGetter(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DRClusterConfig")
 		os.Exit(1)

--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -65,6 +65,11 @@ const (
 
 	DRClusterConditionReasonError        = "Error"
 	DRClusterConditionReasonErrorUnknown = "UnknownError"
+
+	DRClusterReasonDRClusterConfigReadFailed = "DRClusterConfigReadFailed"
+
+	DRClusterReasonS3Unreachable = "S3Unreachable"
+	DRClusterReasonS3Reachable   = "S3Reachable"
 )
 
 //nolint:gosec
@@ -430,8 +435,7 @@ func (r DRClusterReconciler) processCreateOrUpdate(u *drclusterInstance) (ctrl.R
 		u.log.Info("Error during processing fencing", "error", err)
 	}
 
-	if reason, err := validateS3Profile(u.ctx, r.APIReader, r.ObjectStoreGetter, u.object, u.namespacedName.String(),
-		u.log); err != nil {
+	if reason, err := u.syncS3HealthFromDRClusterConfig(); err != nil {
 		return ctrl.Result{}, fmt.Errorf("drclusters s3Profile validate: %w", u.validatedSetFalseAndUpdate(reason, err))
 	}
 
@@ -574,32 +578,40 @@ func (u *drclusterInstance) validateCIDRs(metrics InvalidCIDRsDetectedMetrics, l
 	return nil
 }
 
-func validateS3Profile(ctx context.Context, apiReader client.Reader,
-	objectStoreGetter ObjectStoreGetter,
-	drcluster *ramen.DRCluster, listKeyPrefix string, log logr.Logger,
-) (string, error) {
-	if drcluster.Spec.S3ProfileName != NoS3StoreAvailable {
-		if reason, err := s3ProfileValidate(ctx, apiReader, objectStoreGetter,
-			drcluster.Spec.S3ProfileName, listKeyPrefix, log); err != nil {
-			return reason, err
-		}
-	}
-
-	return "", nil
-}
-
-func s3ProfileValidate(ctx context.Context, apiReader client.Reader,
-	objectStoreGetter ObjectStoreGetter, s3ProfileName, listKeyPrefix string,
-	log logr.Logger,
-) (string, error) {
-	objectStore, _, err := objectStoreGetter.ObjectStore(
-		ctx, apiReader, s3ProfileName, "drpolicy validation", log)
+// syncS3HealthFromDRClusterConfig reads DRClusterConfig's S3Healthy condition via MCV, and sets DRCluster's S3Healthy
+// condition accordingly.
+func (u *drclusterInstance) syncS3HealthFromDRClusterConfig() (string, error) {
+	drcConfig, err := u.getDRCCFromCluster(u.object)
 	if err != nil {
-		return "s3ConnectionFailed", fmt.Errorf("%s: %w", s3ProfileName, err)
+		return DRClusterReasonDRClusterConfigReadFailed, err
 	}
 
-	if _, err := objectStore.ListKeys(listKeyPrefix); err != nil {
-		return "s3ListFailed", fmt.Errorf("%s: %w", s3ProfileName, err)
+	cond := meta.FindStatusCondition(drcConfig.Status.Conditions, ramen.DRClusterConfigS3Healthy)
+	if cond != nil && cond.Status == metav1.ConditionTrue {
+		if err := u.statusConditionSetAndUpdate(
+			ramen.DRClusterConditionS3Healthy,
+			metav1.ConditionTrue,
+			DRClusterReasonS3Reachable,
+			cond.Message,
+		); err != nil {
+			return ramen.DRClusterConditionS3UpdateFailed, fmt.Errorf("failed to update S3Reachable (true): %w", err)
+		}
+
+		return "", nil
+	}
+
+	msg := "S3 not reachable by the cluster"
+	if cond != nil && cond.Message != "" {
+		msg = cond.Message
+	}
+
+	if err := u.statusConditionSetAndUpdate(
+		ramen.DRClusterConditionS3Healthy,
+		metav1.ConditionFalse,
+		DRClusterReasonS3Unreachable,
+		msg,
+	); err != nil {
+		return ramen.DRClusterConditionS3UpdateFailed, fmt.Errorf("failed to update S3Reachable (false): %w", err)
 	}
 
 	return "", nil

--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -66,6 +66,11 @@ const (
 
 	DRClusterConditionReasonError        = "Error"
 	DRClusterConditionReasonErrorUnknown = "UnknownError"
+
+	DRClusterReasonDRClusterConfigReadFailed = "DRClusterConfigReadFailed"
+
+	DRClusterReasonS3Unreachable = "S3Unreachable"
+	DRClusterReasonS3Reachable   = "S3Reachable"
 )
 
 //nolint:gosec
@@ -432,8 +437,7 @@ func (r DRClusterReconciler) processCreateOrUpdate(u *drclusterInstance) (ctrl.R
 		u.log.Info("Error during processing fencing", "error", err)
 	}
 
-	if reason, err := validateS3Profile(u.ctx, r.APIReader, r.ObjectStoreGetter, u.object, u.namespacedName.String(),
-		u.log); err != nil {
+	if reason, err := u.syncS3HealthFromDRClusterConfig(); err != nil {
 		return ctrl.Result{}, fmt.Errorf("drclusters s3Profile validate: %w", u.validatedSetFalseAndUpdate(reason, err))
 	}
 
@@ -661,36 +665,53 @@ func checkUndetectedCIDRsFound(
 	return false
 }
 
-func validateS3Profile(ctx context.Context, apiReader client.Reader,
-	objectStoreGetter ObjectStoreGetter,
-	drcluster *ramen.DRCluster, listKeyPrefix string, log logr.Logger,
-) (string, error) {
-	if drcluster.Spec.S3ProfileName != NoS3StoreAvailable {
-		if reason, err := s3ProfileValidate(ctx, apiReader, objectStoreGetter,
-			drcluster.Spec.S3ProfileName, listKeyPrefix, log); err != nil {
-			return reason, err
+// syncS3HealthFromDRClusterConfig reads DRClusterConfig's S3Healthy condition via MCV, and sets DRCluster's S3Healthy
+// condition accordingly.
+func (u *drclusterInstance) syncS3HealthFromDRClusterConfig() (string, error) {
+	drcConfig, err := u.getDRCCFromCluster(u.object)
+	if err != nil {
+		return DRClusterReasonDRClusterConfigReadFailed, err
+	}
+
+	cond := meta.FindStatusCondition(drcConfig.Status.Conditions, ramen.DRClusterConfigS3Healthy)
+	if cond != nil && cond.Status == metav1.ConditionTrue {
+		reason := DRClusterReasonS3Reachable
+		if cond.Reason != "" {
+			reason = cond.Reason
+		}
+
+		if err := u.statusConditionSetAndUpdate(
+			ramen.DRClusterConditionS3Healthy,
+			metav1.ConditionTrue,
+			reason,
+			cond.Message,
+		); err != nil {
+			return ramen.DRClusterConditionS3UpdateFailed, fmt.Errorf("failed to update S3Reachable (true): %w", err)
+		}
+
+		return "", nil
+	}
+
+	msg := "S3 not reachable by the cluster"
+	reason := DRClusterReasonS3Unreachable
+
+	if cond != nil {
+		if cond.Message != "" {
+			msg = cond.Message
+		}
+
+		if cond.Reason != "" {
+			reason = cond.Reason
 		}
 	}
 
-	return "", nil
-}
-
-func s3ProfileValidate(ctx context.Context, apiReader client.Reader,
-	objectStoreGetter ObjectStoreGetter, s3ProfileName, listKeyPrefix string,
-	log logr.Logger,
-) (string, error) {
-	objectStore, _, err := objectStoreGetter.ObjectStore(
-		ctx, apiReader, s3ProfileName, "drpolicy validation", log)
-	if err != nil {
-		return "s3ConnectionFailed", fmt.Errorf("%s: %w", s3ProfileName, err)
-	}
-
-	if err := objectStore.HeadBucket(); err != nil {
-		return "s3BucketNotFound", fmt.Errorf("%s: %w", s3ProfileName, err)
-	}
-
-	if _, err := objectStore.ListKeys(listKeyPrefix); err != nil {
-		return "s3ListFailed", fmt.Errorf("%s: %w", s3ProfileName, err)
+	if err := u.statusConditionSetAndUpdate(
+		ramen.DRClusterConditionS3Healthy,
+		metav1.ConditionFalse,
+		reason,
+		msg,
+	); err != nil {
+		return ramen.DRClusterConditionS3UpdateFailed, fmt.Errorf("failed to update S3Reachable (false): %w", err)
 	}
 
 	return "", nil

--- a/internal/controller/drcluster_controller_test.go
+++ b/internal/controller/drcluster_controller_test.go
@@ -29,6 +29,13 @@ import (
 
 var NFClassCount int // Number of NFCs to simulate (0=disabled, 1=single, 2+=multiple)
 
+var (
+	S3HealthyInDRCC   bool
+	S3UnhealthyInDRCC bool
+)
+
+const drccS3UnhealthyMessage = "Found an unhealthy S3 profile for which there's no secret"
+
 var cidrs = [][]string{
 	{"198.51.100.17/24", "198.51.100.18/24", "198.51.100.19/24"}, // valid CIDR
 	{"198.51.100.20/24", "198.51.100.21/24", "198.51.100.22/24"}, // valid CIDR
@@ -170,6 +177,30 @@ func (f FakeMCVGetter) GetDRClusterConfigFromManagedCluster(
 	if NFClassCount > 0 {
 		return generateDRCC(), nil
 	}
+	// Enable tests to force S3 healthy in the returned DRClusterConfig
+	if S3HealthyInDRCC {
+		drcc := generateDRCC()
+		drcc.Status.Conditions = append(drcc.Status.Conditions, metav1.Condition{
+			Type:    ramen.DRClusterConfigS3Healthy,
+			Status:  metav1.ConditionTrue,
+			Reason:  controllers.DRClusterReasonS3Reachable,
+			Message: "All S3 profiles are healthy",
+		})
+
+		return drcc, nil
+	}
+
+	if S3UnhealthyInDRCC {
+		drcc := generateDRCC()
+		drcc.Status.Conditions = append(drcc.Status.Conditions, metav1.Condition{
+			Type:    ramen.DRClusterConfigS3Healthy,
+			Status:  metav1.ConditionFalse,
+			Reason:  controllers.DRClusterConfigS3Unreachable,
+			Message: drccS3UnhealthyMessage,
+		})
+
+		return drcc, nil
+	}
 
 	return &ramen.DRClusterConfig{}, nil
 }
@@ -211,6 +242,31 @@ func inspectClusterManifestSubscriptionCSV(match bool, value string, drcluster *
 	case false:
 		Expect(value == sub.Spec.StartingCSV).To(BeFalse())
 	}
+}
+
+// Helper assertions for DRCluster S3 condition (the controller uses "S3Healthy")
+func expectClusterS3Reachable(drcluster *ramen.DRCluster) {
+	objectConditionExpectEventually(
+		apiReader,
+		drcluster,
+		metav1.ConditionTrue,
+		Equal(controllers.DRClusterReasonS3Reachable),
+		Ignore(),
+		ramen.DRClusterConditionS3Healthy,
+		false,
+	)
+}
+
+func expectClusterS3UnreachableWithMessage(drcluster *ramen.DRCluster, message string) {
+	objectConditionExpectEventually(
+		apiReader,
+		drcluster,
+		metav1.ConditionFalse,
+		Equal(controllers.DRClusterReasonS3Unreachable),
+		Equal(message),
+		ramen.DRClusterConditionS3Healthy,
+		false,
+	)
 }
 
 var _ = Describe("DRClusterController", func() {
@@ -371,58 +427,87 @@ var _ = Describe("DRClusterController", func() {
 		createOtherDRClusters()
 	})
 
-	Context("DRCluster resource S3Profile validation", func() {
+	// -------------------------------------------------------------------------
+	// DRCluster mirrors DRClusterConfig S3Healthy
+	// -------------------------------------------------------------------------
+	Context("DRCluster mirrors DRClusterConfig S3Healthy", func() {
 		Specify("create a drcluster copy for changes", func() {
 			createPolicies()
 
 			drcluster = drclusters[0].DeepCopy()
 		})
-		When("an S3Profile is missing in config", func() {
-			It("reports NOT validated with reason s3ConnectionFailed", func() {
-				By("creating a new DRCluster with an invalid S3Profile")
 
-				drcluster.Spec.S3ProfileName = "missing"
+		When("DRClusterConfig reports S3 healthy", func() {
+			It("reports validated and mirrors S3Healthy True", func() {
+				S3HealthyInDRCC = true
+
+				defer func() { S3HealthyInDRCC = false }()
+
+				drcluster.Spec.S3ProfileName = s3Profiles[0].S3ProfileName
+				drcluster.Spec.ClusterFence = ""
 				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
 				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
+				updateDRClusterConfigMWStatus(k8sClient, apiReader, drcluster.Name)
+
 				objectConditionExpectEventually(
 					apiReader,
 					drcluster,
-					metav1.ConditionFalse,
-					Equal("s3ConnectionFailed"),
+					metav1.ConditionTrue,
+					Equal("Succeeded"),
 					Ignore(),
 					ramen.DRClusterValidated,
 					false,
 				)
+				expectClusterS3Reachable(drcluster)
 			})
 		})
-		When("deleting a DRCluster", func() {
+
+		When("deleting a DRCluster with S3 healthy", func() {
 			It("is successful", func() {
 				drpolicyDelete(syncDRPolicy)
 				drclusterDelete(drcluster)
-				// recreate DRPolicy
+
 				createPolicies()
 
 				drcluster = drclusters[0].DeepCopy()
 			})
 		})
-		When("an S3Profile fails listing", func() {
-			It("reports NOT validated with reason s3ListFailed", func() {
-				By("creating a DRCluster with an invalid S3Profile that fails listing")
 
-				drcluster.Spec.S3ProfileName = s3Profiles[4].S3ProfileName
+		When("DRClusterConfig reports S3 unhealthy", func() {
+			It("mirrors S3Healthy False and DRClusterConfig message", func() {
+				S3UnhealthyInDRCC = true
+
+				defer func() { S3UnhealthyInDRCC = false }()
+
 				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
 				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
-				objectConditionExpectEventually(
-					apiReader,
-					drcluster,
-					metav1.ConditionFalse,
-					Equal("s3ListFailed"),
-					Ignore(),
-					ramen.DRClusterValidated,
-					false,
-				)
+				updateDRClusterConfigMWStatus(k8sClient, apiReader, drcluster.Name)
+
+				expectClusterS3UnreachableWithMessage(drcluster, drccS3UnhealthyMessage)
 			})
 		})
+
+		When("deleting a DRCluster with S3 unhealthy", func() {
+			It("is successful", func() {
+				drpolicyDelete(syncDRPolicy)
+				drclusterDelete(drcluster)
+
+				createPolicies()
+
+				drcluster = drclusters[0].DeepCopy()
+			})
+		})
+
+		When("DRClusterConfig lacks S3Healthy condition", func() {
+			It("mirrors S3Healthy False with default message", func() {
+				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
+				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
+				updateDRClusterConfigMWStatus(k8sClient, apiReader, drcluster.Name)
+
+				expectClusterS3UnreachableWithMessage(drcluster, "S3 not reachable by the cluster")
+			})
+		})
+
 		When("fenced", func() {
 			It("reports validated with reason Succeeded and ignores S3Profile errors", func() {
 				By("fencing an existing DRCluster with an invalid S3Profile")
@@ -441,115 +526,7 @@ var _ = Describe("DRClusterController", func() {
 			})
 		})
 
-		When("deleting a DRCluster", func() {
-			It("is successful", func() {
-				drpolicyDelete(syncDRPolicy)
-				drclusterDelete(drcluster)
-				// recreate DRPolicy
-				createPolicies()
-
-				drcluster = drclusters[0].DeepCopy()
-			})
-		})
-
-		When("S3Profile is valid", func() {
-			It("reports validated with reason Succeeded", func() {
-				By("creating a DRCluster with a valid S3Profile and no cluster fencing")
-
-				drcluster.Spec.S3ProfileName = s3Profiles[0].S3ProfileName
-				drcluster.Spec.ClusterFence = ""
-				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
-				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
-				updateDRClusterConfigMWStatus(k8sClient, apiReader, drcluster.Name)
-				objectConditionExpectEventually(
-					apiReader,
-					drcluster,
-					metav1.ConditionTrue,
-					Equal("Succeeded"),
-					Ignore(),
-					ramen.DRClusterValidated,
-					false,
-				)
-			})
-		})
-
-		When("deleting a DRCluster", func() {
-			It("is successful", func() {
-				drpolicyDelete(syncDRPolicy)
-				drclusterDelete(drcluster)
-				// recreate DRPolicy
-				createPolicies()
-
-				drcluster = drclusters[0].DeepCopy()
-			})
-		})
-
-		When("S3Profile is changed to an invalid profile in ramen config", func() {
-			It("reports NOT validated with reason s3ConnectionFailed", func() {
-				By("creating a DRCluster with the new valid S3Profile")
-
-				drcluster.Spec.S3ProfileName = s3Profiles[5].S3ProfileName
-				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
-				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
-				updateDRClusterConfigMWStatus(k8sClient, apiReader, drcluster.Name)
-				objectConditionExpectEventually(
-					apiReader,
-					drcluster,
-					metav1.ConditionTrue,
-					Equal("Succeeded"),
-					Ignore(),
-					ramen.DRClusterValidated,
-					false,
-				)
-				By("changing the S3Profile in ramen config to an invalid value")
-
-				newS3Profiles := s3Profiles[0:]
-				s3Profiles[5].S3Bucket = bucketNameFail
-
-				s3ProfilesStore(newS3Profiles)
-				objectConditionExpectEventually(
-					apiReader,
-					drcluster,
-					metav1.ConditionFalse,
-					Equal("s3ConnectionFailed"),
-					Ignore(),
-					ramen.DRClusterValidated,
-					false,
-				)
-				// TODO: Ensure when changing S3Profile, dr-cluster's ramen config is updated in MW
-			})
-		})
-
-		When("deleting a DRCluster", func() {
-			It("is successful", func() {
-				drpolicyDelete(syncDRPolicy)
-				drclusterDelete(drcluster)
-				// recreate DRPolicy
-				createPolicies()
-
-				drcluster = drclusters[0].DeepCopy()
-			})
-		})
-
-		When("when adding an invalid S3Profile in DRCLuster", func() {
-			It("reports NOT validated with reason s3ListFailed", func() {
-				By("creating a DRCluster with an invalid S3Profile that fails listing")
-
-				drcluster.Spec.S3ProfileName = s3Profiles[4].S3ProfileName
-				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
-				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
-				objectConditionExpectEventually(
-					apiReader,
-					drcluster,
-					metav1.ConditionFalse,
-					Equal("s3ListFailed"),
-					Ignore(),
-					ramen.DRClusterValidated,
-					false,
-				)
-			})
-		})
-		When("deleting a DRCluster with an invalid s3Profile", func() {
+		When("deleting a DRCluster after fencing", func() {
 			It("is successful", func() {
 				drpolicyDelete(syncDRPolicy)
 				drclusterDelete(drcluster)

--- a/internal/controller/drcluster_controller_test.go
+++ b/internal/controller/drcluster_controller_test.go
@@ -29,6 +29,13 @@ import (
 
 var NFClassCount int // Number of NFCs to simulate (0=disabled, 1=single, 2+=multiple)
 
+var (
+	S3HealthyInDRCC   bool
+	S3UnhealthyInDRCC bool
+)
+
+const drccS3UnhealthyMessage = "Found an unhealthy S3 profile for which there's no secret"
+
 var cidrs = [][]string{
 	{"198.51.100.17/24", "198.51.100.18/24", "198.51.100.19/24"}, // valid CIDR
 	{"198.51.100.20/24", "198.51.100.21/24", "198.51.100.22/24"}, // valid CIDR
@@ -170,6 +177,30 @@ func (f FakeMCVGetter) GetDRClusterConfigFromManagedCluster(
 	if NFClassCount > 0 {
 		return generateDRCC(), nil
 	}
+	// Enable tests to force S3 healthy in the returned DRClusterConfig
+	if S3HealthyInDRCC {
+		drcc := generateDRCC()
+		drcc.Status.Conditions = append(drcc.Status.Conditions, metav1.Condition{
+			Type:    ramen.DRClusterConfigS3Healthy,
+			Status:  metav1.ConditionTrue,
+			Reason:  controllers.DRClusterConfigS3Reachable,
+			Message: "All S3 profiles are healthy",
+		})
+
+		return drcc, nil
+	}
+
+	if S3UnhealthyInDRCC {
+		drcc := generateDRCC()
+		drcc.Status.Conditions = append(drcc.Status.Conditions, metav1.Condition{
+			Type:    ramen.DRClusterConfigS3Healthy,
+			Status:  metav1.ConditionFalse,
+			Reason:  controllers.DRClusterConfigS3BucketNotFound,
+			Message: drccS3UnhealthyMessage,
+		})
+
+		return drcc, nil
+	}
 
 	return &ramen.DRClusterConfig{}, nil
 }
@@ -211,6 +242,31 @@ func inspectClusterManifestSubscriptionCSV(match bool, value string, drcluster *
 	case false:
 		Expect(value == sub.Spec.StartingCSV).To(BeFalse())
 	}
+}
+
+// Helper assertions for DRCluster S3 condition (the controller uses "S3Healthy")
+func expectClusterS3Reachable(drcluster *ramen.DRCluster) {
+	objectConditionExpectEventually(
+		apiReader,
+		drcluster,
+		metav1.ConditionTrue,
+		Equal(controllers.DRClusterReasonS3Reachable),
+		Ignore(),
+		ramen.DRClusterConditionS3Healthy,
+		false,
+	)
+}
+
+func expectClusterS3UnreachableWithMessage(drcluster *ramen.DRCluster, reason, message string) {
+	objectConditionExpectEventually(
+		apiReader,
+		drcluster,
+		metav1.ConditionFalse,
+		Equal(reason),
+		Equal(message),
+		ramen.DRClusterConditionS3Healthy,
+		false,
+	)
 }
 
 var _ = Describe("DRClusterController", func() {
@@ -371,58 +427,89 @@ var _ = Describe("DRClusterController", func() {
 		createOtherDRClusters()
 	})
 
-	Context("DRCluster resource S3Profile validation", func() {
+	// -------------------------------------------------------------------------
+	// DRCluster mirrors DRClusterConfig S3Healthy
+	// -------------------------------------------------------------------------
+	Context("DRCluster mirrors DRClusterConfig S3Healthy", func() {
 		Specify("create a drcluster copy for changes", func() {
 			createPolicies()
 
 			drcluster = drclusters[0].DeepCopy()
 		})
-		When("an S3Profile is missing in config", func() {
-			It("reports NOT validated with reason s3ConnectionFailed", func() {
-				By("creating a new DRCluster with an invalid S3Profile")
 
-				drcluster.Spec.S3ProfileName = "missing"
+		When("DRClusterConfig reports S3 healthy", func() {
+			It("reports validated and mirrors S3Healthy True", func() {
+				S3HealthyInDRCC = true
+
+				defer func() { S3HealthyInDRCC = false }()
+
+				drcluster.Spec.S3ProfileName = s3Profiles[0].S3ProfileName
+				drcluster.Spec.ClusterFence = ""
 				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
 				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
+				updateDRClusterConfigMWStatus(k8sClient, apiReader, drcluster.Name)
+
 				objectConditionExpectEventually(
 					apiReader,
 					drcluster,
-					metav1.ConditionFalse,
-					Equal("s3ConnectionFailed"),
+					metav1.ConditionTrue,
+					Equal("Succeeded"),
 					Ignore(),
 					ramen.DRClusterValidated,
 					false,
 				)
+				expectClusterS3Reachable(drcluster)
 			})
 		})
-		When("deleting a DRCluster", func() {
+
+		When("deleting a DRCluster with S3 healthy", func() {
 			It("is successful", func() {
 				drpolicyDelete(syncDRPolicy)
 				drclusterDelete(drcluster)
-				// recreate DRPolicy
+
 				createPolicies()
 
 				drcluster = drclusters[0].DeepCopy()
 			})
 		})
-		When("an S3Profile fails listing", func() {
-			It("reports NOT validated with reason s3ListFailed", func() {
-				By("creating a DRCluster with an invalid S3Profile that fails listing")
 
-				drcluster.Spec.S3ProfileName = s3Profiles[4].S3ProfileName
+		When("DRClusterConfig reports S3 unhealthy", func() {
+			It("mirrors S3Healthy False and DRClusterConfig message", func() {
+				S3UnhealthyInDRCC = true
+
+				defer func() { S3UnhealthyInDRCC = false }()
+
 				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
 				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
-				objectConditionExpectEventually(
-					apiReader,
-					drcluster,
-					metav1.ConditionFalse,
-					Equal("s3ListFailed"),
-					Ignore(),
-					ramen.DRClusterValidated,
-					false,
-				)
+				updateDRClusterConfigMWStatus(k8sClient, apiReader, drcluster.Name)
+
+				expectClusterS3UnreachableWithMessage(drcluster,
+					controllers.DRClusterConfigS3BucketNotFound, drccS3UnhealthyMessage)
 			})
 		})
+
+		When("deleting a DRCluster with S3 unhealthy", func() {
+			It("is successful", func() {
+				drpolicyDelete(syncDRPolicy)
+				drclusterDelete(drcluster)
+
+				createPolicies()
+
+				drcluster = drclusters[0].DeepCopy()
+			})
+		})
+
+		When("DRClusterConfig lacks S3Healthy condition", func() {
+			It("mirrors S3Healthy False with default message", func() {
+				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
+				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
+				updateDRClusterConfigMWStatus(k8sClient, apiReader, drcluster.Name)
+
+				expectClusterS3UnreachableWithMessage(drcluster,
+					controllers.DRClusterReasonS3Unreachable, "S3 not reachable by the cluster")
+			})
+		})
+
 		When("fenced", func() {
 			It("reports validated with reason Succeeded and ignores S3Profile errors", func() {
 				By("fencing an existing DRCluster with an invalid S3Profile")
@@ -441,115 +528,7 @@ var _ = Describe("DRClusterController", func() {
 			})
 		})
 
-		When("deleting a DRCluster", func() {
-			It("is successful", func() {
-				drpolicyDelete(syncDRPolicy)
-				drclusterDelete(drcluster)
-				// recreate DRPolicy
-				createPolicies()
-
-				drcluster = drclusters[0].DeepCopy()
-			})
-		})
-
-		When("S3Profile is valid", func() {
-			It("reports validated with reason Succeeded", func() {
-				By("creating a DRCluster with a valid S3Profile and no cluster fencing")
-
-				drcluster.Spec.S3ProfileName = s3Profiles[0].S3ProfileName
-				drcluster.Spec.ClusterFence = ""
-				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
-				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
-				updateDRClusterConfigMWStatus(k8sClient, apiReader, drcluster.Name)
-				objectConditionExpectEventually(
-					apiReader,
-					drcluster,
-					metav1.ConditionTrue,
-					Equal("Succeeded"),
-					Ignore(),
-					ramen.DRClusterValidated,
-					false,
-				)
-			})
-		})
-
-		When("deleting a DRCluster", func() {
-			It("is successful", func() {
-				drpolicyDelete(syncDRPolicy)
-				drclusterDelete(drcluster)
-				// recreate DRPolicy
-				createPolicies()
-
-				drcluster = drclusters[0].DeepCopy()
-			})
-		})
-
-		When("S3Profile is changed to an invalid profile in ramen config", func() {
-			It("reports NOT validated with reason s3ConnectionFailed", func() {
-				By("creating a DRCluster with the new valid S3Profile")
-
-				drcluster.Spec.S3ProfileName = s3Profiles[5].S3ProfileName
-				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
-				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
-				updateDRClusterConfigMWStatus(k8sClient, apiReader, drcluster.Name)
-				objectConditionExpectEventually(
-					apiReader,
-					drcluster,
-					metav1.ConditionTrue,
-					Equal("Succeeded"),
-					Ignore(),
-					ramen.DRClusterValidated,
-					false,
-				)
-				By("changing the S3Profile in ramen config to an invalid value")
-
-				newS3Profiles := s3Profiles[0:]
-				s3Profiles[5].S3Bucket = bucketNameFail
-
-				s3ProfilesStore(newS3Profiles)
-				objectConditionExpectEventually(
-					apiReader,
-					drcluster,
-					metav1.ConditionFalse,
-					Equal("s3ConnectionFailed"),
-					Ignore(),
-					ramen.DRClusterValidated,
-					false,
-				)
-				// TODO: Ensure when changing S3Profile, dr-cluster's ramen config is updated in MW
-			})
-		})
-
-		When("deleting a DRCluster", func() {
-			It("is successful", func() {
-				drpolicyDelete(syncDRPolicy)
-				drclusterDelete(drcluster)
-				// recreate DRPolicy
-				createPolicies()
-
-				drcluster = drclusters[0].DeepCopy()
-			})
-		})
-
-		When("when adding an invalid S3Profile in DRCLuster", func() {
-			It("reports NOT validated with reason s3ListFailed", func() {
-				By("creating a DRCluster with an invalid S3Profile that fails listing")
-
-				drcluster.Spec.S3ProfileName = s3Profiles[4].S3ProfileName
-				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
-				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
-				objectConditionExpectEventually(
-					apiReader,
-					drcluster,
-					metav1.ConditionFalse,
-					Equal("s3ListFailed"),
-					Ignore(),
-					ramen.DRClusterValidated,
-					false,
-				)
-			})
-		})
-		When("deleting a DRCluster with an invalid s3Profile", func() {
+		When("deleting a DRCluster after fencing", func() {
 			It("is successful", func() {
 				drpolicyDelete(syncDRPolicy)
 				drclusterDelete(drcluster)

--- a/internal/controller/drcluster_util.go
+++ b/internal/controller/drcluster_util.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func S3ProfileValidate(ctx context.Context, apiReader client.Reader,
+	objectStoreGetter ObjectStoreGetter, s3ProfileName, listKeyPrefix string,
+	log logr.Logger,
+) (string, error) {
+	objectStore, _, err := objectStoreGetter.ObjectStore(
+		ctx, apiReader, s3ProfileName, "drpolicy validation", log)
+	if err != nil {
+		return "s3ConnectionFailed", fmt.Errorf("%s: %w", s3ProfileName, err)
+	}
+
+	if _, err := objectStore.ListKeys(listKeyPrefix); err != nil {
+		return "s3ListFailed", fmt.Errorf("%s: %w", s3ProfileName, err)
+	}
+
+	return "", nil
+}

--- a/internal/controller/drcluster_util.go
+++ b/internal/controller/drcluster_util.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func S3ProfileValidate(ctx context.Context, apiReader client.Reader,
+	objectStoreGetter ObjectStoreGetter, s3ProfileName string,
+	log logr.Logger,
+) (ObjectStorer, string, error) {
+	objectStore, _, err := objectStoreGetter.ObjectStore(
+		ctx, apiReader, s3ProfileName, "drpolicy validation", log)
+	if err != nil {
+		return nil, DRClusterConfigS3ConnectionFailed, fmt.Errorf("%s: %w", s3ProfileName, err)
+	}
+
+	return objectStore, "", nil
+}

--- a/internal/controller/drclusterconfig_controller.go
+++ b/internal/controller/drclusterconfig_controller.go
@@ -16,7 +16,9 @@ import (
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	groupsnapv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	"golang.org/x/time/rate"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,9 +58,10 @@ const (
 // DRClusterConfigReconciler reconciles a DRClusterConfig object
 type DRClusterConfigReconciler struct {
 	client.Client
-	Scheme      *runtime.Scheme
-	Log         logr.Logger
-	RateLimiter *workqueue.TypedRateLimiter[reconcile.Request]
+	Scheme            *runtime.Scheme
+	Log               logr.Logger
+	RateLimiter       *workqueue.TypedRateLimiter[reconcile.Request]
+	ObjectStoreGetter ObjectStoreGetter
 }
 
 //nolint:lll
@@ -149,7 +152,7 @@ func setDRClusterConfigInitialCondition(conditions *[]metav1.Condition, observed
 		Message:            message,
 	})
 	util.SetStatusConditionIfNotFound(conditions, metav1.Condition{
-		Type:               ramen.DRClusterConfigS3Reachable,
+		Type:               ramen.DRClusterConfigS3Healthy,
 		Reason:             DRClusterConfigConditionReasonInitializing,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionUnknown,
@@ -162,6 +165,18 @@ func setDRClusterConfigConfigurationProcessedCondition(conditions *[]metav1.Cond
 ) {
 	util.SetStatusCondition(conditions, metav1.Condition{
 		Type:               ramen.DRClusterConfigConfigurationProcessed,
+		Reason:             reason,
+		ObservedGeneration: observedGeneration,
+		Status:             conditionStatus,
+		Message:            message,
+	})
+}
+
+func setDRClusterConfigS3HealthyCondition(conditions *[]metav1.Condition, observedGeneration int64,
+	message string, conditionStatus metav1.ConditionStatus, reason string,
+) {
+	util.SetStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConfigS3Healthy,
 		Reason:             reason,
 		ObservedGeneration: observedGeneration,
 		Status:             conditionStatus,
@@ -276,7 +291,66 @@ func (r *DRClusterConfigReconciler) processCreateOrUpdate(
 	setDRClusterConfigConfigurationProcessedCondition(&drCConfig.Status.Conditions, drCConfig.Generation,
 		"Configuration processed and validated", metav1.ConditionTrue, DRClusterConfigConditionConfigurationProcessed)
 
+	if err := r.reconcileDRClusterConfigS3Healthy(ctx, drCConfig); err != nil {
+		log.Info("Reconcile error", "error", err)
+
+		return ctrl.Result{Requeue: true}, err
+	}
+
 	return ctrl.Result{}, nil
+}
+
+func (r *DRClusterConfigReconciler) reconcileDRClusterConfigS3Healthy(
+	ctx context.Context, drCConfig *ramen.DRClusterConfig,
+) error {
+	// Fetch the ramen config resource
+	_, ramenConfig, err := ConfigMapGet(ctx, r.Client)
+	if err != nil {
+		return fmt.Errorf("failed to get Ramen configmap: %w", err)
+	}
+
+	// Iterate all profiles listed in it and check for existing healthy ones
+	for profileIdx := range ramenConfig.S3StoreProfiles {
+		// for each profile, check that it has an actual secret attached to its secretRef ID
+		profile := ramenConfig.S3StoreProfiles[profileIdx]
+		secretRef := profile.S3SecretRef
+		secret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretRef.Name, Namespace: secretRef.Namespace},
+		}
+
+		if err := r.Client.Get(ctx, types.NamespacedName{
+			Namespace: secret.Namespace,
+			Name:      secret.Name,
+		}, secret); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				setDRClusterConfigS3HealthyCondition(&drCConfig.Status.Conditions, drCConfig.Generation,
+					fmt.Sprintf("Found an unhealthy S3 profile %q for which there's a faulty secret", profile.S3ProfileName),
+					metav1.ConditionFalse, DRClusterConfigS3Unreachable)
+
+				return fmt.Errorf("failed to get secret: %w", err)
+			}
+			// If there's no secret attached to the secretRef's namespacedname -- mark profile as unhealthy
+			setDRClusterConfigS3HealthyCondition(&drCConfig.Status.Conditions, drCConfig.Generation,
+				fmt.Sprintf("Found an unhealthy S3 profile %q for which there's no secret", profile.S3ProfileName),
+				metav1.ConditionFalse, DRClusterConfigS3Unreachable)
+
+			return fmt.Errorf("secret not found: %w", err)
+		}
+		// Profile does have a secret. Check if it has connectivity and record in status accordingly
+		if reason, err := S3ProfileValidate(ctx, r.Client, r.ObjectStoreGetter, profile.S3ProfileName, types.NamespacedName{
+			Name: drCConfig.Name, Namespace: drCConfig.Namespace,
+		}.String(), r.Log); err != nil {
+			setDRClusterConfigS3HealthyCondition(&drCConfig.Status.Conditions, drCConfig.Generation, err.Error(),
+				metav1.ConditionFalse, reason)
+
+			return fmt.Errorf("failed to validate s3 profile: %w", err)
+		}
+	}
+	// All S3 profiles are healthy -- record to status and exit
+	setDRClusterConfigS3HealthyCondition(&drCConfig.Status.Conditions, drCConfig.Generation,
+		fmt.Sprintf("All S3 profiles are healthy"), metav1.ConditionTrue, DRClusterConfigS3Reachable)
+
+	return nil
 }
 
 // UpdateStatus updates DRClusterConfig status with a list of storage related classes that are marked for DR

--- a/internal/controller/drclusterconfig_controller.go
+++ b/internal/controller/drclusterconfig_controller.go
@@ -17,7 +17,9 @@ import (
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"golang.org/x/time/rate"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -52,11 +54,14 @@ const (
 	DRClusterConfigConditionConfigurationProcessed = "Succeeded"
 	DRClusterConfigConditionConfigurationFailed    = "Failed"
 
-	DRClusterConfigS3Reachable   = "Reachable"
-	DRClusterConfigS3Unreachable = "Unreachable"
-	NADCRDMissing                = "NADCRDMissing"
-	NADWatchNotRegistered        = "NADWatchNotRegistered"
-	StaticIPDiscoveryEnabled     = "StaticIPDiscoveryEnabled"
+	DRClusterConfigS3Reachable        = "S3Reachable"
+	DRClusterConfigS3Unreachable      = "S3Unreachable"
+	DRClusterConfigS3ConnectionFailed = "S3ConnectionFailed"
+	DRClusterConfigS3BucketNotFound   = "S3BucketNotFound"
+	DRClusterConfigS3ListFailed       = "S3ListFailed"
+	NADCRDMissing                     = "NADCRDMissing"
+	NADWatchNotRegistered             = "NADWatchNotRegistered"
+	StaticIPDiscoveryEnabled          = "StaticIPDiscoveryEnabled"
 )
 
 // DRClusterConfigReconciler reconciles a DRClusterConfig object
@@ -67,6 +72,7 @@ type DRClusterConfigReconciler struct {
 	Log                logr.Logger
 	NadWatchRegistered bool
 	RateLimiter        *workqueue.TypedRateLimiter[reconcile.Request]
+	ObjectStoreGetter  ObjectStoreGetter
 }
 
 // NADDRNetworkLabel is an opt-in marker for Ramen's static-IP disaster
@@ -181,7 +187,7 @@ func setDRClusterConfigInitialCondition(conditions *[]metav1.Condition, observed
 		Message:            message,
 	})
 	util.SetStatusConditionIfNotFound(conditions, metav1.Condition{
-		Type:               ramen.DRClusterConfigS3Reachable,
+		Type:               ramen.DRClusterConfigS3Healthy,
 		Reason:             DRClusterConfigConditionReasonInitializing,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionUnknown,
@@ -194,6 +200,18 @@ func setDRClusterConfigConfigurationProcessedCondition(conditions *[]metav1.Cond
 ) {
 	util.SetStatusCondition(conditions, metav1.Condition{
 		Type:               ramen.DRClusterConfigConfigurationProcessed,
+		Reason:             reason,
+		ObservedGeneration: observedGeneration,
+		Status:             conditionStatus,
+		Message:            message,
+	})
+}
+
+func setDRClusterConfigS3HealthyCondition(conditions *[]metav1.Condition, observedGeneration int64,
+	message string, conditionStatus metav1.ConditionStatus, reason string,
+) {
+	util.SetStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConfigS3Healthy,
 		Reason:             reason,
 		ObservedGeneration: observedGeneration,
 		Status:             conditionStatus,
@@ -320,7 +338,82 @@ func (r *DRClusterConfigReconciler) processCreateOrUpdate(
 
 	r.updateStaticIPDiscoveryCondition(ctx, drCConfig)
 
+	if err := r.reconcileDRClusterConfigS3Healthy(ctx, drCConfig); err != nil {
+		log.Info("Reconcile error", "error", err)
+
+		return ctrl.Result{Requeue: true}, err
+	}
+
 	return ctrl.Result{}, nil
+}
+
+func (r *DRClusterConfigReconciler) reconcileDRClusterConfigS3Healthy(
+	ctx context.Context, drCConfig *ramen.DRClusterConfig,
+) error {
+	// Fetch the ramen config resource
+	_, ramenConfig, err := ConfigMapGet(ctx, r.Client)
+	if err != nil {
+		return fmt.Errorf("failed to get Ramen configmap: %w", err)
+	}
+
+	// Iterate all profiles listed in it and check for existing healthy ones
+	for profileIdx := range ramenConfig.S3StoreProfiles {
+		// for each profile, check that it has an actual secret attached to its secretRef ID
+		profile := ramenConfig.S3StoreProfiles[profileIdx]
+		secretRef := profile.S3SecretRef
+		secret := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: secretRef.Name, Namespace: secretRef.Namespace},
+		}
+
+		if err := r.Client.Get(ctx, types.NamespacedName{
+			Namespace: secret.Namespace,
+			Name:      secret.Name,
+		}, secret); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				setDRClusterConfigS3HealthyCondition(&drCConfig.Status.Conditions, drCConfig.Generation,
+					fmt.Sprintf("Found an unhealthy S3 profile %q for which there's a faulty secret", profile.S3ProfileName),
+					metav1.ConditionFalse, DRClusterConfigS3Unreachable)
+
+				return fmt.Errorf("failed to get secret: %w", err)
+			}
+			// If there's no secret attached to the secretRef's namespacedname -- mark profile as unhealthy
+			setDRClusterConfigS3HealthyCondition(&drCConfig.Status.Conditions, drCConfig.Generation,
+				fmt.Sprintf("Found an unhealthy S3 profile %q for which there's no secret", profile.S3ProfileName),
+				metav1.ConditionFalse, DRClusterConfigS3Unreachable)
+
+			return fmt.Errorf("secret not found: %w", err)
+		}
+		// Profile does have a secret. Check if it has connectivity and record in status accordingly
+		objectStore, reason, err := S3ProfileValidate(ctx, r.Client, r.ObjectStoreGetter, profile.S3ProfileName, r.Log)
+		if err != nil {
+			setDRClusterConfigS3HealthyCondition(&drCConfig.Status.Conditions, drCConfig.Generation, err.Error(),
+				metav1.ConditionFalse, reason)
+
+			return fmt.Errorf("failed to validate s3 profile: %w", err)
+		}
+
+		if err := objectStore.HeadBucket(); err != nil {
+			setDRClusterConfigS3HealthyCondition(&drCConfig.Status.Conditions, drCConfig.Generation,
+				fmt.Sprintf("%s: %s", profile.S3ProfileName, err.Error()),
+				metav1.ConditionFalse, DRClusterConfigS3BucketNotFound)
+
+			return fmt.Errorf("failed to validate s3 profile: %s: %w", profile.S3ProfileName, err)
+		}
+
+		listKeyPrefix := types.NamespacedName{Name: drCConfig.Name, Namespace: drCConfig.Namespace}.String()
+		if _, err := objectStore.ListKeys(listKeyPrefix); err != nil {
+			setDRClusterConfigS3HealthyCondition(&drCConfig.Status.Conditions, drCConfig.Generation,
+				fmt.Sprintf("%s: %s", profile.S3ProfileName, err.Error()),
+				metav1.ConditionFalse, DRClusterConfigS3ListFailed)
+
+			return fmt.Errorf("failed to validate s3 profile: %s: %w", profile.S3ProfileName, err)
+		}
+	}
+	// All S3 profiles are healthy -- record to status and exit
+	setDRClusterConfigS3HealthyCondition(&drCConfig.Status.Conditions, drCConfig.Generation,
+		fmt.Sprintf("All S3 profiles are healthy"), metav1.ConditionTrue, DRClusterConfigS3Reachable)
+
+	return nil
 }
 
 // validateClusterIDFromClaim fetches the cluster ID claim and validates it against the DRClusterConfig.

--- a/internal/controller/drclusterconfig_controller_test.go
+++ b/internal/controller/drclusterconfig_controller_test.go
@@ -100,6 +100,7 @@ var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 		baseNFC, nfc1, nfc2               *csiaddonsv1alpha1.NetworkFenceClass
 		baseCSIAddonsNode, csiAddonsNode1 *csiaddonsv1alpha1.CSIAddonsNode
 		classes                           Classes
+		ramenConfig                       *ramen.RamenConfig
 	)
 
 	BeforeAll(func() {
@@ -140,6 +141,32 @@ var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 		ensureNamespaceExists(context.TODO(), k8sClient, ramenNamespace)
 
 		ramencontrollers.ControllerType = ramen.DRHubType
+
+		By("Defining a ramen configuration")
+
+		ramenConfig = &ramen.RamenConfig{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "RamenConfig",
+				APIVersion: ramen.GroupVersion.String(),
+			},
+			LeaderElection: &config.LeaderElectionConfiguration{
+				LeaderElect:  new(bool),
+				ResourceName: ramencontrollers.HubLeaderElectionResourceName,
+			},
+			Metrics: ramen.ControllerMetrics{
+				BindAddress: "0", // Disable metrics
+			},
+			RamenControllerType: ramen.DRHubType,
+		}
+		ramenConfig.DrClusterOperator.DeploymentAutomationEnabled = true
+		ramenConfig.DrClusterOperator.S3SecretDistributionEnabled = true
+		configMap, err := ramencontrollers.ConfigMapNew(
+			ramenNamespace,
+			ramencontrollers.HubOperatorConfigMapName,
+			ramenConfig,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(context.TODO(), configMap)).To(Succeed())
 
 		By("starting the DRClusterConfig reconciler")
 

--- a/internal/controller/drclusterconfig_controller_test.go
+++ b/internal/controller/drclusterconfig_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
+	config "k8s.io/component-base/config/v1alpha1"
 	ocmv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -102,6 +103,7 @@ var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 		baseNFC, nfc1, nfc2               *csiaddonsv1alpha1.NetworkFenceClass
 		baseCSIAddonsNode, csiAddonsNode1 *csiaddonsv1alpha1.CSIAddonsNode
 		classes                           Classes
+		ramenConfig                       *ramen.RamenConfig
 	)
 
 	BeforeAll(func() {
@@ -143,6 +145,32 @@ var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 
 		ramencontrollers.ControllerType = ramen.DRHubType
 
+		By("Defining a ramen configuration")
+
+		ramenConfig = &ramen.RamenConfig{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "RamenConfig",
+				APIVersion: ramen.GroupVersion.String(),
+			},
+			LeaderElection: &config.LeaderElectionConfiguration{
+				LeaderElect:  new(bool),
+				ResourceName: ramencontrollers.HubLeaderElectionResourceName,
+			},
+			Metrics: ramen.ControllerMetrics{
+				BindAddress: "0", // Disable metrics
+			},
+			RamenControllerType: ramen.DRHubType,
+		}
+		ramenConfig.DrClusterOperator.DeploymentAutomationEnabled = true
+		ramenConfig.DrClusterOperator.S3SecretDistributionEnabled = true
+		configMap, err := ramencontrollers.ConfigMapNew(
+			ramenNamespace,
+			ramencontrollers.HubOperatorConfigMapName,
+			ramenConfig,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(k8sClient.Create(context.TODO(), configMap)).To(Succeed())
+
 		By("starting the DRClusterConfig reconciler")
 
 		options := manager.Options{
@@ -169,11 +197,12 @@ var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 		util.ForcePrivateVGSAPIForTesting()
 
 		Expect((&ramencontrollers.DRClusterConfigReconciler{
-			Client:      k8sManager.GetClient(),
-			Scheme:      k8sManager.GetScheme(),
-			Log:         ctrl.Log.WithName("controllers").WithName("DRClusterConfig"),
-			RateLimiter: &rateLimiter,
-			APIReader:   k8sManager.GetAPIReader(),
+			Client:            k8sManager.GetClient(),
+			Scheme:            k8sManager.GetScheme(),
+			Log:               ctrl.Log.WithName("controllers").WithName("DRClusterConfig"),
+			RateLimiter:       &rateLimiter,
+			APIReader:         k8sManager.GetAPIReader(),
+			ObjectStoreGetter: fakeObjectStoreGetter{},
 		}).SetupWithManager(k8sManager)).To(Succeed())
 
 		ctx, cancel = context.WithCancel(context.TODO())


### PR DESCRIPTION
## Changes

- DRClusterConfig reports metadata-store health as `MetaDataStoresHealthy`. For each S3 profile it checks that the secret exists, the store connects, HeadBucket succeeds, and ListKeys succeeds.
- Reasons: `S3Reachable`, `S3Unreachable`, `S3ConnectionFailed`, `S3BucketNotFound`, `S3ListFailed`.
- Hub DRCluster no longer talks to S3. It reads that condition via MCV and copies status, reason, and message onto `S3Healthy`. If the condition or reason is missing, it falls back to `S3Unreachable` / `S3Reachable`.

Hub status now follows what the cluster actually observed, including bucket existence, instead of a second hub-side S3 probe.

## Tests

- Assert DRCluster `S3Healthy` instead of the old Validated S3 reasons
- Cover reason mirroring, including `S3BucketNotFound`
- Drop redundant config-change S3 tests; keep one negative invalid S3Profile case
- Update the CIDR-invalid test in place so it does not hit AlreadyExists

Part of the solution for #1641