### PR TITLE
Handle VolSync PVC unprotection

### DIFF
--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -42,7 +42,9 @@ const (
 	DefaultVolSyncCopyMethod                          = "Snapshot"
 )
 
-var VolumeUnprotectionEnabledForAsyncVolSync = false
+var (
+	VolumeUnprotectionEnabledForAsyncVolSync = true
+)
 
 // FIXME
 const NoS3StoreAvailable = "NoS3"

--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -42,10 +42,6 @@ const (
 	DefaultVolSyncCopyMethod                          = "Snapshot"
 )
 
-var (
-	VolumeUnprotectionEnabledForAsyncVolSync = true
-)
-
 // FIXME
 const NoS3StoreAvailable = "NoS3"
 

--- a/internal/controller/util/labels.go
+++ b/internal/controller/util/labels.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	labelOwnerNamespaceName = "ramendr.openshift.io/owner-namespace-name"
-	labelOwnerName          = "ramendr.openshift.io/owner-name"
+	LabelOwnerNamespaceName = "ramendr.openshift.io/owner-namespace-name"
+	LabelOwnerName          = "ramendr.openshift.io/owner-name"
 
 	MModesLabel                           = "ramendr.openshift.io/maintenancemodes"
 	SClassLabel                           = "ramendr.openshift.io/storageclass"
