### PR TITLE
e2e: Add debug log for wait in subscription and placement ops

### DIFF
--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -19,6 +19,9 @@ func waitSubscriptionPhase(
 ) error {
 	log := ctx.Logger()
 
+	log.Debugf("Waiting until subscription \"%s/%s\" reach phase %q in cluster %q",
+		namespace, name, phase, ctx.Env().Hub.Name)
+
 	for {
 		sub, err := getSubscription(ctx, namespace, name)
 		if err != nil {

--- a/e2e/util/placement.go
+++ b/e2e/util/placement.go
@@ -48,7 +48,10 @@ func GetPlacement(ctx types.Context, namespace, name string) (*v1beta1.Placement
 //nolint:gocognit
 func getClusterDecisionFromPlacement(ctx types.Context, namespace string, placementName string,
 ) (*v1beta1.ClusterDecision, error) {
+	log := ctx.Logger()
 	cluster := ctx.Env().Hub
+
+	log.Debugf("Waiting for placement decisions for \"%s/%s\" in cluster %q", namespace, placementName, cluster.Name)
 
 	for {
 		placement, err := GetPlacement(ctx, namespace, placementName)


### PR DESCRIPTION
Add log when waiting for subscription phase changes and placement decisions to improve debugging visibility during long-running operations that may timeout.

Added debug logs:
```
2025-06-05T20:06:39.548+0530	DEBUG	subscr-deploy-rbd-busybox	deployers/retry.go:22	Waiting until subscription "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" reach phase "Propagated" in cluster "hub"

2025-06-05T20:06:49.559+0530	DEBUG	subscr-deploy-rbd-busybox	util/placement.go:54	Waiting for placement decisions for "e2e-subscr-deploy-rbd-busybox/subscr-deploy-rbd-busybox" in cluster "hub"
```

Fixes #1944 