### PR TITLE
Function IsCGEnabledForVolSync checks if a public or private CRD is installed

### DIFF
--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -36,7 +36,8 @@ const (
 
 	CreatedByRamenLabel = "ramendr.openshift.io/created-by-ramen"
 
-	VGSCRDName = "volumegroupsnapshots.groupsnapshot.storage.k8s.io"
+	VGSCRDPrivateName = "volumegroupsnapshots.groupsnapshot.storage.openshift.io"
+	VGSCRDName        = "volumegroupsnapshots.groupsnapshot.storage.k8s.io"
 )
 
 type ResourceUpdater struct {
@@ -356,7 +357,8 @@ func IsCGEnabled(annotations map[string]string) bool {
 // 2. Whether the VolumeGroupSnapshot CRD is installed.
 // Both conditions must be true for CephFS CG protection to be considered enabled.
 func IsCGEnabledForVolSync(ctx context.Context, apiReader client.Reader, annotations map[string]string) bool {
-	return IsCGEnabled(annotations) && IsCRDInstalled(ctx, apiReader, VGSCRDName)
+	return IsCGEnabled(annotations) &&
+		(IsCRDInstalled(ctx, apiReader, VGSCRDName) || IsCRDInstalled(ctx, apiReader, VGSCRDPrivateName))
 }
 
 // IsCRDInstalled checks whether a specific CustomResourceDefinition (CRD) is installed on the cluster.


### PR DESCRIPTION
Currently, we use only the private VolumeGroupSnapshots API, but in the future, both public and private versions may be supported. Therefore, we must treat consistency groups as supported for VolSync if either the public or private CRD is installed.