### PR TITLE
Do not add VGRClass to drenv as it makes policy default to grouping

### DIFF
--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -111,12 +111,6 @@ def configure_rbd_mirroring(cluster, peer_info):
     yaml = template.substitute(cluster=cluster, scname="rook-ceph-block")
     kubectl.apply("--filename=-", input=yaml, context=cluster)
 
-    template = drenv.template("start-data/vgrc-sample.yaml")
-    yaml = template.substitute(
-        cluster=cluster, pool=POOL_NAME, scname="rook-ceph-block"
-    )
-    kubectl.apply("--filename=-", input=yaml, context=cluster)
-
     print(f"Apply rbd mirror to cluster '{cluster}'")
     kubectl.apply("--kustomize=start-data", context=cluster)
 


### PR DESCRIPTION
As the current rbd-mirror setup creates a VGR class by default, that aligns with the storage and replicaiton IDs across clusters, the DRPolicy reads this information and assumes that grouping is supported.

The issue is that, although we create the class, we do not setup Ceph CSI sidecars and the VGR controller in the environment. This causes all VRGs to fail, as the VGR is never reconciled.

This is potentially introduced as part of recent commits that use class labels to determine grouping, and hence is failing e2e tests.