### PR TITLE
e2e: add timing measurements to wait functions

### DIFF
--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -5,6 +5,7 @@ package deployers
 
 import (
 	"fmt"
+	"time"
 
 	subscriptionv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 
@@ -18,6 +19,7 @@ func waitSubscriptionPhase(
 	phase subscriptionv1.SubscriptionPhase,
 ) error {
 	log := ctx.Logger()
+	start := time.Now()
 
 	log.Debugf("Waiting until subscription \"%s/%s\" reach phase %q in cluster %q",
 		namespace, name, phase, ctx.Env().Hub.Name)
@@ -30,7 +32,9 @@ func waitSubscriptionPhase(
 
 		currentPhase := sub.Status.Phase
 		if currentPhase == phase {
-			log.Debugf("Subscription \"%s/%s\" phase is %s in cluster %q", namespace, name, phase, ctx.Env().Hub.Name)
+			elapsed := time.Since(start)
+			log.Debugf("Subscription \"%s/%s\" phase is %s in cluster %q in %.3f seconds",
+				namespace, name, phase, ctx.Env().Hub.Name, elapsed.Seconds())
 
 			return nil
 		}
@@ -45,13 +49,16 @@ func waitSubscriptionPhase(
 func WaitWorkloadHealth(ctx types.TestContext, cluster types.Cluster, namespace string) error {
 	log := ctx.Logger()
 	w := ctx.Workload()
+	start := time.Now()
 
 	log.Debugf("Waiting until workload \"%s/%s\" is healthy in cluster %q", namespace, w.GetAppName(), cluster.Name)
 
 	for {
 		err := w.Health(ctx, cluster, namespace)
 		if err == nil {
-			log.Debugf("Workload \"%s/%s\" is healthy in cluster %q", namespace, w.GetAppName(), cluster.Name)
+			elapsed := time.Since(start)
+			log.Debugf("Workload \"%s/%s\" is healthy in cluster %q in %.3f seconds",
+				namespace, w.GetAppName(), cluster.Name, elapsed.Seconds())
 
 			return nil
 		}

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -5,6 +5,7 @@ package dractions
 
 import (
 	"fmt"
+	"time"
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -17,6 +18,7 @@ import (
 func waitDRPCReady(ctx types.TestContext, namespace string, drpcName string) error {
 	log := ctx.Logger()
 	hub := ctx.Env().Hub
+	start := time.Now()
 
 	log.Debugf("Waiting until drpc \"%s/%s\" is ready in cluster %q", namespace, drpcName, hub.Name)
 
@@ -38,7 +40,9 @@ func waitDRPCReady(ctx types.TestContext, namespace string, drpcName string) err
 			peerReady &&
 			progressionCompleted &&
 			drpc.Status.LastGroupSyncTime != nil {
-			log.Debugf("drpc \"%s/%s\" is ready in cluster %q", namespace, drpcName, hub.Name)
+			elapsed := time.Since(start)
+			log.Debugf("drpc \"%s/%s\" is ready in cluster %q in %.3f seconds",
+				namespace, drpcName, hub.Name, elapsed.Seconds())
 
 			return nil
 		}
@@ -60,6 +64,7 @@ func conditionMet(conditions []metav1.Condition, conditionType string) bool {
 func waitDRPCPhase(ctx types.TestContext, namespace, name string, phase ramen.DRState) error {
 	log := ctx.Logger()
 	hub := ctx.Env().Hub
+	start := time.Now()
 
 	log.Debugf("Waiting until drpc \"%s/%s\" reach phase %q in cluster %q", namespace, name, phase, hub.Name)
 
@@ -71,7 +76,9 @@ func waitDRPCPhase(ctx types.TestContext, namespace, name string, phase ramen.DR
 
 		currentPhase := drpc.Status.Phase
 		if currentPhase == phase {
-			log.Debugf("drpc \"%s/%s\" phase is %q in cluster %q", namespace, name, phase, hub.Name)
+			elapsed := time.Since(start)
+			log.Debugf("drpc \"%s/%s\" phase is %q in cluster %q in %.3f seconds",
+				namespace, name, phase, hub.Name, elapsed.Seconds())
 
 			return nil
 		}
@@ -110,6 +117,7 @@ func waitDRPCProgression(
 ) error {
 	log := ctx.Logger()
 	hub := ctx.Env().Hub
+	start := time.Now()
 
 	log.Debugf("Waiting until drpc \"%s/%s\" reach progression %q in cluster %q",
 		namespace, name, progression, hub.Name)
@@ -122,7 +130,9 @@ func waitDRPCProgression(
 
 		currentProgression := drpc.Status.Progression
 		if currentProgression == progression {
-			log.Debugf("drpc \"%s/%s\" progression is %q in cluster %q", namespace, name, progression, hub.Name)
+			elapsed := time.Since(start)
+			log.Debugf("drpc \"%s/%s\" progression is %q in cluster %q in %.3f seconds",
+				namespace, name, progression, hub.Name, elapsed.Seconds())
 
 			return nil
 		}

--- a/e2e/util/placement.go
+++ b/e2e/util/placement.go
@@ -5,6 +5,7 @@ package util
 
 import (
 	"fmt"
+	"time"
 
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"open-cluster-management.io/api/cluster/v1beta1"
@@ -50,6 +51,7 @@ func getClusterDecisionFromPlacement(ctx types.Context, namespace string, placem
 ) (*v1beta1.ClusterDecision, error) {
 	log := ctx.Logger()
 	cluster := ctx.Env().Hub
+	start := time.Now()
 
 	log.Debugf("Waiting for placement decisions for \"%s/%s\" in cluster %q", namespace, placementName, cluster.Name)
 
@@ -69,6 +71,10 @@ func getClusterDecisionFromPlacement(ctx types.Context, namespace string, placem
 				if placementDecision.Status.Decisions[idx].Reason == PlacementDecisionReasonFailoverRetained {
 					continue
 				}
+
+				elapsed := time.Since(start)
+				log.Debugf("Placement decisions for \"%s/%s\" available in cluster %q in %.3f seconds",
+					namespace, placementName, cluster.Name, elapsed.Seconds())
 
 				return &placementDecision.Status.Decisions[idx], nil
 			}

--- a/e2e/util/wait.go
+++ b/e2e/util/wait.go
@@ -118,6 +118,7 @@ func waitForResourceDelete(ctx types.Context, cluster types.Cluster, obj client.
 	log := ctx.Logger()
 	kind := getKind(obj)
 	resourceName := logName(obj)
+	start := time.Now()
 
 	log.Debugf("Waiting until %s %q is deleted in cluster %q", kind, resourceName, cluster.Name)
 
@@ -127,7 +128,8 @@ func waitForResourceDelete(ctx types.Context, cluster types.Cluster, obj client.
 				return err
 			}
 
-			log.Debugf("%s %q deleted in cluster %q", kind, resourceName, cluster.Name)
+			elapsed := time.Since(start)
+			log.Debugf("%s %q deleted in cluster %q in %.3f seconds", kind, resourceName, cluster.Name, elapsed.Seconds())
 
 			return nil
 		}


### PR DESCRIPTION
Add elapsed time tracking to various wait functions throughout the e2e testing framework to improve observability and help identify operations which are taking lot of time and increase timeouts if necessary.

As part of this change, added missing debug log for placement decision availability that was previously absent with time taken.

sample elapsed time info:
```
2025-06-06T17:42:45.178+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/retry.go:80	drpc "argocd/appset-deploy-cephfs-busybox" phase is "Relocated" in cluster "hub" in 270.177 seconds
2025-06-06T17:43:15.198+0530	DEBUG	appset-deploy-cephfs-busybox	dractions/retry.go:44	drpc "argocd/appset-deploy-cephfs-busybox" is ready in cluster "hub" in 30.019 seconds
2025-06-06T17:45:35.256+0530	DEBUG	appset-deploy-cephfs-busybox	deployers/retry.go:60	Workload "e2e-appset-deploy-cephfs-busybox/busybox" is healthy in cluster "dr1" in 140.066 seconds
2025-06-06T17:45:35.267+0530	DEBUG	appset-deploy-cephfs-busybox	util/placement.go:76	Placement decisions for "argocd/appset-deploy-cephfs-busybox" available in cluster "hub" in 0.010 seconds
2025-06-06T17:45:41.290+0530	DEBUG	appset-deploy-cephfs-busybox	util/placement.go:76	Placement decisions for "argocd/appset-deploy-cephfs-busybox" available in cluster "hub" in 0.003 seconds
2025-06-06T17:45:41.316+0530	DEBUG	appset-deploy-cephfs-busybox	util/wait.go:132	ApplicationSet "argocd/appset-deploy-cephfs-busybox" deleted in cluster "hub" in 0.002 seconds
2025-06-06T17:45:41.318+0530	DEBUG	appset-deploy-cephfs-busybox	util/wait.go:132	ConfigMap "argocd/appset-deploy-cephfs-busybox" deleted in cluster "hub" in 0.001 seconds
2025-06-06T17:45:41.319+0530	DEBUG	appset-deploy-cephfs-busybox	util/wait.go:132	Placement "argocd/appset-deploy-cephfs-busybox" deleted in cluster "hub" in 0.001 seconds
2025-06-06T17:45:47.335+0530	DEBUG	appset-deploy-cephfs-busybox	util/wait.go:132	Namespace "e2e-appset-deploy-cephfs-busybox" deleted in cluster "dr1" in 6.015 seconds
```
[ramen-e2e.log](https://github.com/user-attachments/files/20628031/ramen-e2e.log)

Fixes #2074 