### PR TITLE
Adapt drenv to work with consistency groups

### DIFF
--- a/test/addons/external-snapshotter/cache
+++ b/test/addons/external-snapshotter/cache
@@ -7,5 +7,5 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh("crds", "addons/external-snapshotter-crds-8.3.yaml")
-cache.refresh("controller", "addons/external-snapshotter-controller-8.3.yaml")
+cache.refresh("crds", "addons/external-snapshotter-crds-8.4.yaml")
+cache.refresh("controller", "addons/external-snapshotter-controller-8.4.yaml")

--- a/test/addons/external-snapshotter/crds/kustomization.yaml
+++ b/test/addons/external-snapshotter/crds/kustomization.yaml
@@ -1,8 +1,8 @@
 ---
 resources:
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml

--- a/test/addons/external-snapshotter/start
+++ b/test/addons/external-snapshotter/start
@@ -12,14 +12,14 @@ from drenv import cache
 
 def deploy(cluster):
     print("Deploying crds")
-    path = cache.get("crds", "addons/external-snapshotter-crds-8.3.yaml")
+    path = cache.get("crds", "addons/external-snapshotter-crds-8.4.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
     print("Waiting until crds are established")
     kubectl.wait("--for=condition=established", "--filename", path, context=cluster)
 
     print("Deploying snapshot-controller")
-    path = cache.get("controller", "addons/external-snapshotter-controller-8.3.yaml")
+    path = cache.get("controller", "addons/external-snapshotter-controller-8.4.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
 

--- a/test/addons/odf-external-snapshotter/cache
+++ b/test/addons/odf-external-snapshotter/cache
@@ -7,4 +7,5 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh("crds", "addons/odf-external-snapshotter-8.2.yaml")
+cache.refresh("crds", "addons/odf-external-snapshotter-crds-8.2.yaml")
+cache.refresh("controller", "addons/odf-external-snapshotter-controller-8.2.yaml")

--- a/test/addons/odf-external-snapshotter/controller/kustomization.yaml
+++ b/test/addons/odf-external-snapshotter/controller/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+resources:
+  - https://raw.githubusercontent.com/red-hat-storage/external-snapshotter/refs/heads/master/deploy/kubernetes/snapshot-controller/odf-rbac-snapshot-controller.yaml
+  - https://raw.githubusercontent.com/red-hat-storage/external-snapshotter/refs/heads/master/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+namespace: kube-system
+
+patches:
+  # Enable volume group replication support
+  - target:
+      kind: Deployment
+      name: odf-external-snapshotter-operator
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: "--feature-gates=CSIVolumeGroupSnapshot=true"
+
+images:
+  - name: registry.k8s.io/sig-storage/snapshot-controller
+    newName: quay.io/ocs-dev/snapshot-controller
+    newTag: latest

--- a/test/addons/odf-external-snapshotter/start
+++ b/test/addons/odf-external-snapshotter/start
@@ -12,11 +12,28 @@ from drenv import cache
 
 def deploy(cluster):
     print("Deploying crds")
-    path = cache.get("crds", "addons/odf-external-snapshotter-8.2.yaml")
+    path = cache.get("crds", "addons/odf-external-snapshotter-crds-8.2.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
     print("Waiting until crds are established")
     kubectl.wait("--for=condition=established", "--filename", path, context=cluster)
+
+    print("Deploying snapshot-controller")
+    path = cache.get(
+        "controller", "addons/odf-external-snapshotter-controller-8.2.yaml"
+    )
+    kubectl.apply("--filename", path, context=cluster)
+
+
+def wait(cluster):
+    print("Waiting until snapshot-controller is rolled out")
+    kubectl.rollout(
+        "status",
+        "deploy/odf-external-snapshotter-operator",
+        "--namespace=kube-system",
+        "--timeout=300s",
+        context=cluster,
+    )
 
 
 if len(sys.argv) != 2:
@@ -27,3 +44,4 @@ os.chdir(os.path.dirname(__file__))
 cluster = sys.argv[1]
 
 deploy(cluster)
+wait(cluster)

--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -124,6 +124,13 @@ def configure_rbd_mirroring(cluster, peer_info):
         )
         kubectl.apply("--filename=-", input=yaml, context=cluster)
 
+    for interval in VRC_INTERVALS:
+        template = drenv.template("start-data/vgrc.yaml")
+        yaml = template.substitute(
+            cluster=cluster, pool=POOL_NAME, scname="rook-ceph-block", interval=interval
+        )
+        kubectl.apply("--filename=-", input=yaml, context=cluster)
+
     print(f"Apply rbd mirror to cluster '{cluster}'")
     kubectl.apply("--kustomize=start-data", context=cluster)
 

--- a/test/addons/rbd-mirror/test
+++ b/test/addons/rbd-mirror/test
@@ -8,13 +8,28 @@ import json
 import os
 import sys
 import time
+import uuid
 
 from drenv import kubectl
 
 NAMESPACE = "rbd-mirror-test"
 POOL_NAME = "replicapool"
 PVC_NAME = "rbd-pvc"
-VR_NAME = "vr-1m"
+VGR_NAME = "vgr-1m"
+
+
+def to_csi_vol_group(s: str, prefix: str = "csi-vol-group") -> str:
+    parts = s.rsplit("-", 5)  # split at the 5 rightmost dashes
+    if len(parts) < 6:
+        raise RuntimeError(f"Expected a trailing UUID, got: {s!r}")
+
+    candidate = "-".join(parts[1:6])  # the 5 UUID chunks
+    try:
+        u = str(uuid.UUID(candidate))  # validate & normalize
+    except ValueError as e:
+        raise RuntimeError(f"Trailing token is not a valid UUID: {candidate!r}") from e
+
+    return f"{prefix}-{u}"
 
 
 def rbd(*args, cluster=None):
@@ -36,7 +51,7 @@ def rbd(*args, cluster=None):
 def rbd_mirror_image_status(cluster, image):
     out = rbd(
         "mirror",
-        "image",
+        "group",
         "status",
         image,
         "--format=json",
@@ -69,64 +84,71 @@ def test_volume_replication(primary, secondary):
         context=primary,
     )
 
-    print(f"Deploying vr {NAMESPACE}/{VR_NAME} in cluster '{primary}'")
+    print(f"Deploying vgr {NAMESPACE}/{VGR_NAME} in cluster '{primary}'")
     kubectl.apply(
-        f"--filename=test-data/{VR_NAME}.yaml",
+        f"--filename=test-data/{VGR_NAME}.yaml",
         f"--namespace={NAMESPACE}",
         context=primary,
     )
 
-    print(f"Waiting until vr {NAMESPACE}/{VR_NAME} is completed in cluster '{primary}'")
+    print(
+        f"Waiting until vgr {NAMESPACE}/{VGR_NAME} is completed in cluster '{primary}'"
+    )
     kubectl.wait(
-        f"volumereplication/{VR_NAME}",
+        f"volumegroupreplication/{VGR_NAME}",
         "--for=condition=Completed",
         f"--namespace={NAMESPACE}",
         context=primary,
     )
 
     print(
-        f"Waiting until vr {NAMESPACE}/{VR_NAME} state is primary in cluster '{primary}'"
+        f"Waiting until vgr {NAMESPACE}/{VGR_NAME} state is primary in cluster '{primary}'"
     )
     kubectl.wait(
-        f"volumereplication/{VR_NAME}",
+        f"volumegroupreplication/{VGR_NAME}",
         "--for=jsonpath={.status.state}=Primary",
         f"--namespace={NAMESPACE}",
         context=primary,
     )
 
-    print(f"Looking up pvc {NAMESPACE}/{PVC_NAME} pv name in cluster '{primary}'")
-    pv_name = kubectl.get(
-        f"pvc/{PVC_NAME}",
-        "--output=jsonpath={.spec.volumeName}",
+    print(f"Looking up vgr {NAMESPACE}/{VGR_NAME} vgr_content in cluster '{primary}'")
+    vgrcontent_name = kubectl.get(
+        f"volumegroupreplication/{VGR_NAME}",
+        "--output=jsonpath={.spec.volumeGroupReplicationContentName}",
         f"--namespace={NAMESPACE}",
         context=primary,
     )
 
-    print(f"Looking up rbd image for pv {pv_name} in cluster '{primary}'")
-    rbd_image = kubectl.get(
-        f"pv/{pv_name}",
-        "--output=jsonpath={.spec.csi.volumeAttributes.imageName}",
+    print(
+        f"Looking up rbd image for vrgcontent {vgrcontent_name} in cluster '{primary}'"
+    )
+    rbd_handle = kubectl.get(
+        f"volumegroupreplicationcontent/{vgrcontent_name}",
+        "--output=jsonpath={.spec.volumeGroupReplicationHandle}",
+        f"--namespace={NAMESPACE}",
         context=primary,
     )
 
+    rbd_image = to_csi_vol_group(rbd_handle)
+
     print(f"rbd image {rbd_image} info in cluster '{primary}'")
-    out = rbd("info", rbd_image, cluster=primary)
+    out = rbd("group", "info", rbd_image, cluster=primary)
     print(out)
 
     print(f"Waiting until rbd image {rbd_image} is created in cluster '{secondary}'")
     for i in range(60):
         time.sleep(1)
-        out = rbd("list", cluster=primary)
+        out = rbd("group", "list", cluster=primary)
         if rbd_image in out:
-            out = rbd("info", rbd_image, cluster=primary)
+            out = rbd("group", "info", rbd_image, cluster=primary)
             print(out)
             break
     else:
         raise RuntimeError(f"Timeout waiting for image {rbd_image}")
 
-    print(f"vr {NAMESPACE}/{VR_NAME} info on primary cluster '{primary}'")
+    print(f"vgr {NAMESPACE}/{VGR_NAME} info on primary cluster '{primary}'")
     kubectl.get(
-        f"volumereplication/{VR_NAME}",
+        f"volumegroupreplication/{VGR_NAME}",
         "--output=yaml",
         f"--namespace={NAMESPACE}",
         context=primary,
@@ -136,9 +158,9 @@ def test_volume_replication(primary, secondary):
     image_status = rbd_mirror_image_status(primary, rbd_image)
     print(json.dumps(image_status, indent=2))
 
-    print(f"Deleting vr {NAMESPACE}/{VR_NAME} in primary cluster '{primary}'")
+    print(f"Deleting vgr {NAMESPACE}/{VGR_NAME} in primary cluster '{primary}'")
     kubectl.delete(
-        f"--filename=test-data/{VR_NAME}.yaml",
+        f"--filename=test-data/{VGR_NAME}.yaml",
         f"--namespace={NAMESPACE}",
         context=primary,
     )

--- a/test/addons/rbd-mirror/test-data/vgr-1m.yaml
+++ b/test/addons/rbd-mirror/test-data/vgr-1m.yaml
@@ -8,6 +8,7 @@ metadata:
   name: vgr-1m
 spec:
   volumeGroupReplicationClassName: vgrc-1m
+  volumeReplicationClassName: vrc-1m
   replicationState: primary
   source:
     selector:

--- a/test/addons/rook-cephfs/snapshot-group-class.yaml
+++ b/test/addons/rook-cephfs/snapshot-group-class.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: groupsnapshot.storage.openshift.io/v1beta1
+deletionPolicy: Delete
+driver: rook-ceph.cephfs.csi.ceph.com
+kind: VolumeGroupSnapshotClass
+metadata:
+  name: csi-cephfsplugin-groupsnapclass
+  labels:
+    ramendr.openshift.io/storageid: $scname-$cluster-1
+parameters:
+  clusterID: rook-ceph
+  fsName: $fsname
+  csi.storage.k8s.io/group-snapshotter-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/group-snapshotter-secret-namespace: rook-ceph

--- a/test/addons/rook-cephfs/start
+++ b/test/addons/rook-cephfs/start
@@ -34,6 +34,14 @@ def deploy(cluster):
     yaml = template.substitute(cluster=cluster, scname=storage_class_name)
     kubectl.apply("--filename=-", input=yaml, context=cluster)
 
+    print("Creating SnapshotGroupClass")
+    template = drenv.template("snapshot-group-class.yaml")
+    storage_class_name = STORAGE_CLASS_NAME_PREFIX + FILE_SYSTEMS[0]
+    yaml = template.substitute(
+        cluster=cluster, scname=storage_class_name, fsname=FILE_SYSTEMS[0]
+    )
+    kubectl.apply("--filename=-", input=yaml, context=cluster)
+
 
 def wait(cluster):
     print("Waiting until Ceph File Systems are ready")

--- a/test/addons/rook-cluster/cache
+++ b/test/addons/rook-cluster/cache
@@ -7,4 +7,4 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh(".", "addons/rook-cluster-1.18.yaml")
+cache.refresh(".", "addons/rook-cluster-1.18-1.yaml")

--- a/test/addons/rook-cluster/kustomization.yaml
+++ b/test/addons/rook-cluster/kustomization.yaml
@@ -29,3 +29,12 @@ patches:
           enabled: true
           periodicity: daily
           maxLogSize: 50M
+
+  - target:
+      kind: CephCluster
+      name: my-cluster
+      namespace: rook-ceph
+    patch: |-
+      - op: replace
+        path: /spec/cephVersion/image
+        value: quay.ceph.io/ceph-ci/ceph:wip-rbd-cgsm-base

--- a/test/addons/rook-cluster/start
+++ b/test/addons/rook-cluster/start
@@ -47,7 +47,7 @@ CSIADDONS_NODES = [
 
 def deploy(cluster):
     print("Deploying rook ceph cluster")
-    path = cache.get(".", "addons/rook-cluster-1.18.yaml")
+    path = cache.get(".", "addons/rook-cluster-1.18-1.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
 

--- a/test/addons/rook-operator/cache
+++ b/test/addons/rook-operator/cache
@@ -7,4 +7,4 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh(".", "addons/rook-operator-1.18-5.yaml")
+cache.refresh(".", "addons/rook-operator-1.18-7.yaml")

--- a/test/addons/rook-operator/kustomization.yaml
+++ b/test/addons/rook-operator/kustomization.yaml
@@ -4,9 +4,9 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/crds.yaml
-  - https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/common.yaml
-  - https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/operator.yaml
+  - https://raw.githubusercontent.com/Nikhil-Ladha/rook/refs/heads/private-snapshot/deploy/examples/crds.yaml
+  - https://raw.githubusercontent.com/Nikhil-Ladha/rook/refs/heads/private-snapshot/deploy/examples/common.yaml
+  - https://raw.githubusercontent.com/Nikhil-Ladha/rook/refs/heads/private-snapshot/deploy/examples/operator.yaml
 
 patches:
   - target:
@@ -49,3 +49,19 @@ patches:
                     value: 'true'
                   - name: ROOK_CSIADDONS_IMAGE
                     value: quay.io/nladha/csiaddons-sidecar:cg
+                  - name: ROOK_CSI_CEPH_IMAGE
+                    value: quay.io/nladha/cephcsi:cg
+  - target:
+      kind: Deployment
+      name: rook-ceph-operator
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: not-used
+      spec:
+        template:
+          spec:
+            containers:
+             - name: rook-ceph-operator
+               image: quay.io/nladha/rook:snapshot

--- a/test/addons/rook-operator/start
+++ b/test/addons/rook-operator/start
@@ -12,7 +12,7 @@ from drenv import cache
 
 def deploy(cluster):
     print("Deploying rook ceph operator")
-    path = cache.get(".", "addons/rook-operator-1.18-5.yaml")
+    path = cache.get(".", "addons/rook-operator-1.18-7.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
 

--- a/test/addons/rook-toolbox/cache
+++ b/test/addons/rook-toolbox/cache
@@ -7,4 +7,4 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh(".", "addons/rook-toolbox-1.18.yaml")
+cache.refresh(".", "addons/rook-toolbox-1.18-1.yaml")

--- a/test/addons/rook-toolbox/kustomization.yaml
+++ b/test/addons/rook-toolbox/kustomization.yaml
@@ -5,3 +5,7 @@
 ---
 resources:
   - https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/toolbox.yaml
+images:
+  - name: quay.io/ceph/ceph:v19
+    newName: quay.ceph.io/ceph-ci/ceph
+    newTag: wip-rbd-cgsm-base

--- a/test/addons/rook-toolbox/start
+++ b/test/addons/rook-toolbox/start
@@ -13,7 +13,7 @@ from drenv import cache
 
 def deploy(cluster):
     print("Deploying rook ceph toolbox")
-    path = cache.get(".", "addons/rook-toolbox-1.18.yaml")
+    path = cache.get(".", "addons/rook-toolbox-1.18-1.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
 

--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -21,8 +21,8 @@ templates:
         io.containerd.cri.v1.runtime:
           device_ownership_from_security_context: true
     network: "$network"
-    cpus: 4
-    memory: "8g"
+    cpus: 8
+    memory: "16g"
     extra_disks: 1
     disk_size: "50g"
     workers:


### PR DESCRIPTION
Adapt drenv to work with consistency groups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated external snapshotter addon from version 8.3 to 8.4.
  * Refactored ODF external snapshotter deployment with separate CRD and controller manifests.
  * Enhanced RBD mirror tests to validate VolumeGroupReplication workflows.
  * Added VolumeGroupSnapshotClass support for Rook CephFS.
  * Updated Rook operator and toolbox to version 1.18-7 and 1.18-1 respectively.
  * Increased test environment resources for disaster recovery cluster testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramen/pull/2240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->