### PR TITLE
App ns

### DIFF
--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -77,6 +77,18 @@ func (a ApplicationSet) Undeploy(ctx types.TestContext) error {
 		return err
 	}
 
+	if err := util.WaitForApplicationSetDelete(ctx, ctx.Env().Hub, name, managementNamespace); err != nil {
+		return err
+	}
+
+	if err := util.WaitForConfigMapDelete(ctx, ctx.Env().Hub, name, managementNamespace); err != nil {
+		return err
+	}
+
+	if err := util.WaitForPlacementDelete(ctx, ctx.Env().Hub, name, managementNamespace); err != nil {
+		return err
+	}
+
 	log.Info("Workload undeployed")
 
 	return nil

--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -23,6 +23,10 @@ func (a ApplicationSet) Deploy(ctx types.TestContext) error {
 	log.Infof("Deploying applicationset app \"%s/%s\" in cluster %q",
 		ctx.AppNamespace(), ctx.Workload().GetAppName(), cluster.Name)
 
+	if err := util.CreateAppNamespaces(ctx, ctx.AppNamespace()); err != nil {
+		return err
+	}
+
 	err := CreatePlacement(ctx, name, managementNamespace, cluster.Name)
 	if err != nil {
 		return err
@@ -44,6 +48,7 @@ func (a ApplicationSet) Deploy(ctx types.TestContext) error {
 }
 
 // Undeploy deletes an ApplicationSet from the hub cluster, deleting the workload from the managed clusters.
+// nolint:cyclop
 func (a ApplicationSet) Undeploy(ctx types.TestContext) error {
 	name := ctx.Name()
 	log := ctx.Logger()
@@ -77,6 +82,10 @@ func (a ApplicationSet) Undeploy(ctx types.TestContext) error {
 		return err
 	}
 
+	if err := util.DeleteAppNamespaces(ctx, ctx.AppNamespace()); err != nil {
+		return err
+	}
+
 	if err := util.WaitForApplicationSetDelete(ctx, ctx.Env().Hub, name, managementNamespace); err != nil {
 		return err
 	}
@@ -86,6 +95,10 @@ func (a ApplicationSet) Undeploy(ctx types.TestContext) error {
 	}
 
 	if err := util.WaitForPlacementDelete(ctx, ctx.Env().Hub, name, managementNamespace); err != nil {
+		return err
+	}
+
+	if err := util.WaitForAppNamespacesDelete(ctx, ctx.AppNamespace()); err != nil {
 		return err
 	}
 

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -431,7 +431,7 @@ func DeleteDiscoveredApps(ctx types.TestContext, cluster types.Cluster, namespac
 	}
 
 	cmd := exec.Command("kubectl", "delete", "-k", tempDir, "-n", namespace,
-		"--kubeconfig", cluster.Kubeconfig, "--timeout=5m", "--ignore-not-found=true")
+		"--kubeconfig", cluster.Kubeconfig, "--wait=false", "--ignore-not-found=true")
 
 	if out, err := cmd.Output(); err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -97,6 +97,16 @@ func (d DiscoveredApp) Undeploy(ctx types.TestContext) error {
 		return err
 	}
 
+	// wait for namespace to be deleted on both clusters
+
+	if err := util.WaitForNamespaceDelete(ctx, ctx.Env().C1, appNamespace); err != nil {
+		return err
+	}
+
+	if err := util.WaitForNamespaceDelete(ctx, ctx.Env().C2, appNamespace); err != nil {
+		return err
+	}
+
 	log.Info("Workload undeployed")
 
 	return nil

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -30,9 +30,7 @@ func (d DiscoveredApp) Deploy(ctx types.TestContext) error {
 	// Deploys the application on the first DR cluster (c1).
 	cluster := ctx.Env().C1
 
-	// Create namespace on the first DR cluster (c1)
-	err := util.CreateNamespace(ctx, cluster, appNamespace)
-	if err != nil {
+	if err := util.CreateAppNamespaces(ctx, ctx.AppNamespace()); err != nil {
 		return err
 	}
 
@@ -90,22 +88,12 @@ func (d DiscoveredApp) Undeploy(ctx types.TestContext) error {
 	}
 
 	// delete namespace on both clusters
-
-	if err := util.DeleteNamespace(ctx, ctx.Env().C1, appNamespace); err != nil {
-		return err
-	}
-
-	if err := util.DeleteNamespace(ctx, ctx.Env().C2, appNamespace); err != nil {
+	if err := util.DeleteAppNamespaces(ctx, ctx.AppNamespace()); err != nil {
 		return err
 	}
 
 	// wait for namespace to be deleted on both clusters
-
-	if err := util.WaitForNamespaceDelete(ctx, ctx.Env().C1, appNamespace); err != nil {
-		return err
-	}
-
-	if err := util.WaitForNamespaceDelete(ctx, ctx.Env().C2, appNamespace); err != nil {
+	if err := util.WaitForAppNamespacesDelete(ctx, ctx.AppNamespace()); err != nil {
 		return err
 	}
 

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -80,6 +80,7 @@ func (d DiscoveredApp) Undeploy(ctx types.TestContext) error {
 		appNamespace, ctx.Workload().GetAppName(), ctx.Env().C1.Name, ctx.Env().C2.Name)
 
 	// delete app on both clusters
+	
 	if err := DeleteDiscoveredApps(ctx, ctx.Env().C1, appNamespace); err != nil {
 		return err
 	}
@@ -89,6 +90,7 @@ func (d DiscoveredApp) Undeploy(ctx types.TestContext) error {
 	}
 
 	// delete namespace on both clusters
+
 	if err := util.DeleteNamespace(ctx, ctx.Env().C1, appNamespace); err != nil {
 		return err
 	}

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -80,7 +80,7 @@ func (d DiscoveredApp) Undeploy(ctx types.TestContext) error {
 		appNamespace, ctx.Workload().GetAppName(), ctx.Env().C1.Name, ctx.Env().C2.Name)
 
 	// delete app on both clusters
-	
+
 	if err := DeleteDiscoveredApps(ctx, ctx.Env().C1, appNamespace); err != nil {
 		return err
 	}

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -112,6 +112,10 @@ func (s Subscription) Undeploy(ctx types.TestContext) error {
 		return err
 	}
 
+	if err := util.WaitForNamespaceDelete(ctx, ctx.Env().Hub, managementNamespace); err != nil {
+		return err
+	}
+
 	log.Info("Workload undeployed")
 
 	return nil

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -47,6 +47,10 @@ func (s Subscription) Deploy(ctx types.TestContext) error {
 		return err
 	}
 
+	if err := util.CreateAppNamespaces(ctx, ctx.AppNamespace()); err != nil {
+		return err
+	}
+
 	err = CreateManagedClusterSetBinding(ctx, config.ClusterSet, managementNamespace)
 	if err != nil {
 		return err
@@ -112,7 +116,15 @@ func (s Subscription) Undeploy(ctx types.TestContext) error {
 		return err
 	}
 
+	if err := util.DeleteAppNamespaces(ctx, ctx.AppNamespace()); err != nil {
+		return err
+	}
+
 	if err := util.WaitForNamespaceDelete(ctx, ctx.Env().Hub, managementNamespace); err != nil {
+		return err
+	}
+
+	if err := util.WaitForAppNamespacesDelete(ctx, ctx.AppNamespace()); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -127,8 +127,7 @@ func DisableProtection(ctx types.TestContext) error {
 		return err
 	}
 
-	err = waitDRPCDeleted(ctx, managementNamespace, drpcName)
-	if err != nil {
+	if err := util.WaitForDRPCDelete(ctx, ctx.Env().Hub, drpcName, managementNamespace); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -8,7 +8,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 
-	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 )
@@ -80,7 +79,7 @@ func EnableProtection(ctx types.TestContext) error {
 		return err
 	}
 
-	if err := createNamespaces(ctx, appNamespace); err != nil {
+	if err := util.AddVolsyncAnnotation(ctx, appNamespace); err != nil {
 		return err
 	}
 
@@ -259,15 +258,4 @@ func waitAndUpdateDRPC(
 
 		return nil
 	})
-}
-
-// createNamespaces creates namespaces and annotations for managed app protection on
-// both DR clusters for Volsync based replication if the distribution is Kubernetes.
-// Returns an error if namespace creation or annotation fails.
-func createNamespaces(ctx types.TestContext, appNamespace string) error {
-	if ctx.Config().Distro == config.DistroK8s {
-		return util.CreateNamespaceAndAddAnnotation(ctx, appNamespace)
-	}
-
-	return nil
 }

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -96,10 +96,6 @@ func DisableProtectionDiscoveredApps(ctx types.TestContext) error {
 		return err
 	}
 
-	if err := waitDRPCDeleted(ctx, managementNamespace, drpcName); err != nil {
-		return err
-	}
-
 	// delete placement
 	if err := deployers.DeletePlacement(ctx, placementName, managementNamespace); err != nil {
 		return err
@@ -107,6 +103,19 @@ func DisableProtectionDiscoveredApps(ctx types.TestContext) error {
 
 	err = deployers.DeleteManagedClusterSetBinding(ctx, config.ClusterSet, managementNamespace)
 	if err != nil {
+		return err
+	}
+
+	if err := util.WaitForDRPCDelete(ctx, ctx.Env().Hub, drpcName, managementNamespace); err != nil {
+		return err
+	}
+
+	if err := util.WaitForPlacementDelete(ctx, ctx.Env().Hub, placementName, managementNamespace); err != nil {
+		return err
+	}
+
+	if err := util.WaitForManagedClusterSetBindingDelete(ctx, ctx.Env().Hub, config.ClusterSet,
+		managementNamespace); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -4,11 +4,8 @@
 package dractions
 
 import (
-	"fmt"
-
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 
-	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/deployers"
 	"github.com/ramendr/ramen/e2e/env"
 	"github.com/ramendr/ramen/e2e/types"
@@ -52,7 +49,7 @@ func EnableProtectionDiscoveredApps(ctx types.TestContext) error {
 		return err
 	}
 
-	if err := createNamespacesDiscoveredApps(ctx, appNamespace); err != nil {
+	if err := util.AddVolsyncAnnotation(ctx, appNamespace); err != nil {
 		return err
 	}
 
@@ -171,20 +168,4 @@ func failoverRelocateDiscoveredApps(
 	}
 
 	return deployers.WaitWorkloadHealth(ctx, targetCluster, appNamespace)
-}
-
-// createNamespacesDiscoveredApps creates namespaces and adds annotations for discovered app protection
-// based on the Kubernetes distribution.
-// For Kubernetes, creates namespaces and adds annotation on both DR clusters for volsync based replication.
-// For OpenShift, creates namespace only on the target DR cluster (c2) before failover.
-// Returns an error if the distribution is unknown, and if namespace creation or annotation fails.
-func createNamespacesDiscoveredApps(ctx types.TestContext, namespace string) error {
-	switch ctx.Config().Distro {
-	case config.DistroK8s:
-		return util.CreateNamespaceAndAddAnnotation(ctx, namespace)
-	case config.DistroOcp:
-		return util.CreateNamespace(ctx, ctx.Env().C2, namespace)
-	default:
-		return fmt.Errorf("unknown distro: %s", ctx.Config().Distro)
-	}
 }

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -101,30 +100,6 @@ func getTargetCluster(
 	}
 
 	return targetCluster, nil
-}
-
-func waitDRPCDeleted(ctx types.TestContext, namespace string, name string) error {
-	log := ctx.Logger()
-	hub := ctx.Env().Hub
-
-	log.Debugf("Waiting until drpc \"%s/%s\" is deleted in cluster %q", namespace, name, hub.Name)
-
-	for {
-		_, err := getDRPC(ctx, namespace, name)
-		if err != nil {
-			if k8serrors.IsNotFound(err) {
-				log.Debugf("drpc \"%s/%s\" is deleted in cluster %q", namespace, name, hub.Name)
-
-				return nil
-			}
-
-			log.Debugf("Failed to get drpc \"%s/%s\" in cluster %q: %s", namespace, name, hub.Name, err)
-		}
-
-		if err := util.Sleep(ctx.Context(), util.RetryInterval); err != nil {
-			return fmt.Errorf("drpc %q is not deleted in cluster %q: %w", name, hub.Name, err)
-		}
-	}
 }
 
 // nolint:unparam

--- a/e2e/util/channel.go
+++ b/e2e/util/channel.go
@@ -26,7 +26,11 @@ func EnsureChannelDeleted(ctx types.Context) error {
 		return err
 	}
 
-	return DeleteNamespace(ctx, ctx.Env().Hub, ctx.Config().Channel.Namespace)
+	if err := DeleteNamespace(ctx, ctx.Env().Hub, ctx.Config().Channel.Namespace); err != nil {
+		return err
+	}
+
+	return WaitForNamespaceDelete(ctx, ctx.Env().Hub, ctx.Config().Channel.Namespace)
 }
 
 func createChannel(ctx types.Context) error {

--- a/e2e/util/namespace.go
+++ b/e2e/util/namespace.go
@@ -4,9 +4,6 @@
 package util
 
 import (
-	"fmt"
-	"time"
-
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,25 +60,7 @@ func DeleteNamespace(ctx types.Context, cluster types.Cluster, namespace string)
 		return nil
 	}
 
-	log.Debugf("Waiting until namespace %q is deleted in cluster %q", namespace, cluster.Name)
-
-	key := k8stypes.NamespacedName{Name: namespace}
-
-	for {
-		if err := cluster.Client.Get(ctx.Context(), key, ns); err != nil {
-			if !k8serrors.IsNotFound(err) {
-				return err
-			}
-
-			log.Debugf("Namespace %q deleted in cluster %q", namespace, cluster.Name)
-
-			return nil
-		}
-
-		if err := Sleep(ctx.Context(), time.Second); err != nil {
-			return fmt.Errorf("namespace %q not deleted in cluster %q: %w", namespace, cluster.Name, err)
-		}
-	}
+	return nil
 }
 
 // Problem: currently we must manually add an annotation to application’s namespace to make volsync work.

--- a/e2e/util/namespace.go
+++ b/e2e/util/namespace.go
@@ -10,19 +10,28 @@ import (
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 )
 
-// Namespace annotation for volsync to grant elevated permissions for mover pods
-// More info: https://volsync.readthedocs.io/en/stable/usage/permissionmodel.html#controlling-mover-permissions
-const volsyncPrivilegedMovers = "volsync.backube/privileged-movers"
+const (
+	// Namespace annotation for volsync to grant elevated permissions for mover pods
+	// More info: https://volsync.readthedocs.io/en/stable/usage/permissionmodel.html#controlling-mover-permissions
+	volsyncPrivilegedMovers = "volsync.backube/privileged-movers"
+
+	// Label to identify namespaces created by ramen e2e
+	ramenE2EManagedLabel = "app.kubernetes.io/managed-by"
+	ramenE2EManagedValue = "ramen-e2e"
+)
 
 func CreateNamespace(ctx types.Context, cluster types.Cluster, namespace string) error {
 	log := ctx.Logger()
-
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
+			Labels: map[string]string{
+				ramenE2EManagedLabel: ramenE2EManagedValue,
+			},
 		},
 	}
 
@@ -32,56 +41,86 @@ func CreateNamespace(ctx types.Context, cluster types.Cluster, namespace string)
 			return err
 		}
 
-		log.Debugf("Namespace %q already exist in cluster %q", namespace, cluster.Name)
+		log.Debugf("Namespace %q already exists in cluster %q", namespace, cluster.Name)
+	} else {
+		log.Debugf("Created namespace %q in cluster %q with label %s=%s",
+			namespace, cluster.Name, ramenE2EManagedLabel, ramenE2EManagedValue)
 	}
-
-	log.Debugf("Created namespace %q in cluster %q", namespace, cluster.Name)
 
 	return nil
 }
 
 func DeleteNamespace(ctx types.Context, cluster types.Cluster, namespace string) error {
 	log := ctx.Logger()
+	key := k8stypes.NamespacedName{Name: namespace}
+	objNs := &corev1.Namespace{}
 
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
-		},
+	err := cluster.Client.Get(ctx.Context(), key, objNs)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			log.Debugf("Namespace %q not found in cluster %q", namespace, cluster.Name)
+
+			return nil
+		}
+
+		return err
 	}
 
-	err := cluster.Client.Delete(ctx.Context(), ns)
+	labels := objNs.GetLabels()
+	if labels == nil || labels[ramenE2EManagedLabel] != ramenE2EManagedValue {
+		log.Debugf("Namespace %q in cluster %q is not managed by ramen-e2e, skipping deletion",
+			namespace, cluster.Name)
+
+		return nil
+	}
+
+	err = cluster.Client.Delete(ctx.Context(), objNs)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 
 		log.Debugf("Namespace %q not found in cluster %q", namespace, cluster.Name)
-
-		return nil
 	}
 
 	return nil
 }
 
