### PR TITLE
e2e: increase DeployTimeout from 3 to 5 minutes

### DIFF
--- a/e2e/util/timeout.go
+++ b/e2e/util/timeout.go
@@ -56,7 +56,7 @@ import (
 */
 
 const (
-	DeployTimeout   = 3 * time.Minute
+	DeployTimeout   = 5 * time.Minute
 	UndeployTimeout = 5 * time.Minute
 	EnableTimeout   = 5 * time.Minute
 	DisableTimeout  = 5 * time.Minute


### PR DESCRIPTION
Deploy timeout was previously reduced from 10 to 3 minutes, but we have observed appset deployments timing out at 3 minutes even though the same workload reach running state within seconds after the timeout expires.

Increase timeout to 5 minutes to reduce test flakiness while maintaining reasonable deploy execution time.

related ci run with appset deploy failure:
https://github.com/RamenDR/ramen/actions/runs/15844489691/job/44663391702