### PR TITLE
e2e: Enhance Deployment health check using condition status and reason

### DIFF
--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -42,7 +42,7 @@ func (a ApplicationSet) Deploy(ctx types.TestContext) error {
 		return err
 	}
 
-	if err = WaitWorkloadHealth(ctx, cluster, ctx.AppNamespace()); err != nil {
+	if err = WaitWorkloadHealth(ctx, cluster); err != nil {
 		return err
 	}
 

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -62,7 +62,7 @@ func (d DiscoveredApp) Deploy(ctx types.TestContext) error {
 		return err
 	}
 
-	if err = WaitWorkloadHealth(ctx, cluster, appNamespace); err != nil {
+	if err = WaitWorkloadHealth(ctx, cluster); err != nil {
 		return err
 	}
 

--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -46,26 +46,27 @@ func waitSubscriptionPhase(
 	}
 }
 
-func WaitWorkloadHealth(ctx types.TestContext, cluster *types.Cluster, namespace string) error {
+func WaitWorkloadHealth(ctx types.TestContext, cluster *types.Cluster) error {
 	log := ctx.Logger()
 	w := ctx.Workload()
 	start := time.Now()
 
-	log.Debugf("Waiting until workload \"%s/%s\" is healthy in cluster %q", namespace, w.GetAppName(), cluster.Name)
+	log.Debugf("Waiting until workload \"%s/%s\" is healthy in cluster %q",
+		ctx.AppNamespace(), w.GetAppName(), cluster.Name)
 
 	for {
-		err := w.Health(ctx, cluster, namespace)
+		err := w.Health(ctx, cluster)
 		if err == nil {
 			elapsed := time.Since(start)
 			log.Debugf("Workload \"%s/%s\" is healthy in cluster %q in %.3f seconds",
-				namespace, w.GetAppName(), cluster.Name, elapsed.Seconds())
+				ctx.AppNamespace(), w.GetAppName(), cluster.Name, elapsed.Seconds())
 
 			return nil
 		}
 
 		if err := util.Sleep(ctx.Context(), util.RetryInterval); err != nil {
 			return fmt.Errorf("workload \"%s/%s\" is not healthy in cluster %q: %w",
-				namespace, w.GetAppName(), cluster.Name, err)
+				ctx.AppNamespace(), w.GetAppName(), cluster.Name, err)
 		}
 	}
 }

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -71,7 +71,7 @@ func (s Subscription) Deploy(ctx types.TestContext) error {
 		return err
 	}
 
-	if err = WaitWorkloadHealth(ctx, cluster, ctx.AppNamespace()); err != nil {
+	if err = WaitWorkloadHealth(ctx, cluster); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -89,7 +89,7 @@ func EnableProtection(ctx types.TestContext) error {
 		return err
 	}
 
-	if err = deployers.WaitWorkloadHealth(ctx, cluster, appNamespace); err != nil {
+	if err = deployers.WaitWorkloadHealth(ctx, cluster); err != nil {
 		return err
 	}
 
@@ -228,7 +228,7 @@ func failoverRelocate(
 		return err
 	}
 
-	return deployers.WaitWorkloadHealth(ctx, targetCluster, ctx.AppNamespace())
+	return deployers.WaitWorkloadHealth(ctx, targetCluster)
 }
 
 func waitAndUpdateDRPC(

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -59,7 +59,7 @@ func EnableProtectionDiscoveredApps(ctx types.TestContext) error {
 		return err
 	}
 
-	if err = deployers.WaitWorkloadHealth(ctx, cluster, appNamespace); err != nil {
+	if err = deployers.WaitWorkloadHealth(ctx, cluster); err != nil {
 		return err
 	}
 
@@ -160,7 +160,7 @@ func failoverRelocateDiscoveredApps(
 		return err
 	}
 
-	return deployers.WaitWorkloadHealth(ctx, targetCluster, appNamespace)
+	return deployers.WaitWorkloadHealth(ctx, targetCluster)
 }
 
 // findProtectCluster determines which cluster contains the discovered application

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -59,7 +59,7 @@ type Workload interface {
 	GetAppName() string
 	GetPath() string
 	GetBranch() string
-	Health(ctx TestContext, cluster *Cluster, namespace string) error
+	Health(ctx TestContext, cluster *Cluster) error
 	Status(ctx TestContext) ([]WorkloadStatus, error)
 }
 

--- a/e2e/workloads/deploy.go
+++ b/e2e/workloads/deploy.go
@@ -86,9 +86,9 @@ func (w Deployment) GetResources() error {
 	return nil
 }
 
-// Check the workload health deployed in a cluster namespace
-func (w Deployment) Health(ctx types.TestContext, cluster *types.Cluster, namespace string) error {
-	deploy, err := getDeployment(ctx, cluster, namespace, w.GetAppName())
+// Check the workload health deployed in a cluster
+func (w Deployment) Health(ctx types.TestContext, cluster *types.Cluster) error {
+	deploy, err := getDeployment(ctx, cluster, ctx.AppNamespace(), w.GetAppName())
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func (w Deployment) Health(ctx types.TestContext, cluster *types.Cluster, namesp
 	}
 
 	return fmt.Errorf("deployment \"%s/%s\" not ready in cluster %q: %d/%d replicas ready",
-		namespace, w.GetAppName(), cluster.Name, deploy.Status.ReadyReplicas, deploy.Status.Replicas)
+		ctx.AppNamespace(), w.GetAppName(), cluster.Name, deploy.Status.ReadyReplicas, deploy.Status.Replicas)
 }
 
 // Status returns the deployment status across managed clusters.

--- a/e2e/workloads/deploy.go
+++ b/e2e/workloads/deploy.go
@@ -19,7 +19,7 @@ const (
 	deploymentName    = "deploy"
 	deploymentAppName = "busybox"
 	deploymentPath    = "workloads/deployment/base"
-	pvcName           = "busybox-pvc"
+	deploymentPVCName = "busybox-pvc"
 
 	//nolint:lll
 	// deploymentMinimumReplicasAvailable is added in a deployment when it has its minimum replicas required available.
@@ -151,7 +151,7 @@ func (w Deployment) statusForCluster(ctx types.TestContext, cluster *types.Clust
 		return types.WorkloadStatus{}, err
 	}
 
-	pvcExist, err := findPVC(ctx, cluster, ctx.AppNamespace(), pvcName)
+	pvcExist, err := findPVC(ctx, cluster, ctx.AppNamespace(), deploymentPVCName)
 	if err != nil {
 		return types.WorkloadStatus{}, err
 	}


### PR DESCRIPTION
Replaced basic ReadyReplicas check with a evaluation of the DeploymentAvailable condition, ensuring the reason is "MinimumReplicasAvailable" and the condition status is True.


Fixes #2076 