### PR TITLE
Add a new addon to regional-dr configuration

### DIFF
--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -39,6 +39,7 @@ templates:
             args: ["$name", "hub"]
           - name: recipe
       - addons:
+          - name: odf-external-snapshotter
           - name: external-snapshotter
           - name: csi-addons
           - name: olm


### PR DESCRIPTION
Since we have the private VGS API, we need to install the CRDs for this API in drenv regional-dr environment. Adding the new addon, that will install these CRDs.