### PR TITLE
Fix type assertion error in DeleteTypedObjectList

### DIFF
--- a/internal/controller/cephfscg/cghandler.go
+++ b/internal/controller/cephfscg/cghandler.go
@@ -487,16 +487,8 @@ func ListReplicationGroupByOwner(ctx context.Context, k8sClient client.Client, o
 func DeleteTypedObjectList[T client.Object](ctx context.Context, k8sClient client.Client, items []T, logger logr.Logger,
 ) error {
 	for _, obj := range items {
-		// Ensure obj is a pointer
-		objCopy := obj
-
-		objPtr, ok := any(&objCopy).(client.Object)
-		if !ok {
-			return fmt.Errorf("obj is not a client.Object")
-		}
-
-		if err := k8sClient.Delete(ctx, objPtr); err != nil {
-			logger.Error(err, "Error cleaning up object", "name", objPtr.GetName())
+		if err := k8sClient.Delete(ctx, obj); err != nil {
+			logger.Error(err, "Error cleaning up object", "name", obj.GetName())
 		}
 	}
 


### PR DESCRIPTION
Taking `&objCopy` results in a double pointer (`**T`) which does not satisfy the `client.Object` interface. The fix uses `objCopy` directly, assuming T is already a pointer to a type that implements `client.Object`.

Fixes: https://issues.redhat.com/browse/DFBUGS-2950