### PR TITLE
e2e: Avoid duplicate error in env.New()

### DIFF
--- a/e2e/env/env.go
+++ b/e2e/env/env.go
@@ -51,23 +51,23 @@ func New(ctx context.Context, clusters map[string]config.Cluster, log *zap.Sugar
 
 	env.Hub, err = newCluster(ctx, "hub", clusters["hub"], log)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create env: %w", err)
+		return nil, err
 	}
 
 	env.C1, err = newCluster(ctx, "c1", clusters["c1"], log)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create env: %w", err)
+		return nil, err
 	}
 
 	env.C2, err = newCluster(ctx, "c2", clusters["c2"], log)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create env: %w", err)
+		return nil, err
 	}
 
 	if clusters["passive-hub"].Kubeconfig != "" {
 		env.PassiveHub, err = newCluster(ctx, "passive-hub", clusters["passive-hub"], log)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create env: %w", err)
+			return nil, err
 		}
 	}
 

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -107,7 +107,7 @@ func testMain(m *testing.M) int {
 
 	Ctx.env, err = env.New(Ctx.Context(), Ctx.config.Clusters, Ctx.log)
 	if err != nil {
-		log.Errorf("Failed to create testing context: %s", err)
+		log.Errorf("Failed to create env: %s", err)
 
 		return 1
 	}


### PR DESCRIPTION
Adding "failed to create env: " in env.New() does not help and duplicate the same message added by the caller, as can be seen in ramenctl.

In e2e we did not have duplicate message since the message was stale, leftover from previous code.

Example error with this change:

    % ./run.sh -test.run TestDR
    2025-09-21T21:40:02.387+0300	INFO	Using config file "config.yaml"
    2025-09-21T21:40:02.388+0300	INFO	Using log file "ramen-e2e.log"
    2025-09-21T21:40:02.389+0300	ERROR	Failed to create env: failed to create cluster
    "hub": failed to build config from kubeconfig (/Users/nir/.config/drenv/rdr/kubeconfigs/hub):
    stat /Users/nir/.config/drenv/rdr/kubeconfigs/hub: no such file or directory