### PR TITLE
velero: add metadata only label for kubevirt plugin

### DIFF
--- a/internal/controller/util/labels.go
+++ b/internal/controller/util/labels.go
@@ -12,11 +12,12 @@ const (
 	labelOwnerNamespaceName = "ramendr.openshift.io/owner-namespace-name"
 	labelOwnerName          = "ramendr.openshift.io/owner-name"
 
-	MModesLabel             = "ramendr.openshift.io/maintenancemodes"
-	SClassLabel             = "ramendr.openshift.io/storageclass"
-	VSClassLabel            = "ramendr.openshift.io/volumesnapshotclass"
-	VRClassLabel            = "ramendr.openshift.io/volumereplicationclass"
-	ExcludeFromVeleroBackup = "velero.io/exclude-from-backup"
+	MModesLabel                           = "ramendr.openshift.io/maintenancemodes"
+	SClassLabel                           = "ramendr.openshift.io/storageclass"
+	VSClassLabel                          = "ramendr.openshift.io/volumesnapshotclass"
+	VRClassLabel                          = "ramendr.openshift.io/volumereplicationclass"
+	ExcludeFromVeleroBackup               = "velero.io/exclude-from-backup"
+	VeleroKubevirtMetadataOnlyBackupLabel = "velero.kubevirt.io/metadataBackup"
 )
 
 type Labels map[string]string

--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -301,6 +301,7 @@ func (v *VRGInstance) executeCaptureSteps(result *ctrl.Result, pathName, capture
 	requestsProcessedCount := 0
 	requestsCompletedCount := 0
 	labels := util.OwnerLabels(v.instance)
+	labels[util.VeleroKubevirtMetadataOnlyBackupLabel] = "true"
 
 	for groupNumber, captureGroup := range captureSteps {
 		var err error


### PR DESCRIPTION
Adding velero.kubevirt.io/metadataBackup label to the backup request ensures that kubevirt velero plugin skips the restore check and consistency-specific checks when a backup is taken. This is required as we backup the pvc/pv ourselves in Ramen and skip them from the velero backup; otherwise the checks fail.