### PR TITLE
e2e: add separate delete and wait function for discovered app

### DIFF
--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -147,8 +147,8 @@ func failoverRelocateDiscoveredApps(
 		return err
 	}
 
-	// delete pvc and deployment from dr cluster
-	if err := deployers.DeleteDiscoveredApps(ctx, currentCluster, appNamespace); err != nil {
+	// delete and wait for discovered app deletion from dr cluster
+	if err := deployers.DeleteDiscoveredAppsAndWait(ctx, currentCluster, appNamespace); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Add DeleteDiscoveredAppsAndWait() for cases where we need to wait for deletion completion and log timing. During undeploy,we delete apps on both clusters without waiting. During failover/relocate, we need to wait for deletion completion and log the time taken.

- DeleteDiscoveredApps() - doing delete without wait
- Add DeleteDiscoveredAppsAndWait() - doing delete and wait
- Implement both with deleteDiscoveredApps with wait flag
- Update failover/relocate to use DeleteDiscoveredAppsAndWait()
- Update comment to indicate that discovered app deletion waits for
  completion for failover/relocate.

Testing discovered app delete(To be updated):

1. During failover:
```
2025-06-27T18:32:24.289+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/disapp.go:126	Deleting discovered app "e2e-disapp-deploy-cephfs-busybox/busybox" in cluster "dr1" and waiting for deletion
2025-06-27T18:33:51.160+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/disapp.go:135	Discovered app "e2e-disapp-deploy-cephfs-busybox/busybox" deleted in cluster "dr1" in 86.871 seconds
2025-06-27T18:33:51.160+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:69	Waiting until drpc "ramen-ops/disapp-deploy-cephfs-busybox" reach phase "FailedOver" in cluster "hub"
2025-06-27T18:33:51.173+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:80	drpc "ramen-ops/disapp-deploy-cephfs-busybox" phase is "FailedOver" in cluster "hub" in 0.012 seconds
```

2. During relocate:
```
2025-06-27T18:37:21.826+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/disapp.go:126	Deleting discovered app "e2e-disapp-deploy-cephfs-busybox/busybox" in cluster "dr2" and waiting for deletion
2025-06-27T18:41:11.469+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/disapp.go:135	Discovered app "e2e-disapp-deploy-cephfs-busybox/busybox" deleted in cluster "dr2" in 229.643 seconds
2025-06-27T18:41:11.469+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:69	Waiting until drpc "ramen-ops/disapp-deploy-cephfs-busybox" reach phase "Relocated" in cluster "hub"
2025-06-27T18:42:26.683+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/retry.go:80	drpc "ramen-ops/disapp-deploy-cephfs-busybox" phase is "Relocated" in cluster "hub" in 75.214 seconds
```

Fixes #2120 