### PR TITLE
Upgrade of k8s tools to be compatible with gov1.24

### DIFF
--- a/config/crd/bases/ramendr.openshift.io_drclusterconfigs.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drclusterconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: drclusterconfigs.ramendr.openshift.io
 spec:
   group: ramendr.openshift.io

--- a/config/crd/bases/ramendr.openshift.io_drclusters.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: drclusters.ramendr.openshift.io
 spec:
   group: ramendr.openshift.io

--- a/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: drplacementcontrols.ramendr.openshift.io
 spec:
   group: ramendr.openshift.io

--- a/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: drpolicies.ramendr.openshift.io
 spec:
   group: ramendr.openshift.io

--- a/config/crd/bases/ramendr.openshift.io_maintenancemodes.yaml
+++ b/config/crd/bases/ramendr.openshift.io_maintenancemodes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: maintenancemodes.ramendr.openshift.io
 spec:
   group: ramendr.openshift.io

--- a/config/crd/bases/ramendr.openshift.io_protectedvolumereplicationgrouplists.yaml
+++ b/config/crd/bases/ramendr.openshift.io_protectedvolumereplicationgrouplists.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: protectedvolumereplicationgrouplists.ramendr.openshift.io
 spec:
   group: ramendr.openshift.io

--- a/config/crd/bases/ramendr.openshift.io_replicationgroupdestinations.yaml
+++ b/config/crd/bases/ramendr.openshift.io_replicationgroupdestinations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: replicationgroupdestinations.ramendr.openshift.io
 spec:
   group: ramendr.openshift.io

--- a/config/crd/bases/ramendr.openshift.io_replicationgroupsources.yaml
+++ b/config/crd/bases/ramendr.openshift.io_replicationgroupsources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: replicationgroupsources.ramendr.openshift.io
 spec:
   group: ramendr.openshift.io

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.5
+    controller-gen.kubebuilder.io/version: v0.18.0
   name: volumereplicationgroups.ramendr.openshift.io
 spec:
   group: ramendr.openshift.io

--- a/hack/install-controller-gen.sh
+++ b/hack/install-controller-gen.sh
@@ -3,7 +3,7 @@ set -e
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
-required_version="v0.16.5"
+required_version="v0.18.0"
 source_url="sigs.k8s.io/controller-tools/cmd/controller-gen@${required_version}"
 target_dir="${script_dir}/../bin"
 target_path="${target_dir}/controller-gen"

--- a/hack/install-kustomize.sh
+++ b/hack/install-kustomize.sh
@@ -3,7 +3,7 @@ set -e
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
-required_version="v5.4.1"
+required_version="v5.7.0"
 os=$(go env GOOS)
 arch=$(go env GOARCH)
 source_url="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2F${required_version}/kustomize_${required_version}_${os}_${arch}.tar.gz"

--- a/hack/install-operator-sdk.sh
+++ b/hack/install-operator-sdk.sh
@@ -5,7 +5,7 @@ script_dir="$(cd "$(dirname "$0")" && pwd)"
 
 os=$(go env GOOS)
 arch=$(go env GOARCH)
-required_version="v1.34.2"
+required_version="v1.41.1"
 source_url="https://github.com/operator-framework/operator-sdk/releases/download/${required_version}/operator-sdk_${os}_${arch}"
 target_dir="${script_dir}/../bin"
 target_path="${target_dir}/operator-sdk"

--- a/hack/install-opm.sh
+++ b/hack/install-opm.sh
@@ -5,7 +5,7 @@ script_dir="$(cd "$(dirname "$0")" && pwd)"
 
 os=$(go env GOOS)
 arch=$(go env GOARCH)
-required_version="v1.43.0"
+required_version="v1.56.0"
 source_url="https://github.com/operator-framework/operator-registry/releases/download/${required_version}/${os}-${arch}-opm"
 target_dir="${script_dir}/../bin"
 target_path="${target_dir}/opm"

--- a/hack/install-setup-envtest.sh
+++ b/hack/install-setup-envtest.sh
@@ -3,11 +3,12 @@ set -e
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
-required_version="release-0.19"
+# Reference : https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.40.0/#envtest-version-automation-and-improved-test-binary-discovery
+required_version=$(go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $2, $3}')
 source_url="sigs.k8s.io/controller-runtime/tools/setup-envtest@${required_version}"
 target_dir="${script_dir}/../testbin"
 target_path="${target_dir}/setup-envtest"
-k8s_version="1.29.0"
+k8s_version="1.33.0"
 
 # The setup-envtest tool has no versioning, so we need to use the latest version.
 # The go install command is fast enough that it can be run every time.


### PR DESCRIPTION
Update the K8S tools of Kubernetes operator ecosystem
	1. controller-gen : v0.18.0
	2. kustomize : v5.7.0
	3. operator-sdk : v1.41.1
	4. Operator Framework : v1.56.0
	5. EnvTest : As there is no version with this naming - release-x.yy, updated the latest version which is compatible with go v1.24 https://pkg.go.dev/sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250716215226-c024d17ca0c1 Refer: https://pkg.go.dev/sigs.k8s.io/controller-runtime/tools/setup-envtest?tab=versions