### PR TITLE
e2e: add helper function for listing clusters

### DIFF
--- a/e2e/types/env.go
+++ b/e2e/types/env.go
@@ -19,3 +19,8 @@ func (e *Env) GetCluster(clusterName string) (*Cluster, error) {
 		return nil, fmt.Errorf("cluster %q not found in environment", clusterName)
 	}
 }
+
+// ManagedClusters returns the list of managed clusters from the env.
+func (e *Env) ManagedClusters() []*Cluster {
+	return []*Cluster{e.C1, e.C2}
+}

--- a/e2e/validate/storageclass.go
+++ b/e2e/validate/storageclass.go
@@ -16,10 +16,8 @@ func validateStorageClasses(ctx types.Context) error {
 	env := ctx.Env()
 	config := ctx.Config()
 
-	clusters := []*types.Cluster{env.C1, env.C2}
-
 	for _, spec := range config.PVCSpecs {
-		for _, cluster := range clusters {
+		for _, cluster := range env.ManagedClusters() {
 			_, err := getStorageClass(ctx, cluster, spec.StorageClassName)
 			if err != nil {
 				return fmt.Errorf("failed to validate pvcSpec %q storage class: %w", spec.Name, err)

--- a/e2e/validate/validate.go
+++ b/e2e/validate/validate.go
@@ -134,7 +134,7 @@ func clustersInDRPolicy(ctx types.Context) error {
 		return fmt.Errorf("failed to get DRPolicy %q: %w", config.DRPolicy, err)
 	}
 
-	clusters := []*types.Cluster{env.C1, env.C2}
+	clusters := env.ManagedClusters()
 	for _, cluster := range clusters {
 		if !slices.Contains(drpolicy.Spec.DRClusters, cluster.Name) {
 			return fmt.Errorf("cluster %q is not defined in drpolicy %q, clusters in drpolicy: %q",
@@ -164,7 +164,7 @@ func clustersInClusterSet(ctx types.Context) error {
 		return err
 	}
 
-	clusters := []*types.Cluster{env.C1, env.C2}
+	clusters := env.ManagedClusters()
 	for _, cluster := range clusters {
 		if !slices.Contains(clusterNames, cluster.Name) {
 			return fmt.Errorf("cluster %q is not defined in ClusterSet %q, clusters in ClusterSet: %q",

--- a/e2e/workloads/deploy.go
+++ b/e2e/workloads/deploy.go
@@ -128,9 +128,7 @@ func (w Deployment) Health(ctx types.TestContext, cluster *types.Cluster) error 
 func (w Deployment) Status(ctx types.TestContext) ([]types.WorkloadStatus, error) {
 	var statuses []types.WorkloadStatus
 
-	clusters := []*types.Cluster{ctx.Env().C1, ctx.Env().C2}
-
-	for _, cluster := range clusters {
+	for _, cluster := range ctx.Env().ManagedClusters() {
 		status, err := w.statusForCluster(ctx, cluster)
 		if err != nil {
 			return nil, fmt.Errorf("error checking application \"%s/%s\" on cluster %q: %w",

--- a/e2e/workloads/vm.go
+++ b/e2e/workloads/vm.go
@@ -111,9 +111,7 @@ func (w *VM) Health(ctx types.TestContext, cluster *types.Cluster) error {
 func (w *VM) Status(ctx types.TestContext) ([]types.WorkloadStatus, error) {
 	var statuses []types.WorkloadStatus
 
-	clusters := []*types.Cluster{ctx.Env().C1, ctx.Env().C2}
-
-	for _, cluster := range clusters {
+	for _, cluster := range ctx.Env().ManagedClusters() {
 		status, err := w.statusForCluster(ctx, cluster)
 		if err != nil {
 			return nil, fmt.Errorf("error checking application \"%s/%s\" on cluster %q: %w",


### PR DESCRIPTION
This commit will add helper function to list the managed clusters present in the env. This will helpful in case iteration over the clusters is needed