### PR TITLE
e2e: add workload health validation to DR ops and refactor cluster name handling

### DIFF
--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -54,7 +54,7 @@ func (a ApplicationSet) Undeploy(ctx types.TestContext) error {
 	log := ctx.Logger()
 	managementNamespace := ctx.ManagementNamespace()
 
-	clusterName, err := util.GetCurrentCluster(ctx, managementNamespace, name)
+	cluster, err := util.GetCurrentCluster(ctx, managementNamespace, name)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
@@ -64,7 +64,7 @@ func (a ApplicationSet) Undeploy(ctx types.TestContext) error {
 		log.Infof("Undeploying applicationset app \"%s/%s\"", ctx.AppNamespace(), ctx.Workload().GetAppName())
 	} else {
 		log.Infof("Undeploying applicationset app \"%s/%s\" in cluster %q",
-			ctx.AppNamespace(), ctx.Workload().GetAppName(), clusterName)
+			ctx.AppNamespace(), ctx.Workload().GetAppName(), cluster.Name)
 	}
 
 	err = DeleteApplicationSet(ctx, a)

--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -42,6 +42,10 @@ func (a ApplicationSet) Deploy(ctx types.TestContext) error {
 		return err
 	}
 
+	if err = WaitWorkloadHealth(ctx, cluster, ctx.AppNamespace()); err != nil {
+		return err
+	}
+
 	log.Info("Workload deployed")
 
 	return nil

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -59,7 +59,7 @@ func (d DiscoveredApp) Deploy(ctx types.TestContext) error {
 		return err
 	}
 
