### PR TITLE
docs: Require clusteradm 0.11.0

### DIFF
--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -144,13 +144,13 @@ enough resources:
 1. Install the `clusteradm` tool
 
    ```
-   curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+   curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash -s 0.11.0
    ```
 
    For more info see
    [Install clusteradm CLI tool](https://open-cluster-management.io/docs/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool).
-   Version v0.8.1 or later is required.
-   Tested with version v0.11.0-0-g73281f6.
+
+   **WARNING**: clusteradm 0.11.1 is not compatible
 
 1. Install the `subctl` tool
 

--- a/test/README.md
+++ b/test/README.md
@@ -53,13 +53,13 @@ environment.
 1. Install the `clusteradm` tool
 
    ```
-   curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+   curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash -s 0.11.0
    ```
 
    For more info see
    [Install clusteradm CLI tool](https://open-cluster-management.io/docs/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool).
-   Version v0.8.1 or later is required.
-   Tested with version v0.11.0-0-g73281f6.
+
+   **WARNING**: clusteradm 0.11.1 is not compatible
 
 1. Install the `subctl` tool
 
@@ -175,13 +175,13 @@ environment.
 1. Install the `clusteradm` tool
 
    ```
-   curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
+   curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash -s 0.11.0
    ```
 
    For more info see
    [Install clusteradm CLI tool](https://open-cluster-management.io/docs/getting-started/installation/start-the-control-plane/#install-clusteradm-cli-tool).
-   Version v0.8.1 or later is required.
-   Tested with version v0.11.0-0-g73281f6.
+
+   **WARNING**: clusteradm 0.11.1 is not compatible
 
 1. Install the `subctl` tool
 


### PR DESCRIPTION
Latest clusteradm (0.11.1) made incompatible change[1], replacing
application-manager with argocd. This can simplify drenv by installing
argocd for use, but it breaks current code.

Until we change drenv we must continue using clusteradm 0.11.0 and ocm 
0.16.0.

[1] https://github.com/open-cluster-management-io/clusteradm/issues/489

Fixes #2059 