+// CreateAppNamespaces creates a namespace on both drclusters with ramen-e2e label.
+// The label ensure safe deletion by allowing only ramen-e2e managed namespaces to be removed.
+// This prevents accidental deletion of namespaces not created by the e2e test framework.
+func CreateAppNamespaces(ctx types.Context, namespace string) error {
+	if err := CreateNamespace(ctx, ctx.Env().C1, namespace); err != nil {
+		return err
+	}
+
+	return CreateNamespace(ctx, ctx.Env().C2, namespace)
+}
+
+// DeleteAppNamespaces safely deletes a namespace from both drclusters.
+// Only deletes namespaces that were created by ramen-e2e.
+// This provides protection against accidentally deleting user or system namespaces.
+func DeleteAppNamespaces(ctx types.Context, namespace string) error {
+	if err := DeleteNamespace(ctx, ctx.Env().C1, namespace); err != nil {
+		return err
+	}
+
+	return DeleteNamespace(ctx, ctx.Env().C2, namespace)
+}
+
 // Problem: currently we must manually add an annotation to application’s namespace to make volsync work.
 // See this link https://volsync.readthedocs.io/en/stable/usage/permissionmodel.html#controlling-mover-permissions
-// Workaround: create ns in both drclusters and add annotation
-func CreateNamespaceAndAddAnnotation(ctx types.Context, namespace string) error {
-	env := ctx.Env()
+// Workaround: add volsync annotation on app namespaces on both drclusters
+func AddVolsyncAnnotation(ctx types.Context, namespace string) error {
+	if ctx.Config().Distro == config.DistroK8s {
+		if err := addNamespaceAnnotationForVolSync(ctx, ctx.Env().C1, namespace); err != nil {
+			return err
+		}
 
-	if err := CreateNamespace(ctx, env.C1, namespace); err != nil {
-		return err
+		return addNamespaceAnnotationForVolSync(ctx, ctx.Env().C2, namespace)
 	}
 
-	if err := addNamespaceAnnotationForVolSync(ctx, env.C1, namespace); err != nil {
-		return err
-	}
-
-	if err := CreateNamespace(ctx, env.C2, namespace); err != nil {
-		return err
-	}
-
-	return addNamespaceAnnotationForVolSync(ctx, env.C2, namespace)
+	return nil
 }
 
 func addNamespaceAnnotationForVolSync(ctx types.Context, cluster types.Cluster, namespace string) error {

--- a/e2e/util/wait.go
+++ b/e2e/util/wait.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	argocdv1alpha1hack "github.com/ramendr/ramen/e2e/argocd"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	ocmv1b1 "open-cluster-management.io/api/cluster/v1beta1"
+	ocmv1b2 "open-cluster-management.io/api/cluster/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ramendr/ramen/e2e/types"
+)
+
+func WaitForApplicationSetDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
+	obj := &argocdv1alpha1hack.ApplicationSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	return waitForResourceDelete(ctx, cluster, obj)
+}
+
+func WaitForConfigMapDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
+	obj := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	return waitForResourceDelete(ctx, cluster, obj)
+}
+
+func WaitForPlacementDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
+	obj := &ocmv1b1.Placement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	return waitForResourceDelete(ctx, cluster, obj)
+}
+
+func WaitForManagedClusterSetBindingDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
+	obj := &ocmv1b2.ManagedClusterSetBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	return waitForResourceDelete(ctx, cluster, obj)
+}
+
+// waitForResourceDelete waits until a resource is deleted or deadline is reached
+func waitForResourceDelete(ctx types.Context, cluster types.Cluster, obj client.Object) error {
+	log := ctx.Logger()
+	kind := getKind(obj)
+	key := k8stypes.NamespacedName{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+	resourceName := logName(obj)
+
+	log.Debugf("Waiting until %s %q is deleted in cluster %q", kind, resourceName, cluster.Name)
+
+	for {
+		if err := cluster.Client.Get(ctx.Context(), key, obj); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				return err
+			}
+
+			log.Debugf("%s %q deleted in cluster %q", kind, resourceName, cluster.Name)
+
+			return nil
+		}
+
+		if err := Sleep(ctx.Context(), time.Second); err != nil {
+			return fmt.Errorf("%s %q not deleted in cluster %q: %w", kind, resourceName, cluster.Name, err)
+		}
+	}
+}
+
+// getKind extracts resource type name from the object
+func getKind(obj client.Object) string {
+	t := reflect.TypeOf(obj)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	return t.Name()
+}
+
+// logName returns the resource name for logging (namespace/name or just name)
+func logName(obj client.Object) string {
+	if obj.GetNamespace() != "" {
+		return obj.GetNamespace() + "/" + obj.GetName()
+	}
+
+	return obj.GetName()
+}

