### PR TITLE
Ensure DRPC transition status remain at WaitForUserToCleanup until secondaries cleanedup

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -2047,7 +2047,15 @@ func (d *DRPCInstance) EnsureCleanup(clusterToSkip string) error {
 		condition.ObservedGeneration == d.instance.Generation {
 		d.log.Info("Condition values tallied, cleanup is considered complete")
 
-		return nil
+		for cluster, vrg := range d.vrgs {
+			if cluster == clusterToSkip {
+				continue
+			}
+
+			if vrg.Status.State == rmn.SecondaryState {
+				return nil
+			}
+		}
 	}
 
 	d.log.Info(fmt.Sprintf("PeerReady Condition is %s, msg: %s", condition.Status, condition.Message))


### PR DESCRIPTION
This fix ensures that when the failed cluster recovers during an ongoing DR failover operation, the DRPC failover progression remains in the 'WaitForUserToCleanup' state until the target discovered application is successfully cleaned up on the failed cluster.