### PR TITLE
drenv: Add debug log

### DIFF
--- a/.github/workflows/e2e-daily.yaml
+++ b/.github/workflows/e2e-daily.yaml
@@ -33,7 +33,7 @@ jobs:
           max_attempts: 10
           command: |
             cd test
-            drenv cache -v envs/regional-dr.yaml
+            drenv cache envs/regional-dr.yaml
 
   prune-images:
     runs-on: [self-hosted, e2e-rdr]

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -39,7 +39,7 @@ jobs:
       working-directory: test
       run: |
         source ../venv
-        drenv setup -v envs/regional-dr.yaml
+        drenv setup envs/regional-dr.yaml
 
     - name: Delete clusters
       if: always()
@@ -102,7 +102,7 @@ jobs:
     # https://github.com/actions/upload-artifact/issues/546
     - name: Archive artifacts
       if: always()
-      run: tar czf e2e.${{ env.BUILD_ID }}.tar.gz test/gather.rdr e2e/*.log
+      run: tar czf e2e.${{ env.BUILD_ID }}.tar.gz test/gather.rdr test/*.log e2e/*.log
 
     - name: Upload artifacts
       if: always()
@@ -125,4 +125,4 @@ jobs:
       working-directory: test
       run: |
         source ../venv
-        drenv cleanup -v envs/regional-dr.yaml
+        drenv cleanup envs/regional-dr.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ venv
 test/.coverage
 test/.coverage.*
 test/addons/kubevirt/vm/id_rsa.pub
+test/drenv.log
 
 # Python generated files
 *.egg-info/

--- a/test/Makefile
+++ b/test/Makefile
@@ -65,7 +65,7 @@ coverage-clean:
 	rm -f .coverage
 
 cluster:
-	drenv start --name-prefix $(prefix) $(env) --verbose --timeout $(TIMEOUT)
+	drenv start --name-prefix $(prefix) $(env) --timeout $(TIMEOUT)
 
 clean:
 	drenv delete --name-prefix $(prefix) $(env)

--- a/test/README.md
+++ b/test/README.md
@@ -545,13 +545,13 @@ $ drenv start envs/example.yaml
 2023-01-03 23:41:01,166 INFO    [example] Environment started in 35.71 seconds
 ```
 
-#### Using --verbose option
+#### The log file
 
-While debugging it is useful to use the `--verbose` option to see much
-more details:
+The console logs contains INFO level message. To see all log messages check the
+log file:
 
-```
-$ drenv start envs/example.yaml -v
+```console
+$ cat drenv.log
 2023-01-03 23:41:53,414 INFO    [example] Starting environment
 2023-01-03 23:41:53,416 INFO    [ex1] Starting cluster
 2023-01-03 23:41:53,539 DEBUG   [ex1] * [ex1] minikube v1.28.0 on Fedora 37

--- a/test/drenv/drenv_test.py
+++ b/test/drenv/drenv_test.py
@@ -21,12 +21,12 @@ EXTERNAL_ENV = os.path.join("envs", "external.yaml")
 def test_start_unknown():
     # Cluster does not exists, so it should fail.
     with pytest.raises(commands.Error):
-        watch("drenv", "start", "--name-prefix", "unknown-", EXTERNAL_ENV, "--verbose")
+        watch("drenv", "start", "--name-prefix", "unknown-", EXTERNAL_ENV)
 
 
 @pytest.mark.cluster
 def test_start(tmpenv):
-    watch("drenv", "start", "--name-prefix", tmpenv.prefix, EXTERNAL_ENV, "--verbose")
+    watch("drenv", "start", "--name-prefix", tmpenv.prefix, EXTERNAL_ENV)
     assert cluster.status(tmpenv.prefix + "cluster") == cluster.READY
 
 

--- a/test/scripts/refresh-cache
+++ b/test/scripts/refresh-cache
@@ -14,7 +14,7 @@ source ../venv
 
 for i in $(seq 1 $attempts); do
 	echo "$(date) Refreshing drenv cache (attempt $i/$attempts)"
-	drenv cache -v "$env_file" && exit 0
+	drenv cache "$env_file" && exit 0
 	sleep $delay_seconds
 done
 

--- a/test/stress-test/run
+++ b/test/stress-test/run
@@ -121,7 +121,7 @@ def run(name, args):
     log = os.path.join(args.outdir, name + ".log")
 
     start = time.monotonic()
-    cp = drenv("start", args.envfile, log, name_prefix=args.name_prefix, verbose=True)
+    cp = drenv("start", args.envfile, log, name_prefix=args.name_prefix)
     elapsed = time.monotonic() - start
     passed = cp.returncode == 0
 
@@ -140,7 +140,6 @@ def run(name, args):
             args.envfile,
             log,
             name_prefix=args.name_prefix,
-            verbose=True,
             check=True,
         )
 
@@ -157,19 +156,15 @@ def drenv(
     log,
     name_prefix=None,
     directory=None,
-    verbose=False,
     check=False,
 ):
-    cmd = ["drenv", command]
+    cmd = ["drenv", command, "--logfile", log]
     if name_prefix:
         cmd.extend(("--name-prefix", name_prefix))
     if directory:
         cmd.extend(("--directory", directory))
-    if verbose:
-        cmd.append("--verbose")
     cmd.append(envfile)
-    with open(log, "a") as f:
-        return subprocess.run(cmd, stderr=f, check=check)
+    return subprocess.run(cmd, stderr=subprocess.DEVNULL, check=check)
 
 
 def git_info():


### PR DESCRIPTION
Previouly debug log were dropped by default so we never had enough information to debug drenv failures. We had to run again with --verbose mode. To keep the verbose log file we had to redirect stderrr to file which makes it harder to use.

Now we always log all message to log file (defualt "drenv.log"), and alwasy log non-verbose log to the console. If the run fail we can inspect the complete debug log. This is the same way we log in e2e.

The new log is included in the e2e build artifacts, so we have enough information to debug build failures in the CI.

New options:
- `--logfile`

Removed options:
- `-v, --verbose`

Example log in e2e run:

```console
% tree -L2 e2e.17800232823-1
e2e.17800232823-1
├── e2e
│   ├── dr.log
│   └── validation.log
└── test
    ├── drenv.log
    └── gather.rdr
```

Fixes #1126