### PR TITLE
ReplicationGroupSourceReconciler must check for private VGS API

### DIFF
--- a/internal/controller/replicationgroupsource_controller.go
+++ b/internal/controller/replicationgroupsource_controller.go
@@ -143,7 +143,7 @@ func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ct
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReplicationGroupSourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	if util.IsCRDInstalled(context.TODO(), r.APIReader, util.VGSCRDName) {
+	if util.IsCRDInstalled(context.TODO(), r.APIReader, util.VGSCRDPrivateName) {
 		r.volumeGroupSnapshotCRsAreWatched = true
 	}
 


### PR DESCRIPTION
ReplicationGroupSourceReconciler must check for private VGS CRDs installed (fixing the error of checking if public API CRDs installed)

Fixes: https://github.com/RamenDR/ramen/issues/2166