--- a/e2e/util/wait.go
+++ b/e2e/util/wait.go
@@ -64,6 +64,16 @@ func WaitForManagedClusterSetBindingDelete(ctx types.Context, cluster types.Clus
 	return waitForResourceDelete(ctx, cluster, obj)
 }
 
+func WaitForNamespaceDelete(ctx types.Context, cluster types.Cluster, namespace string) error {
+	obj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+
+	return waitForResourceDelete(ctx, cluster, obj)
+}
+
 // waitForResourceDelete waits until a resource is deleted or deadline is reached
 func waitForResourceDelete(ctx types.Context, cluster types.Cluster, obj client.Object) error {
 	log := ctx.Logger()

--- a/e2e/util/wait.go
+++ b/e2e/util/wait.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"time"
 
+	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	argocdv1alpha1hack "github.com/ramendr/ramen/e2e/argocd"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -68,6 +69,17 @@ func WaitForNamespaceDelete(ctx types.Context, cluster types.Cluster, namespace 
 	obj := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
+		},
+	}
+
+	return waitForResourceDelete(ctx, cluster, obj)
+}
+
+func WaitForDRPCDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
+	obj := &ramen.DRPlacementControl{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
 		},
 	}
 

--- a/e2e/util/wait.go
+++ b/e2e/util/wait.go
@@ -75,6 +75,14 @@ func WaitForNamespaceDelete(ctx types.Context, cluster types.Cluster, namespace 
 	return waitForResourceDelete(ctx, cluster, obj)
 }
 
