### PR TITLE
Improve objects filtering upon reconcile of VR, VGR, RS and RD

### DIFF
--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -2036,8 +2036,7 @@ func vrgInAdminNamespace(vrg *ramendrv1alpha1.VolumeReplicationGroup, ramenConfi
 	return slices.Contains(vrgAdminNamespaceNames, vrg.Namespace)
 }
 
-func filterVRGDependentObjects(reader client.Reader, obj client.Object, objNamespacedName types.NamespacedName,
-	log logr.Logger,
+func filterVRGDependentObjects(reader client.Reader, obj client.Object, log logr.Logger,
 ) []reconcile.Request {
 	req := []reconcile.Request{}
 
@@ -2054,13 +2053,6 @@ func filterVRGDependentObjects(reader client.Reader, obj client.Object, objNames
 		log1 := log.WithValues("vrg", vrg.Name)
 
 		if vrg.Spec.ProtectedNamespaces == nil || len(*vrg.Spec.ProtectedNamespaces) == 0 {
-			if vrg.Namespace == objNamespacedName.Namespace {
-				req = append(req, reconcile.Request{NamespacedName: types.NamespacedName{
-					Name:      vrg.Name,
-					Namespace: vrg.Namespace,
-				}})
-			}
-
 			continue
 		}
 
@@ -2090,9 +2082,8 @@ func (r *VolumeReplicationGroupReconciler) VGRMapFunc(ctx context.Context, obj c
 		return []reconcile.Request{}
 	}
 
-	vgrNamespacedName := types.NamespacedName{Name: vgr.Name, Namespace: vgr.Namespace}
-
-	return filterVRGDependentObjects(r.Client, obj, vgrNamespacedName, log.WithValues("vgr", vgrNamespacedName))
+	return filterVRGDependentObjects(r.Client, obj,
+		log.WithValues("vgr", types.NamespacedName{Name: vgr.Name, Namespace: vgr.Namespace}))
 }
 
 func (r *VolumeReplicationGroupReconciler) VRMapFunc(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -2105,9 +2096,8 @@ func (r *VolumeReplicationGroupReconciler) VRMapFunc(ctx context.Context, obj cl
 		return []reconcile.Request{}
 	}
 
-	vrNamespacedName := types.NamespacedName{Name: vr.Name, Namespace: vr.Namespace}
-
-	return filterVRGDependentObjects(r.Client, obj, vrNamespacedName, log.WithValues("vr", vrNamespacedName))
+	return filterVRGDependentObjects(r.Client, obj,
+		log.WithValues("vr", types.NamespacedName{Name: vr.Name, Namespace: vr.Namespace}))
 }
 
 func (r *VolumeReplicationGroupReconciler) RDMapFunc(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -2120,9 +2110,8 @@ func (r *VolumeReplicationGroupReconciler) RDMapFunc(ctx context.Context, obj cl
 		return []reconcile.Request{}
 	}
 
-	rdNamespacedName := types.NamespacedName{Name: rd.Name, Namespace: rd.Namespace}
-
-	return filterVRGDependentObjects(r.Client, obj, rdNamespacedName, log.WithValues("rd", rdNamespacedName))
+	return filterVRGDependentObjects(r.Client, obj,
+		log.WithValues("rd", types.NamespacedName{Name: rd.Name, Namespace: rd.Namespace}))
 }
 
 func (r *VolumeReplicationGroupReconciler) RSMapFunc(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -2135,9 +2124,8 @@ func (r *VolumeReplicationGroupReconciler) RSMapFunc(ctx context.Context, obj cl
 		return []reconcile.Request{}
 	}
 
-	rsNamespacedName := types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}
-
-	return filterVRGDependentObjects(r.Client, obj, rsNamespacedName, log.WithValues("rs", rsNamespacedName))
+	return filterVRGDependentObjects(r.Client, obj,
+		log.WithValues("rs", types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}))
 }
 
 func (r *VolumeReplicationGroupReconciler) addVolsyncOwnsAndWatches(ctrlBuilder *builder.Builder) *builder.Builder {


### PR DESCRIPTION
During the implementation of Consistency Group support, I initially discovered that after a Failover or Relocate, VGR objects were being filtered out during reconciliation. To address this, I added code to eliminate the filtering. However, I later realized that the actual issue was the missing owner reference after restoring the VGR from S3, which prevented reconciliation requests from being triggered.

Since the owner reference is now correctly restored, the additional filtering logic is no longer needed.
This PR removes the unnecessary code and addresses this comment: https://github.com/RamenDR/ramen/pull/1472/commits/4025dbb115e7c9536abf0144ef3d7fe385afad70#r2031989353