### PR TITLE
e2e: Unify namespace prefix with ramenctl

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -23,15 +23,18 @@ const (
 	// ClusterSet
 	DefaultClusterSetName = "default"
 
-	// Channel
-	defaultChannelNamespace = "e2e-gitops"
-
 	// Git repository
 	defaultGitURL    = "https://github.com/RamenDR/ocm-ramen-samples.git"
 	defaultGitBranch = "main"
 
 	// DRPolicy
 	defaultDRPolicyName = "dr-policy"
+
+	// Make it easier to manage namespaces created by the tests.
+	defaultNamespacePrefix = "test-"
+
+	// Channel
+	defaultChannelNamespace = defaultNamespacePrefix + "gitops"
 )
 
 // Channel defines the name and namespace for the channel CR.
@@ -128,14 +131,15 @@ type Test struct {
 // Config keeps configuration for e2e tests.
 type Config struct {
 	// User configurable values.
-	Clusters   map[string]Cluster `json:"clusters"`
-	ClusterSet string             `json:"clusterSet"`
-	Distro     string             `json:"distro"`
-	Repo       Repo               `json:"repo"`
-	DRPolicy   string             `json:"drPolicy"`
-	PVCSpecs   []PVCSpec          `json:"pvcSpecs"`
-	Deployers  []Deployer         `json:"deployers"`
-	Tests      []Test             `json:"tests"`
+	Clusters        map[string]Cluster `json:"clusters"`
+	ClusterSet      string             `json:"clusterSet"`
+	Distro          string             `json:"distro"`
+	Repo            Repo               `json:"repo"`
+	DRPolicy        string             `json:"drPolicy"`
+	NamespacePrefix string             `json:"namespacePrefix"`
+	PVCSpecs        []PVCSpec          `json:"pvcSpecs"`
+	Deployers       []Deployer         `json:"deployers"`
+	Tests           []Test             `json:"tests"`
 
 	// Generated values
 	Channel    Channel    `json:"channel"`
@@ -204,6 +208,7 @@ func readConfig(configFile string, config *Config) error {
 	viper.SetDefault("Repo.Branch", defaultGitBranch)
 	viper.SetDefault("DRPolicy", defaultDRPolicyName)
 	viper.SetDefault("ClusterSet", DefaultClusterSetName)
+	viper.SetDefault("NamespacePrefix", defaultNamespacePrefix)
 
 	viper.SetConfigFile(configFile)
 
@@ -495,6 +500,10 @@ func (c *Config) Equal(o *Config) bool {
 	}
 
 	if c.ClusterSet != o.ClusterSet {
+		return false
+	}
+
+	if c.NamespacePrefix != o.NamespacePrefix {
 		return false
 	}
 

--- a/e2e/config/config_test.go
+++ b/e2e/config/config_test.go
@@ -31,7 +31,8 @@ func TestReadConfig(t *testing.T) {
 			URL:    "https://github.com/RamenDR/ocm-ramen-samples.git",
 			Branch: "main",
 		},
-		DRPolicy: "dr-policy",
+		DRPolicy:        "dr-policy",
+		NamespacePrefix: "test-",
 		PVCSpecs: []PVCSpec{
 			{Name: "rbd", StorageClassName: "rook-ceph-block", AccessModes: "ReadWriteOnce"},
 			{Name: "cephfs", StorageClassName: "rook-cephfs-fs1", AccessModes: "ReadWriteMany"},
@@ -47,7 +48,7 @@ func TestReadConfig(t *testing.T) {
 		},
 		Channel: Channel{
 			Name:      "https-github-com-ramendr-ocm-ramen-samples-git",
-			Namespace: "e2e-gitops",
+			Namespace: "test-gitops",
 		},
 	}
 	if !c.Equal(expected) {

--- a/e2e/test/context.go
+++ b/e2e/test/context.go
@@ -18,9 +18,6 @@ import (
 	"github.com/ramendr/ramen/e2e/util"
 )
 
-// Make it easier to manage namespaces created by the tests.
-const appNamespacePrefix = "e2e-"
-
 type Context struct {
 	parent   types.Context
 	context  context.Context
@@ -68,7 +65,7 @@ func (c *Context) ManagementNamespace() string {
 }
 
 func (c *Context) AppNamespace() string {
-	return appNamespacePrefix + c.name
+	return c.Config().NamespacePrefix + c.name
 }
 
 func (c *Context) Logger() *zap.SugaredLogger {


### PR DESCRIPTION
We used "e2e-" prefix, but ramenctl is using "test-". This creates a conflict when ramenctl try to create an application when the application was already created by e2e. We want to keep the ramenctl prefix, so lets simplify by using the same prefix.

To make it easy to consume in ramenctl, move the value to the config. Ramenctl will automatically get the value from the config.

The new config is intentionally not documented since users do not have to change it normally. The value will be visible in in ramenctl report.config.

ramenctl PR: https://github.com/RamenDR/ramenctl/pull/322

Fixes: #2255