### PR TITLE
Fix for UT failure at protects kube objects

### DIFF
--- a/internal/controller/protectedvolumereplicationgrouplist_controller_test.go
+++ b/internal/controller/protectedvolumereplicationgrouplist_controller_test.go
@@ -134,6 +134,10 @@ func vrgStatusStateUpdate(vrgS3, vrgK8s *ramen.VolumeReplicationGroup) {
 		vrgS3.ResourceVersion = vrgK8s.ResourceVersion
 		vrgS3.Status.LastUpdateTime = vrgK8s.Status.LastUpdateTime
 	}
+
+	if vrgS3.Status.State == vrgK8s.Status.State {
+		vrgS3.Status.LastUpdateTime = vrgK8s.Status.LastUpdateTime
+	}
 }
 
 var _ = Describe("ProtectedVolumeReplicationGroupListController", func() {


### PR DESCRIPTION
Fix for "protects kube objects" UT failure.
Following are the few of the reasons why we see UT failures:
1. There is inconsistent upload and download of the object, as part of test these objects are compared and failed to match.
The sequence of the steps in the test are as follows:

> 1. Upload is done by VRG controller.
> 2. Download is done by ProtectedVolumeReplicationGroupList(PVRGL) and the the object is updated within its CR Status.
> 3. From the test the object is downloaded from fake S3 again and compared against the PVRGL status. 

In the above steps the problem is in between the step#1 and step#2, because even before VRG object is uploaded to S3 bucket PVRGL downloads it. The downloaded objects are compared against PVRGL status and we notice a mismatch.

Fix: This has been fixed by waiting until condition ClusterDataProtected.Reason=Uploaded to create PVRGL object.

2. Same fake S3 bucket (which is a map of key and an k8s object) used in every test context without cleanup of the map. The stale data from the previous tests caused inconsistent behavior in the trailing tests.

3. Within the VRG test, vrg object status is updated which conflicts with the updates done on the object by the controller leading to errors like :
```
 Operation cannot be fulfilled on volumereplicationgroups.ramendr.openshift.io "vrg-lgeec": the object has been modified; please apply your changes to the latest version and try again
```
4. VRG controller keeps uploading the VRG object to S3 bucket with its updated "lastUpdateTime" which is being compared against the same VRG object downloaded by ProtectedVolumeReplicationGroupList controller. This leads to object mismatch due to the difference in timestamp.

![Image](https://github.com/user-attachments/assets/f7ede7dd-f9cc-422b-bc62-82a47652e6e5)


Tested locally and it works.
```
/root/DR/VM_DR_Within_NS/defect-fix/fence-off/blocker-fix/latest/latest/ramen/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
/root/DR/VM_DR_Within_NS/defect-fix/fence-off/blocker-fix/latest/latest/ramen/bin/controller-gen rbac:roleName=operator-role crd:generateEmbeddedObjectMeta=true webhook paths="./..." output:crd:artifacts:config=config/crd/bases
hack/install-setup-envtest.sh
go test ./... -coverprofile cover.out
	github.com/ramendr/ramen/hack/fakes		coverage: 0.0% of statements
	github.com/ramendr/ramen/cmd		coverage: 0.0% of statements
?   	github.com/ramendr/ramen/internal/controller/core	[no test files]
	github.com/ramendr/ramen/internal/controller/kubeobjects/velero		coverage: 0.0% of statements
	github.com/ramendr/ramen/internal/controller/testutils		coverage: 0.0% of statements
	github.com/ramendr/ramen/internal/controller/argocd		coverage: 0.0% of statements
ok  	github.com/ramendr/ramen/internal/controller	198.013s	coverage: 64.4% of statements
ok  	github.com/ramendr/ramen/internal/controller/cel	27.750s	coverage: [no statements]
ok  	github.com/ramendr/ramen/internal/controller/cephfscg	26.694s	coverage: 64.6% of statements
ok  	github.com/ramendr/ramen/internal/controller/hooks	0.493s	coverage: 43.0% of statements
ok  	github.com/ramendr/ramen/internal/controller/kubeobjects	0.325s	coverage: 33.3% of statements
ok  	github.com/ramendr/ramen/internal/controller/util	25.274s	coverage: 25.1% of statements
ok  	github.com/ramendr/ramen/internal/controller/volsync	41.292s	coverage: 45.6% of statements
```

Fixes: #2060 