### PR TITLE
Annotates for submariner dependency

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -1817,6 +1817,7 @@ func (d *DRPCInstance) updateVRGOptionalFields(vrg, vrgFromView *rmn.VolumeRepli
 		DoNotDeletePVCAnnotation:        d.instance.GetAnnotations()[DoNotDeletePVCAnnotation],
 		DRPCUIDAnnotation:               string(d.instance.UID),
 		rmnutil.UseVolSyncAnnotation:    d.instance.GetAnnotations()[rmnutil.UseVolSyncAnnotation],
+		SubmarinerEnabledAnnotation:     d.instance.GetAnnotations()[SubmarinerEnabledAnnotation],
 	}
 
 	vrg.Spec.ProtectedNamespaces = d.instance.Spec.ProtectedNamespaces

--- a/internal/controller/vrg_volrep_test.go
+++ b/internal/controller/vrg_volrep_test.go
@@ -2115,6 +2115,7 @@ func (v *vrgTest) createVRG() {
 		}
 
 		vrg.ObjectMeta.Annotations[util.IsCGEnabledAnnotation] = "true"
+		vrg.ObjectMeta.Annotations[vrgController.SubmarinerEnabledAnnotation] = vrgController.SubmarinerEnabledAnnotationVal
 	}
 
 	err := k8sClient.Create(context.TODO(), vrg)


### PR DESCRIPTION
- Adds an annotation to DRPC which states whether submariner dependency should be enabled or not
- Propagates said annotation to the VRG resource
- Resolves [RHSTOR-7417](https://issues.redhat.com/browse/RHSTOR-7417)