### PR TITLE
drenv: Update minimal memory to 3g for vm based envs

### DIFF
--- a/test/envs/argocd.yaml
+++ b/test/envs/argocd.yaml
@@ -17,7 +17,7 @@ templates:
     container_runtime: containerd
     network: "$network"
     cpus: 2
-    memory: "2g"
+    memory: "3g"
 
 profiles:
   - name: hub

--- a/test/envs/e2e.yaml
+++ b/test/envs/e2e.yaml
@@ -14,7 +14,7 @@ templates:
   - name: cluster
     driver: "$vm"
     container_runtime: containerd
-    memory: "2g"
+    memory: "3g"
 
 profiles:
   - name: dr1

--- a/test/envs/error.yaml
+++ b/test/envs/error.yaml
@@ -8,7 +8,7 @@ templates:
   - name: cluster
     driver: $vm
     container_runtime: containerd
-    memory: 2g
+    memory: 3g
 profiles:
   - name: c1
     template: cluster

--- a/test/envs/minio.yaml
+++ b/test/envs/minio.yaml
@@ -9,7 +9,7 @@ profiles:
   - name: c1
     driver: $vm
     container_runtime: containerd
-    memory: 2g
+    memory: 3g
     workers:
       - addons:
           - name: minio

--- a/test/envs/olm.yaml
+++ b/test/envs/olm.yaml
@@ -9,7 +9,7 @@ profiles:
   - name: c1
     driver: $vm
     container_runtime: containerd
-    memory: 2g
+    memory: 3g
     workers:
       - addons:
           - name: olm

--- a/test/envs/velero.yaml
+++ b/test/envs/velero.yaml
@@ -9,7 +9,7 @@ profiles:
   - name: velero
     driver: $vm
     container_runtime: containerd
-    memory: 2g
+    memory: 3g
     workers:
       - addons:
           - name: minio

--- a/test/envs/vm.yaml
+++ b/test/envs/vm.yaml
@@ -9,7 +9,7 @@ profiles:
     driver: $vm
     container_runtime: containerd
     cpus: 2
-    memory: "2g"
+    memory: "3g"
     rosetta: false
     workers:
       - addons:

--- a/test/envs/volsync.yaml
+++ b/test/envs/volsync.yaml
@@ -10,7 +10,7 @@ templates:
     driver: $vm
     container_runtime: containerd
     network: $network
-    memory: 2g
+    memory: 3g
     workers:
       - addons:
           - name: submariner


### PR DESCRIPTION
Minikube does not start reliably with 2 GiB of memory. Upstream use now 3 GiB as the fallback memory size.