### PR TITLE
drenv: Update tools versions

### DIFF
--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -92,7 +92,7 @@ enough resources:
    sudo dnf install https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
    ```
 
-   Tested with version v1.34.0.
+   Tested with version v1.36.0.
 
 1. Install the `kubectl` tool
 
@@ -104,7 +104,7 @@ enough resources:
 
    For more info see
    [Install and Set Up kubectl on Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
-   Tested with version v1.31.3.
+   Tested with version v1.33.2.
 
 1. Validate the installation
 
@@ -144,7 +144,7 @@ enough resources:
 1. Install the `clusteradm` tool
 
    ```
-   curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash -s 0.11.0
+   curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash -s 0.11.2
    ```
 
    For more info see
@@ -162,7 +162,7 @@ enough resources:
 
    For more info see
    [Submariner subctl installation](https://submariner.io/operations/deployment/subctl/).
-   Version v0.18.0 or later is required.
+   Version v0.18.0 or later is required. Tested with version v0.20.1.
 
 1. Install the `velero` tool
 
@@ -232,7 +232,8 @@ enough resources:
    rm kubectl-gather
    ```
 
-   kubectl-gather version 0.6.0 or later is required.
+   kubectl-gather version 0.6.0 or later is required. Tested with
+   version 0.7.0.
    For more info see [kubectl-gather](https://github.com/nirs/kubectl-gather)
 
 1. Install `helm` tool - on Fedora you can use:
@@ -241,7 +242,7 @@ enough resources:
    sudo dnf install helm
    ```
 
-   Tested with version v3.11.
+   Tested with version v3.18.1.
 
 1. Install `podman` - on Fedora you can use:
 
@@ -249,7 +250,7 @@ enough resources:
    sudo dnf install podman
    ```
 
-   Tested with version 4.7.0.
+   Tested with version 5.5.1.
 
 1. Install `golang` - on Fedora you can use:
 
@@ -257,7 +258,7 @@ enough resources:
    sudo dnf install golang
    ```
 
-   Tested with version go1.22.0.
+   Tested with version go1.24.4.
 
 ## Starting the test environment
 

--- a/test/README.md
+++ b/test/README.md
@@ -36,7 +36,7 @@ environment.
    sudo dnf install https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
    ```
 
-   Tested with version v1.34.0.
+   Tested with version v1.36.0.
 
 1. Install the `kubectl` tool
 
@@ -48,12 +48,12 @@ environment.
 
    For more info see
    [Install and Set Up kubectl on Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
-   Tested with version v1.31.3.
+   Tested with version v1.33.2.
 
 1. Install the `clusteradm` tool
 
    ```
-   curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash -s 0.11.0
+   curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash -s 0.11.2
    ```
 
    For more info see
@@ -71,6 +71,7 @@ environment.
 
    For more info see
    [Submariner subctl installation](https://submariner.io/operations/deployment/subctl/).
+   Tested with version v0.20.1.
    Version v0.18.0 or later is required.
 
 1. Install the `velero` tool
@@ -92,7 +93,7 @@ environment.
    ```
 
    See [Installing Helm](https://helm.sh/docs/intro/install/) for other options.
-   Tested with version v3.11.
+   Tested with version v3.18.1.
 
 1. Install the `virtctl` tool
 
@@ -146,7 +147,8 @@ environment.
    rm kubectl-gather
    ```
 
-   kubectl-gather version 0.6.0 or later is required.
+   kubectl-gather version 0.6.0 or later is required. Tested with
+   version 0.7.0.
    For more info see [kubectl-gather](https://github.com/nirs/kubectl-gather)
 
 ## Setup on macOS
@@ -175,7 +177,7 @@ environment.
 1. Install the `clusteradm` tool
 
    ```
-   curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash -s 0.11.0
+   curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash -s 0.11.2
    ```
 
    For more info see
@@ -193,7 +195,7 @@ environment.
 
    For more info see
    [Submariner subctl installation](https://submariner.io/operations/deployment/subctl/).
-   Version v0.18.0 or later is required.
+   Version v0.18.0 or later is required. Tested with version v0.20.1.
 
 1. Install the `kubectl-gather` plugin
 
@@ -204,7 +206,8 @@ environment.
    rm kubectl-gather
    ```
 
-   kubectl-gather version 0.6.0 or later is required.
+   kubectl-gather version 0.6.0 or later is required. Tested with
+   version 0.7.0.
    For more info see [kubectl-gather](https://github.com/nirs/kubectl-gather)
 
 1. Install `socket_vmnet`


### PR DESCRIPTION
- Update "tested with" version for tools getting the latest versions
- Update clusteradm version to 0.11.2
- Update go and podman versions for Fedora 24

The tools were tested with the CI runner with Fedora 24.