### PR TITLE
Annotate DRPC to avoid workload PVC deletion

### DIFF
--- a/test/drenv/test.py
+++ b/test/drenv/test.py
@@ -146,6 +146,7 @@ def enable_dr():
     placement_name = placement.split("/")[1]
     consistency_groups = env["features"].get("consistency_groups", False)
     cg_enabled = "true" if consistency_groups else "false"
+    do_not_delete_pvc = "true"
 
     drpc = f"""
 apiVersion: ramendr.openshift.io/v1alpha1
@@ -155,6 +156,7 @@ metadata:
   namespace: {config['namespace']}
   annotations:
     drplacementcontrol.ramendr.openshift.io/is-cg-enabled: '{cg_enabled}'
+    drplacementcontrol.ramendr.openshift.io/do-not-delete-pvc: '{do_not_delete_pvc}'
   labels:
     app: {config['name']}
 spec:


### PR DESCRIPTION
Prevent DR from deleting workload PVCs in “drenv” by annotating the DRPlacementControl (DRPC) resource appropriately. Previously, Disaster Recovery (DR) workflows in the drenv environment were unintentionally deleting PersistentVolumeClaims (PVCs) associated with workloads. This update introduces a safeguard by leveraging DRPC annotations to ensure PVCs are retained after DR is disabled for the corresponding workload.