### PR TITLE
ci: Prune images daily

### DIFF
--- a/.github/workflows/e2e-daily.yaml
+++ b/.github/workflows/e2e-daily.yaml
@@ -34,3 +34,10 @@ jobs:
           command: |
             cd test
             drenv cache -v envs/regional-dr.yaml
+
+  prune-images:
+    runs-on: [self-hosted, e2e-rdr]
+    if: github.repository == 'RamenDR/ramen'
+    steps:
+      - name: Prune images
+        run: podman image prune -f


### PR DESCRIPTION
Currently the e2e runner is keeping temporary build images that are never deleted and can cause the disk to fill up. Add prune-images job to clean up automatically daily.