### PR TITLE
Upgrade versions of golangci-lint ,mdl, yamllint, shellcheck

### DIFF
--- a/.github/workflows/ramen.yaml
+++ b/.github/workflows/ramen.yaml
@@ -91,9 +91,9 @@ jobs:
           cache: false
 
       - name: GolangCI Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.62.0
+          version: v2.2.2
           working-directory: ${{ matrix.directory }}
 
   unit-test:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,97 +6,113 @@
 run:
   timeout: 5m
 
+version: "2"
 # all available settings of specific linters
-linters-settings:
-  errcheck:
-    # report about not checking of errors in type assertions: `a := b.(MyStruct)`;
-    # default is false: such cases aren't reported by default.
-    check-type-assertions: true
-    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
-    # default is false: such cases aren't reported by default.
-    check-blank: true
-  exhaustive:
-    # check switch statements in generated files also
-    check-generated: true
-  gocognit:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 15
-  gocyclo:
-    # minimal code complexity to report, 30 by default (but we recommend 10-20)
-    min-complexity: 15
-  goheader:
-    template: |
-      SPDX-FileCopyrightText: The RamenDR authors
-      SPDX-License-Identifier: Apache-2.0
-  misspell:
-    locale: US
-  promlinter:
-    strict: true
-  wsl:
-    allow-trailing-comment: true
-    force-err-cuddling: true
-  revive:
-    ignore-generated-header: false
-    severity: error
-    rules:
-      - name: blank-imports
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: exported
-      - name: increment-decrement
-      - name: var-naming
-      - name: var-declaration
-      - name: package-comments
-      - name: range
-      - name: receiver-naming
-      - name: time-naming
-      - name: unexported-return
-      - name: indent-error-flow
-      - name: errorf
-      - name: empty-block
-      - name: superfluous-else
-      - name: unreachable-code
-      - name: redefines-builtin-id
-      - name: atomic
-      - name: constant-logical-expr
-      - name: unnecessary-stmt
-      - name: get-return
-      - name: modifies-parameter
-      - name: modifies-value-receiver
-      - name: range-val-in-closure
-      - name: waitgroup-by-value
-      - name: call-to-gc
-      - name: duplicated-imports
-      - name: unhandled-error
-      # - name: flag-parameter
-      # - name: unused-receiver
-      # - name: unused-parameter
-      # - name: confusing-naming
-      # - name: import-shadowing
-      # - name: confusing-results
-      # - name: bool-literal-in-expr
-
-issues:
-  exclude-rules:
-    # Allow dot imports for ginkgo and gomega
-    - source: ginkgo|gomega
-      linters:
-        - revive
-      text: "should not use dot imports"
-    - source: "^func Test"
-      linters:
-        - funlen
-    - source: "^//"
-      linters:
-        - lll
-
-
 linters:
-  disable-all: true
+  settings:
+    errcheck:
+      # report about not checking of errors in type assertions:
+      # `a := b.(MyStruct)`;
+      # default is false: such cases aren't reported by default.
+      check-type-assertions: true
+      check-blank: true
+    gocognit:
+      # minimal code complexity to report, 30 by default
+      # (but we recommend 10-20)
+      min-complexity: 15
+    gocyclo:
+      # minimal code complexity to report, 30 by default
+      # (but we recommend 10-20)
+      min-complexity: 15
+    goheader:
+      template: |
+        SPDX-FileCopyrightText: The RamenDR authors
+        SPDX-License-Identifier: Apache-2.0
+    misspell:
+      locale: US
+    promlinter:
+      strict: true
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
+      enable:
+        - err
+    revive:
+      severity: error
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: increment-decrement
+        # This rule warns when initialism, variable or package naming conventions are not followed
+        # Refer: https://github.com/mgechev/revive/blob/HEAD/RULES_DESCRIPTIONS.md#var-naming
+        - name: var-naming
+          arguments:
+            - []    # allowlist of initialisms
+            - []    # blocklist of initialisms
+            -
+              - upper-case-const: true      # allow UPPER_CASE for const
+                skip-package-name-checks: true      # skip package name checks
+        - name: var-declaration
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: unreachable-code
+        - name: redefines-builtin-id
+        - name: atomic
+        - name: constant-logical-expr
+        - name: unnecessary-stmt
+        - name: get-return
+        - name: modifies-parameter
+        - name: modifies-value-receiver
+        - name: range-val-in-closure
+        - name: waitgroup-by-value
+        - name: call-to-gc
+        - name: duplicated-imports
+        - name: unhandled-error
+        # - name: flag-parameter
+        # - name: unused-receiver
+        # - name: unused-parameter
+        # - name: confusing-naming
+        # - name: import-shadowing
+        # - name: confusing-results
+        # - name: bool-literal-in-expr
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # Allow dot imports for ginkgo and gomega
+      - linters:
+          - revive
+        text: should not use dot imports
+        source: ginkgo|gomega
+      - linters:
+          - funlen
+        source: ^func Test
+      - linters:
+          - lll
+        source: ^//
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+  default: none
   enable:
     - asasalint
     - asciicheck
