### PR TITLE
e2e: enhance workload and deployer registrations

### DIFF
--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -126,3 +126,11 @@ func (a ApplicationSet) GetNamespace(ctx types.TestContext) string {
 func (a ApplicationSet) IsDiscovered() bool {
 	return false
 }
+
+func NewApplicationSet() types.Deployer {
+	return &ApplicationSet{}
+}
+
+func init() {
+	register("appset", NewApplicationSet)
+}

--- a/e2e/deployers/deployers.go
+++ b/e2e/deployers/deployers.go
@@ -5,36 +5,58 @@ package deployers
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/ramendr/ramen/e2e/types"
 )
 
-var registry map[string]types.Deployer
+// factoryFunc is the new() function type for deployers
+type factoryFunc func() types.Deployer
 
-func init() {
-	appset := &ApplicationSet{}
-	subscr := &Subscription{}
-	disapp := &DiscoveredApp{}
+var mutex sync.Mutex
 
-	registry = map[string]types.Deployer{
-		appset.GetName(): appset,
-		subscr.GetName(): subscr,
-		disapp.GetName(): disapp,
+var registry map[string]factoryFunc
+
+// register needs to be called by every deployer in the init() function to
+// register itself with the deployer registry.
+func register(deployerType string, f factoryFunc) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if registry == nil {
+		registry = make(map[string]factoryFunc)
 	}
+
+	if _, exists := registry[deployerType]; exists {
+		panic(fmt.Sprintf("deployer %q already registered", deployerType))
+	}
+
+	registry[deployerType] = f
+}
+
+func getFactory(name string) factoryFunc {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	return registry[name]
 }
 
 // New creates a new deployer for name
 func New(name string) (types.Deployer, error) {
-	deployer := registry[name]
-	if deployer == nil {
+	factory := getFactory(name)
+	if factory == nil {
 		return nil, fmt.Errorf("unknown deployer %q (choose from %q)", name, AvailableNames())
 	}
 
-	return deployer, nil
+	return factory(), nil
 }
 
 func AvailableNames() []string {
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	keys := make([]string, 0, len(registry))
+
 	for k := range registry {
 		keys = append(keys, k)
 	}

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -194,3 +194,11 @@ func chooseDeployCluster(ctx types.TestContext) (*types.Cluster, error) {
 			ctx.AppNamespace(), ctx.Workload().GetAppName(), statuses)
 	}
 }
+
+func NewDiscoveredApp() types.Deployer {
+	return &DiscoveredApp{}
+}
+
+func init() {
+	register("disapp", NewDiscoveredApp)
+}

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -143,3 +143,11 @@ func (s Subscription) WaitForResourcesDelete(ctx types.TestContext) error {
 func (s Subscription) IsDiscovered() bool {
 	return false
 }
+
+func NewSubscription() types.Deployer {
+	return &Subscription{}
+}
+
+func init() {
+	register("subscr", NewSubscription)
+}

--- a/e2e/workloads/deploy.go
+++ b/e2e/workloads/deploy.go
@@ -236,3 +236,7 @@ func findDeploymentCondition(
 
 	return nil
 }
+
+func init() {
+	register(deploymentName, NewDeployment)
+}

--- a/e2e/workloads/workloads.go
+++ b/e2e/workloads/workloads.go
@@ -5,19 +5,45 @@ package workloads
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 )
 
-type factory func(revision string, pvcSpec config.PVCSpec) types.Workload
+// factoryFunc is the new() function type for workloads
+type factoryFunc func(revision string, pvcSpec config.PVCSpec) types.Workload
 
-var registry = map[string]factory{
-	deploymentName: NewDeployment,
+var mutex sync.Mutex
+
+var registry map[string]factoryFunc
+
+// register needs to be called by every workload in the init() function to
+// register itself with the workload registry.
+func register(workloadType string, f factoryFunc) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if registry == nil {
+		registry = make(map[string]factoryFunc)
+	}
+
+	if _, exists := registry[workloadType]; exists {
+		panic(fmt.Sprintf("workload %q already registered", workloadType))
+	}
+
+	registry[workloadType] = f
+}
+
+func getFactory(name string) factoryFunc {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	return registry[name]
 }
 
 func New(name, branch string, pvcSpec config.PVCSpec) (types.Workload, error) {
-	fac := registry[name]
+	fac := getFactory(name)
 	if fac == nil {
 		return nil, fmt.Errorf("unknown deployment: %q (choose from %q)", name, AvailableNames())
 	}
@@ -26,7 +52,11 @@ func New(name, branch string, pvcSpec config.PVCSpec) (types.Workload, error) {
 }
 
 func AvailableNames() []string {
+	mutex.Lock()
+	defer mutex.Unlock()
+
 	keys := make([]string, 0, len(registry))
+
 	for k := range registry {
 		keys = append(keys, k)
 	}


### PR DESCRIPTION
This provides a mechanism for the deployers and workloads to provide a factory function to create a new instance type. We can enhance the factory function to take specification for the them later on.
