### PR TITLE
drenv: Test on macos-latest

### DIFF
--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -99,7 +99,7 @@ jobs:
       matrix:
         os:
           # arm64, 3 cpus (M1), 7 GiB RAM, no nested virtalization.
-          - macos-14
+          - macos-latest
         python-version:
           - "3.13"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This now macos-15, and soon it will switch to macos-26. There seems to be an issue with the macos-14 now, and our job times out since no runner pick it up.