### PR TITLE
Fixing race condition for [protects kube objects] in VRG UTs

### DIFF
--- a/internal/controller/vrg_volrep_test.go
+++ b/internal/controller/vrg_volrep_test.go
@@ -2520,6 +2520,11 @@ func kubeObjectProtectionValidate(tests []*vrgTest) {
 	}
 
 	protectedVrgList := protectedVrgListCreateAndStatusWait("protectedvrglist-vrg-"+tests[0].uniqueID, vrgS3ProfileNumber)
+
+	// Refresh the list once all VRGs have been uploaded to S3 store to fix race condition,
+	// since the initial scan may have happened before all uploads completed successfully.
+	protectedVrgListRefresh(protectedVrgList)
+
 	vrgs := make([]ramendrv1alpha1.VolumeReplicationGroup, len(tests))
 
 	for i, v := range tests {


### PR DESCRIPTION
I tried to refresh the VRG list just before running tests. And it seems to fix the [protects kube objects] intermittent failure, which was kind of because of a race condition.