### PR TITLE
Deploy private odf external-snapshotter for drenv testing

### DIFF
--- a/test/addons/odf-external-snapshotter/cache
+++ b/test/addons/odf-external-snapshotter/cache
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from drenv import cache
+
+os.chdir(os.path.dirname(__file__))
+cache.refresh("crds", "addons/odf-external-snapshotter-8.2.yaml")

--- a/test/addons/odf-external-snapshotter/crds/kustomization.yaml
+++ b/test/addons/odf-external-snapshotter/crds/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+resources:
+  # Private VGS CRDs (Red Hat fork of Kubernetes CSI)
+  - https://raw.githubusercontent.com/red-hat-storage/external-snapshotter/refs/heads/master/config/crd/bases/groupsnapshot.storage.openshift.io_volumegroupsnapshotclasses.yaml
+  - https://raw.githubusercontent.com/red-hat-storage/external-snapshotter/refs/heads/master/config/crd/bases/groupsnapshot.storage.openshift.io_volumegroupsnapshotcontents.yaml
+  - https://raw.githubusercontent.com/red-hat-storage/external-snapshotter/refs/heads/master/config/crd/bases/groupsnapshot.storage.openshift.io_volumegroupsnapshots.yaml
+
+  # Standard CSI VolumeSnapshot CRDs
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml

--- a/test/addons/odf-external-snapshotter/start
+++ b/test/addons/odf-external-snapshotter/start
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+
+from drenv import kubectl
+from drenv import cache
+
+
+def deploy(cluster):
+    print("Deploying crds")
+    path = cache.get("crds", "addons/odf-external-snapshotter-8.2.yaml")
+    kubectl.apply("--filename", path, context=cluster)
+
+    print("Waiting until crds are established")
+    kubectl.wait("--for=condition=established", "--filename", path, context=cluster)
+
+
+if len(sys.argv) != 2:
+    print(f"Usage: {sys.argv[0]} cluster")
+    sys.exit(1)
+
+os.chdir(os.path.dirname(__file__))
+cluster = sys.argv[1]
+
+deploy(cluster)


### PR DESCRIPTION
In order to unblock https://github.com/RamenDR/ramen/pull/2030 for e2e tests we need both public and private VolumeGroupSnapshots CRDs installed. This PR is creating a new addon, which currently only installs CRDs, but in future will have more functionality.