### PR TITLE
Update kubevirt and cdi plugin versions in drenv

### DIFF
--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -179,7 +179,7 @@ enough resources:
 1. Install the `virtctl` tool.
 
    ```
-   curl -L -o virtctl https://github.com/kubevirt/kubevirt/releases/download/v1.3.0/virtctl-v1.3.0-linux-amd64
+   curl -L -o virtctl https://github.com/kubevirt/kubevirt/releases/download/v1.5.2/virtctl-v1.5.2-linux-amd64
    sudo install virtctl /usr/local/bin
    rm virtctl
    ```

--- a/test/README.md
+++ b/test/README.md
@@ -98,7 +98,7 @@ environment.
 1. Install the `virtctl` tool
 
    ```
-   curl -L -o virtctl https://github.com/kubevirt/kubevirt/releases/download/v1.3.0/virtctl-v1.3.0-linux-amd64
+   curl -L -o virtctl https://github.com/kubevirt/kubevirt/releases/download/v1.5.2/virtctl-v1.5.2-linux-amd64
    sudo install virtctl /usr/local/bin
    rm virtctl
    ```

--- a/test/addons/cdi/cache
+++ b/test/addons/cdi/cache
@@ -7,5 +7,5 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh("operator", "addons/cdi-operator-1.60.2.yaml")
-cache.refresh("cr", "addons/cdi-cr-1.60.2.yaml")
+cache.refresh("operator", "addons/cdi-operator-1.62.0.yaml")
+cache.refresh("cr", "addons/cdi-cr-1.62.0.yaml")

--- a/test/addons/cdi/cr/kustomization.yaml
+++ b/test/addons/cdi/cr/kustomization.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.60.2/cdi-cr.yaml
+  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.62.0/cdi-cr.yaml
 patches:
   # Allow pulling from local insecure registry.
   - target:

--- a/test/addons/cdi/operator/kustomization.yaml
+++ b/test/addons/cdi/operator/kustomization.yaml
@@ -4,4 +4,4 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.60.2/cdi-operator.yaml
+  - https://github.com/kubevirt/containerized-data-importer/releases/download/v1.62.0/cdi-operator.yaml

--- a/test/addons/cdi/start
+++ b/test/addons/cdi/start
@@ -14,7 +14,7 @@ NAMESPACE = "cdi"
 
 def deploy(cluster):
     print("Deploying cdi operator")
-    path = cache.get("operator", "addons/cdi-operator-1.60.2.yaml")
+    path = cache.get("operator", "addons/cdi-operator-1.62.0.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
     print("Waiting until cdi-operator is rolled out")
@@ -27,7 +27,7 @@ def deploy(cluster):
     )
 
     print("Deploying cdi cr")
-    path = cache.get("cr", "addons/cdi-cr-1.60.2.yaml")
+    path = cache.get("cr", "addons/cdi-cr-1.62.0.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
 

--- a/test/addons/kubevirt/cache
+++ b/test/addons/kubevirt/cache
@@ -7,5 +7,5 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh("operator", "addons/kubevirt-operator-1.3.1.yaml")
-cache.refresh("cr", "addons/kubevirt-cr-1.3.1.yaml")
+cache.refresh("operator", "addons/kubevirt-operator-1.5.2.yaml")
+cache.refresh("cr", "addons/kubevirt-cr-1.5.2.yaml")

--- a/test/addons/kubevirt/cr/kustomization.yaml
+++ b/test/addons/kubevirt/cr/kustomization.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://github.com/kubevirt/kubevirt/releases/download/v1.3.1/kubevirt-cr.yaml
+  - https://github.com/kubevirt/kubevirt/releases/download/v1.5.2/kubevirt-cr.yaml
 patches:
   # Incrase certificate duration to avoid certificates renewals while a cluster
   # is suspended and resumed.

--- a/test/addons/kubevirt/start
+++ b/test/addons/kubevirt/start
@@ -14,7 +14,7 @@ NAMESPACE = "kubevirt"
 
 def deploy(cluster):
     print("Deploying kubevirt operator")
-    path = cache.get("operator", "addons/kubevirt-operator-1.3.1.yaml")
+    path = cache.get("operator", "addons/kubevirt-operator-1.5.2.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
     print("Waiting until virt-operator is rolled out")
@@ -27,7 +27,7 @@ def deploy(cluster):
     )
 
     print("Deploying kubevirt cr")
-    path = cache.get("cr", "addons/kubevirt-cr-1.3.1.yaml")
+    path = cache.get("cr", "addons/kubevirt-cr-1.5.2.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
 


### PR DESCRIPTION
Updated kubevirt and cdi version update in drenv:
kubevirt : v1.5.2
cdi : v1.62.0