@@ -54,14 +54,14 @@ func ObjectOwnerUnsetIfSet(object, owner metav1.Object) bool {
 
 func OwnerLabels(owner metav1.Object) Labels {
 	return Labels{
-		labelOwnerNamespaceName: owner.GetNamespace(),
-		labelOwnerName:          owner.GetName(),
+		LabelOwnerNamespaceName: owner.GetNamespace(),
+		LabelOwnerName:          owner.GetName(),
 	}
 }
 
 func OwnerNamespaceNameAndName(labels Labels) (string, string, bool) {
-	ownerNamespaceName, ok1 := labels[labelOwnerNamespaceName]
-	ownerName, ok2 := labels[labelOwnerName]
+	ownerNamespaceName, ok1 := labels[LabelOwnerNamespaceName]
+	ownerName, ok2 := labels[LabelOwnerName]
 
 	return ownerNamespaceName, ownerName, ok1 && ok2
 }

--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -259,14 +259,15 @@ func AddOwnerReference(obj, owner metav1.Object, scheme *runtime.Scheme) (bool, 
 func RemoveOwnerReference(obj, owner metav1.Object, scheme *runtime.Scheme) (bool, error) {
 	currentOwnerRefs := obj.GetOwnerReferences()
 
-	err := controllerutil.RemoveOwnerReference(owner, obj, scheme)
-	if err != nil {
-		return false, err
+	length := len(currentOwnerRefs)
+	if length < 1 {
+		return false, nil // No owner references to remove
 	}
 
-	ownerRemoved := !reflect.DeepEqual(obj.GetOwnerReferences(), currentOwnerRefs)
+	// TODO: Remove just the owner's Reference instead of blindly removing all ownerreferences.
+	obj.SetOwnerReferences(nil)
 
-	return ownerRemoved, nil
+	return true, nil
 }
 
 func AddFinalizer(obj client.Object, finalizer string) bool {

--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -84,7 +84,7 @@ func (u *ResourceUpdater) DeleteAnnotation(key string) *ResourceUpdater {
 		return u
 	}
 
-	u.obj.SetLabels(annotations)
+	u.obj.SetAnnotations(annotations)
 
 	u.objModified = u.objModified || deleted
 

--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -61,10 +61,32 @@ func (u *ResourceUpdater) AddLabel(key, value string) *ResourceUpdater {
 	return u
 }
 
-func (u *ResourceUpdater) RemoveLabel(key string, value *string) *ResourceUpdater {
-	removed := RemoveLabel(u.obj, key, value)
+func (u *ResourceUpdater) DeleteLabel(key string) *ResourceUpdater {
+	labels := u.obj.GetLabels()
 
-	u.objModified = u.objModified || removed
+	deleted := DeleteKey(labels, key)
+	if !deleted {
+		return u
+	}
+
+	u.obj.SetLabels(labels)
+
+	u.objModified = u.objModified || deleted
+
+	return u
+}
+
+func (u *ResourceUpdater) DeleteAnnotation(key string) *ResourceUpdater {
+	annotations := u.obj.GetAnnotations()
+
+	deleted := DeleteKey(annotations, key)
+	if !deleted {
+		return u
+	}
+
+	u.obj.SetLabels(annotations)
+
+	u.objModified = u.objModified || deleted
 
 	return u
 }
@@ -233,6 +255,18 @@ func AddFinalizer(obj client.Object, finalizer string) bool {
 	}
 
 	return !finalizerAdded
+}
+
+func DeleteKey(keys map[string]string, key string) bool {
+	if keys == nil {
+		return false // No keys to delete from
+	}
+
+	startLen := len(keys)
+
+	delete(keys, key)
+
+	return startLen != len(keys)
 }
 
 // UpdateStringMap copies all key/value pairs in src adding them to map

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -2661,7 +2661,6 @@ func (v *VSHandler) UnprotectVolSyncPVC(pvc *corev1.PersistentVolumeClaim) error
 		return err
 	}
 
-	v.log.Info("UNPROTECT DELETING LABELS+ANNO+FINALIZERS", "pvcName", pvc.GetName(), "pvcNamespace", pvc.GetNamespace())
 	// Remove the VolSync labels and annotations from the PVC
 	return util.NewResourceUpdater(pvc).
 		DeleteLabel(util.CreatedByRamenLabel).

--- a/internal/controller/volsync/vshandler_test.go
+++ b/internal/controller/volsync/vshandler_test.go
@@ -1432,7 +1432,8 @@ var _ = Describe("VolSync_Handler", func() {
 		Context("When rdSpec List is empty", func() {
 			It("Should clean up all rd instances for the VRG", func() {
 				// Empty RDSpec list
-				Expect(vsHandler.CleanupRDNotInSpecList([]ramendrv1alpha1.VolSyncReplicationDestinationSpec{})).To(Succeed())
+				Expect(vsHandler.CleanupRDNotInSpecList([]ramendrv1alpha1.VolSyncReplicationDestinationSpec{},
+					ramendrv1alpha1.Primary)).To(Succeed())
 
 				rdList := &volsyncv1alpha1.ReplicationDestinationList{}
 				Eventually(func() int {
@@ -1456,7 +1457,7 @@ var _ = Describe("VolSync_Handler", func() {
 					rdSpecList[5],
 					rdSpecList[6],
 				}
-				Expect(vsHandler.CleanupRDNotInSpecList(sList)).To(Succeed())
+				Expect(vsHandler.CleanupRDNotInSpecList(sList, ramendrv1alpha1.Secondary)).To(Succeed())
 
 				rdList := &volsyncv1alpha1.ReplicationDestinationList{}
 				Eventually(func() int {

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1494,6 +1494,10 @@ func (v *VRGInstance) pvcsDeselectedUnprotect() error {
 		return err
 	}
 
+	log.Info("Selected PVCS owned by VRG",
+		"count", len(pvcsOwned.Items),
+		"namespaces", v.instance.Namespace)
+
 	pvcsVr := util.ObjectsMap(v.volRepPVCs...)
 	pvcsVs := util.ObjectsMap(v.volSyncPVCs...)
 

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -646,7 +646,13 @@ func (v *VRGInstance) pvcUnprotectVolSync(pvc corev1.PersistentVolumeClaim, log 
 
 		return
 	}
-	// TODO: Delete ReplicationSource, ReplicationDestination, etc.
+	// This call is only from Primary cluster. delete ReplicationSource/CG resources.
+	if err := v.volSyncHandler.UnprotectVolSyncPVC(&pvc); err != nil {
+		log.Error(err, "Failed to unprotect VolSync PVC", "PVC", pvc.Name)
+
+		return
+	}
+	// Remove the PVC from VRG status
 	v.pvcStatusDeleteIfPresent(pvc.Namespace, pvc.Name, log)
 }
 

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -703,11 +703,6 @@ func (v *VRGInstance) pvcUnprotectVolSync(pvc corev1.PersistentVolumeClaim, log 
 		return
 	}
 
-	if !VolumeUnprotectionEnabledForAsyncVolSync {
-		log.Info("Volume unprotection disabled for VolSync")
-
-		return
-	}
 	// This call is only from Primary cluster. delete ReplicationSource/CG resources.
 	if err := v.volSyncHandler.UnprotectVolSyncPVC(&pvc); err != nil {
 		log.Error(err, "Failed to unprotect VolSync PVC", "PVC", pvc.Name)

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -712,7 +712,15 @@ func (v *VRGInstance) pvcUnprotectVolSyncIfDeleted(
 }
 
 func (v *VRGInstance) pvcUnprotectVolSync(pvc corev1.PersistentVolumeClaim, log logr.Logger) {
-	// This call is only from Primary cluster. delete ReplicationSource/CG resources.
+	if util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader, v.instance.Annotations) {
+		// At this moment, we don't support unprotecting CG PVCs.
+		log.Info("Unprotecting CG PVCs is not supported", "PVC", pvc.Name)
+
+		return
+	}
+
+	log.Info("Unprotecting VolSync PVC", "PVC", pvc.Name)
+	// This call is only from Primary cluster. delete ReplicationSource and related resources.
 	if err := v.volSyncHandler.UnprotectVolSyncPVC(&pvc); err != nil {
 		log.Error(err, "Failed to unprotect VolSync PVC", "PVC", pvc.Name)
 

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -712,6 +712,12 @@ func (v *VRGInstance) pvcUnprotectVolSyncIfDeleted(
 }
 
 func (v *VRGInstance) pvcUnprotectVolSync(pvc corev1.PersistentVolumeClaim, log logr.Logger) {
+	if !v.ramenConfig.VolumeUnprotectionEnabled {
+		log.Info("Volume unprotection disabled")
+
+		return
+	}
+
 	if util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader, v.instance.Annotations) {
 		// At this moment, we don't support unprotecting CG PVCs.
 		log.Info("Unprotecting CG PVCs is not supported", "PVC", pvc.Name)


### PR DESCRIPTION
1. Cleanup ReplicationSource when a PVC is unprotected
2. Ensures ReplicationSource resources are deleted when a PVC is no longer protected by VolSync.
3. Cleanup ReplicationDestination when a PVC is unprotected
4. Restrict unprotection logic to VolSync-protected PVCs only.

TODO:
- [x] Manual testing with drenv and real setup
- [ ] Do the same for CG (VolSync)
- [x] Test mixed workload (Cephfs + RBD)
- [ ] Add e2e cases