### PR TITLE
drenv: Fix tests watching stderr

### DIFF
--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -185,7 +185,7 @@ import sys
 for i in range(10):
     sys.stderr.write(f"line {i}\n")
 """
-    cmd = ["python3", "-c", script]
+    cmd = ["python3", "-Wignore", "-c", script]
     output = list(commands.watch(*cmd, stderr=subprocess.STDOUT))
     assert output == [f"line {i}" for i in range(10)]
 
@@ -197,7 +197,7 @@ import sys
 sys.stderr.write("before error\n")
 sys.exit("error")
 """
-    cmd = ["python3", "-c", script]
+    cmd = ["python3", "-Wignore", "-c", script]
     output = []
     with pytest.raises(commands.Error) as e:
         for line in commands.watch(*cmd, stderr=subprocess.STDOUT):


### PR DESCRIPTION
These tests started fail with python 3.14 because it logs warnings to stderr:

    >       assert output == ["before error", "error"]
    E       assert ["/opt/hosted...ror', 'error'] == ['before error', 'error']
    E
    E         At index 0 diff: "/opt/hostedtoolcache/Python/3.14.0-beta.2/x64/lib/python3.14/site-packages/coverage/core.py:96:
              CoverageWarning: Couldn't import C tracer: No module named 'coverage.tracer' (no-ctracer)" != 'before error'
    E         Left contains 2 more items, first extra item: 'before error'
    E
    E         Full diff:
    E           [
    E         +     '/opt/hostedtoolcache/Python/3.14.0-beta.2/x64/lib/python3.14/site-packages/coverage/core.py:96: '
    E         +     "CoverageWarning: Couldn't import C tracer: No module named "
    E         +     "'coverage.tracer' (no-ctracer)",
    E         +     '  warn(f"Couldn\'t import C tracer: {IMPORT_ERROR}", slug="no-ctracer", '
    E         +     'once=True)',
    E               'before error',
    E               'error',
    E           ]

The purpose of the tests is checking that we can read from stderr of the child process. The child process *must not* write anything to stderr expect the value we the tests writes, so we must disable all warnings in the child.

This fixes these failures:

- https://github.com/red-hat-storage/ramen/actions/runs/15605075343/job/43952550382
- https://github.com/RamenDR/ramen/actions/runs/15599342733