### PR TITLE
recipe: support addition for CRs in check hooks

### DIFF
--- a/internal/controller/hooks/check_hook.go
+++ b/internal/controller/hooks/check_hook.go
@@ -21,8 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const three = 3
-
 type CheckHook struct {
 	Hook   *kubeobjects.HookSpec
 	Reader client.Reader
@@ -181,6 +179,8 @@ func getResourcesList(k8sReader client.Reader, hook *kubeobjects.HookSpec, log l
 }
 
 func validateAndGetUnstructedListBasedOnType(resourceType string) (*unstructured.UnstructuredList, error) {
+	const three = 3
+
 	resourceParts := strings.Split(resourceType, "/")
 	if len(resourceParts) != 1 && len(resourceParts) != three {
 		return nil, fmt.Errorf("invalid resource type, supported resource types are pod/deployment/statefulset," +

--- a/internal/controller/hooks/check_hook_test.go
+++ b/internal/controller/hooks/check_hook_test.go
@@ -4,16 +4,22 @@
 package hooks_test
 
 import (
+	"context"
 	"encoding/json"
 	"strconv"
 	"testing"
 
+	rmnv1 "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/internal/controller/hooks"
 	"github.com/ramendr/ramen/internal/controller/kubeobjects"
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
@@ -219,6 +225,32 @@ var testCasesObjectData = []testCasesObject{
 	},
 }
 
+func setupFakeClient(t *testing.T) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	err := corev1.AddToScheme(scheme)
+	assert.NoError(t, err)
+
+	err = appsv1.AddToScheme(scheme)
+	assert.NoError(t, err)
+
+	err = rmnv1.AddToScheme(scheme)
+	assert.NoError(t, err)
+
+	// nolint:errcheck
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithIndex(&corev1.Pod{}, "metadata.name", func(obj client.Object) []string {
+			return []string{obj.(*corev1.Pod).Name}
+		}).
+		WithIndex(&appsv1.Deployment{}, "metadata.name", func(obj client.Object) []string {
+			return []string{obj.(*unstructured.Unstructured).GetName()}
+		}).Build()
+	assert.NotNil(t, fakeClient)
+
+	return fakeClient
+}
+
 func getHookSpec(resourceType, condition string) *kubeobjects.HookSpec {
 	return &kubeobjects.HookSpec{
 		Name:           "test-hook",
@@ -228,6 +260,102 @@ func getHookSpec(resourceType, condition string) *kubeobjects.HookSpec {
 			Condition: condition,
 		},
 	}
+}
+
+func TestExecutCheckHookForPodWithNoSelector(t *testing.T) {
+	fakeClient := setupFakeClient(t)
+
+	assert.NotNil(t, fakeClient)
+
+	pod := getPodSpec("busybox")
+	err := fakeClient.Create(context.Background(), pod)
+	assert.Nil(t, err)
+
+	cHook := hooks.CheckHook{
+		Hook:   getHookSpec("pod", "{$.status.phase} == {Running}"),
+		Reader: fakeClient,
+	}
+
+	log := zap.New(zap.UseDevMode(true))
+	err = cHook.Execute(log)
+	assert.NotNil(t, err)
+}
+
+func TestExecutCheckHookForPodWithNameSelector(t *testing.T) {
+	fakeClient := setupFakeClient(t)
+	assert.NotNil(t, fakeClient)
+
+	pod := getPodSpec("busybox")
+	pod.Status.Phase = "Running"
+	err := fakeClient.Create(context.Background(), pod)
+	assert.Nil(t, err)
+
+	pod = getPodSpec("busybox1")
+	err = fakeClient.Create(context.Background(), pod)
+	assert.Nil(t, err)
+
+	hook := getHookSpec("pod", "{$.status.phase} == {Running}")
+	hook.NameSelector = "busybox"
+
+	cHook := hooks.CheckHook{
+		Hook:   hook,
+		Reader: fakeClient,
+	}
+
+	log := zap.New(zap.UseDevMode(true))
+	err = cHook.Execute(log)
+	assert.Nil(t, err)
+}
+
+func TestExecuteCheckHookForDeployment(t *testing.T) {
+	fakeClient := setupFakeClient(t)
+	assert.NotNil(t, fakeClient)
+
+	dep := getDeploymentContent()
+
+	err := fakeClient.Create(context.Background(), dep)
+	assert.Nil(t, err)
+
+	hook := getHookSpec("deployment", "{$.spec.replicas} == {$.status.replicas}")
+	hook.NameSelector = "test-deploy"
+
+	cHook := hooks.CheckHook{
+		Hook:   hook,
+		Reader: fakeClient,
+	}
+
+	log := zap.New(zap.UseDevMode(true))
+	err = cHook.Execute(log)
+	assert.Nil(t, err)
+}
+
+func TestExecuteCheckHookForStatefulSet(t *testing.T) {
+	fakeClient := setupFakeClient(t)
+	assert.NotNil(t, fakeClient)
+
+	ss := getStatefulSetContent()
+	ss.Labels = map[string]string{
+		"appname": "test",
+	}
+
+	err := fakeClient.Create(context.Background(), ss)
+	assert.Nil(t, err)
+
+	hook := getHookSpec("statefulset", "{$.spec.replicas} != {$.status.readyReplicas}")
+	hook.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"appname": "test",
+		},
+	}
+
+	cHook := hooks.CheckHook{
+		Hook:   hook,
+		Reader: fakeClient,
+	}
+
+	log := zap.New(zap.UseDevMode(true))
+	err = cHook.Execute(log)
+	assert.Nil(t, err)
 }
 
 func TestEvaluateCheckHookExp(t *testing.T) {

--- a/internal/controller/hooks/hooks_util.go
+++ b/internal/controller/hooks/hooks_util.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/fields"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -60,9 +59,6 @@ func getObjectsUsingValidK8sName(r client.Reader, hook *kubeobjects.HookSpec,
 ) ([]client.Object, error) {
 	listOps := &client.ListOptions{
 		Namespace: hook.Namespace,
-		FieldSelector: fields.SelectorFromSet(fields.Set{
-			"metadata.name": hook.NameSelector, // needs exact matching with the name
-		}),
 	}
 
 	err := r.List(context.Background(), objList, listOps)
@@ -70,7 +66,53 @@ func getObjectsUsingValidK8sName(r client.Reader, hook *kubeobjects.HookSpec,
 		return nil, fmt.Errorf("error listing resources using nameSelector: %w", err)
 	}
 
-	return getObjectsBasedOnType(objList), err
+	return getFilteredObjectsBasedOnTypeAndNameSelector(objList, hook.NameSelector), err
+}
+
+// Based on the type of resource, slice of objects is returned.
+func getFilteredObjectsBasedOnTypeAndNameSelector(objList client.ObjectList, nameSelector string) []client.Object {
+	objs := make([]client.Object, 0)
+
+	switch v := objList.(type) {
+	case *unstructured.UnstructuredList:
+		objs = filterUnstructuredObjects(v.Items, nameSelector)
+	case *corev1.PodList:
+		objs = filterPods(v.Items, nameSelector)
+	case *appsv1.DeploymentList:
+		objs = filterDeployments(v.Items, nameSelector)
+	case *appsv1.StatefulSetList:
+		objs = filterStatefulSets(v.Items, nameSelector)
+	}
+
+	return objs
+}
+
+func filterStatefulSets(objs []appsv1.StatefulSet, nameSelector string) []client.Object {
+	return filterObjectsSameAsNameSelector(toPointerSlice(objs), nameSelector)
+}
+
+func filterDeployments(objs []appsv1.Deployment, nameSelector string) []client.Object {
+	return filterObjectsSameAsNameSelector(toPointerSlice(objs), nameSelector)
+}
+
+func filterPods(objs []corev1.Pod, nameSelector string) []client.Object {
+	return filterObjectsSameAsNameSelector(toPointerSlice(objs), nameSelector)
+}
+
+func filterUnstructuredObjects(objs []unstructured.Unstructured, nameSelector string) []client.Object {
+	return filterObjectsSameAsNameSelector(toPointerSlice(objs), nameSelector)
+}
+
+func filterObjectsSameAsNameSelector[T client.Object](objs []T, nameSelector string) []client.Object {
+	filteredObjs := make([]client.Object, 0, len(objs))
+
+	for _, obj := range objs {
+		if obj.GetName() == nameSelector {
+			filteredObjs = append(filteredObjs, obj)
+		}
+	}
+
+	return filteredObjs
 }
 
 // Based on the type of resource, slice of objects is returned.
@@ -195,49 +237,39 @@ func getOpHookTimeoutValue(hook *kubeobjects.HookSpec) int {
 }
 
 func getMatchingUnstructedObjs(uList *unstructured.UnstructuredList, re *regexp.Regexp) []client.Object {
-	objs := make([]client.Object, 0)
-
-	for _, uObj := range uList.Items {
-		if re.MatchString(uObj.GetName()) {
-			objs = append(objs, &uObj)
-		}
-	}
-
-	return objs
+	return getRegexMatchingObjects(toPointerSlice(uList.Items), re)
 }
 
 func getMatchingPods(pList *corev1.PodList, re *regexp.Regexp) []client.Object {
-	objs := make([]client.Object, 0)
-
-	for _, pod := range pList.Items {
-		if re.MatchString(pod.Name) {
-			objs = append(objs, &pod)
-		}
-	}
-
-	return objs
+	return getRegexMatchingObjects(toPointerSlice(pList.Items), re)
 }
 
 func getMatchingDeployments(dList *appsv1.DeploymentList, re *regexp.Regexp) []client.Object {
-	objs := make([]client.Object, 0)
+	return getRegexMatchingObjects(toPointerSlice(dList.Items), re)
+}
 
-	for _, pod := range dList.Items {
-		if re.MatchString(pod.Name) {
-			objs = append(objs, &pod)
+func getMatchingStatefulSets(ssList *appsv1.StatefulSetList, re *regexp.Regexp) []client.Object {
+	return getRegexMatchingObjects(toPointerSlice(ssList.Items), re)
+}
+
+func getRegexMatchingObjects[T client.Object](items []T, re *regexp.Regexp) []client.Object {
+	objs := make([]client.Object, 0, len(items))
+
+	for _, item := range items {
+		if re.MatchString(item.GetName()) {
+			obj := item
+			objs = append(objs, obj)
 		}
 	}
 
 	return objs
 }
 
-func getMatchingStatefulSets(ssList *appsv1.StatefulSetList, re *regexp.Regexp) []client.Object {
-	objs := make([]client.Object, 0)
-
-	for _, pod := range ssList.Items {
-		if re.MatchString(pod.Name) {
-			objs = append(objs, &pod)
-		}
+func toPointerSlice[T any](items []T) []*T {
+	ptrs := make([]*T, len(items))
+	for i := range items {
+		ptrs[i] = &items[i]
 	}
 
-	return objs
+	return ptrs
 }


### PR DESCRIPTION
As of now the supported resource types were pod, deployment and statefulset. Additional changes have been done to support for any Custom Resources(CRs) for which the supported format of the resource is of the form `<apiGroup>/<apiVersion>/<resourceNamePlural>`. Additional user responsibility is to add the required Role and RoleBinding combination on the cluster.