### PR TITLE
Updating missed UT for the ServiceAccount fix

### DIFF
--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -1055,7 +1055,7 @@ func verifyVRGManifestWorkCreatedAsPrimary(namespace, managedCluster string) {
 		return err == nil
 	}, timeout, interval).Should(BeTrue())
 
-	Expect(len(createdVRGRolesManifest.Spec.Workload.Manifests)).To(Equal(12))
+	Expect(len(createdVRGRolesManifest.Spec.Workload.Manifests)).To(Equal(8))
 
 	vrgClusterRoleManifest := createdVRGRolesManifest.Spec.Workload.Manifests[0]
 	Expect(vrgClusterRoleManifest).ToNot(BeNil())


### PR DESCRIPTION
A change to unit test was missed as part of the blocker [DFBUGS-2842](https://issues.redhat.com/browse/DFBUGS-2842) fix in [PR](https://github.com/RamenDR/ramen/pull/2116)