### PR TITLE
Updating configs to use applicationset samples

### DIFF
--- a/test/configs/deployment-k8s-regional-rbd.yaml
+++ b/test/configs/deployment-k8s-regional-rbd.yaml
@@ -3,7 +3,7 @@
 
 ---
 repo: https://github.com/ramendr/ocm-ramen-samples.git
-path: subscription/deployment-k8s-regional-rbd
+path: applicationset/deployment-k8s-regional-rbd
 branch: main
 name: deployment-rbd
 namespace: deployment-rbd


### PR DESCRIPTION
This PR changes usage of subscriptions based application(deprecated) samples to applicationset, from OCM ramen samples.

Migration strategy:
Step 1: Update ramen repository to use ApplicationSets (this PR)
Step 2: Remove subscription samples [(PR)](https://github.com/RamenDR/ocm-ramen-samples/pull/68)