### PR TITLE
e2e: Fix windows compatibility

### DIFF
--- a/e2e/util/exec.go
+++ b/e2e/util/exec.go
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// RunCommand runs a command and return the error. The command will be killed when the context is canceled or the
+// deadline is exceeded.
+func RunCommand(ctx context.Context, command string, args ...string) error {
+	cmd := exec.CommandContext(ctx, command, args...)
+
+	// Run the command in a new process group so it is not terminated by the shell when the user interrupt go test.
+	cmd.SysProcAttr = &runInBackground
+
+	if out, err := cmd.Output(); err != nil {
+		// If the context was canceled or the deadline exceeded, ignore the unhelpful "killed" error from the command.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if ee, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("%w: stdout=%q stderr=%q", err, out, ee.Stderr)
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/e2e/util/exec_other.go
+++ b/e2e/util/exec_other.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import "syscall"
+
+var runInBackground = syscall.SysProcAttr{
+	Setpgid: true,
+}

--- a/e2e/util/exec_windows.go
+++ b/e2e/util/exec_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import "syscall"
+
+var runInBackground = syscall.SysProcAttr{
+	CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+}


### PR DESCRIPTION
In #2049 we started to use:

    syscall.SysProcAttr{Setpgid: true}

This does not compile on windows, which should use:

    syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}

For ramenctl we must support windows. For ramen/e2e this is not required but nice to have.

Fixed by moving runCommand() to util.RunCommand(), and adding windows and non-windows version of the syscall.SysProcAttr.