### PR TITLE
Fix missing velero exclude labels on VolSync/Submariner resources

### DIFF
--- a/internal/controller/cephfscg/cghandler.go
+++ b/internal/controller/cephfscg/cghandler.go
@@ -119,6 +119,7 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupDestination(
 	}
 
 	util.AddLabel(rgd, util.CreatedByRamenLabel, "true")
+	util.AddLabel(rgd, util.ExcludeFromVeleroBackup, "true")
 
 	_, err := ctrlutil.CreateOrUpdate(c.ctx, c.Client, rgd, func() error {
 		if c.VSHandler != nil && !c.VSHandler.IsVRGInAdminNamespace() {
@@ -214,6 +215,7 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupSource(
 	}
 
 	util.AddLabel(rgs, util.CreatedByRamenLabel, "true")
+	util.AddLabel(rgs, util.ExcludeFromVeleroBackup, "true")
 
 	_, err = ctrlutil.CreateOrUpdate(c.ctx, c.Client, rgs, func() error {
 		if c.VSHandler != nil && !c.VSHandler.IsVRGInAdminNamespace() {

--- a/internal/controller/kubeobjects/velero/requests.go
+++ b/internal/controller/kubeobjects/velero/requests.go
@@ -428,9 +428,13 @@ func getBackupSpecFromObjectsSpec(objectsSpec kubeobjects.Spec) velero.BackupSpe
 		IncludedNamespaces: objectsSpec.IncludedNamespaces,
 		IncludedResources:  objectsSpec.IncludedResources,
 		// exclude VRs from Backup so VRG can create them: see https://github.com/RamenDR/ramen/issues/884
+		// exclude EndpointSlices/Endpoints to prevent Submariner conflicts: see https://github.com/RamenDR/ramen/issues/1889
+		// exclude VolumeSnapshots and VolumeGroupSnapshots from backup
 		ExcludedResources: append(objectsSpec.ExcludedResources, "volumereplications.replication.storage.openshift.io",
-			"replicationsources.volsync.backube", "replicationdestinations.volsync.backube",
-			"PersistentVolumeClaims", "PersistentVolumes"),
+			"volumegroupreplications.replication.storage.openshift.io", "replicationsources.volsync.backube",
+			"replicationdestinations.volsync.backube", "PersistentVolumeClaims", "PersistentVolumes",
+			"endpointslices.discovery.k8s.io", "endpoints", "volumesnapshots.snapshot.storage.k8s.io",
+			"volumegroupsnapshots.groupsnapshot.storage.k8s.io"),
 		LabelSelector:           newLabelSelector,
 		OrLabelSelectors:        objectsSpec.OrLabelSelectors,
 		TTL:                     metav1.Duration{}, // TODO: set default here

--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -806,6 +806,8 @@ func (v *VRGInstance) createVGR(vrNamespacedName types.NamespacedName,
 		},
 	}
 
+	rmnutil.AddLabel(volRep, rmnutil.CreatedByRamenLabel, "true")
+
 	if !vrgInAdminNamespace(v.instance, v.ramenConfig) {
 		// This is to keep existing behavior of ramen.
 		// Set the owner reference only for the VRs which are in the same namespace as the VRG and


### PR DESCRIPTION
Following resources now excluded from Velero backups:

VolSync Infrastructure:
- ReplicationDestination
- ReplicationSource
- VolumeReplication
- VolumeGroupReplication
- ReplicationGroupDestination
- ReplicationGroupSource
- Copied secrets in application namespaces

Submariner Resources:
- ServiceExport
- EndpointSlices
- Endpoints

Storage Resources:
- VolumeSnapshots
- VolumeGroupSnapshots

Fixes: [DFBUGS-1652](https://issues.redhat.com/browse/DFBUGS-1652), [DFBUGS-1773](https://issues.redhat.com/browse/DFBUGS-1773) and [DFBUGS-2890](https://issues.redhat.com/browse/DFBUGS-2890)

Also added created-by-ramen label to some resources, which should fix: [DFBUGS-918](https://issues.redhat.com/browse/DFBUGS-918)