### PR TITLE
Change CG enablement logic to use PeerClass capabilities

### DIFF
--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -1387,7 +1387,7 @@ func (r *DRPlacementControlReconciler) updateResourceCondition(
 
 	drpc.Status.ResourceConditions.ResourceMeta.ProtectedPVCs = protectedPVCs
 
-	if rmnutil.IsCGEnabled(vrg.GetAnnotations()) {
+	if vrg.Status.PVCGroups != nil {
 		drpc.Status.ResourceConditions.ResourceMeta.PVCGroups = vrg.Status.PVCGroups
 	}
 

--- a/internal/controller/util/misc_test.go
+++ b/internal/controller/util/misc_test.go
@@ -10,10 +10,6 @@ import (
 )
 
 var _ = Describe("misc", func() {
-	Expect(util.IsCGEnabled(nil)).Should(Equal(false))
-	Expect(util.IsCGEnabled(map[string]string{})).Should(Equal(false))
-	Expect(util.IsCGEnabled(map[string]string{util.IsCGEnabledAnnotation: "true"})).Should(Equal(true))
-
 	Expect(util.IsPVCMarkedForVolSync(nil)).Should(Equal(false))
 	Expect(util.IsPVCMarkedForVolSync(map[string]string{})).Should(Equal(false))
 	Expect(util.IsPVCMarkedForVolSync(map[string]string{util.UseVolSyncAnnotation: "true"})).

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -818,7 +818,7 @@ func (v *VSHandler) PreparePVC(pvcNamespacedName types.NamespacedName,
 		}
 	}
 
-	if prepFinalSync && !util.IsCGEnabledForVolSync(v.ctx, v.client, v.owner.GetAnnotations()) {
+	if prepFinalSync && !util.IsCGEnabledForVolSync(v.ctx, v.client) {
 		err := v.prepareForFinalSync(pvcNamespacedName)
 		if err != nil {
 			return err

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -806,6 +806,7 @@ func (v *VSHandler) undoAfterFinalSync(pvcName, pvcNamespace string) error {
 }
 
 func (v *VSHandler) PreparePVC(pvcNamespacedName types.NamespacedName,
+	isCGEnabled,
 	copyMethodDirect,
 	prepFinalSync,
 	runFinalSync bool,
@@ -818,7 +819,7 @@ func (v *VSHandler) PreparePVC(pvcNamespacedName types.NamespacedName,
 		}
 	}
 
-	if prepFinalSync && !util.IsCGEnabledForVolSync(v.ctx, v.client) {
+	if prepFinalSync && !isCGEnabled {
 		err := v.prepareForFinalSync(pvcNamespacedName)
 		if err != nil {
 			return err

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -581,10 +581,6 @@ func (v *VRGInstance) processVRG() ctrl.Result {
 		return v.invalid(err, "Failed to process list of PVCs to protect", true)
 	}
 
-	if err := v.labelPVCsForCG(); err != nil {
-		return v.invalid(err, "Failed to label PVCs for consistency groups", true)
-	}
-
 	v.log = v.log.WithValues("State", v.instance.Spec.ReplicationState)
 	v.s3StoreAccessorsGet()
 
@@ -735,36 +731,6 @@ func (v *VRGInstance) updatePVCList() error {
 	return v.separateAsyncPVCs(pvcList)
 }
 
-func (v *VRGInstance) labelPVCsForCG() error {
-	if v.instance.Spec.Async == nil {
-		return nil
-	}
-
-	if util.IsCGEnabledForVolRep(v.ctx, v.reconciler.APIReader) {
-		for idx := range v.volRepPVCs {
-			pvc := &v.volRepPVCs[idx]
-
-			if err := v.addVolRepConsistencyGroupLabel(pvc); err != nil {
-				return fmt.Errorf("failed to label PVC %s/%s for consistency group (%w)",
-					pvc.GetNamespace(), pvc.GetName(), err)
-			}
-		}
-	}
-
-	if util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader) {
-		for idx := range v.volSyncPVCs {
-			pvc := &v.volSyncPVCs[idx]
-
-			if err := v.addConsistencyGroupLabel(pvc); err != nil {
-				return fmt.Errorf("failed to label PVC %s/%s for consistency group (%w)",
-					pvc.GetNamespace(), pvc.GetName(), err)
-			}
-		}
-	}
-
-	return nil
-}
-
 // addVolRepConsistencyGroupLabel ensures that the given PVC is labeled as part of a consistency group.
 // It does this by retrieving the associated VolumeGroupReplicationClass and extracting its replication ID,
 // which is then added as a label to the PVC.
@@ -904,7 +870,6 @@ func (v *VRGInstance) validateSyncPVCs(pvcList *corev1.PersistentVolumeClaimList
 	return nil
 }
 
-// nolint:gocognit
 func (v *VRGInstance) separatePVCsUsingOnlySC(storageClass *storagev1.StorageClass, pvc *corev1.PersistentVolumeClaim) {
 	v.log.Info("separating PVC using only sc provisioner")
 
@@ -914,28 +879,12 @@ func (v *VRGInstance) separatePVCsUsingOnlySC(storageClass *storagev1.StorageCla
 
 	//nolint:nestif
 	if !pvcEnabledForVolSync {
-		separatePVCs := func(provisioner string) {
-			if storageClass.Provisioner == provisioner {
+		for _, replicationClass := range v.replClassList.Items {
+			if storageClass.Provisioner == replicationClass.Spec.Provisioner {
 				v.volRepPVCs = append(v.volRepPVCs, *pvc)
 				replicationClassMatchFound = true
-			}
-		}
 
-		if util.IsCGEnabledForVolRep(v.ctx, v.reconciler.APIReader) {
-			for _, replicationClass := range v.grpReplClassList.Items {
-				separatePVCs(replicationClass.Spec.Provisioner)
-
-				if replicationClassMatchFound {
-					break
-				}
-			}
-		} else {
-			for _, replicationClass := range v.replClassList.Items {
-				separatePVCs(replicationClass.Spec.Provisioner)
-
-				if replicationClassMatchFound {
-					break
-				}
+				break
 			}
 		}
 	}
@@ -945,6 +894,7 @@ func (v *VRGInstance) separatePVCsUsingOnlySC(storageClass *storagev1.StorageCla
 	}
 }
 
+//nolint:cyclop,funlen,nestif,gocognit
 func (v *VRGInstance) separatePVCUsingPeerClassAndSC(peerClasses []ramendrv1alpha1.PeerClass,
 	storageClass *storagev1.StorageClass, pvc *corev1.PersistentVolumeClaim,
 ) error {
@@ -968,6 +918,14 @@ func (v *VRGInstance) separatePVCUsingPeerClassAndSC(peerClasses []ramendrv1alph
 		if peerClass.ReplicationID != "" {
 			replicationClass := v.findReplicationClassUsingPeerClass(peerClass, storageClass)
 			if replicationClass != nil {
+				// label VolRep PVCs if peerClass.grouping is enabled
+				if peerClass.Grouping {
+					if err := v.addVolRepConsistencyGroupLabel(pvc); err != nil {
+						return fmt.Errorf("failed to label PVC %s/%s for consistency group (%w)",
+							pvc.GetNamespace(), pvc.GetName(), err)
+					}
+				}
+
 				v.volRepPVCs = append(v.volRepPVCs, *pvc)
 
 				return nil
@@ -989,6 +947,14 @@ func (v *VRGInstance) separatePVCUsingPeerClassAndSC(peerClasses []ramendrv1alph
 
 	if snapClass == nil {
 		return fmt.Errorf("failed to find snapshotClass for PVC %s/%s", pvc.Namespace, pvc.Name)
+	}
+
+	// label VolSync PVCs if peerClass.grouping is enabled
+	if peerClass.Grouping {
+		if err := v.addConsistencyGroupLabel(pvc); err != nil {
+			return fmt.Errorf("failed to label PVC %s/%s for consistency group (%w)",
+				pvc.GetNamespace(), pvc.GetName(), err)
+		}
 	}
 
 	v.volSyncPVCs = append(v.volSyncPVCs, *pvc)

--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -616,7 +616,7 @@ func (v *VRGInstance) reconcileMissingVGR(vrNamespacedName types.NamespacedName,
 func (v *VRGInstance) isCGEnabled(pvc *corev1.PersistentVolumeClaim) (string, bool) {
 	cg, ok := pvc.GetLabels()[ConsistencyGroupLabel]
 
-	return cg, ok && rmnutil.IsCGEnabled(v.instance.GetAnnotations())
+	return cg, ok && rmnutil.IsCGEnabledForVolRep(v.ctx, v.reconciler.APIReader)
 }
 
 func (v *VRGInstance) processVGRAsPrimary(vrNamespacedName types.NamespacedName,
@@ -854,7 +854,7 @@ func (v *VRGInstance) addArchivedAnnotationForVGRandVGRC(vgr *volrep.VolumeGroup
 }
 
 func (v *VRGInstance) restoreVGRsAndVGRCsForVolRep(result *ctrl.Result) error {
-	if !rmnutil.IsCGEnabled(v.instance.GetAnnotations()) {
+	if !rmnutil.IsCGEnabledForVolRep(v.ctx, v.reconciler.APIReader) {
 		return nil
 	}
 

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -305,7 +305,7 @@ func (v *VRGInstance) updateProtectedPVCs(pvc *corev1.PersistentVolumeClaim) err
 			pvc.GetName(), err)
 	}
 
-	selectVolumeGroup := rmnutil.IsCGEnabled(v.instance.GetAnnotations())
+	_, selectVolumeGroup := v.isCGEnabled(pvc)
 
 	volumeReplicationClass, err := v.selectVolumeReplicationClass(pvc, selectVolumeGroup)
 	if err != nil {

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -39,7 +39,7 @@ func (v *VRGInstance) restorePVsAndPVCsForVolSync() (int, error) {
 		rdSpec.ProtectedPVC.Conditions = nil
 
 		cgLabelVal, ok := rdSpec.ProtectedPVC.Labels[ConsistencyGroupLabel]
-		if ok && util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader, v.instance.Annotations) {
+		if ok && util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader) {
 			v.log.Info("The CG label from the primary cluster found in RDSpec", "Label", cgLabelVal)
 			// Get the CG label value for this cluster
 			cgLabelVal, err = v.getCGLabelValue(rdSpec.ProtectedPVC.StorageClassName,
@@ -206,7 +206,7 @@ func (v *VRGInstance) reconcilePVCAsVolSyncPrimary(pvc corev1.PersistentVolumeCl
 	*finalSyncPrepared = true
 
 	cg, ok := pvc.Labels[ConsistencyGroupLabel]
-	if ok && util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader, v.instance.Annotations) {
+	if ok && util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader) {
 		v.log.Info("PVC has CG label", "Labels", pvc.Labels)
 		cephfsCGHandler := cephfscg.NewVSCGHandler(
 			v.ctx, v.reconciler.Client, v.instance,
@@ -383,7 +383,7 @@ func (v *VRGInstance) reconcileCGMembership() (map[string]struct{}, bool, error)
 
 	for _, rdSpec := range v.instance.Spec.VolSync.RDSpec {
 		cgLabelVal, ok := rdSpec.ProtectedPVC.Labels[ConsistencyGroupLabel]
-		if ok && util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader, v.instance.Annotations) {
+		if ok && util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader) {
 			v.log.Info("RDSpec contains the CG label from the primary cluster", "Label", cgLabelVal)
 			// Get the CG label value for this cluster
 			cgLabelVal, err := v.getCGLabelValue(rdSpec.ProtectedPVC.StorageClassName,
@@ -724,7 +724,7 @@ func (v *VRGInstance) pvcUnprotectVolSync(pvc corev1.PersistentVolumeClaim, log 
 		return
 	}
 
-	if util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader, v.instance.Annotations) {
+	if util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader) {
 		// At this moment, we don't support unprotecting CG PVCs.
 		log.Info("Unprotecting CG PVCs is not supported", "PVC", pvc.Name)
 


### PR DESCRIPTION
Previously, consistency grouping (CG) was controlled by the annotation `drplacementcontrol.ramendr.openshift.io/is-cg-enabled` on the DRPlacementControl. This allowed CG to be enabled per workload, with the default value being false.

With this change, CG enablement is no longer defined by that annotation. Instead, it is based on the selected PeerClass in the
VolumeGroupReplicationClass: if `peerClass.grouping == true`, the PVC is marked as part of a consistency group.

This makes CG a storage-level capability (inherited from the class), rather than a workload-level setting.