### PR TITLE
ci: Allow failures when testing next python

### DIFF
--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -84,10 +84,14 @@ jobs:
       - name: Run tests
         run: make test
         working-directory: test
+        # Don't fail when testing python next.
+        continue-on-error: ${{ matrix.python-version == '3.14-dev' }}
 
       - name: Report test coverage
         run: make coverage
         working-directory: test
+        # Don't fail when testing python next.
+        continue-on-error: ${{ matrix.python-version == '3.14-dev' }}
 
       - name: Clean up
         run: make clean


### PR DESCRIPTION
We want to know about issues with python development version, but we don't want to fail the build. These failures are likely temporary, since we test the latest development branch. It they are not temporary we may need to change something in our code.

Using now continue-on-error: true when testing "3.14-dev".

This will avoid these failures:
- https://github.com/red-hat-storage/ramen/actions/runs/15605075343/job/43952550382
- https://github.com/RamenDR/ramen/actions/runs/15599342733

Replaced by #2087 