### PR TITLE
Delete RD using existing function DeleteRD

### DIFF
--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -1268,7 +1268,7 @@ func (v *VSHandler) CleanupRDNotInSpecList(rdSpecList []ramendrv1alpha1.VolSyncR
 			}
 
 			// Delete the ReplicationDestination, log errors with cleanup but continue on
-			if err := v.client.Delete(v.ctx, &rd); err != nil {
+			if err := v.DeleteRD(rd.GetName(), rd.GetNamespace()); err != nil {
 				v.log.Error(err, "Error cleaning up ReplicationDestination", "name", rd.GetName())
 			} else {
 				v.log.Info("Deleted ReplicationDestination", "name", rd.GetName())


### PR DESCRIPTION
During CephFS workload failover, PVCs or jobs may occasionally remain orphaned due to timing issues during cleanup. It doesn’t happen consistently, but using DeleteRD function for deleting RD (instead of removing RD directly) also ensures that all related local resources are cleaned up.

Fixes: https://issues.redhat.com/browse/DFBUGS-2934