### PR TITLE
e2e: Build ramen container first

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,6 +28,9 @@ jobs:
     - name: Checkout Repo
       uses: actions/checkout@v4
 
+    - name: Build ramen-operator container
+      run: make docker-build
+
     - name: Create virtual environment
       run: |
         hack/make-venv .venv
@@ -57,9 +60,6 @@ jobs:
           cd test
           source ../venv
           drenv start --max-workers ${{ env.MAX_WORKERS }} envs/regional-dr.yaml
-
-    - name: Build ramen-operator container
-      run: make docker-build
 
     - name: Deploy ramen
       run: |


### PR DESCRIPTION
Currently we build the container only if we could start the clusters. If the code is broken and building the container fail, we waste 10-20 minutes on starting the clusters, and then fail the build. This causes delays for other PRs for no benefit.

We build now the container first so we can fail quickly when the code is not ready to be deployed.

Example build with this issue:
https://github.com/RamenDR/ramen/actions/runs/15851158008/job/44692142814