### PR TITLE
e2e: Increase Disable timeout to 10 minutes

### DIFF
--- a/e2e/util/timeout.go
+++ b/e2e/util/timeout.go
@@ -59,8 +59,10 @@ const (
 	DeployTimeout   = 5 * time.Minute
 	UndeployTimeout = 5 * time.Minute
 	EnableTimeout   = 5 * time.Minute
-	DisableTimeout  = 5 * time.Minute
-	PurgeTimeout    = 5 * time.Minute
+
+	// Typically less than 90 seconds, but in some cases it can take more than 5 minutes.
+	DisableTimeout = 10 * time.Minute
+	PurgeTimeout   = 10 * time.Minute
 
 	// With appset deployment may need 2m30s after failover and relocate.
 	FailoverTimeout = 15 * time.Minute


### PR DESCRIPTION
Since #2088 we are using timeout per action and much shorter timeouts for faster failures. This works well except for disabling protection. We see many random timeouts in the CI and it is also reproducible when running locally.

Typically Disable takeks less than 90 seocnds, but in some cases it can take more than 5 mintues. Inspecting the logs to understand the failure and re-running e2e jobs is very time consuming so it is better to use a larger timeout.

We need to understand why disable can take so much time randomly.

Related to #2156 