### PR TITLE
e2e: pass the deployer spec to the New functions

### DIFF
--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -11,10 +11,14 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-type ApplicationSet struct{}
+type ApplicationSet struct {
+	DeployerSpec config.Deployer
+}
 
 func NewApplicationSet(deployer config.Deployer) types.Deployer {
-	return &ApplicationSet{}
+	return &ApplicationSet{
+		DeployerSpec: deployer,
+	}
 }
 
 // Deploy creates an ApplicationSet on the hub cluster, creating the workload on one of the managed clusters.

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -13,10 +13,14 @@ import (
 	"github.com/ramendr/ramen/e2e/util"
 )
 
-type DiscoveredApp struct{}
+type DiscoveredApp struct {
+	DeployerSpec config.Deployer
+}
 
 func NewDiscoveredApp(deployer config.Deployer) types.Deployer {
-	return &DiscoveredApp{}
+	return &DiscoveredApp{
+		DeployerSpec: deployer,
+	}
 }
 
 func (d DiscoveredApp) GetName() string {

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -12,10 +12,14 @@ import (
 	"github.com/ramendr/ramen/e2e/util"
 )
 
-type Subscription struct{}
+type Subscription struct {
+	DeployerSpec config.Deployer
+}
 
 func NewSubscription(deployer config.Deployer) types.Deployer {
-	return &Subscription{}
+	return &Subscription{
+		DeployerSpec: deployer,
+	}
 }
 
 func (s Subscription) GetName() string {

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -47,7 +47,7 @@ type Deployer interface {
 	GetName() string
 	// GetNamespace return the namespace for the ramen resources, or empty string if not using a special namespace.
 	GetNamespace(TestContext) string
-	// Return true for OCM discovered application, false for OCM managed applications.
+	// IsDiscovered returns true for OCM discovered application, false for OCM managed applications.
 	IsDiscovered() bool
 
 	// DeleteResources removes all resources that were deployed as part of the workload


### PR DESCRIPTION
This will allow the deployers to behave differently based on the specification.