### PR TITLE
Dfbugs 4055

### DIFF
--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -471,8 +471,8 @@ func (v *VRGInstance) deleteVGRIfUnused(vgr *volrep.VolumeGroupReplication) erro
 		return nil
 	}
 
-	err := v.reconciler.Delete(v.ctx, vgr)
-	if err != nil && !k8serrors.IsNotFound(err) {
+	vrNamespacedName := types.NamespacedName{Name: vgr.Name, Namespace: vgr.Namespace}
+	if err := v.deleteVGR(vrNamespacedName, v.log); err != nil {
 		return err
 	}
 	// TODO: Delete VGR from S3 store

--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -403,7 +403,7 @@ func (v *VRGInstance) resetCGLabelValue(pvc *corev1.PersistentVolumeClaim) (bool
 		return !reset, fmt.Errorf("error (%s) updating PVC labels", err)
 	}
 
-	return !reset, nil
+	return reset, nil
 }
 
 // getVGRUsingSCLabel fetches the VGR that is protecting the PVC using the SC and VGRC labels, it is useful when the CG


### PR DESCRIPTION
This PR has two fixes.
1. When function resetCGLabelValue succeeds to reset CG label, it must return true. If not, we will not continue for VGR deletion
2. When deleting VGR we must use deleteVGR function, which is not only deleting VGR, but also ensures that resource was actually deleted from API server before proceeding to other cleanups

Fixes: https://issues.redhat.com/browse/DFBUGS-4055