-	if err = WaitWorkloadHealth(ctx, ctx.Env().C1, appNamespace); err != nil {
+	if err = WaitWorkloadHealth(ctx, cluster, appNamespace); err != nil {
 		return err
 	}
 

--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -43,6 +43,8 @@ func WaitWorkloadHealth(ctx types.TestContext, cluster types.Cluster, namespace 
 	log := ctx.Logger()
 	w := ctx.Workload()
 
+	log.Debugf("Waiting until workload \"%s/%s\" is healthy in cluster %q", namespace, w.GetAppName(), cluster.Name)
+
 	for {
 		err := w.Health(ctx, cluster, namespace)
 		if err == nil {
@@ -52,8 +54,8 @@ func WaitWorkloadHealth(ctx types.TestContext, cluster types.Cluster, namespace 
 		}
 
 		if err := util.Sleep(ctx.Context(), util.RetryInterval); err != nil {
-			return fmt.Errorf("workload %q is not healthy in cluster %q: %w",
-				w.GetName(), cluster.Name, err)
+			return fmt.Errorf("workload \"%s/%s\" is not healthy in cluster %q: %w",
+				namespace, w.GetAppName(), cluster.Name, err)
 		}
 	}
 }

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -83,7 +83,7 @@ func (s Subscription) Undeploy(ctx types.TestContext) error {
 	config := ctx.Config()
 	managementNamespace := ctx.ManagementNamespace()
 
-	clusterName, err := util.GetCurrentCluster(ctx, managementNamespace, name)
+	cluster, err := util.GetCurrentCluster(ctx, managementNamespace, name)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
@@ -93,7 +93,7 @@ func (s Subscription) Undeploy(ctx types.TestContext) error {
 		log.Infof("Undeploying subscription app \"%s/%s\"", ctx.AppNamespace(), ctx.Workload().GetAppName())
 	} else {
 		log.Infof("Undeploying subscription app \"%s/%s\" in cluster %q",
-			ctx.AppNamespace(), ctx.Workload().GetAppName(), clusterName)
+			ctx.AppNamespace(), ctx.Workload().GetAppName(), cluster.Name)
 	}
 
 	err = DeleteSubscription(ctx, s)

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -71,6 +71,10 @@ func (s Subscription) Deploy(ctx types.TestContext) error {
 		return err
 	}
 
+	if err = WaitWorkloadHealth(ctx, cluster, ctx.AppNamespace()); err != nil {
+		return err
+	}
+
 	log.Info("Workload deployed")
 
 	return nil

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -211,7 +211,7 @@ func failoverRelocate(
 	drpcName := ctx.Name()
 	managementNamespace := ctx.ManagementNamespace()
 
-	if err := waitAndUpdateDRPC(ctx, managementNamespace, drpcName, action, targetCluster.Name); err != nil {
+	if err := waitAndUpdateDRPC(ctx, managementNamespace, drpcName, action, targetCluster); err != nil {
 		return err
 	}
 
@@ -226,7 +226,7 @@ func waitAndUpdateDRPC(
 	ctx types.TestContext,
 	namespace, drpcName string,
 	action ramen.DRAction,
-	targetCluster string,
+	targetCluster types.Cluster,
 ) error {
 	log := ctx.Logger()
 
@@ -243,9 +243,9 @@ func waitAndUpdateDRPC(
 
 		drpc.Spec.Action = action
 		if action == ramen.ActionFailover {
-			drpc.Spec.FailoverCluster = targetCluster
+			drpc.Spec.FailoverCluster = targetCluster.Name
 		} else {
-			drpc.Spec.PreferredCluster = targetCluster
+			drpc.Spec.PreferredCluster = targetCluster.Name
 		}
 
 		if err := updateDRPC(ctx, drpc); err != nil {
@@ -253,7 +253,7 @@ func waitAndUpdateDRPC(
 		}
 
 		log.Debugf("Updated drpc \"%s/%s\" with action %q to target cluster %q",
-			namespace, drpcName, action, targetCluster)
+			namespace, drpcName, action, targetCluster.Name)
 
 		return nil
 	})

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -152,9 +152,9 @@ func Failover(ctx types.TestContext) error {
 	}
 
 	log.Infof("Failing over workload \"%s/%s\" from cluster %q to cluster %q",
-		ctx.AppNamespace(), ctx.Workload().GetAppName(), currentCluster.Name, targetCluster)
+		ctx.AppNamespace(), ctx.Workload().GetAppName(), currentCluster.Name, targetCluster.Name)
 
-	err = failoverRelocate(ctx, ramen.ActionFailover, ramen.FailedOver, currentCluster.Name, targetCluster)
+	err = failoverRelocate(ctx, ramen.ActionFailover, ramen.FailedOver, currentCluster.Name, targetCluster.Name)
 	if err != nil {
 		return err
 	}
@@ -185,9 +185,9 @@ func Relocate(ctx types.TestContext) error {
 	}
 
 	log.Infof("Relocating workload \"%s/%s\" from cluster %q to cluster %q",
-		ctx.AppNamespace(), ctx.Workload().GetAppName(), currentCluster.Name, targetCluster)
+		ctx.AppNamespace(), ctx.Workload().GetAppName(), currentCluster.Name, targetCluster.Name)
 
-	err = failoverRelocate(ctx, ramen.ActionRelocate, ramen.Relocated, currentCluster.Name, targetCluster)
+	err = failoverRelocate(ctx, ramen.ActionRelocate, ramen.Relocated, currentCluster.Name, targetCluster.Name)
 	if err != nil {
 		return err
 	}

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -154,7 +154,7 @@ func Failover(ctx types.TestContext) error {
 	log.Infof("Failing over workload \"%s/%s\" from cluster %q to cluster %q",
 		ctx.AppNamespace(), ctx.Workload().GetAppName(), currentCluster.Name, targetCluster.Name)
 
-	err = failoverRelocate(ctx, ramen.ActionFailover, ramen.FailedOver, currentCluster.Name, targetCluster.Name)
+	err = failoverRelocate(ctx, ramen.ActionFailover, ramen.FailedOver, currentCluster, targetCluster)
 	if err != nil {
 		return err
 	}
@@ -187,7 +187,7 @@ func Relocate(ctx types.TestContext) error {
 	log.Infof("Relocating workload \"%s/%s\" from cluster %q to cluster %q",
 		ctx.AppNamespace(), ctx.Workload().GetAppName(), currentCluster.Name, targetCluster.Name)
 
-	err = failoverRelocate(ctx, ramen.ActionRelocate, ramen.Relocated, currentCluster.Name, targetCluster.Name)
+	err = failoverRelocate(ctx, ramen.ActionRelocate, ramen.Relocated, currentCluster, targetCluster)
 	if err != nil {
 		return err
 	}
@@ -201,8 +201,7 @@ func failoverRelocate(
 	ctx types.TestContext,
 	action ramen.DRAction,
 	state ramen.DRState,
-	currentCluster string,
-	targetCluster string,
+	currentCluster, targetCluster types.Cluster,
 ) error {
 	d := ctx.Deployer()
 	if d.IsDiscovered() {
@@ -212,7 +211,7 @@ func failoverRelocate(
 	drpcName := ctx.Name()
 	managementNamespace := ctx.ManagementNamespace()
 
-	if err := waitAndUpdateDRPC(ctx, managementNamespace, drpcName, action, targetCluster); err != nil {
+	if err := waitAndUpdateDRPC(ctx, managementNamespace, drpcName, action, targetCluster.Name); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -58,6 +58,10 @@ func EnableProtectionDiscoveredApps(ctx types.TestContext) error {
 		return err
 	}
 
+	if err = deployers.WaitWorkloadHealth(ctx, cluster, appNamespace); err != nil {
+		return err
+	}
+
 	log.Info("Workload protected")
 
 	return nil

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -133,7 +133,7 @@ func failoverRelocateDiscoveredApps(
 
 	drpcName := name
 
-	if err := waitAndUpdateDRPC(ctx, managementNamespace, drpcName, action, targetCluster.Name); err != nil {
+	if err := waitAndUpdateDRPC(ctx, managementNamespace, drpcName, action, targetCluster); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -75,7 +75,7 @@ func DisableProtectionDiscoveredApps(ctx types.TestContext) error {
 	placementName := name
 	drpcName := name
 
-	clusterName, err := util.GetCurrentCluster(ctx, managementNamespace, placementName)
+	cluster, err := util.GetCurrentCluster(ctx, managementNamespace, placementName)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
 			return err
@@ -85,7 +85,7 @@ func DisableProtectionDiscoveredApps(ctx types.TestContext) error {
 		log.Infof("Unprotecting workload \"%s/%s\"", appNamespace, ctx.Workload().GetAppName())
 	} else {
 		log.Infof("Unprotecting workload \"%s/%s\" in cluster %q",
-			appNamespace, ctx.Workload().GetAppName(), clusterName)
+			appNamespace, ctx.Workload().GetAppName(), cluster.Name)
 	}
 
 	if err := deleteDRPC(ctx, managementNamespace, drpcName); err != nil {

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -7,7 +7,6 @@ import (
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 
 	"github.com/ramendr/ramen/e2e/deployers"
-	"github.com/ramendr/ramen/e2e/env"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -144,7 +143,7 @@ func failoverRelocateDiscoveredApps(
 		return err
 	}
 
-	currentCluster, err := env.GetCluster(ctx.Env(), currentClusterName)
+	currentCluster, err := ctx.Env().GetCluster(currentClusterName)
 	if err != nil {
 		return err
 	}
@@ -162,7 +161,7 @@ func failoverRelocateDiscoveredApps(
 		return err
 	}
 
-	targetCluster, err := env.GetCluster(ctx.Env(), targetClusterName)
+	targetCluster, err := ctx.Env().GetCluster(targetClusterName)
 	if err != nil {
 		return err
 	}

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -125,8 +125,7 @@ func failoverRelocateDiscoveredApps(
 	ctx types.TestContext,
 	action ramen.DRAction,
 	state ramen.DRState,
-	currentClusterName string,
-	targetClusterName string,
+	currentCluster, targetCluster types.Cluster,
 ) error {
 	name := ctx.Name()
 	managementNamespace := ctx.ManagementNamespace()
@@ -134,17 +133,12 @@ func failoverRelocateDiscoveredApps(
 
 	drpcName := name
 
-	if err := waitAndUpdateDRPC(ctx, managementNamespace, drpcName, action, targetClusterName); err != nil {
+	if err := waitAndUpdateDRPC(ctx, managementNamespace, drpcName, action, targetCluster.Name); err != nil {
 		return err
 	}
 
 	if err := waitDRPCProgression(ctx, managementNamespace, name,
 		ramen.ProgressionWaitOnUserToCleanUp); err != nil {
-		return err
-	}
-
-	currentCluster, err := ctx.Env().GetCluster(currentClusterName)
-	if err != nil {
 		return err
 	}
 
@@ -158,11 +152,6 @@ func failoverRelocateDiscoveredApps(
 	}
 
 	if err := waitDRPCReady(ctx, managementNamespace, name); err != nil {
-		return err
-	}
-
-	targetCluster, err := ctx.Env().GetCluster(targetClusterName)
-	if err != nil {
 		return err
 	}
 

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -86,20 +86,20 @@ func getTargetCluster(
 	ctx types.TestContext,
 	cluster types.Cluster,
 	drPolicyName, currentCluster string,
-) (string, error) {
+) (types.Cluster, error) {
 	drpolicy, err := util.GetDRPolicy(ctx, cluster, drPolicyName)
 	if err != nil {
-		return "", err
+		return types.Cluster{}, err
 	}
 
-	var targetCluster string
+	var targetClusterName string
 	if currentCluster == drpolicy.Spec.DRClusters[0] {
-		targetCluster = drpolicy.Spec.DRClusters[1]
+		targetClusterName = drpolicy.Spec.DRClusters[1]
 	} else {
-		targetCluster = drpolicy.Spec.DRClusters[0]
+		targetClusterName = drpolicy.Spec.DRClusters[0]
 	}
 
-	return targetCluster, nil
+	return ctx.Env().GetCluster(targetClusterName)
 }
 
 // nolint:unparam

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -153,18 +153,3 @@ func New(ctx context.Context, config *types.Config, log *zap.SugaredLogger) (*ty
 
 	return env, nil
 }
-
-// GetCluster returns the cluster from the env that matches clusterName.
-// If not found, it returns an empty Cluster and an error.
-func GetCluster(env *types.Env, clusterName string) (types.Cluster, error) {
-	switch clusterName {
-	case env.C1.Name:
-		return env.C1, nil
-	case env.C2.Name:
-		return env.C2, nil
-	case env.Hub.Name:
-		return env.Hub, nil
-	default:
-		return types.Cluster{}, fmt.Errorf("cluster %q not found in environment", clusterName)
-	}
-}

--- a/e2e/types/env.go
+++ b/e2e/types/env.go
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package types
+
+import "fmt"
+
+// GetCluster returns the cluster from the env that matches clusterName.
+// If not found, it returns an empty Cluster and an error.
+func (e *Env) GetCluster(clusterName string) (Cluster, error) {
+	switch clusterName {
+	case e.C1.Name:
+		return e.C1, nil
+	case e.C2.Name:
+		return e.C2, nil
+	case e.Hub.Name:
+		return e.Hub, nil
+	default:
+		return Cluster{}, fmt.Errorf("cluster %q not found in environment", clusterName)
+	}
+}

--- a/e2e/util/placement.go
+++ b/e2e/util/placement.go
@@ -16,17 +16,17 @@ import (
 // TODO: Carried over from internal/controllers, this is not part of API, may need a better way to reference it!
 const PlacementDecisionReasonFailoverRetained = "RetainedForFailover"
 
-// GetCurrentCluster returns the name of the cluster where the workload is currently placed,
-// based on the PlacementDecision for the given Placement resource.
-// Assumes the PlacementDecision exists with a Decision.
+// GetCurrentCluster retrieves the cluster object where the workload is currently placed
+// by looking up the cluster name from the PlacementDecision and returning the corresponding
+// cluster from the environment. Requires an existing PlacementDecision with a valid decision.
 // Not applicable for discovered apps before enabling protection, as no Placement exists.
-func GetCurrentCluster(ctx types.Context, namespace string, placementName string) (string, error) {
+func GetCurrentCluster(ctx types.Context, namespace string, placementName string) (types.Cluster, error) {
 	clusterDecision, err := getClusterDecisionFromPlacement(ctx, namespace, placementName)
 	if err != nil {
-		return "", err
+		return types.Cluster{}, err
 	}
 
-	return clusterDecision.ClusterName, nil
+	return ctx.Env().GetCluster(clusterDecision.ClusterName)
 }
 
 func GetPlacement(ctx types.Context, namespace, name string) (*v1beta1.Placement, error) {

--- a/e2e/workloads/deploy.go
+++ b/e2e/workloads/deploy.go
@@ -97,7 +97,8 @@ func (w Deployment) Health(ctx types.TestContext, cluster types.Cluster, namespa
 		return nil
 	}
 
-	return nil
+	return fmt.Errorf("deployment \"%s/%s\" not ready in cluster %q: %d/%d replicas ready",
+		namespace, w.GetAppName(), cluster.Name, deploy.Status.ReadyReplicas, deploy.Status.Replicas)
 }
 
 func getDeployment(ctx types.TestContext, cluster types.Cluster, namespace, name string) (*appsv1.Deployment, error) {

--- a/e2e/workloads/deploy.go
+++ b/e2e/workloads/deploy.go
@@ -84,16 +84,12 @@ func (w Deployment) GetResources() error {
 
 // Check the workload health deployed in a cluster namespace
 func (w Deployment) Health(ctx types.TestContext, cluster types.Cluster, namespace string) error {
-	log := ctx.Logger()
-
 	deploy, err := getDeployment(ctx, cluster, namespace, w.GetAppName())
 	if err != nil {
 		return err
 	}
 
 	if deploy.Status.Replicas == deploy.Status.ReadyReplicas {
-		log.Debugf("Deployment \"%s/%s\" is ready in cluster %q", namespace, w.GetAppName(), cluster.Name)
-
 		return nil
 	}
 


### PR DESCRIPTION
This PR adds workload health validation to all DR operations and deployer methods to ensure workloads are fully operational before considering operations successful. The implementation required refactoring to work with cluster objects instead of cluster name strings.

### Changes Made

Workload Health Validation:
- Added health validation after all deployment operations (ApplicationSet & Subscription)
- Added health validation after DR protection enable operation for both regular and discovered apps
- Added health validation after failover/relocate operations to ensure workloads are healthy on target clusters

Cluster Handling Refactoring: 
Moved GetCluster from standalone function to method on *Env type, updated functions to return and accept types.Cluster objects instead of cluster name strings, and refactored failoverRelocate functions to eliminate redundant cluster lookups.



Fixes #2018 