### PR TITLE
Fix for panic in kubeObjectsCaptureStartOrResume()

### DIFF
--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -125,6 +125,8 @@ func (r *VolumeReplicationGroupReconciler) SetupWithManager(
 		r.Log.Info("Kube object protection disabled; don't watch kube objects requests")
 	}
 
+	r.recipeStatus = make(map[string]*util.RecipeStatus)
+
 	return ctrlBuilder.Complete(r)
 }
 


### PR DESCRIPTION
Panic due to uninitialized map in volumereplicationgroup_controller

```
2025-05-29T16:14:26.471Z	ERROR	controller/vrg_kubeobjects.go:248	Observed a panic	{"controller": "volumereplicationgroup", "controllerGroup": "ramendr.openshift.io", "controllerKind": "VolumeReplicationGroup", "VolumeReplicationGroup": {"name":"vm-cirros-dr","namespace":"ramen-ops"}, "namespace": "ramen-ops", "name": "vm-cirros-dr", "reconcileID": "c0fa2e7a-6ede-4cf3-9da4-2d6250e02d11", "panic": "assignment to entry in nil map", "panicGoValue": "\"assignment to entry in nil map\"", "stacktrace": "goroutine 601 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x262b638, 0xc0015943c0}, {0x1eabbe0, 0x2604650})
\t/go/pkg/mod/k8s.io/apimachinery@v0.32.0/pkg/util/runtime/runtime.go:107 +0xbc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile.func1()
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.3/pkg/internal/controller/controller.go:105 +0x114
panic({0x1eabbe0?, 0x2604650?})
\t/usr/local/go/src/runtime/panic.go:791 +0x132
github.com/ramendr/ramen/internal/controller.(*VRGInstance).kubeObjectsCaptureStartOrResume(0xc001402248, 0xc001402458, 0x2306d10, 0x2306c40, 0x0, {0xc000c37710, 0x26}, {0xc001529600, 0x35}, {0xc0017bb800, ...}, ...)
\t/workspace/internal/controller/vrg_kubeobjects.go:248 +0x3e7
github.com/ramendr/ramen/internal/controller.(*VRGInstance).kubeObjectsCaptureStartOrResumeOrDelay.func1(0x2, {0x21a0c8e, 0x6})
\t/workspace/internal/controller/vrg_kubeobjects.go:145 +0x2c5
github.com/ramendr/ramen/internal/controller.(*VRGInstance).kubeObjectsCaptureStartOrResumeOrDelay(0xc001402248, 0xc001402458, 0x2306d10, 0x2306c40, 0xc0017fe540)
\t/workspace/internal/controller/vrg_kubeobjects.go:156 +0x689
github.com/ramendr/ramen/internal/controller.(*VRGInstance).kubeObjectsProtect(0xc001402248, 0xc001402458, 0x2306d10, 0x2306c40)
\t/workspace/internal/controller/vrg_kubeobjects.go:110 +0x17a
github.com/ramendr/ramen/internal/controller.(*VRGInstance).kubeObjectsProtectPrimary(0xc001402248?, 0xc000cc39e0?)
\t/workspace/internal/controller/vrg_kubeobjects.go:71 +0x66
github.com/ramendr/ramen/internal/controller.(*VRGInstance).processAsPrimary(0xc001402248)
\t/workspace/internal/controller/volumereplicationgroup_controller.go:1353 +0x3fe
github.com/ramendr/ramen/internal/controller.(*VRGInstance).processVRG(0xc001402248)
\t/workspace/internal/controller/volumereplicationgroup_controller.go:600 +0x6ed
github.com/ramendr/ramen/internal/controller.(*VolumeReplicationGroupReconciler).Reconcile(0xc00086a800, {0x262b638, 0xc0015943c0}, {{{0xc0016bcfb0, 0x9}, {0xc0016bcfa0, 0xc}}})
\t/workspace/internal/controller/volumereplicationgroup_controller.go:473 +0xb96
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile(0xc001594330?, {0x262b638?, 0xc0015943c0?}, {{{0xc0016bcfb0?, 0x0?}, {0xc0016bcfa0?, 0x0?}}})
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.3/pkg/internal/controller/controller.go:116 +0xbf
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler(0x263d4e0, {0x262b670, 0xc000841630}, {{{0xc0016bcfb0, 0x9}, {0xc0016bcfa0, 0xc}}})
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.3/pkg/internal/controller/controller.go:303 +0x398
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem(0x263d4e0, {0x262b670, 0xc000841630})
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.3/pkg/internal/controller/controller.go:263 +0x230
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2()
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.3/pkg/internal/controller/controller.go:224 +0x85
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2 in goroutine 143
\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.3/pkg/internal/controller/controller.go:220 +0x490
"}
```

Fixes #2069