### PR TITLE
Implement PVC deselect/delete for PVCs protected by VGR

### DIFF
--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -42,10 +42,7 @@ const (
 	DefaultVolSyncCopyMethod                          = "Snapshot"
 )
 
-var (
-	VolumeUnprotectionEnabledForAsyncVolRep  = false
-	VolumeUnprotectionEnabledForAsyncVolSync = false
-)
+var VolumeUnprotectionEnabledForAsyncVolSync = false
 
 // FIXME
 const NoS3StoreAvailable = "NoS3"

--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -61,6 +61,14 @@ func (u *ResourceUpdater) AddLabel(key, value string) *ResourceUpdater {
 	return u
 }
 
+func (u *ResourceUpdater) RemoveLabel(key string, value *string) *ResourceUpdater {
+	removed := RemoveLabel(u.obj, key, value)
+
+	u.objModified = u.objModified || removed
+
+	return u
+}
+
 func (u *ResourceUpdater) AddFinalizer(finalizerName string) *ResourceUpdater {
 	added := AddFinalizer(u.obj, finalizerName)
 
@@ -116,6 +124,30 @@ func AddLabel(obj client.Object, key, value string) bool {
 	}
 
 	return !labelAdded
+}
+
+func RemoveLabel(obj client.Object, key string, value *string) bool {
+	const labelRemoved = true
+
+	labels := obj.GetLabels()
+	if labels == nil {
+		return !labelRemoved
+	}
+
+	if value == nil {
+		if !HasLabel(obj, key) {
+			return !labelRemoved
+		}
+	} else {
+		if !HasLabelWithValue(obj, key, *value) {
+			return !labelRemoved
+		}
+	}
+
+	delete(labels, key)
+	obj.SetLabels(labels)
+
+	return labelRemoved
 }
 
 func UpdateLabel(obj client.Object, key, newValue string) bool {

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1478,6 +1478,20 @@ func (v *VRGInstance) reconcileAsPrimary() {
 func (v *VRGInstance) pvcsDeselectedUnprotect() error {
 	log := v.log.WithName("PvcsDeselectedUnprotect")
 
+	if !(v.instance.Spec.ReplicationState == ramendrv1alpha1.Primary &&
+		!v.instance.Spec.PrepareForFinalSync &&
+		!v.instance.Spec.RunFinalSync) {
+		log.Info(
+			"PVC deselection skipped",
+			"replicationstate",
+			v.instance.Spec.ReplicationState,
+			"finalsync",
+			v.instance.Spec.PrepareForFinalSync || v.instance.Spec.RunFinalSync,
+		)
+
+		return nil
+	}
+
 	pvcsOwned, err := v.listPVCsOwnedByVrg()
 	if err != nil {
 		log.Error(err, "PVCs owned by VRG list")

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1516,45 +1516,7 @@ func (v *VRGInstance) pvcsDeselectedUnprotect() error {
 		}
 	}
 
-	v.cleanupProtectedPVCs(pvcsVr, pvcsVs, log)
-
 	return nil
-}
-
-func (v *VRGInstance) cleanupProtectedPVCs(
-	pvcsVr, pvcsVs map[client.ObjectKey]corev1.PersistentVolumeClaim, log logr.Logger,
-) {
-	if !v.ramenConfig.VolumeUnprotectionEnabled {
-		log.Info("Volume unprotection disabled")
-
-		return
-	}
-
-	if v.instance.Spec.Async != nil && !VolumeUnprotectionEnabledForAsyncVolRep {
-		log.Info("Volume unprotection disabled for async mode")
-
-		return
-	}
-	// clean up the PVCs that are part of protected pvcs but not in v.volReps and v.volSyncs
-	protectedPVCsFiltered := make([]ramendrv1alpha1.ProtectedPVC, 0)
-
-	for _, protectedPVC := range v.instance.Status.ProtectedPVCs {
-		pvcNamespacedName := client.ObjectKey{Namespace: protectedPVC.Namespace, Name: protectedPVC.Name}
-
-		if _, ok := pvcsVr[pvcNamespacedName]; ok {
-			protectedPVCsFiltered = append(protectedPVCsFiltered, protectedPVC)
-
-			continue
-		}
-
-		if _, ok := pvcsVs[pvcNamespacedName]; ok {
-			protectedPVCsFiltered = append(protectedPVCsFiltered, protectedPVC)
-
-			continue
-		}
-	}
-
-	v.instance.Status.ProtectedPVCs = protectedPVCsFiltered
 }
 
 // processAsSecondary reconciles the current instance of VRG as secondary

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -773,7 +773,9 @@ func (v *VRGInstance) labelPVCsForCG() error {
 // Returns:
 // - error: An error if the VolumeGroupReplicationClass is missing or if the label update fails.
 func (v *VRGInstance) addVolRepConsistencyGroupLabel(pvc *corev1.PersistentVolumeClaim) error {
-	if _, ok := v.isCGEnabled(pvc); ok {
+	// Skip refreshing CG label value if PVC is being deleted, as it maybe under delete orchestration with empty
+	// string as the value (see resetCGLabelValue)
+	if _, ok := v.isCGEnabled(pvc); ok && util.ResourceIsDeleted(pvc) {
 		return nil
 	}
 

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -777,20 +777,9 @@ func (v *VRGInstance) addVolRepConsistencyGroupLabel(pvc *corev1.PersistentVolum
 		return nil
 	}
 
-	pvcNamespacedName := types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}
-
-	volumeReplicationClass, err := v.selectVolumeReplicationClass(pvcNamespacedName, true)
+	replicationID, err := v.getVGRClassReplicationID(pvc)
 	if err != nil {
 		return err
-	}
-
-	replicationID, ok := volumeReplicationClass.GetLabels()[VolumeReplicationIDLabel]
-	if !ok {
-		v.log.Info(fmt.Sprintf("VolumeGroupReplicationClass %s is missing replicationID for PVC %s/%s",
-			volumeReplicationClass.GetName(), pvc.GetNamespace(), pvc.GetName()))
-
-		return fmt.Errorf("volumeGroupReplicationClass %s is missing replicationID for PVC %s/%s",
-			volumeReplicationClass.GetName(), pvc.GetNamespace(), pvc.GetName())
 	}
 
 	// Add label for PVC, showing that this PVC is part of consistency group

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -773,6 +773,10 @@ func (v *VRGInstance) labelPVCsForCG() error {
 // Returns:
 // - error: An error if the VolumeGroupReplicationClass is missing or if the label update fails.
 func (v *VRGInstance) addVolRepConsistencyGroupLabel(pvc *corev1.PersistentVolumeClaim) error {
+	if _, ok := v.isCGEnabled(pvc); ok {
+		return nil
+	}
+
 	pvcNamespacedName := types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}
 
 	volumeReplicationClass, err := v.selectVolumeReplicationClass(pvcNamespacedName, true)

--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -311,14 +311,184 @@ func (v *VRGInstance) getVGRCFromVGR(vgr *volrep.VolumeGroupReplication) (volrep
 	return vgrc, nil
 }
 
+// pvcUnprotectVolGroupRep removes protection for a PVC when VRG is Primary and is protected by VGR in a CG.
+// The unprotection works as follows:
+// - Sets the CG label value to an empty string, ensuring the PVC is deselected from the CG that it belongs to
+// - Ensures the PVC is no longer reported as part of the VGR status as protected
+// - Deletes the VGR if it was protecting only this PVC
+// - Removes PV/PVC protection metadata
+// As the order ensures that the last action for the PVC is to remove its CG label, the entire workflow is idempotent
+// across multiple reconcile loops.
+// Further, all errors/progress is reported into the PVC DataReady condition.
+func (v *VRGInstance) pvcUnprotectVolGroupRep(pvc *corev1.PersistentVolumeClaim) {
+	if reset, err := v.resetCGLabelValue(pvc); err != nil || !reset {
+		if err != nil {
+			v.updatePVCDataReadyCondition(pvc.Namespace, pvc.Name, VRGConditionReasonError,
+				fmt.Sprintf("Retrying, on error (%s) processing PVC for deletion or deselection from protection", err))
+		} else {
+			v.updatePVCDataReadyCondition(pvc.Namespace, pvc.Name, VRGConditionReasonError,
+				"PVC is deleted or deselected from protection, and is not protected as part of a consistency group")
+		}
+
+		v.requeue()
+
+		return
+	}
+
+	vgr, err := v.getVGRUsingSCLabel(pvc)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		v.updatePVCDataReadyCondition(pvc.Namespace, pvc.Name, VRGConditionReasonError,
+			fmt.Sprintf("Retrying, on error (%s) processing PVC for deletion or deselection from protection", err))
+
+		v.requeue()
+
+		return
+	}
+
+	if err == nil {
+		if !v.ensurePVCUnprotected(pvc, vgr) {
+			v.updatePVCDataReadyCondition(pvc.Namespace, pvc.Name, VRGConditionReasonProgressing,
+				"PVC is being processed for deletion or deselection from protection")
+
+			v.requeue()
+
+			return
+		}
+
+		if err := v.deleteVGRIfUnused(vgr); err != nil {
+			v.updatePVCDataReadyCondition(pvc.Namespace, pvc.Name, VRGConditionReasonError,
+				fmt.Sprintf("Retrying, on error (%s) processing PVC for deletion or deselection from protection", err),
+			)
+
+			v.requeue()
+
+			return
+		}
+	}
+
+	// VGR not found or ensured that PVC is not part of VRG status
+	if err := v.preparePVCForVRDeletion(pvc, v.log); err != nil {
+		v.updatePVCDataReadyCondition(pvc.Namespace, pvc.Name, VRGConditionReasonError,
+			fmt.Sprintf("Retrying due to error (%s) processing PVC for deletion or deselection from protection", err),
+		)
+
+		v.requeue()
+
+		return
+	}
+}
+
+// resetCGLabelValue resets the CG label value to an empty string, and returns if reset was detected as a success
+func (v *VRGInstance) resetCGLabelValue(pvc *corev1.PersistentVolumeClaim) (bool, error) {
+	const reset = true
+
+	cg, ok := v.isCGEnabled(pvc)
+	if !ok {
+		v.log.Info("PVC is not protected by a CG", "VR instance", v.instance.Name)
+
+		return !reset, fmt.Errorf("PVC is not protected as part of a consistency group")
+	}
+
+	if cg == "" {
+		return reset, nil
+	}
+
+	err := rmnutil.NewResourceUpdater(pvc).AddLabel(ConsistencyGroupLabel, "").Update(v.ctx, v.reconciler.Client)
+	if err != nil {
+		return !reset, fmt.Errorf("error (%s) updating PVC labels", err)
+	}
+
+	return !reset, nil
+}
+
+// getVGRUsingSCLabel fetches the VGR that is protecting the PVC using the SC and VGRC labels, it is useful when the CG
+// label is present without a correlating value to construuct the VGR name
+func (v *VRGInstance) getVGRUsingSCLabel(pvc *corev1.PersistentVolumeClaim) (*volrep.VolumeGroupReplication, error) {
+	rID, err := v.getVGRClassReplicationID(pvc)
+	if err != nil {
+		// Error is masked here, as caller expects k8serrors regarding vgr resource
+		return nil, fmt.Errorf("error determining replicationID")
+	}
+
+	vgrNamespacedName := types.NamespacedName{
+		Name:      rmnutil.TrimToK8sResourceNameLength(rID + v.instance.Name),
+		Namespace: pvc.Namespace,
+	}
+
+	vgr := &volrep.VolumeGroupReplication{}
+	err = v.reconciler.Get(v.ctx, vgrNamespacedName, vgr)
+
+	return vgr, err
+}
+
+// getVGRClassReplicationID is a utilti function that fetches the replicationID for the PVC looking at the class labels
+func (v *VRGInstance) getVGRClassReplicationID(pvc *corev1.PersistentVolumeClaim) (string, error) {
+	pvcNamespacedName := types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}
+
+	vgrClass, err := v.selectVolumeReplicationClass(pvcNamespacedName, true)
+	if err != nil {
+		return "", err
+	}
+
+	replicationID, ok := vgrClass.GetLabels()[VolumeReplicationIDLabel]
+	if !ok {
+		v.log.Info(fmt.Sprintf("VolumeGroupReplicationClass %s is missing replicationID for PVC %s/%s",
+			vgrClass.GetName(), pvc.GetNamespace(), pvc.GetName()))
+
+		return "", fmt.Errorf("volumeGroupReplicationClass %s is missing replicationID for PVC %s/%s",
+			vgrClass.GetName(), pvc.GetNamespace(), pvc.GetName())
+	}
+
+	return replicationID, nil
+}
+
+// ensurePVCUnprotected returns true if the passed in PVC is not protected by the vgr
+func (v *VRGInstance) ensurePVCUnprotected(
+	pvc *corev1.PersistentVolumeClaim,
+	vgr *volrep.VolumeGroupReplication,
+) bool {
+	const unprotected = true
+
+	if rmnutil.ResourceIsDeleted(vgr) {
+		return !unprotected
+	}
+
+	for i := range vgr.Status.PersistentVolumeClaimsRefList {
+		if vgr.Status.PersistentVolumeClaimsRefList[i].Name == pvc.GetName() {
+			return !unprotected
+		}
+	}
+
+	return unprotected
+}
+
+// deleteVGRIfUnused garbage collects a VGR that is not protecting any PVCs
+func (v *VRGInstance) deleteVGRIfUnused(vgr *volrep.VolumeGroupReplication) error {
+	if len(vgr.Status.PersistentVolumeClaimsRefList) != 0 {
+		return nil
+	}
+
+	err := v.reconciler.Delete(v.ctx, vgr)
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+	// TODO: Delete VGR from S3 store
+
+	return nil
+}
+
 //nolint:gocognit
 func (v *VRGInstance) pvcsUnprotectVolGroupRep(groupPVCs map[types.NamespacedName][]*corev1.PersistentVolumeClaim) {
+	// Single PVC that is deselected/deleted will not come here, in a circutious way!
+	// VRG deletion will invoke this routine
 	for vgrNamespacedName, pvcs := range groupPVCs {
 		log := v.log.WithValues("vgr", vgrNamespacedName.String())
 
 		vgrMissing, requeueResult := v.reconcileMissingVGR(vgrNamespacedName, pvcs, log)
 		if vgrMissing || requeueResult {
-			v.requeue()
+			if requeueResult {
+				v.requeue()
+			}
 
 			continue
 		}

--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -421,11 +421,9 @@ func (v *VRGInstance) getVGRUsingSCLabel(pvc *corev1.PersistentVolumeClaim) (*vo
 	return vgr, err
 }
 
-// getVGRClassReplicationID is a utilti function that fetches the replicationID for the PVC looking at the class labels
+// getVGRClassReplicationID is a utility function that fetches the replicationID for the PVC looking at the class labels
 func (v *VRGInstance) getVGRClassReplicationID(pvc *corev1.PersistentVolumeClaim) (string, error) {
-	pvcNamespacedName := types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}
-
-	vgrClass, err := v.selectVolumeReplicationClass(pvcNamespacedName, true)
+	vgrClass, err := v.selectVolumeReplicationClass(pvc, true)
 	if err != nil {
 		return "", err
 	}
@@ -751,15 +749,13 @@ func (v *VRGInstance) updateVGR(pvcs []*corev1.PersistentVolumeClaim,
 func (v *VRGInstance) createVGR(vrNamespacedName types.NamespacedName,
 	pvcs []*corev1.PersistentVolumeClaim, state volrep.ReplicationState,
 ) error {
-	pvcNamespacedName := types.NamespacedName{Name: pvcs[0].Name, Namespace: pvcs[0].Namespace}
-
-	volumeReplicationClass, err := v.selectVolumeReplicationClass(pvcNamespacedName, false)
+	volumeReplicationClass, err := v.selectVolumeReplicationClass(pvcs[0], false)
 	if err != nil {
 		return fmt.Errorf("failed to find the appropriate VolumeReplicationClass (%s) %w",
 			v.instance.Name, err)
 	}
 
-	volumeGroupReplicationClass, err := v.selectVolumeReplicationClass(pvcNamespacedName, true)
+	volumeGroupReplicationClass, err := v.selectVolumeReplicationClass(pvcs[0], true)
 	if err != nil {
 		return fmt.Errorf("failed to find the appropriate VolumeGroupReplicationClass (%s) %w",
 			v.instance.Name, err)

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -91,8 +91,10 @@ func (v *VRGInstance) reconcileVolRepsAsPrimary() {
 		}
 
 		if cg, ok := v.isCGEnabled(pvc); ok {
-			pvcNamespacedName.Name = rmnutil.TrimToK8sResourceNameLength(cg + v.instance.Name)
-			groupPVCs[pvcNamespacedName] = append(groupPVCs[pvcNamespacedName], pvc)
+			vgrName := rmnutil.TrimToK8sResourceNameLength(cg + v.instance.Name)
+			vgrNamespacedName := types.NamespacedName{Name: vgrName, Namespace: pvc.Namespace}
+
+			groupPVCs[vgrNamespacedName] = append(groupPVCs[vgrNamespacedName], pvc)
 
 			continue
 		}

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -828,16 +828,8 @@ func (v *VRGInstance) pvcUnprotectVolRepIfDeleted(
 }
 
 func (v *VRGInstance) pvcUnprotectVolRep(pvc corev1.PersistentVolumeClaim, log logr.Logger) {
-	vrg := v.instance
-
 	if !v.ramenConfig.VolumeUnprotectionEnabled {
 		log.Info("Volume unprotection disabled")
-
-		return
-	}
-
-	if vrg.Spec.Async != nil && !VolumeUnprotectionEnabledForAsyncVolRep {
-		log.Info("Volume unprotection disabled for async mode")
 
 		return
 	}
@@ -852,6 +844,10 @@ func (v *VRGInstance) pvcUnprotectVolRep(pvc corev1.PersistentVolumeClaim, log l
 	}
 
 	v.pvcsUnprotectVolRep([]corev1.PersistentVolumeClaim{pvc})
+
+	if v.result.Requeue {
+		return
+	}
 
 	v.pvcStatusDeleteIfPresent(pvc.Namespace, pvc.Name, log)
 }

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -181,6 +181,8 @@ func (v *VRGInstance) reconcileVolRepsAsSecondary() bool {
 
 		vrMissing, requeueResult := v.reconcileMissingVR(pvc, log)
 		if vrMissing || requeueResult {
+			// TODO: set requeue only if required, remove PVC from status?
+			// - Will it hamper determination of secondary completion?
 			requeue = true
 
 			continue
@@ -889,9 +891,13 @@ func (v *VRGInstance) pvcsUnprotectVolRep(pvcs []corev1.PersistentVolumeClaim) {
 		}
 
 		vrMissing, requeueResult := v.reconcileMissingVR(pvc, log)
-		if vrMissing || requeueResult {
+		if requeueResult {
 			v.requeue()
 
+			continue
+		}
+
+		if vrMissing {
 			continue
 		}
 

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -296,20 +296,18 @@ func (v *VRGInstance) updateProtectedPVCs(pvc *corev1.PersistentVolumeClaim) err
 		return nil
 	}
 
-	pvcNamespacedName := types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}
-
-	storageClass, err := v.getStorageClass(pvcNamespacedName)
+	storageClass, err := v.getStorageClass(pvc)
 	if err != nil {
 		v.log.Info(fmt.Sprintf("Failed to get the storageclass for pvc %s",
-			pvcNamespacedName))
+			pvc.GetName()))
 
 		return fmt.Errorf("failed to get the storageclass for pvc %s (%w)",
-			pvcNamespacedName, err)
+			pvc.GetName(), err)
 	}
 
 	selectVolumeGroup := rmnutil.IsCGEnabled(v.instance.GetAnnotations())
 
-	volumeReplicationClass, err := v.selectVolumeReplicationClass(pvcNamespacedName, selectVolumeGroup)
+	volumeReplicationClass, err := v.selectVolumeReplicationClass(pvc, selectVolumeGroup)
 	if err != nil {
 		return fmt.Errorf("failed to find the appropriate VolumeReplicationClass (%s) %w",
 			v.instance.Name, err)
@@ -1282,7 +1280,12 @@ func (v *VRGInstance) updateVR(pvc *corev1.PersistentVolumeClaim, volRep *volrep
 
 // createVR creates a VolumeReplication CR with a PVC as its data source.
 func (v *VRGInstance) createVR(vrNamespacedName types.NamespacedName, state volrep.ReplicationState) error {
-	volumeReplicationClass, err := v.selectVolumeReplicationClass(vrNamespacedName, false)
+	pvc, err := v.getPVCForVRNSName(vrNamespacedName)
+	if err != nil {
+		return err
+	}
+
+	volumeReplicationClass, err := v.selectVolumeReplicationClass(pvc, false)
 	if err != nil {
 		return fmt.Errorf("failed to find the appropriate VolumeReplicationClass (%s) %w",
 			v.instance.Name, err)
@@ -1328,6 +1331,30 @@ func (v *VRGInstance) createVR(vrNamespacedName types.NamespacedName, state volr
 	return nil
 }
 
+func (v *VRGInstance) getPVCForVRNSName(vrNamespacedName types.NamespacedName) (*corev1.PersistentVolumeClaim, error) {
+	var pvc *corev1.PersistentVolumeClaim
+
+	for idx := range v.volRepPVCs {
+		pvcItem := &v.volRepPVCs[idx]
+
+		pvcNamespacedName := types.NamespacedName{Name: pvcItem.Name, Namespace: pvcItem.Namespace}
+		if pvcNamespacedName == vrNamespacedName {
+			pvc = pvcItem
+
+			break
+		}
+	}
+
+	if pvc == nil {
+		v.log.Info(fmt.Sprintf("failed to get the pvc with namespaced name (%s)", vrNamespacedName))
+
+		// Need the storage driver of pvc. If pvc is not found return error.
+		return nil, fmt.Errorf("failed to get the pvc with namespaced name %s", vrNamespacedName)
+	}
+
+	return pvc, nil
+}
+
 // namespacedName applies to both VolumeReplication resource and pvc as of now.
 // This is because, VolumeReplication resource for a pvc that is created by the
 // VolumeReplicationGroup has the same name as pvc. But in future if it changes
@@ -1336,7 +1363,7 @@ func (v *VRGInstance) createVR(vrNamespacedName types.NamespacedName, state volr
 
 //nolint:funlen,cyclop,gocognit,nestif,gocyclo
 func (v *VRGInstance) selectVolumeReplicationClass(
-	namespacedName types.NamespacedName, selectVolumeGroup bool,
+	pvc *corev1.PersistentVolumeClaim, selectVolumeGroup bool,
 ) (client.Object, error) {
 	if err := v.updateReplicationClassList(); err != nil {
 		return nil, err
@@ -1348,13 +1375,13 @@ func (v *VRGInstance) selectVolumeReplicationClass(
 		return nil, fmt.Errorf("no VolumeReplicationClass and VolumeGroupReplicationClass available")
 	}
 
-	storageClass, err := v.getStorageClass(namespacedName)
+	storageClass, err := v.getStorageClass(pvc)
 	if err != nil {
 		v.log.Info(fmt.Sprintf("Failed to get the storageclass of pvc %s",
-			namespacedName))
+			pvc.GetName()))
 
 		return nil, fmt.Errorf("failed to get the storageclass of pvc %s (%w)",
-			namespacedName, err)
+			pvc.GetName(), err)
 	}
 
 	matchingReplicationClassList := []client.Object{}
@@ -1483,32 +1510,12 @@ func (v *VRGInstance) getStorageClassFromSCName(scName *string) (*storagev1.Stor
 // getStorageClass inspects the PVCs being protected by this VRG instance for the passed in namespacedName, and
 // returns its corresponding StorageClass resource from an instance cache if available, or fetches it from the API
 // server and stores it in an instance cache before returning the StorageClass
-func (v *VRGInstance) getStorageClass(namespacedName types.NamespacedName) (*storagev1.StorageClass, error) {
-	var pvc *corev1.PersistentVolumeClaim
-
-	for idx := range v.volRepPVCs {
-		pvcItem := &v.volRepPVCs[idx]
-
-		pvcNamespacedName := types.NamespacedName{Name: pvcItem.Name, Namespace: pvcItem.Namespace}
-		if pvcNamespacedName == namespacedName {
-			pvc = pvcItem
-
-			break
-		}
-	}
-
-	if pvc == nil {
-		v.log.Info(fmt.Sprintf("failed to get the pvc with namespaced name (%s)", namespacedName))
-
-		// Need the storage driver of pvc. If pvc is not found return error.
-		return nil, fmt.Errorf("failed to get the pvc with namespaced name %s", namespacedName)
-	}
-
+func (v *VRGInstance) getStorageClass(pvc *corev1.PersistentVolumeClaim) (*storagev1.StorageClass, error) {
 	scName := pvc.Spec.StorageClassName
 	if scName == nil {
-		v.log.Info(fmt.Sprintf("missing StorageClass name for pvc (%s)", namespacedName))
+		v.log.Info(fmt.Sprintf("missing StorageClass name for pvc (%s)", pvc.GetName()))
 
-		return nil, fmt.Errorf("missing StorageClass name for pvc (%s)", namespacedName)
+		return nil, fmt.Errorf("missing StorageClass name for pvc (%s)", pvc.GetName())
 	}
 
 	return v.getStorageClassFromSCName(scName)

--- a/internal/controller/vrg_volrep_test.go
+++ b/internal/controller/vrg_volrep_test.go
@@ -419,12 +419,12 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		Context("PVC selection", func() {
 			var t *vrgTest
 			BeforeAll(func() {
-				vrgController.VolumeUnprotectionEnabledForAsyncVolRep = true
-				DeferCleanup(func() {
-					vrgController.VolumeUnprotectionEnabledForAsyncVolRep = false
-				})
 				t = vrgTestBoundPV
 				vrgNamespacedName = t.vrgNamespacedName()
+			})
+			AfterAll(func() {
+				ramenConfig.VolumeUnprotectionEnabled = false
+				configMapUpdate()
 			})
 			var pvcNamesSelected, pvcNamesDeselected []types.NamespacedName
 			pvcsVerify := func(pvcNames []types.NamespacedName,
@@ -2568,7 +2568,7 @@ func (v *vrgTest) cleanupPVCs(
 	vrg := v.getVRG()
 
 	pvcPostDeleteVerify1 := pvcPostDeleteVerify
-	if !vrgController.VolumeUnprotectionEnabledForAsyncVolRep {
+	if !ramenConfig.VolumeUnprotectionEnabled {
 		pvcPostDeleteVerify1 = func(pvcNamespacedName types.NamespacedName, pvName string) {
 			pvcDeletionTimestampRecentVerify(pvcNamespacedName)
 		}

--- a/internal/controller/vrg_volrep_test.go
+++ b/internal/controller/vrg_volrep_test.go
@@ -368,20 +368,20 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 				}
 
 				By("storing VRG status without PVC namespace name")
-				vrg = t.getVRG()
-				Expect(vrg.GetGeneration()).To(Equal(vrgGenerationExpected))
-				for i := range vrg.Status.ProtectedPVCs {
-					pvc := &vrg.Status.ProtectedPVCs[i]
-					pvcNamespacedNamesActual[i] = types.NamespacedName{Namespace: pvc.Namespace, Name: pvc.Name}
-				}
-				Expect(pvcNamespacedNamesActual).To(ConsistOf(t.pvcNames))
-				for _, pvcNamespacedName := range pvcNamespacedNamesUnqualified {
-					pvc := vrgController.FindProtectedPVC(vrg, pvcNamespacedName.Namespace, pvcNamespacedName.Name)
-					Expect(pvc).ToNot(BeNil())
-					pvc.Namespace = ""
-				}
-
 				Eventually(func() bool {
+					vrg = t.getVRG()
+					Expect(vrg.GetGeneration()).To(Equal(vrgGenerationExpected))
+					for i := range vrg.Status.ProtectedPVCs {
+						pvc := &vrg.Status.ProtectedPVCs[i]
+						pvcNamespacedNamesActual[i] = types.NamespacedName{Namespace: pvc.Namespace, Name: pvc.Name}
+					}
+					Expect(pvcNamespacedNamesActual).To(ConsistOf(t.pvcNames))
+					for _, pvcNamespacedName := range pvcNamespacedNamesUnqualified {
+						pvc := vrgController.FindProtectedPVC(vrg, pvcNamespacedName.Namespace, pvcNamespacedName.Name)
+						Expect(pvc).ToNot(BeNil())
+						pvc.Namespace = ""
+					}
+
 					if err := k8sClient.Status().Update(ctx, vrg); err != nil {
 						return false
 					}


### PR DESCRIPTION
Implements pvcUnprotectVolGroupRep which removes protection for a PVC when VRG
is Primary and is protected by VGR in a CG.

The unprotection works as follows:
- Sets the CG label value to an empty string, ensuring the PVC is deselected
from the CG that it belongs to
- Ensures the PVC is no longer reported as part of the VGR status as protected
- Deletes the VGR if it was protecting only this PVC
- Removes PV/PVC protection metadata

As the order ensures that the last action for the PVC is to remove its CG
label, the entire workflow is idempotent across multiple reconcile loops.

Further, all errors/progress is reported into the PVC DataReady condition.

An additional change is made to pvcsUnprotectVolGroupRep to set VRG for requeue
only if reconcileMissingVGR returns a requeue. If it reports a missing VGR and
no requeue, then further processing of the VGR is not required, and neither is
a requeue required, as VGR is cleaned up and PV/PVC is also cleaned up as
required.

Also corrects getStorageClass to use a PVC to determine what
its SC is, and corrects createVR to pass in a PVC to getStorageClass
instead of getStorageClass relying on finding the PVC in the list of
PVCs to protect. Thereby allowing common routines to fetch SC and related
classes given a PVC, even when these are not in the selected PVC lists, addressing
cases where a PVC is deselected.