### PR TITLE
drenv: Recommend kubectl-gather 0.8.0

### DIFF
--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -233,7 +233,7 @@ enough resources:
    ```
 
    kubectl-gather version 0.6.0 or later is required. Tested with
-   version 0.7.0.
+   version 0.8.0.
    For more info see [kubectl-gather](https://github.com/nirs/kubectl-gather)
 
 1. Install `helm` tool - on Fedora you can use:

--- a/test/README.md
+++ b/test/README.md
@@ -148,7 +148,7 @@ environment.
    ```
 
    kubectl-gather version 0.6.0 or later is required. Tested with
-   version 0.7.0.
+   version 0.8.0.
    For more info see [kubectl-gather](https://github.com/nirs/kubectl-gather)
 
 ## Setup on macOS
@@ -207,7 +207,7 @@ environment.
    ```
 
    kubectl-gather version 0.6.0 or later is required. Tested with
-   version 0.7.0.
+   version 0.8.0.
    For more info see [kubectl-gather](https://github.com/nirs/kubectl-gather)
 
 1. Install `socket_vmnet`


### PR DESCRIPTION
This version introduced improved gather pipeline avoiding excessive memory usage.