### PR TITLE
Configure E2E setup for VM workload support

### DIFF
--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -24,6 +24,15 @@ and add the clusters kubeconfig paths into `config.yaml` using:
 cat config.yaml.sample ~/.config/drenv/rdr/config.yaml > config.yaml
 ```
 
+If the `drenv` tool was used to configure RDR clusters with the KubeVirt addon
+for deploying VirtualMachine workloads using the configuration file located at
+`envs/regional-dr-kubevirt.yaml`, follow these steps to complete the e2e setup
+for VM workload testing:
+
+```sh
+cat config-vm.yaml.sample ~/.config/drenv/rdr-kubevirt/config.yaml > config.yaml
+```
+
 #### For real cluster
 
 Create a `config.yaml` file by copying the `config.yaml.sample` template:

--- a/e2e/config-vm.yaml.sample
+++ b/e2e/config-vm.yaml.sample
@@ -1,0 +1,48 @@
+# Configuration for RamenDR End to End testing with virtual machines.
+
+---
+# Git repository url and branch containing application manifests
+# to be deployed on the clusters.
+repo:
+  url: "https://github.com/RamenDR/ocm-ramen-samples.git"
+  branch: main
+
+# DRPolicy name in the hub cluster.
+drPolicy: dr-policy
+
+# Add ClusterSet name to match your Open Cluster Management configuration.
+clusterSet: default
+
+# List of PVC specifications for workloads.
+# These define storage configurations, such as 'storageClassName' and
+# 'accessModes', and are used to kustomize workloads.
+pvcspecs:
+  - name: rbd
+    storageclassname: rook-ceph-block
+    accessmodes: ReadWriteOnce
+
+# List to tests to run.
+# Available workloads: deploy
+# Available deployers: appset, subscr, disapp
+# Test names are generated as "{deployer}-{workload}-{pvcspec}".
+tests:
+  - deployer: disapp
+    workload: vm-pvc
+    pvcspec: rbd
+  - deployer: appset
+    workload: vm-pvc
+    pvcspec: rbd
+  - deployer: subscr
+    workload: vm-pvc
+    pvcspec: rbd
+
+# Sample cluster configurations:
+# Uncomment and edit the following lines to set the cluster
+# kubeconfig paths for the hub and managed clusters.
+# clusters:
+#   hub:
+#     kubeconfig: hub/config
+#   c1:
+#     kubeconfig: dr1/config
+#   c2:
+#     kubeconfig: dr2/config


### PR DESCRIPTION
- docs/e2e.md document update to configure E2E setup to test DR on VM workload

- config-vm.yaml addition for VM workload configuration file on E2E setup
 
 Fixes: #2194 