### PR TITLE
e2e: Add deployer configuration to e2e config

### DIFF
--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -143,7 +143,8 @@ All tests completed successfully!
 ### Tests configuration
 
 The tests are defined in the configuration file. Each test specifies a deployer
-name, workload name, and PVCSpec:
+name, workload name, and PVCSpec. The PVCSpec and Deployer names should match a
+name in the PVCSpecs and Deployers sections of the configuration file.:
 
 ```yaml
 tests:
@@ -156,6 +157,13 @@ tests:
 The tests are generated from the configuration as
 "TestDR/{deployer}-{workload}-{pvcspec}-busybox".
 See [Running DR tests](#running-dr-tests) section for complete test list.
+
+#### Deployers
+
+The deployers section defines the available deployment methods. Each deployer
+has a name, type, and description. The type is used to identify the deployer
+implementation. There are 3 types available, appset, subscr, and disapp. The
+description provides additional context about the deployer.
 
 ### Run specific DR tests
 

--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -24,9 +24,23 @@ pvcspecs:
     storageclassname: rook-cephfs-fs1
     accessmodes: ReadWriteMany
 
+# List of Deployer specifications.
+# These define the configuration values for different deployers.
+# Available types: appset, subscr, disapp
+deployers:
+  - name: appset
+    type: appset
+    description: "ApplicationSet deployer for ArgoCD"
+  - name: subscr
+    type: subscr
+    description: "Subscription deployer for OCM subscriptions"
+  - name: disapp
+    type: disapp
+    description: "Discovered Application deployer for discovered applications"
+
 # List to tests to run.
 # Available workloads: deploy
-# Available deployers: appset, subscr, disapp
+# Deployer should be the name of the deployer to use from the deployers list.
 # Test names are generated as "{deployer}-{workload}-{pvcspec}".
 tests:
   - deployer: appset

--- a/e2e/config/testdata/test.yaml
+++ b/e2e/config/testdata/test.yaml
@@ -21,6 +21,13 @@ pvcspecs:
   - name: cephfs
     storageclassname: rook-cephfs-fs1
     accessmodes: ReadWriteMany
+deployers:
+  - name: appset
+    type: appset
+  - name: subscr
+    type: subscr
+  - name: disapp
+    type: disapp
 tests:
   - deployer: appset
     workload: deploy

--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -4,14 +4,16 @@
 package deployers
 
 import (
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
+
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 type ApplicationSet struct{}
 
-func NewApplicationSet() types.Deployer {
+func NewApplicationSet(deployer config.Deployer) types.Deployer {
 	return &ApplicationSet{}
 }
 

--- a/e2e/deployers/deployers.go
+++ b/e2e/deployers/deployers.go
@@ -8,25 +8,26 @@ import (
 	"maps"
 	"slices"
 
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 )
 
 // factoryFunc is the new() function type for deployers
-type factoryFunc func() types.Deployer
+type factoryFunc func(config.Deployer) types.Deployer
 
 var registry = map[string]factoryFunc{}
 
 // New creates a new deployer for name
-func New(name string) (types.Deployer, error) {
-	factory := registry[name]
+func New(deployer config.Deployer) (types.Deployer, error) {
+	factory := registry[deployer.Type]
 	if factory == nil {
-		return nil, fmt.Errorf("unknown deployer %q (choose from %q)", name, AvailableNames())
+		return nil, fmt.Errorf("unknown deployer %q (choose from %q)", deployer.Type, AvailableTypes())
 	}
 
-	return factory(), nil
+	return factory(deployer), nil
 }
 
-func AvailableNames() []string {
+func AvailableTypes() []string {
 	return slices.Collect(maps.Keys(registry))
 }
 

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -8,13 +8,14 @@ import (
 	"os"
 	"time"
 
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 )
 
 type DiscoveredApp struct{}
 
-func NewDiscoveredApp() types.Deployer {
+func NewDiscoveredApp(deployer config.Deployer) types.Deployer {
 	return &DiscoveredApp{}
 }
 

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -7,13 +7,14 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	subscriptionv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
 )
 
 type Subscription struct{}
 
-func NewSubscription() types.Deployer {
+func NewSubscription(deployer config.Deployer) types.Deployer {
 	return &Subscription{}
 }
 

--- a/e2e/dr_test.go
+++ b/e2e/dr_test.go
@@ -41,6 +41,7 @@ func TestDR(dt *testing.T) {
 	})
 
 	pvcSpecs := config.PVCSpecsMap(Ctx.config)
+	deploySpecs := config.DeployersMap(Ctx.config)
 
 	for _, tc := range Ctx.config.Tests {
 		pvcSpec, ok := pvcSpecs[tc.PVCSpec]
@@ -53,7 +54,12 @@ func TestDR(dt *testing.T) {
 			panic(err)
 		}
 
-		deployer, err := deployers.New(tc.Deployer)
+		deployerSpec, ok := deploySpecs[tc.Deployer]
+		if !ok {
+			panic("unknown deployer")
+		}
+
+		deployer, err := deployers.New(deployerSpec)
 		if err != nil {
 			panic(err)
 		}

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -88,7 +88,7 @@ func testMain(m *testing.M) int {
 	log.Infof("Using log file %q", logFile)
 
 	options := config.Options{
-		Deployers: deployers.AvailableNames(),
+		Deployers: deployers.AvailableTypes(),
 		Workloads: workloads.AvailableNames(),
 	}
 


### PR DESCRIPTION
Introduce a new `deployers` section in the configuration YAML to define different deployers that can be used in tests.

- Deployers can be added by specifying a name and type.
- Type of the deployers should match the existing deployers in the code.
- Added tests for validating deployers.
- Updated sample yaml.

Fixes #2153