### PR TITLE
e2e: Remove -busybox suffix from test names

### DIFF
--- a/e2e/test/context.go
+++ b/e2e/test/context.go
@@ -35,7 +35,7 @@ func NewContext(
 	w types.Workload,
 	d types.Deployer,
 ) Context {
-	name := strings.ToLower(d.GetName() + "-" + w.GetName() + "-" + w.GetAppName())
+	name := strings.ToLower(d.GetName() + "-" + w.GetName())
 
 	return Context{
 		parent:   parent,


### PR DESCRIPTION
We used to append "-busybox" to all names. This was never helpful but it becomes worse since we want to add recipe tests with exec and check hooks, and vms tests with different types of vms.

Example of new test names:

    disapp-recipe-exe-chk-vm-pvc-rbd

In ramenctl we add a test- prefix to the namespaces, so this becomes:

    test-disapp-recipe-exe-chk-vm-pvc-rbd

This change was already done in ramenctl, it will be helpful to have consistent names in e2e and ramenctl.