### PR TITLE
Add VRG as owner reference to newly created RGS and RGD

### DIFF
--- a/internal/controller/cephfscg/cghandler.go
+++ b/internal/controller/cephfscg/cghandler.go
@@ -18,6 +18,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -120,6 +121,12 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupDestination(
 	util.AddLabel(rgd, util.CreatedByRamenLabel, "true")
 
 	_, err := ctrlutil.CreateOrUpdate(c.ctx, c.Client, rgd, func() error {
+		if c.VSHandler != nil && !c.VSHandler.IsVRGInAdminNamespace() {
+			if err := ctrl.SetControllerReference(c.VSHandler.GetOwner(), rgd, c.Client.Scheme()); err != nil {
+				return fmt.Errorf("unable to set controller reference %w", err)
+			}
+		}
+
 		util.AddLabel(rgd, volsync.VRGOwnerNameLabel, c.instance.GetName())
 		util.AddLabel(rgd, volsync.VRGOwnerNamespaceLabel, c.instance.GetNamespace())
 		util.AddAnnotation(rgd, volsync.OwnerNameAnnotation, c.instance.GetName())
@@ -209,6 +216,12 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupSource(
 	util.AddLabel(rgs, util.CreatedByRamenLabel, "true")
 
 	_, err = ctrlutil.CreateOrUpdate(c.ctx, c.Client, rgs, func() error {
+		if c.VSHandler != nil && !c.VSHandler.IsVRGInAdminNamespace() {
+			if err := ctrl.SetControllerReference(c.VSHandler.GetOwner(), rgs, c.Client.Scheme()); err != nil {
+				return fmt.Errorf("unable to set controller reference %w", err)
+			}
+		}
+
 		util.AddLabel(rgs, volsync.VRGOwnerNameLabel, c.instance.GetName())
 		util.AddLabel(rgs, volsync.VRGOwnerNamespaceLabel, c.instance.GetNamespace())
 		util.AddAnnotation(rgs, volsync.OwnerNameAnnotation, c.instance.GetName())

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -114,6 +114,10 @@ func (v *VSHandler) GetWorkloadStatus() string {
 	return v.workloadStatus
 }
 
+func (v *VSHandler) GetOwner() metav1.Object {
+	return v.owner
+}
+
 func (v *VSHandler) SetWorkloadStatus(status string) {
 	v.workloadStatus = status
 }


### PR DESCRIPTION
We observed an issue where the VolumeReplicationGroup (VRG) did not reconcile after changes were made to the ReplicationGroupSource and ReplicationGroupDestination resources.
Upon investigation, I found that the root cause was a missing owner reference. After creating the ReplicationGroupSource and ReplicationGroupDestination objects, we did not set the appropriate OwnerReference to the VRG. As a result,  VRG reconciliation was not triggered as expected.