### PR TITLE
Fix CephFS CG Enablement by also checking the CRD presence

### DIFF
--- a/internal/controller/replicationgroupsource_controller.go
+++ b/internal/controller/replicationgroupsource_controller.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-logr/logr"
 	vgsv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -142,10 +141,7 @@ func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ct
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReplicationGroupSourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	vgsCRD := &apiextensionsv1.CustomResourceDefinition{}
-	if err := r.APIReader.Get(context.TODO(),
-		types.NamespacedName{Name: "volumegroupsnapshots.groupsnapshot.storage.k8s.io"}, vgsCRD,
-	); err == nil {
+	if util.IsCRDInstalled(context.TODO(), r.Client, util.VGSCRDName) {
 		r.volumeGroupSnapshotCRsAreWatched = true
 	}
 

--- a/internal/controller/replicationgroupsource_controller.go
+++ b/internal/controller/replicationgroupsource_controller.go
@@ -141,7 +141,7 @@ func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ct
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReplicationGroupSourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	if util.IsCRDInstalled(context.TODO(), r.Client, util.VGSCRDName) {
+	if util.IsCRDInstalled(context.TODO(), r.APIReader, util.VGSCRDName) {
 		r.volumeGroupSnapshotCRsAreWatched = true
 	}
 

--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -35,6 +35,8 @@ const (
 	ServiceNameMaxLength = validation.DNS1123LabelMaxLength
 
 	CreatedByRamenLabel = "ramendr.openshift.io/created-by-ramen"
+
+	VGSCRDName = "volumegroupsnapshots.groupsnapshot.storage.k8s.io"
 )
 
 type ResourceUpdater struct {
@@ -270,9 +272,7 @@ func IsCRDInstalled(ctx context.Context, client client.Client, crdName string) b
 // 2. Whether the VolumeGroupSnapshot CRD is installed.
 // Both conditions must be true for CephFS CG protection to be considered enabled.
 func IsCGEnabledForVolSync(ctx context.Context, client client.Client, annotations map[string]string) bool {
-	crdName := "volumegroupsnapshots.groupsnapshot.storage.k8s.io"
-
-	return IsCGEnabled(annotations) && IsCRDInstalled(ctx, client, crdName)
+	return IsCGEnabled(annotations) && IsCRDInstalled(ctx, client, VGSCRDName)
 }
 
 func IsPVCMarkedForVolSync(annotations map[string]string) bool {

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -819,7 +819,7 @@ func (v *VSHandler) PreparePVC(pvcNamespacedName types.NamespacedName,
 		}
 	}
 
-	if prepFinalSync && !util.IsCGEnabled(v.owner.GetAnnotations()) {
+	if prepFinalSync && !util.IsCGEnabledForVolSync(v.ctx, v.client, v.owner.GetAnnotations()) {
 		err := v.prepareForFinalSync(pvcNamespacedName)
 		if err != nil {
 			return err

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -39,7 +39,7 @@ func (v *VRGInstance) restorePVsAndPVCsForVolSync() (int, error) {
 		rdSpec.ProtectedPVC.Conditions = nil
 
 		cgLabelVal, ok := rdSpec.ProtectedPVC.Labels[ConsistencyGroupLabel]
-		if ok && util.IsCGEnabled(v.instance.Annotations) {
+		if ok && util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader, v.instance.Annotations) {
 			v.log.Info("The CG label from the primary cluster found in RDSpec", "Label", cgLabelVal)
 			// Get the CG label value for this cluster
 			cgLabelVal, err = v.getCGLabelValue(rdSpec.ProtectedPVC.StorageClassName,
@@ -190,7 +190,7 @@ func (v *VRGInstance) reconcilePVCAsVolSyncPrimary(pvc corev1.PersistentVolumeCl
 	*finalSyncPrepared = true
 
 	cg, ok := pvc.Labels[ConsistencyGroupLabel]
-	if ok && util.IsCGEnabled(v.instance.Annotations) {
+	if ok && util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader, v.instance.Annotations) {
 		v.log.Info("PVC has CG label", "Labels", pvc.Labels)
 		cephfsCGHandler := cephfscg.NewVSCGHandler(
 			v.ctx, v.reconciler.Client, v.instance,
@@ -355,7 +355,7 @@ func (v *VRGInstance) reconcileCGMembership() (map[string]struct{}, bool, error)
 
 	for _, rdSpec := range v.instance.Spec.VolSync.RDSpec {
 		cgLabelVal, ok := rdSpec.ProtectedPVC.Labels[ConsistencyGroupLabel]
-		if ok && util.IsCGEnabled(v.instance.Annotations) {
+		if ok && util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader, v.instance.Annotations) {
 			v.log.Info("RDSpec contains the CG label from the primary cluster", "Label", cgLabelVal)
 			// Get the CG label value for this cluster
 			cgLabelVal, err := v.getCGLabelValue(rdSpec.ProtectedPVC.StorageClassName,


### PR DESCRIPTION
This pull request updates the codebase to use the `IsCGEnabledForVolSync` function wherever we need to determine whether Consistency Group (CG) protection is enabled for CephFS workloads.

**How it works:**
The `IsCGEnabledForVolSync` function:
1. Checks whether the workload’s annotations for CG protection is enabled.
2. Checks whether the `VolumeGroupSnapshot` CRD is available in the cluster.

Only if both conditions are met is CG protection enabled for CephFS.

This update is a temporary solution until CG support becomes generally available for both RBD and CephFS. For now, it’s only applied to CephFS since CG for RBD is expected to be generally available in 4.19.

Fixes: https://issues.redhat.com/browse/DFBUGS-2652