+func WaitForAppNamespacesDelete(ctx types.Context, namespace string) error {
+	if err := WaitForNamespaceDelete(ctx, ctx.Env().C1, namespace); err != nil {
+		return err
+	}
+
+	return WaitForNamespaceDelete(ctx, ctx.Env().C2, namespace)
+}
+
 func WaitForDRPCDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
 	obj := &ramen.DRPlacementControl{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This update ensures only namespaces created by ramen e2e can be deleted
safely using label.

- Implemented adding ramen-e2e label (app.kubernetes.io/managed-by=ramen-e2e)
  during ns creation to prevent accidental deletion by checking 
  whether the lable exist.
- Add CreateAppNamespaces/DeleteAppNamespaces functions to delete ns on
  both drclusters
- Consolidate volsync annotation logic into AddVolsyncAnnotation function
- Add WaitForAppNamespacesDelete for consistent ns cleanup waiting on
  both drclusters


Testing:

Namespaces created during tests on both dr clusters:

```
$kubectl get namespace --context=dr2 | grep e2e
e2e-appset-deploy-cephfs-busybox      Active   18s
e2e-appset-deploy-rbd-busybox         Active   18s
e2e-disapp-deploy-cephfs-busybox      Active   18s
e2e-disapp-deploy-rbd-busybox         Active   18s
e2e-subscr-deploy-cephfs-busybox      Active   18s
e2e-subscr-deploy-rbd-busybox         Active   18s

$ kubectl get namespace --context=dr1 | grep e2e
e2e-appset-deploy-cephfs-busybox      Active   21s
e2e-appset-deploy-rbd-busybox         Active   21s
e2e-disapp-deploy-cephfs-busybox      Active   21s
e2e-disapp-deploy-rbd-busybox         Active   21s
e2e-subscr-deploy-cephfs-busybox      Active   21s
e2e-subscr-deploy-rbd-busybox         Active   21s
```

Namespaces deleted during undeploy:

```
$ kubectl get namespace --context=dr2 | grep e2e

$ kubectl get namespace --context=dr1 | grep e2e
```
Based on #2035 