### PR TITLE
modernize: Use standard maps package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/vmware-tanzu/velero v1.15.0
 	go.uber.org/zap v1.27.0
-	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67
 	golang.org/x/time v0.9.0
 	k8s.io/api v0.33.3
 	k8s.io/apiextensions-apiserver v0.33.3
@@ -99,6 +98,7 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 // indirect
 	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/oauth2 v0.29.0 // indirect
 	golang.org/x/sync v0.13.0 // indirect

--- a/internal/controller/util/maps.go
+++ b/internal/controller/util/maps.go
@@ -4,7 +4,7 @@
 package util
 
 import (
-	"golang.org/x/exp/maps" // TODO "maps" in go1.21+
+	"maps"
 )
 
 // Copies src's key-value pairs into dst.

--- a/internal/controller/util/maps_test.go
+++ b/internal/controller/util/maps_test.go
@@ -4,10 +4,11 @@
 package util_test
 
 import (
+	"maps"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/ramendr/ramen/internal/controller/util"
-	"golang.org/x/exp/maps" // TODO replace with "maps" in Go 1.21+
 )
 
 var _ = Describe("Maps", func() {

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"slices"
 	"sync"
@@ -20,7 +21,6 @@ import (
 	"github.com/ramendr/ramen/internal/controller/kubeobjects"
 	"github.com/ramendr/ramen/internal/controller/kubeobjects/velero"
 	"github.com/ramendr/ramen/internal/controller/util"
-	"golang.org/x/exp/maps" // TODO replace with "maps" in go1.21+
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"


### PR DESCRIPTION
Like #2231 for maps package, replace golang.org/x/exp dependency with the standard maps package.

golang.org/x/exp is an indirect dependency now:

    % go mod why -m golang.org/x/exp
    # golang.org/x/exp
    github.com/ramendr/ramen/internal/controller/util
    github.com/backube/volsync/controllers/utils
    github.com/spf13/viper
    github.com/sagikazarmark/slog-shim
    golang.org/x/exp/slog