### PR TITLE
ci: Run drenv gather from the virtual environment

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -92,7 +92,9 @@ jobs:
       working-directory: test
       # Gathering typically takes less than 15 seconds.
       timeout-minutes: 3
-      run: drenv gather --directory gather.rdr envs/regional-dr.yaml
+      run: |
+        source ../venv
+        drenv gather --directory gather.rdr envs/regional-dr.yaml
 
     # Tar manually to work around github limitations with special characters (:)
     # in file names, and getting much smaller archives compared with zip (6m vs


### PR DESCRIPTION
For some reason we did run run `drenv gather` using the virtual environment and the issue was hidden by local install of drenv in ~/.local/bin. Upgrading the runner revealed the issue.

We enter the vent now in the shell running `drenv gather` like all other drenv commands.