### PR TITLE
recipe: skip logging of recipe for pvc updates

### DIFF
--- a/internal/controller/util/recipe.go
+++ b/internal/controller/util/recipe.go
@@ -9,6 +9,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const RecipeElementsGetForPVC = "recipeElementsGetForPVC"
+
 type RecipeElements struct {
 	PvcSelector         PvcSelector
 	CaptureWorkflow     []kubeobjects.CaptureSpec

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -335,7 +335,9 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 	for _, vrg := range vrgs.Items {
 		log1 := log.WithValues("vrg", vrg.Name)
 
-		pvcSelector, err := GetPVCSelector(context.TODO(), reader, vrg, *ramenConfig, log)
+		ctx := context.WithValue(context.Background(), util.RecipeElementsGetForPVC, "true")
+
+		pvcSelector, err := GetPVCSelector(ctx, reader, vrg, *ramenConfig, log)
 		if err != nil {
 			continue
 		}

--- a/internal/controller/vrg_recipe.go
+++ b/internal/controller/vrg_recipe.go
@@ -136,7 +136,7 @@ func RecipeElementsGet(ctx context.Context, reader client.Reader, vrg ramen.Volu
 	}
 
 	parameters := getRecipeParameters(vrg, ramenConfig)
-	if err := RecipeParametersExpand(&recipe, parameters, log); err != nil {
+	if err := RecipeParametersExpand(ctx, &recipe, parameters, log); err != nil {
 		return recipeElements, fmt.Errorf("recipe %v parameters expansion error: %w", recipeNamespacedName.String(), err)
 	}
 
@@ -224,11 +224,14 @@ func getRecipeObj(ctx context.Context, recipeNamespacedName types.NamespacedName
 	return recipe, nil
 }
 
-func RecipeParametersExpand(recipe *recipev1.Recipe, parameters map[string][]string,
+func RecipeParametersExpand(ctx context.Context, recipe *recipev1.Recipe, parameters map[string][]string,
 	log logr.Logger,
 ) error {
 	spec := &recipe.Spec
-	log.V(1).Info("Recipe pre-expansion", "spec", *spec, "parameters", parameters)
+
+	if ctx.Value(util.RecipeElementsGetForPVC) == nil {
+		log.V(1).Info("Recipe pre-expansion", "spec", *spec, "parameters", parameters)
+	}
 
 	bytes, err := json.Marshal(*spec)
 	if err != nil {
@@ -242,7 +245,9 @@ func RecipeParametersExpand(recipe *recipev1.Recipe, parameters map[string][]str
 		return fmt.Errorf("recipe spec %v json unmarshal error: %w", s2, err)
 	}
 
-	log.V(1).Info("Recipe post-expansion", "spec", *spec)
+	if ctx.Value(util.RecipeElementsGetForPVC) == nil {
+		log.V(1).Info("Recipe post-expansion", "spec", *spec)
+	}
 
 	return nil
 }

--- a/internal/controller/vrg_recipe_test.go
+++ b/internal/controller/vrg_recipe_test.go
@@ -4,6 +4,7 @@
 package controllers_test
 
 import (
+	"context"
 	"strings"
 
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
@@ -466,8 +467,9 @@ var _ = Describe("VolumeReplicationGroupRecipe", func() {
 						recipeHooksDefine(hook(ns0ParameterRef))
 					})
 					JustBeforeEach(func() {
-						recipeExpanded = &*r
-						Expect(controllers.RecipeParametersExpand(recipeExpanded, vrgRecipeParameters(), testLogger)).To(Succeed())
+						recipeExpanded = r
+						Expect(controllers.RecipeParametersExpand(context.TODO(),
+							recipeExpanded, vrgRecipeParameters(), testLogger)).To(Succeed())
 					})
 					It("expands a parameter list enclosed in double quotes to a single string with quotes preserved", func() {
 						Skip("feature not supported")


### PR DESCRIPTION
Currently, recipe before and after parameters expand is being logged in following scenarios:
1. When a PVC update is being processed, that is when either a pvc is either created or updated.
2. When vrg is being processed which refers to recipe and its expansion.

The logging of the recipe during pvc update leads to lot of logging. Hence, by using the context values, logging is not done now for pvc updates.