### PR TITLE
PVC deselect/delete for VR

### DIFF
--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -42,10 +42,7 @@ const (
 	DefaultVolSyncCopyMethod                          = "Snapshot"
 )
 
-var (
-	VolumeUnprotectionEnabledForAsyncVolRep  = false
-	VolumeUnprotectionEnabledForAsyncVolSync = false
-)
+var VolumeUnprotectionEnabledForAsyncVolSync = false
 
 // FIXME
 const NoS3StoreAvailable = "NoS3"

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1478,6 +1478,20 @@ func (v *VRGInstance) reconcileAsPrimary() {
 func (v *VRGInstance) pvcsDeselectedUnprotect() error {
 	log := v.log.WithName("PvcsDeselectedUnprotect")
 
+	if !(v.instance.Spec.ReplicationState == ramendrv1alpha1.Primary &&
+		!v.instance.Spec.PrepareForFinalSync &&
+		!v.instance.Spec.RunFinalSync) {
+		log.Info(
+			"PVC deselection skipped",
+			"replicationstate",
+			v.instance.Spec.ReplicationState,
+			"finalsync",
+			v.instance.Spec.PrepareForFinalSync || v.instance.Spec.RunFinalSync,
+		)
+
+		return nil
+	}
+
 	pvcsOwned, err := v.listPVCsOwnedByVrg()
 	if err != nil {
 		log.Error(err, "PVCs owned by VRG list")

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1516,45 +1516,7 @@ func (v *VRGInstance) pvcsDeselectedUnprotect() error {
 		}
 	}
 
-	v.cleanupProtectedPVCs(pvcsVr, pvcsVs, log)
-
 	return nil
-}
-
-func (v *VRGInstance) cleanupProtectedPVCs(
-	pvcsVr, pvcsVs map[client.ObjectKey]corev1.PersistentVolumeClaim, log logr.Logger,
-) {
-	if !v.ramenConfig.VolumeUnprotectionEnabled {
-		log.Info("Volume unprotection disabled")
-
-		return
-	}
-
-	if v.instance.Spec.Async != nil && !VolumeUnprotectionEnabledForAsyncVolRep {
-		log.Info("Volume unprotection disabled for async mode")
-
-		return
-	}
-	// clean up the PVCs that are part of protected pvcs but not in v.volReps and v.volSyncs
-	protectedPVCsFiltered := make([]ramendrv1alpha1.ProtectedPVC, 0)
-
-	for _, protectedPVC := range v.instance.Status.ProtectedPVCs {
-		pvcNamespacedName := client.ObjectKey{Namespace: protectedPVC.Namespace, Name: protectedPVC.Name}
-
-		if _, ok := pvcsVr[pvcNamespacedName]; ok {
-			protectedPVCsFiltered = append(protectedPVCsFiltered, protectedPVC)
-
-			continue
-		}
-
-		if _, ok := pvcsVs[pvcNamespacedName]; ok {
-			protectedPVCsFiltered = append(protectedPVCsFiltered, protectedPVC)
-
-			continue
-		}
-	}
-
-	v.instance.Status.ProtectedPVCs = protectedPVCsFiltered
 }
 
 // processAsSecondary reconciles the current instance of VRG as secondary

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -828,16 +828,8 @@ func (v *VRGInstance) pvcUnprotectVolRepIfDeleted(
 }
 
 func (v *VRGInstance) pvcUnprotectVolRep(pvc corev1.PersistentVolumeClaim, log logr.Logger) {
-	vrg := v.instance
-
 	if !v.ramenConfig.VolumeUnprotectionEnabled {
 		log.Info("Volume unprotection disabled")
-
-		return
-	}
-
-	if vrg.Spec.Async != nil && !VolumeUnprotectionEnabledForAsyncVolRep {
-		log.Info("Volume unprotection disabled for async mode")
 
 		return
 	}
@@ -852,6 +844,10 @@ func (v *VRGInstance) pvcUnprotectVolRep(pvc corev1.PersistentVolumeClaim, log l
 	}
 
 	v.pvcsUnprotectVolRep([]corev1.PersistentVolumeClaim{pvc})
+
+	if v.result.Requeue {
+		return
+	}
 
 	v.pvcStatusDeleteIfPresent(pvc.Namespace, pvc.Name, log)
 }

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -181,6 +181,8 @@ func (v *VRGInstance) reconcileVolRepsAsSecondary() bool {
 
 		vrMissing, requeueResult := v.reconcileMissingVR(pvc, log)
 		if vrMissing || requeueResult {
+			// TODO: set requeue only if required, remove PVC from status?
+			// - Will it hamper determination of secondary completion?
 			requeue = true
 
 			continue
@@ -889,9 +891,13 @@ func (v *VRGInstance) pvcsUnprotectVolRep(pvcs []corev1.PersistentVolumeClaim) {
 		}
 
 		vrMissing, requeueResult := v.reconcileMissingVR(pvc, log)
-		if vrMissing || requeueResult {
+		if requeueResult {
 			v.requeue()
 
+			continue
+		}
+
+		if vrMissing {
 			continue
 		}
 

--- a/internal/controller/vrg_volrep_test.go
+++ b/internal/controller/vrg_volrep_test.go
@@ -419,12 +419,12 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		Context("PVC selection", func() {
 			var t *vrgTest
 			BeforeAll(func() {
-				vrgController.VolumeUnprotectionEnabledForAsyncVolRep = true
-				DeferCleanup(func() {
-					vrgController.VolumeUnprotectionEnabledForAsyncVolRep = false
-				})
 				t = vrgTestBoundPV
 				vrgNamespacedName = t.vrgNamespacedName()
+			})
+			AfterAll(func() {
+				ramenConfig.VolumeUnprotectionEnabled = false
+				configMapUpdate()
 			})
 			var pvcNamesSelected, pvcNamesDeselected []types.NamespacedName
 			pvcsVerify := func(pvcNames []types.NamespacedName,
@@ -2568,7 +2568,7 @@ func (v *vrgTest) cleanupPVCs(
 	vrg := v.getVRG()
 
 	pvcPostDeleteVerify1 := pvcPostDeleteVerify
-	if !vrgController.VolumeUnprotectionEnabledForAsyncVolRep {
+	if !ramenConfig.VolumeUnprotectionEnabled {
 		pvcPostDeleteVerify1 = func(pvcNamespacedName types.NamespacedName, pvName string) {
 			pvcDeletionTimestampRecentVerify(pvcNamespacedName)
 		}

--- a/internal/controller/vrg_volrep_test.go
+++ b/internal/controller/vrg_volrep_test.go
@@ -368,20 +368,20 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 				}
 
 				By("storing VRG status without PVC namespace name")
-				vrg = t.getVRG()
-				Expect(vrg.GetGeneration()).To(Equal(vrgGenerationExpected))
-				for i := range vrg.Status.ProtectedPVCs {
-					pvc := &vrg.Status.ProtectedPVCs[i]
-					pvcNamespacedNamesActual[i] = types.NamespacedName{Namespace: pvc.Namespace, Name: pvc.Name}
-				}
-				Expect(pvcNamespacedNamesActual).To(ConsistOf(t.pvcNames))
-				for _, pvcNamespacedName := range pvcNamespacedNamesUnqualified {
-					pvc := vrgController.FindProtectedPVC(vrg, pvcNamespacedName.Namespace, pvcNamespacedName.Name)
-					Expect(pvc).ToNot(BeNil())
-					pvc.Namespace = ""
-				}
-
 				Eventually(func() bool {
+					vrg = t.getVRG()
+					Expect(vrg.GetGeneration()).To(Equal(vrgGenerationExpected))
+					for i := range vrg.Status.ProtectedPVCs {
+						pvc := &vrg.Status.ProtectedPVCs[i]
+						pvcNamespacedNamesActual[i] = types.NamespacedName{Namespace: pvc.Namespace, Name: pvc.Name}
+					}
+					Expect(pvcNamespacedNamesActual).To(ConsistOf(t.pvcNames))
+					for _, pvcNamespacedName := range pvcNamespacedNamesUnqualified {
+						pvc := vrgController.FindProtectedPVC(vrg, pvcNamespacedName.Namespace, pvcNamespacedName.Name)
+						Expect(pvc).ToNot(BeNil())
+						pvc.Namespace = ""
+					}
+
 					if err := k8sClient.Status().Update(ctx, vrg); err != nil {
 						return false
 					}


### PR DESCRIPTION
Commit https://github.com/ShyamsundarR/ramen/commit/1203605d6e9fda481bf5c833cd632a7d5ea218b7 updated DRPC orchestration to ensure that VRG is Secondary on the cluster before workload is cleaned up, which includes
PVCs.

As a result in VRG orchestration, additional stricter latches are added to determine when to process PVC deletion or deselection as a separate operation from workload deletion due to DR actions.

IOW, PVCs that are deleted/deselected when VRG is primary and not in preparing or executing final sync states, are user deleted PVCs that do not need further protection.

Some minor corrections to handling PVC deselect/delete for VR use cases are also included:

- Remove VolumeUnprotectionEnabledForAsyncVolRep as it is not required any further, instead if DRPC sets the ramen config option VolumeUnprotectionEnabled VRG can act on PVC deselect/delete as DRPC orchestration would be stricter

- Cleanup of protected PVCs status is not required at the end of PVC deselection, as the called PVC deselection functions for VR/VS are expected to cleanup protected PVCs

- Fix envtest failure in multi-namespace support, [BeforeAll] 