### PR TITLE
test: Use minikube 1.36.0

### DIFF
--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -89,7 +89,7 @@ enough resources:
 1. Install minikube - on Fedora you can use::
 
    ```
-   sudo dnf install https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
+   sudo dnf install https://github.com/kubernetes/minikube/releases/download/v1.36.0/minikube-1.36.0-0.x86_64.rpm
    ```
 
    Tested with version v1.36.0.

--- a/test/README.md
+++ b/test/README.md
@@ -33,7 +33,7 @@ environment.
 1. Install minikube, for example on RHEL/CentOS/Fedora:
 
    ```
-   sudo dnf install https://storage.googleapis.com/minikube/releases/latest/minikube-latest.x86_64.rpm
+   sudo dnf install https://github.com/kubernetes/minikube/releases/download/v1.36.0/minikube-1.36.0-0.x86_64.rpm
    ```
 
    Tested with version v1.36.0.


### PR DESCRIPTION
Minikube 1.37.0 was released but it broken on Fedora[1]. Update the download URL to use minikube 1.36.0.

[1] https://github.com/kubernetes/minikube/issues/21548