### PR TITLE
test: Add pyproject.toml for tool configuration

### DIFF
--- a/test/pyproject.toml
+++ b/test/pyproject.toml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+[tool.pytest.ini_options]
+# -r chars: (s)skipped, (x)failed, (X)passed
+addopts = "--verbose -rsxX --durations 10"
+
+# https://docs.pytest.org/en/latest/how-to/mark.html#registering-marks
+markers = [
+    "cluster: marks tests requiring a test cluster (deselect with -m 'not cluster')"
+]

--- a/test/pyproject.toml
+++ b/test/pyproject.toml
@@ -9,3 +9,6 @@ addopts = "--verbose -rsxX --durations 10"
 markers = [
     "cluster: marks tests requiring a test cluster (deselect with -m 'not cluster')"
 ]
+
+[tool.basedpyright]
+typeCheckingMode = "standard"

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,7 +1,0 @@
-[pytest]
-# -r chars: (s)skipped, (x)failed, (X)passed
-addopts = --verbose -rsxX --durations 10
-
-# https://docs.pytest.org/en/latest/how-to/mark.html#registering-marks
-markers =
-    cluster: marks tests requiring a test cluster (deselect with '-m "not cluster"')


### PR DESCRIPTION
Add pyproject.toml configuration for keeping tools configurations.

- pytest: moved from pytest.ini
- basedpyright: new configuration for people using [basedpyright language serer](https://github.com/DetachHead/basedpyright)