### PR TITLE
e2e: prepare env for adding optional passive hub

### DIFF
--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -107,7 +107,7 @@ func (d DiscoveredApp) IsDiscovered() bool {
 	return true
 }
 
-func DeleteDiscoveredApps(ctx types.TestContext, cluster types.Cluster, namespace string) error {
+func DeleteDiscoveredApps(ctx types.TestContext, cluster *types.Cluster, namespace string) error {
 	log := ctx.Logger()
 
 	tempDir, err := os.MkdirTemp("", "ramen-")
@@ -143,12 +143,12 @@ func DeleteDiscoveredApps(ctx types.TestContext, cluster types.Cluster, namespac
 
 // chooseDeployCluster determines which cluster to deploy the discovered
 // application on based on the status of the workload across clusters.
-func chooseDeployCluster(ctx types.TestContext) (types.Cluster, error) {
+func chooseDeployCluster(ctx types.TestContext) (*types.Cluster, error) {
 	log := ctx.Logger()
 
 	statuses, err := ctx.Workload().Status(ctx)
 	if err != nil {
-		return types.Cluster{}, err
+		return nil, err
 	}
 
 	switch len(statuses) {
@@ -164,7 +164,7 @@ func chooseDeployCluster(ctx types.TestContext) (types.Cluster, error) {
 
 		return ctx.Env().GetCluster(statuses[0].ClusterName)
 	default:
-		return types.Cluster{}, fmt.Errorf("application \"%s/%s\" found on multiple clusters: %+v",
+		return nil, fmt.Errorf("application \"%s/%s\" found on multiple clusters: %+v",
 			ctx.AppNamespace(), ctx.Workload().GetAppName(), statuses)
 	}
 }

--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -46,7 +46,7 @@ func waitSubscriptionPhase(
 	}
 }
 
-func WaitWorkloadHealth(ctx types.TestContext, cluster types.Cluster, namespace string) error {
+func WaitWorkloadHealth(ctx types.TestContext, cluster *types.Cluster, namespace string) error {
 	log := ctx.Logger()
 	w := ctx.Workload()
 	start := time.Now()

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -206,7 +206,7 @@ func failoverRelocate(
 	ctx types.TestContext,
 	action ramen.DRAction,
 	state ramen.DRState,
-	currentCluster, targetCluster types.Cluster,
+	currentCluster, targetCluster *types.Cluster,
 ) error {
 	d := ctx.Deployer()
 	if d.IsDiscovered() {
@@ -235,7 +235,7 @@ func waitAndUpdateDRPC(
 	ctx types.TestContext,
 	namespace, drpcName string,
 	action ramen.DRAction,
-	targetCluster types.Cluster,
+	targetCluster *types.Cluster,
 ) error {
 	log := ctx.Logger()
 

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -130,7 +130,7 @@ func failoverRelocateDiscoveredApps(
 	ctx types.TestContext,
 	action ramen.DRAction,
 	state ramen.DRState,
-	currentCluster, targetCluster types.Cluster,
+	currentCluster, targetCluster *types.Cluster,
 ) error {
 	name := ctx.Name()
 	managementNamespace := ctx.ManagementNamespace()
@@ -165,24 +165,24 @@ func failoverRelocateDiscoveredApps(
 
 // findProtectCluster determines which cluster contains the discovered application
 // to be protected based on the status of the workload across clusters.
-func findProtectCluster(ctx types.TestContext) (types.Cluster, error) {
+func findProtectCluster(ctx types.TestContext) (*types.Cluster, error) {
 	log := ctx.Logger()
 
 	statuses, err := ctx.Workload().Status(ctx)
 	if err != nil {
-		return types.Cluster{}, err
+		return nil, err
 	}
 
 	switch len(statuses) {
 	case 0:
-		return types.Cluster{}, fmt.Errorf("application \"%s/%s\" not found", ctx.AppNamespace(), ctx.Workload().GetAppName())
+		return nil, fmt.Errorf("application \"%s/%s\" not found", ctx.AppNamespace(), ctx.Workload().GetAppName())
 	case 1:
 		log.Debugf("Application \"%s/%s\" found in cluster %q with status %q",
 			ctx.AppNamespace(), ctx.Workload().GetAppName(), statuses[0].ClusterName, statuses[0].Status)
 
 		return ctx.Env().GetCluster(statuses[0].ClusterName)
 	default:
-		return types.Cluster{}, fmt.Errorf("application \"%s/%s\" found on multiple clusters: %+v",
+		return nil, fmt.Errorf("application \"%s/%s\" found on multiple clusters: %+v",
 			ctx.AppNamespace(), ctx.Workload().GetAppName(), statuses)
 	}
 }

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -91,12 +91,12 @@ func waitDRPCPhase(ctx types.TestContext, namespace, name string, phase ramen.DR
 
 func getTargetCluster(
 	ctx types.TestContext,
-	cluster types.Cluster,
+	cluster *types.Cluster,
 	drPolicyName, currentCluster string,
-) (types.Cluster, error) {
+) (*types.Cluster, error) {
 	drpolicy, err := util.GetDRPolicy(ctx, cluster, drPolicyName)
 	if err != nil {
-		return types.Cluster{}, err
+		return nil, err
 	}
 
 	var targetClusterName string

--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -93,13 +93,13 @@ func newCluster(
 	key string,
 	clusterConfig config.Cluster,
 	log *zap.SugaredLogger,
-) (types.Cluster, error) {
+) (*types.Cluster, error) {
 	client, err := newClient(clusterConfig.Kubeconfig)
 	if err != nil {
-		return types.Cluster{}, fmt.Errorf("failed to create cluster %q: %w", key, err)
+		return nil, fmt.Errorf("failed to create cluster %q: %w", key, err)
 	}
 
-	cluster := types.Cluster{
+	cluster := &types.Cluster{
 		Client:     client,
 		Kubeconfig: clusterConfig.Kubeconfig,
 	}
@@ -111,9 +111,9 @@ func newCluster(
 		log.Infof("Using %q cluster name: %q", key, cluster.Name)
 	case "c1", "c2":
 		// For c1 and c2 clusters, get the cluster name from ClusterClaim
-		cluster.Name, err = getClusterClaimName(ctx, &cluster)
+		cluster.Name, err = getClusterClaimName(ctx, cluster)
 		if err != nil {
-			return types.Cluster{}, fmt.Errorf("failed to get ClusterClaim name for the %q managed cluster: %w", key, err)
+			return nil, fmt.Errorf("failed to get ClusterClaim name for the %q managed cluster: %w", key, err)
 		}
 
 		log.Infof("Detected %q managed cluster name: %q", key, cluster.Name)

--- a/e2e/types/env.go
+++ b/e2e/types/env.go
@@ -7,7 +7,7 @@ import "fmt"
 
 // GetCluster returns the cluster from the env that matches clusterName.
 // If not found, it returns an empty Cluster and an error.
-func (e *Env) GetCluster(clusterName string) (Cluster, error) {
+func (e *Env) GetCluster(clusterName string) (*Cluster, error) {
 	switch clusterName {
 	case e.C1.Name:
 		return e.C1, nil
@@ -16,6 +16,6 @@ func (e *Env) GetCluster(clusterName string) (Cluster, error) {
 	case e.Hub.Name:
 		return e.Hub, nil
 	default:
-		return Cluster{}, fmt.Errorf("cluster %q not found in environment", clusterName)
+		return nil, fmt.Errorf("cluster %q not found in environment", clusterName)
 	}
 }

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -28,9 +28,9 @@ type Cluster struct {
 }
 
 type Env struct {
-	Hub Cluster `json:"hub"`
-	C1  Cluster `json:"c1"`
-	C2  Cluster `json:"c2"`
+	Hub *Cluster `json:"hub"`
+	C1  *Cluster `json:"c1"`
+	C2  *Cluster `json:"c2"`
 }
 
 // WorkloadStatus holds the status of an application on a specific cluster
@@ -58,7 +58,7 @@ type Workload interface {
 	GetAppName() string
 	GetPath() string
 	GetBranch() string
-	Health(ctx TestContext, cluster Cluster, namespace string) error
+	Health(ctx TestContext, cluster *Cluster, namespace string) error
 	Status(ctx TestContext) ([]WorkloadStatus, error)
 }
 

--- a/e2e/util/drpolicy.go
+++ b/e2e/util/drpolicy.go
@@ -11,7 +11,7 @@ import (
 )
 
 // nolint:unparam
-func GetDRPolicy(ctx types.Context, cluster types.Cluster, name string) (*ramen.DRPolicy, error) {
+func GetDRPolicy(ctx types.Context, cluster *types.Cluster, name string) (*ramen.DRPolicy, error) {
 	drpolicy := &ramen.DRPolicy{}
 	key := k8stypes.NamespacedName{Name: name}
 

--- a/e2e/util/namespace.go
+++ b/e2e/util/namespace.go
@@ -27,7 +27,7 @@ const (
 
 // CreateNamespace creates a namespace in the specified cluster with the ramen-e2e managed label.
 // If the namespace already exists, it checks whether it's managed by ramen-e2e and logs a warning if not.
-func CreateNamespace(ctx types.Context, cluster types.Cluster, name string) error {
+func CreateNamespace(ctx types.Context, cluster *types.Cluster, name string) error {
 	log := ctx.Logger()
 
 	ns := &corev1.Namespace{
@@ -67,7 +67,7 @@ func CreateNamespace(ctx types.Context, cluster types.Cluster, name string) erro
 
 // DeleteNamespace safely deletes a namespace from the specified cluster.
 // Only deletes namespaces that are managed by ramen-e2e.
-func DeleteNamespace(ctx types.Context, cluster types.Cluster, name string) error {
+func DeleteNamespace(ctx types.Context, cluster *types.Cluster, name string) error {
 	log := ctx.Logger()
 
 	ns := &corev1.Namespace{
@@ -145,7 +145,7 @@ func AddVolsyncAnnontationOnManagedClusters(ctx types.Context, namespace string)
 	return addNamespaceAnnotationForVolSync(ctx, ctx.Env().C2, namespace)
 }
 
-func addNamespaceAnnotationForVolSync(ctx types.Context, cluster types.Cluster, namespace string) error {
+func addNamespaceAnnotationForVolSync(ctx types.Context, cluster *types.Cluster, namespace string) error {
 	log := ctx.Logger()
 
 	key := k8stypes.NamespacedName{Name: namespace}
@@ -179,7 +179,7 @@ func addNamespaceAnnotationForVolSync(ctx types.Context, cluster types.Cluster, 
 // isManagedByRamenE2e checks if a Kubernetes object is managed by the ramen-e2e.
 // Returns true if the object exists and has the required label, false if it exists but lacks the label.
 // Returns an error if the object cannot be retrieved (e.g., not found).
-func isManagedByRamenE2e(ctx types.Context, cluster types.Cluster, obj client.Object) (bool, error) {
+func isManagedByRamenE2e(ctx types.Context, cluster *types.Cluster, obj client.Object) (bool, error) {
 	err := cluster.Client.Get(ctx.Context(), client.ObjectKeyFromObject(obj), obj)
 	if err != nil {
 		return false, err

--- a/e2e/util/placement.go
+++ b/e2e/util/placement.go
@@ -21,10 +21,10 @@ const PlacementDecisionReasonFailoverRetained = "RetainedForFailover"
 // by looking up the cluster name from the PlacementDecision and returning the corresponding
 // cluster from the environment. Requires an existing PlacementDecision with a valid decision.
 // Not applicable for discovered apps before enabling protection, as no Placement exists.
-func GetCurrentCluster(ctx types.Context, namespace string, placementName string) (types.Cluster, error) {
+func GetCurrentCluster(ctx types.Context, namespace string, placementName string) (*types.Cluster, error) {
 	clusterDecision, err := getClusterDecisionFromPlacement(ctx, namespace, placementName)
 	if err != nil {
-		return types.Cluster{}, err
+		return nil, err
 	}
 
 	return ctx.Env().GetCluster(clusterDecision.ClusterName)

--- a/e2e/util/wait.go
+++ b/e2e/util/wait.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ramendr/ramen/e2e/types"
 )
 
-func WaitForApplicationSetDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
+func WaitForApplicationSetDelete(ctx types.Context, cluster *types.Cluster, name, namespace string) error {
 	obj := &argocdv1alpha1hack.ApplicationSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -31,7 +31,7 @@ func WaitForApplicationSetDelete(ctx types.Context, cluster types.Cluster, name,
 	return waitForResourceDelete(ctx, cluster, obj)
 }
 
-func WaitForConfigMapDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
+func WaitForConfigMapDelete(ctx types.Context, cluster *types.Cluster, name, namespace string) error {
 	obj := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -42,7 +42,7 @@ func WaitForConfigMapDelete(ctx types.Context, cluster types.Cluster, name, name
 	return waitForResourceDelete(ctx, cluster, obj)
 }
 
-func WaitForPlacementDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
+func WaitForPlacementDelete(ctx types.Context, cluster *types.Cluster, name, namespace string) error {
 	obj := &ocmv1b1.Placement{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -53,7 +53,7 @@ func WaitForPlacementDelete(ctx types.Context, cluster types.Cluster, name, name
 	return waitForResourceDelete(ctx, cluster, obj)
 }
 
-func WaitForManagedClusterSetBindingDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
+func WaitForManagedClusterSetBindingDelete(ctx types.Context, cluster *types.Cluster, name, namespace string) error {
 	obj := &ocmv1b2.ManagedClusterSetBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -64,7 +64,7 @@ func WaitForManagedClusterSetBindingDelete(ctx types.Context, cluster types.Clus
 	return waitForResourceDelete(ctx, cluster, obj)
 }
 
-func WaitForDRPCDelete(ctx types.Context, cluster types.Cluster, name, namespace string) error {
+func WaitForDRPCDelete(ctx types.Context, cluster *types.Cluster, name, namespace string) error {
 	obj := &ramen.DRPlacementControl{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -75,7 +75,7 @@ func WaitForDRPCDelete(ctx types.Context, cluster types.Cluster, name, namespace
 	return waitForResourceDelete(ctx, cluster, obj)
 }
 
-func WaitForNamespaceDelete(ctx types.Context, cluster types.Cluster, name string) error {
+func WaitForNamespaceDelete(ctx types.Context, cluster *types.Cluster, name string) error {
 	log := ctx.Logger()
 	obj := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -114,7 +114,7 @@ func WaitForNamespaceDeleteOnManagedClusters(ctx types.Context, name string) err
 }
 
 // waitForResourceDelete waits until a resource is deleted or deadline is reached
-func waitForResourceDelete(ctx types.Context, cluster types.Cluster, obj client.Object) error {
+func waitForResourceDelete(ctx types.Context, cluster *types.Cluster, obj client.Object) error {
 	log := ctx.Logger()
 	kind := getKind(obj)
 	resourceName := logName(obj)

--- a/e2e/validate/storageclass.go
+++ b/e2e/validate/storageclass.go
@@ -16,7 +16,7 @@ func validateStorageClasses(ctx types.Context) error {
 	env := ctx.Env()
 	config := ctx.Config()
 
-	clusters := []*types.Cluster{&env.C1, &env.C2}
+	clusters := []*types.Cluster{env.C1, env.C2}
 
 	for _, spec := range config.PVCSpecs {
 		for _, cluster := range clusters {

--- a/e2e/validate/validate.go
+++ b/e2e/validate/validate.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ramendr/ramen/e2e/util"
 )
 
-func RamenHubOperator(ctx types.Context, cluster types.Cluster) error {
+func RamenHubOperator(ctx types.Context, cluster *types.Cluster) error {
 	config := ctx.Config()
 	log := ctx.Logger()
 
@@ -42,7 +42,7 @@ func RamenHubOperator(ctx types.Context, cluster types.Cluster) error {
 	return nil
 }
 
-func RamenDRClusterOperator(ctx types.Context, cluster types.Cluster) error {
+func RamenDRClusterOperator(ctx types.Context, cluster *types.Cluster) error {
 	config := ctx.Config()
 	log := ctx.Logger()
 
@@ -65,7 +65,7 @@ func RamenDRClusterOperator(ctx types.Context, cluster types.Cluster) error {
 }
 
 // FindPod returns the first pod matching the label selector including the pod identifier in the namespace.
-func FindPod(ctx types.Context, cluster types.Cluster, namespace, labelSelector, podIdentifier string) (
+func FindPod(ctx types.Context, cluster *types.Cluster, namespace, labelSelector, podIdentifier string) (
 	*v1.Pod, error,
 ) {
 	ls, err := labels.Parse(labelSelector)
@@ -134,7 +134,7 @@ func clustersInDRPolicy(ctx types.Context) error {
 		return fmt.Errorf("failed to get DRPolicy %q: %w", config.DRPolicy, err)
 	}
 
-	clusters := []types.Cluster{env.C1, env.C2}
+	clusters := []*types.Cluster{env.C1, env.C2}
 	for _, cluster := range clusters {
 		if !slices.Contains(drpolicy.Spec.DRClusters, cluster.Name) {
 			return fmt.Errorf("cluster %q is not defined in drpolicy %q, clusters in drpolicy: %q",
@@ -164,7 +164,7 @@ func clustersInClusterSet(ctx types.Context) error {
 		return err
 	}
 
-	clusters := []types.Cluster{env.C1, env.C2}
+	clusters := []*types.Cluster{env.C1, env.C2}
 	for _, cluster := range clusters {
 		if !slices.Contains(clusterNames, cluster.Name) {
 			return fmt.Errorf("cluster %q is not defined in ClusterSet %q, clusters in ClusterSet: %q",
@@ -193,7 +193,7 @@ func detectDistro(ctx types.Context) error {
 
 	var detectedDistro string
 
-	clusters := []*types.Cluster{&env.Hub, &env.C1, &env.C2}
+	clusters := []*types.Cluster{env.Hub, env.C1, env.C2}
 	for _, cluster := range clusters {
 		distro, err := probeDistro(ctx, cluster)
 		if err != nil {

--- a/e2e/workloads/deploy.go
+++ b/e2e/workloads/deploy.go
@@ -87,7 +87,7 @@ func (w Deployment) GetResources() error {
 }
 
 // Check the workload health deployed in a cluster namespace
-func (w Deployment) Health(ctx types.TestContext, cluster types.Cluster, namespace string) error {
+func (w Deployment) Health(ctx types.TestContext, cluster *types.Cluster, namespace string) error {
 	deploy, err := getDeployment(ctx, cluster, namespace, w.GetAppName())
 	if err != nil {
 		return err
@@ -105,7 +105,7 @@ func (w Deployment) Health(ctx types.TestContext, cluster types.Cluster, namespa
 func (w Deployment) Status(ctx types.TestContext) ([]types.WorkloadStatus, error) {
 	var statuses []types.WorkloadStatus
 
-	clusters := []types.Cluster{ctx.Env().C1, ctx.Env().C2}
+	clusters := []*types.Cluster{ctx.Env().C1, ctx.Env().C2}
 
 	for _, cluster := range clusters {
 		status, err := w.statusForCluster(ctx, cluster)
@@ -122,7 +122,7 @@ func (w Deployment) Status(ctx types.TestContext) ([]types.WorkloadStatus, error
 	return statuses, nil
 }
 
-func (w Deployment) statusForCluster(ctx types.TestContext, cluster types.Cluster) (types.WorkloadStatus, error) {
+func (w Deployment) statusForCluster(ctx types.TestContext, cluster *types.Cluster) (types.WorkloadStatus, error) {
 	deploymentExist, err := findDeployment(ctx, cluster, ctx.AppNamespace(), w.GetAppName())
 	if err != nil {
 		return types.WorkloadStatus{}, err
@@ -147,7 +147,7 @@ func (w Deployment) statusForCluster(ctx types.TestContext, cluster types.Cluste
 	return types.WorkloadStatus{ClusterName: cluster.Name, Status: status}, nil
 }
 
-func getDeployment(ctx types.TestContext, cluster types.Cluster, namespace, name string) (*appsv1.Deployment, error) {
+func getDeployment(ctx types.TestContext, cluster *types.Cluster, namespace, name string) (*appsv1.Deployment, error) {
 	deploy := &appsv1.Deployment{}
 	key := k8stypes.NamespacedName{Name: name, Namespace: namespace}
 
@@ -159,7 +159,7 @@ func getDeployment(ctx types.TestContext, cluster types.Cluster, namespace, name
 	return deploy, nil
 }
 
-func findDeployment(ctx types.TestContext, cluster types.Cluster, namespace, name string) (bool, error) {
+func findDeployment(ctx types.TestContext, cluster *types.Cluster, namespace, name string) (bool, error) {
 	_, err := getDeployment(ctx, cluster, namespace, name)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {
@@ -174,7 +174,7 @@ func findDeployment(ctx types.TestContext, cluster types.Cluster, namespace, nam
 
 func getPVC(
 	ctx types.TestContext,
-	cluster types.Cluster,
+	cluster *types.Cluster,
 	namespace, name string,
 ) (*corev1.PersistentVolumeClaim, error) {
 	pvc := &corev1.PersistentVolumeClaim{}
@@ -188,7 +188,7 @@ func getPVC(
 	return pvc, nil
 }
 
-func findPVC(ctx types.TestContext, cluster types.Cluster, namespace, name string) (bool, error) {
+func findPVC(ctx types.TestContext, cluster *types.Cluster, namespace, name string) (bool, error) {
 	_, err := getPVC(ctx, cluster, namespace, name)
 	if err != nil {
 		if !k8serrors.IsNotFound(err) {


### PR DESCRIPTION
Refactoring e2e env infra to support passive hub.

Refactor:

- Added init func to register schemes once
- Converted setupCluster to newCluster constructor which creates and returns new cluster instances instead of modifying existing ones
- Client Creation: Renamed setupClient to newClient for consistency
- Changed Env struct fields (Hub, C1, C2) from Cluster to *Cluster

Infra changes for passive hub support #2107 