### PR TITLE
Ensure PVC is deselected only when not in both VR and VS lists

### DIFF
--- a/internal/controller/vrg_volrep_test.go
+++ b/internal/controller/vrg_volrep_test.go
@@ -2575,7 +2575,7 @@ func (v *vrgTest) cleanupPVCs(
 	} else if vrg.Spec.ReplicationState == ramendrv1alpha1.Primary {
 		pvcPostDeleteVerify1 = func(pvcNamespacedName types.NamespacedName, pvName string) {
 			pvcPostDeleteVerify(pvcNamespacedName, pvName)
-			pvcUnprotectedEventuallyVerify(client.ObjectKeyFromObject(vrg), pvcNamespacedName, pvName)
+			pvcUnprotectedVerify(*vrg, pvcNamespacedName, pvName)
 		}
 	}
 
@@ -2610,11 +2610,6 @@ func pvcDelete(
 	postDeleteVerify(pvcNamespacedName, pvNamespacedName.Name)
 }
 
-func pvcUnprotectedEventuallyVerify(vrgNamespacedName, pvcNamespacedName types.NamespacedName, pvName string) {
-	pvAndPvcObjectReplicasAbsentVerify(vrgNamespacedName, pvcNamespacedName, pvName)
-	vrgPvcStatusAbsentEventually(vrgNamespacedName, pvcNamespacedName)
-}
-
 func vrgPvcStatusAbsentEventually(vrgNamespacedName, pvcNamespacedName types.NamespacedName) {
 	Eventually(func() *ramendrv1alpha1.ProtectedPVC {
 		return vrgController.FindProtectedPVC(vrgGet(vrgNamespacedName), pvcNamespacedName.Namespace, pvcNamespacedName.Name)
@@ -2624,8 +2619,8 @@ func vrgPvcStatusAbsentEventually(vrgNamespacedName, pvcNamespacedName types.Nam
 func pvcUnprotectedVerify(
 	vrg ramendrv1alpha1.VolumeReplicationGroup, pvcNamespacedName types.NamespacedName, pvName string,
 ) {
+	vrgPvcStatusAbsentEventually(client.ObjectKeyFromObject(&vrg), pvcNamespacedName)
 	pvAndPvcObjectReplicasAbsentVerify(client.ObjectKeyFromObject(&vrg), pvcNamespacedName, pvName)
-	vrgPvcStatusAbsentVerify(vrg, pvcNamespacedName, pvName)
 }
 
 type pvcPreDeleteVerify func(ramendrv1alpha1.VolumeReplicationGroup, types.NamespacedName, string)


### PR DESCRIPTION
Current deselection code checks if a PVC is part of VR PVC lists and if not invokes deselection. This was "assumed" safe as there was a finalizer check for the PVC to ensure it is protected by VR before progressing. This check was deep in the code, and was not applicable to PVCs that were marked for CG based protection. It was also not safe as it removed the PVC from the protectedPVC status unconditionally.

Further, if the PVC was part of VolSync protection, the above was unconditionally executed, and caused PVC protection issues for VolSync PVCs.

The fix provided, ensures that a PVC is NOT protected by either VolSync or VR based protection, before deselecting the same. Further it uses the VR finalizer on the PVC to determine of it was protected by VR or by VolSync to invoke the right deselection function.

Additional changes:
The envtests for deselect/delete of PVCs did not account for an eventual clause to wait for VRG to report that the PVC is no loner protected, before checking S3 for related contents to be absent. This is also fixed as part of this commit.