@@ -121,13 +137,10 @@ linters:
     #  - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - gofumpt
     #  - golint // Fully deprecated, remove this line once an alternative is enabled for the same
     - gomodguard
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - grouper
     #  - ifshort // Fully deprecated, remove this line once an alternative is enabled for the same
@@ -156,21 +169,19 @@ linters:
     - rowserrcheck
     #  - scopelint // Fully deprecated, remove this line once an alternative is enabled for the same
     - sqlclosecheck
-    #  - structcheck // Fully deprecated, remove this line once an alternative is enabled for the same
-    - stylecheck
-    - tenv
+    # - structcheck // Fully deprecated, remove this line once an alternative is enabled for the same
     - testpackage
     - thelper
     - tparallel
-    - typecheck
     - unconvert
     - unparam
     - unused
     - usestdlibvars
+    - usetesting
     #  - varcheck // Fully deprecated, remove this line once an alternative is enabled for the same
     - wastedassign
     - whitespace
-    - wsl
+    - wsl_v5
     #  - gochecknoglobals
     #  - gochecknoinits
     #  - godot
@@ -195,3 +206,13 @@ linters:
     #  - forcetypeassert
     #  - contextcheck
     #  - errname
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/api/v1alpha1/drclusterconfig_types.go
+++ b/api/v1alpha1/drclusterconfig_types.go
@@ -65,8 +65,6 @@ type DRClusterConfigStatus struct {
 //+kubebuilder:resource:scope=Cluster
 
 // DRClusterConfig is the Schema for the drclusterconfigs API
-//
-//nolint:maligned
 type DRClusterConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/e2e/argocd/appset_hack.go
+++ b/e2e/argocd/appset_hack.go
@@ -24,7 +24,6 @@ type ApplicationSetList struct {
 	Items           []ApplicationSet `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//nolint:maligned
 type ApplicationSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata" protobuf:"bytes,1,opt,name=metadata"`
@@ -109,14 +108,14 @@ type KustomizePatch struct {
 	Options map[string]bool    `json:"options,omitempty" yaml:"options,omitempty" protobuf:"bytes,4,opt,name=options"`
 }
 
-//nolint:lll, golint
+//nolint:lll
 type KustomizeSelector struct {
 	KustomizeResId     `json:",inline,omitempty" yaml:",inline,omitempty" protobuf:"bytes,1,opt,name=resId"`
 	AnnotationSelector string `json:"annotationSelector,omitempty" yaml:"annotationSelector,omitempty" protobuf:"bytes,2,opt,name=annotationSelector"`
 	LabelSelector      string `json:"labelSelector,omitempty" yaml:"labelSelector,omitempty" protobuf:"bytes,3,opt,name=labelSelector"`
 }
 
-//nolint:golint, revive, stylecheck
+//nolint:revive
 type KustomizeResId struct {
 	KustomizeGvk `json:",inline,omitempty" yaml:",inline,omitempty" protobuf:"bytes,1,opt,name=gvk"`
 	Name         string `json:"name,omitempty" yaml:"name,omitempty" protobuf:"bytes,2,opt,name=name"`

--- a/e2e/deployers/crud.go
+++ b/e2e/deployers/crud.go
@@ -94,6 +94,7 @@ func CreatePlacement(ctx types.TestContext, name, namespace string, clusterName 
 	clusterSet := []string{config.ClusterSet}
 
 	var numClusters int32 = 1
+
 	placement := &ocmv1b1.Placement{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/e2e/dractions/crud.go
+++ b/e2e/dractions/crud.go
@@ -157,6 +157,7 @@ func createPlacementManagedByRamen(ctx types.TestContext, name, namespace string
 	annotations[OcmSchedulingDisable] = "true"
 
 	var numClusters int32 = 1
+
 	placement := &clusterv1beta1.Placement{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -101,6 +101,7 @@ func testMain(m *testing.M) int {
 
 	// The context will be canceled when receiving a signal.
 	var stop context.CancelFunc
+
 	Ctx.context, stop = signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 

--- a/hack/install-golangci-lint.sh
+++ b/hack/install-golangci-lint.sh
@@ -4,13 +4,13 @@ set -e
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
 source_url="https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
-required_version="1.62.0"
+required_version="2.2.2"
 target_dir="${script_dir}/../testbin"
 target_path="${target_dir}/golangci-lint"
 tool="golangci-lint"
 
 # sample output to parse: 'golangci-lint has version 1.55.2 built with go1.21.3 from e3c2265f on 2023-11-03T12:59:25Z'
-installed_version=$("${target_path}" version --format=short || true)
+installed_version=$("${target_path}" version --short || true)
 
 if [ "$required_version" == "$installed_version" ]; then
   exit 0

--- a/hack/pre-commit.sh
+++ b/hack/pre-commit.sh
@@ -53,7 +53,7 @@ check_tool() {
 # https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
 run_mdl() {
     local tool="mdl"
-    local required_version="0.11.0"
+    local required_version="0.13.0"
     local detected_version
 
     echo "=====  $tool ====="
@@ -70,7 +70,7 @@ run_mdl() {
 
 run_shellcheck() {
     local tool="shellcheck"
-    local required_version="0.7.0"
+    local required_version="0.9.0"
     local detected_version
 
     echo "=====  $tool  ====="
@@ -87,7 +87,7 @@ run_shellcheck() {
 
 run_yamllint() {
     local tool="yamllint"
-    local required_version="1.33.0"
+    local required_version="1.35.0"
     local detected_version
 
     echo "=====  $tool  ====="

--- a/internal/controller/argocd/appset_hack.go
+++ b/internal/controller/argocd/appset_hack.go
@@ -24,7 +24,6 @@ type ApplicationSetList struct {
 	Items           []ApplicationSet `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//nolint:maligned
 type ApplicationSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata" protobuf:"bytes,1,opt,name=metadata"`

--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -1359,7 +1359,7 @@ func setDRClusterUnfencingFailedCondition(conditions *[]metav1.Condition, observ
 // Unfence operation, unfence = true, fence = false, clean = false
 // TODO: Remove the linter skip when this function is used
 //
-//nolint:deadcode,unused
+//nolint:unused
 func setDRClusterCleaningFailedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	util.SetStatusCondition(conditions, metav1.Condition{
 		Type:               ramen.DRClusterConditionTypeFenced,

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -591,10 +591,10 @@ func deleteDRPC() {
 func ensureNamespaceMWsDeletedFromAllClusters(namespace string) {
 	foundMW := &ocmworkv1.ManifestWork{}
 	mwName := fmt.Sprintf(rmnutil.ManifestWorkNameFormat, DRPCCommonName, namespace, rmnutil.MWTypeNS)
+
 	err := k8sClient.Get(context.TODO(),
 		types.NamespacedName{Name: mwName, Namespace: East1ManagedCluster},
 		foundMW)
-
 	if err == nil {
 		Expect(foundMW).To(BeNil())
 	}
@@ -1772,7 +1772,7 @@ var _ = Describe("DRPlacementControl Reconciler Errors", func() {
 
 // +kubebuilder:docs-gen:collapse=Imports
 //
-//nolint:errcheck,scopelint
+//nolint:errcheck
 var _ = Describe("DRPlacementControl Reconciler", func() {
 	Specify("DRClusters", func() {
 		populateDRClusters()

--- a/internal/controller/protectedvolumereplicationgrouplist_controller.go
+++ b/internal/controller/protectedvolumereplicationgrouplist_controller.go
@@ -139,6 +139,7 @@ func (s *ProtectedVolumeReplicationGroupListInstance) getVrgContentsFromS3(prefi
 	vrgsAll := make([]ramendrv1alpha1.VolumeReplicationGroup, 0)
 
 	const NoPrefixToRemove = ""
+
 	namespaceNamesList := getUniqueStringsFromList(prefixNamespaceVRG, ParseSingleSlash, NoPrefixToRemove)
 
 	s.log.Info("namespaceNames:")

--- a/internal/controller/s3utils_test.go
+++ b/internal/controller/s3utils_test.go
@@ -103,6 +103,7 @@ func (f *fakeObjectStorer) UploadObject(key string, object interface{}) error {
 func (f *fakeObjectStorer) DownloadObject(key string, objectPointer interface{}) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
+
 	object, ok := f.objects[key]
 
 	objectDestination := reflect.ValueOf(objectPointer).Elem()

--- a/internal/controller/util/mw_util.go
+++ b/internal/controller/util/mw_util.go
@@ -601,7 +601,6 @@ func (mwu *MWUtil) createOrUpdateManifestWork(
 
 			return mwu.Client.Update(mwu.Ctx, foundMW)
 		})
-
 		if err == nil {
 			return ctrlutil.OperationResultUpdated, nil
 		}

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -752,7 +752,6 @@ func (v *VSHandler) undoAfterFinalSync(pvcName, pvcNamespace string) error {
 		Namespace: pvcNamespace,
 		Name:      getTmpPVCNameForFinalSync(pvcName),
 	})
-
 	if err == nil {
 		err2 := v.client.Delete(v.ctx, tmpPVC)
 		if err2 != nil {

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -2185,7 +2185,6 @@ func (v *VRGInstance) CheckForVMConflictOnPrimary() error {
 	var foundVMs []string
 
 	var err error
-
 	if foundVMs, err = util.ListVMsByLabelSelector(v.ctx, v.reconciler.APIReader, v.log,
 		labelSelector,
 		vmNamespace,
@@ -2233,7 +2232,6 @@ func (v *VRGInstance) CheckForVMNameConflictOnSecondary(vmNamespaceList, vmList 
 	var foundVMs []string
 
 	var err error
-
 	if foundVMs, err = util.ListVMsByVMNamespace(v.ctx, v.reconciler.APIReader,
 		v.log, vmNamespaceList, vmList); err != nil {
 		if !k8serrors.IsNotFound(err) {

--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -40,6 +40,7 @@ func kubeObjectsCapturePathNamesAndNamePrefix(
 	namespaceName, vrgName string, captureNumber int64, kubeObjects kubeobjects.RequestsManager,
 ) (string, string, string) {
 	const numberBase = 10
+
 	number := strconv.FormatInt(captureNumber, numberBase)
 	pathName := s3PathNamePrefix(namespaceName, vrgName) + "kube-objects/" + number + "/"
 

--- a/internal/controller/vrg_volrep_test.go
+++ b/internal/controller/vrg_volrep_test.go
@@ -1680,7 +1680,6 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 	// TODO: Add tests to ensure delete as Secondary (check if delete as Primary is tested above)
 })
 
-//nolint:maligned
 type vrgTest struct {
 	uniqueID             string
 	namespace            string


### PR DESCRIPTION
- Update  versions of golangci-lint, mdl, yamllint and SmallCheck used by linter.
- Updated linter config yaml
- Update go files to resolve linter errors and warnings reported by upgraded version of linter.

Reasons for the updates made to the linter config after migration :

1.   staticcheck => was commented in v1.62.0 .golangci.yaml config -> continued the same in v2.2.2 config

2.  var-naming => Updated var-naming as per v2.2.2 updates to skip the package naming checks 
 Refer: https://golangci-lint.run/usage/linters/#var-naming
Errors related to package naming checks:
```
# make lint
testbin/golangci-lint config verify --config=./.golangci.yaml
cd e2e && ../testbin/golangci-lint run ./... --config=../.golangci.yaml
WARN [runner/nolint_filter] Found unknown linters in //nolint directives: var-naming 
e2e/types/types.go:5:9: var-naming: avoid meaningless package names (revive)
package types
        ^
e2e/util/drpolicy.go:4:9: var-naming: avoid meaningless package names (revive)
package util
        ^
2 issues:
* revive: 2
```

3.  wsl => is deprecated and equivalent newer filed is wsl_v5 and this is updated in latest config file.

4. Updates to linter config:

- **gofmt, gofumpt** linters are moved under **formatters** upon migrating the .golangci.yaml
- **gosimple, stylecheck** linters are merged into **staticcheck** linter
          Reference : https://golangci-lint.run/product/migration-guide/#lintersenablestylecheckgosimplestaticcheck
                              https://golangci-lint.run/usage/linters/#staticcheck

- **tenv** is replaced with **usetesting** linter
- **typecheck** : Is not a linter anymore, https://golangci-lint.run/product/migration-guide/#typecheck
- **wsl** is replaced by new major verison **wsl_v5**

Output of linter migration & execution:
```
# golangci-lint migrate
WARN The configuration comments are not migrated. 
WARN Details about the migration: https://golangci-lint.run/product/migration-guide/ 
WARN The configuration `run.timeout` is ignored. By default, in v2, the timeout is disabled. 
╭───────────────────────────────────────────────────────────────────────────╮
│                                                                           │
│                               We need you!                                │
│                                                                           │
│ Donations help fund the ongoing development and maintenance of this tool. │
│  If golangci-lint has been useful to you, please consider contributing.   │
│                                                                           │
│                  Donate now: https://donate.golangci.org                  │
│                                                                           │
╰───────────────────────────────────────────────────────────────────────────╯

# golangci-lint config verify
# echo $?
0
# make lint
testbin/golangci-lint config verify --config=./.golangci.yaml
cd e2e && ../testbin/golangci-lint run ./... --config=../.golangci.yaml
0 issues.
cd api && ../testbin/golangci-lint run ./... --config=../.golangci.yaml
0 issues.
testbin/golangci-lint run ./... --config=./.golangci.yaml
0 issues.
hack/pre-commit.sh
/tmp/tool-errors-hgJuj0
=====  mdl =====


=====  shellcheck  =====


=====  yamllint  =====

```
