### PR TITLE
Expands VRG status to include replication health

### DIFF
--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -48,6 +48,9 @@ const (
 	VRGConditionTypeVolSyncFinalSyncInProgress = "FinalSyncInProgress"
 	VRGConditionTypeVolSyncRepDestinationSetup = "ReplicationDestinationSetup"
 	VRGConditionTypeVolSyncPVsRestored         = "PVsRestored"
+
+	// VRGConditionTypeReplicationHealthy used to reflect new condition from underlying VR/VRG
+	VRGConditionTypeReplicationHealthy = "ReplicationHealthy"
 )
 
 // VRG condition reasons


### PR DESCRIPTION
## Changes
Mirror the VR/VGR `ReplicationState` condition into the VolumeReplicationGroup (VRG) status using a new `ReplicationHealthy` condition so users can view real-time replication health via VRG.

- If VR `ReplicationState=True`: set `ReplicationHealthy=True` and continue reconciliation
- If `False`: set `ReplicationHealthy=False` and stop further status evaluation
- If absent or `Unknown`: leave existing behavior unchanged

This enhancement surfaces replication health through VRG status, with no impact on downstream components like DRPC (which continues consuming VRG status unchanged).

## Remarks

- Resolves [DFBUGS-3670](https://issues.redhat.com/browse/DFBUGS-3670)
- Future enhancement: have it compute an aggregated message instead of breaking after the first caught faulty VR (if any)