### PR TITLE
e2e: validate workload health after unprotect

### DIFF
--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -128,6 +128,16 @@ func DisableProtection(ctx types.TestContext) error {
 		return err
 	}
 
+	// If the cluster is not nil, the workload exists and its health is validated.
+	if cluster != nil {
+		if err := ctx.Workload().Health(ctx, cluster); err != nil {
+			return err
+		}
+
+		log.Debugf("Workload \"%s/%s\" is healthy in cluster %q",
+			appNamespace, ctx.Workload().GetAppName(), cluster.Name)
+	}
+
 	log.Info("Workload unprotected")
 
 	return nil


### PR DESCRIPTION
Added workload health check after unprotecting, to ensure the application is in a healthy state.

This was previously skipped due to race conditions when Unprotect and Undeploy were run in parallel (in ramenctl). Now Purge performs these steps sequentially with this fix RamenDR/ramenctl#220.

Wait for workload health in unprotect:
```
2025-07-11T14:50:43.264+0530	INFO	disapp-deploy-cephfs-busybox	dractions/actions.go:119	Unprotecting workload "e2e-disapp-deploy-cephfs-busybox/busybox" in cluster "dr1"
2025-07-11T14:50:43.303+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/crud.go:93	Deleted drpc "ramen-ops/disapp-deploy-cephfs-busybox" in cluster "hub"
2025-07-11T14:50:43.346+0530	DEBUG	disapp-deploy-cephfs-busybox	deployers/crud.go:161	Deleted placement "ramen-ops/disapp-deploy-cephfs-busybox" in cluster "hub"
2025-07-11T14:50:43.346+0530	DEBUG	disapp-deploy-cephfs-busybox	util/wait.go:123	Waiting until DRPlacementControl "ramen-ops/disapp-deploy-cephfs-busybox" is deleted in cluster "hub"
2025-07-11T14:51:42.766+0530	DEBUG	disapp-deploy-cephfs-busybox	util/wait.go:132	DRPlacementControl "ramen-ops/disapp-deploy-cephfs-busybox" deleted in cluster "hub" in 59.420 seconds
2025-07-11T14:51:42.766+0530	DEBUG	disapp-deploy-cephfs-busybox	util/wait.go:123	Waiting until Placement "ramen-ops/disapp-deploy-cephfs-busybox" is deleted in cluster "hub"
2025-07-11T14:51:42.795+0530	DEBUG	disapp-deploy-cephfs-busybox	util/wait.go:132	Placement "ramen-ops/disapp-deploy-cephfs-busybox" deleted in cluster "hub" in 0.029 seconds
2025-07-11T14:51:42.801+0530	DEBUG	disapp-deploy-cephfs-busybox	dractions/actions.go:137	Workload "e2e-disapp-deploy-cephfs-busybox/busybox" is healthy in cluster "dr1"
2025-07-11T14:51:42.802+0530	INFO	disapp-deploy-cephfs-busybox	dractions/actions.go:141	Workload unprotected
```

Fixes #2139 