### PR TITLE
recipe: updating error message for check hooks

### DIFF
--- a/internal/controller/hooks/json_util.go
+++ b/internal/controller/hooks/json_util.go
@@ -186,8 +186,9 @@ func compare(a, b reflect.Value, operator string) (bool, error) {
 	b = convertString(b)
 
 	// Ensure operands are of the same type before comparison
-	if a.Kind() != b.Kind() {
-		return false, fmt.Errorf("operands of different kinds can't be compared: %v, %v", a.Kind(), b.Kind())
+	if a.Kind() != b.Kind() && (a.Kind() == reflect.Invalid || b.Kind() == reflect.Invalid) {
+		return false, fmt.Errorf("check expression to evaluate, one of the jsonpath is either incorrect" +
+			" or value is not updated")
 	}
 
 	// Validate the operator for the given types


### PR DESCRIPTION
There is a possibility that just after failover/relocated, the deployment status is not updated by the k8s api server. Hence, updating the error message for better clarity.