### PR TITLE
ramendev: Create DRPolicies with multiple scheduling intervals

### DIFF
--- a/e2e/config-vm.yaml.sample
+++ b/e2e/config-vm.yaml.sample
@@ -8,7 +8,7 @@ repo:
   branch: main
 
 # DRPolicy name in the hub cluster.
-drPolicy: dr-policy
+drPolicy: dr-policy-1m
 
 # Add ClusterSet name to match your Open Cluster Management configuration.
 clusterSet: default

--- a/e2e/config.yaml.sample
+++ b/e2e/config.yaml.sample
@@ -8,7 +8,7 @@ repo:
   branch: main
 
 # DRPolicy name in the hub cluster.
-drPolicy: dr-policy
+drPolicy: dr-policy-1m
 
 # Add ClusterSet name to match your Open Cluster Management configuration.
 clusterSet: default

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -28,7 +28,7 @@ const (
 	defaultGitBranch = "main"
 
 	// DRPolicy
-	defaultDRPolicyName = "dr-policy"
+	defaultDRPolicyName = "dr-policy-1m"
 
 	// Make it easier to manage namespaces created by the tests.
 	defaultNamespacePrefix = "test-"

--- a/ramendev/ramendev/command.py
+++ b/ramendev/ramendev/command.py
@@ -8,6 +8,7 @@ from drenv import commands
 from drenv import ramen
 
 RAMEN_NAMESPACE = "ramen-system"
+DRPOLICY_INTERVALS = ["1m", "5m"]
 SOURCE_DIR = "."
 
 log = logging.getLogger("ramendev")

--- a/ramendev/ramendev/resources/regional-dr/dr-policy.yaml
+++ b/ramendev/ramendev/resources/regional-dr/dr-policy.yaml
@@ -4,11 +4,11 @@
 apiVersion: ramendr.openshift.io/v1alpha1
 kind: DRPolicy
 metadata:
-  name: dr-policy
+  name: dr-policy-$interval
 spec:
   drClusters:
   - $cluster1
   - $cluster2
-  schedulingInterval: 1m
+  schedulingInterval: $interval
   replicationClassSelector: {}
   volumeSnapshotClassSelector: {}

--- a/ramendev/ramendev/unconfig.py
+++ b/ramendev/ramendev/unconfig.py
@@ -30,10 +30,13 @@ def run(args):
 
 def delete_hub_dr_resources(hub, clusters, topology):
     # Deleting in reverse order.
-    for name in ["dr-policy", "dr-clusters"]:
-        command.info("Deleting %s for %s", name, topology)
-        template = drenv.template(command.resource(f"{topology}/{name}.yaml"))
-        yaml = template.substitute(cluster1=clusters[0], cluster2=clusters[1])
+
+    for interval in command.DRPOLICY_INTERVALS:
+        command.info("Deleting dr-policy-%s for %s", interval, topology)
+        template = drenv.template(command.resource(f"{topology}/dr-policy.yaml"))
+        yaml = template.substitute(
+            cluster1=clusters[0], cluster2=clusters[1], interval=interval
+        )
         kubectl.delete(
             "--filename=-",
             "--ignore-not-found",
@@ -41,6 +44,17 @@ def delete_hub_dr_resources(hub, clusters, topology):
             context=hub,
             log=command.debug,
         )
+
+    command.info("Deleting dr-clusters for %s", topology)
+    template = drenv.template(command.resource(f"{topology}/dr-clusters.yaml"))
+    yaml = template.substitute(cluster1=clusters[0], cluster2=clusters[1])
+    kubectl.delete(
+        "--filename=-",
+        "--ignore-not-found",
+        input=yaml,
+        context=hub,
+        log=command.debug,
+    )
 
 
 def generate_ramen_s3_secrets(clusters, args):

--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -19,6 +19,7 @@ from drenv import commands
 from drenv import kubectl
 
 POOL_NAME = "replicapool"
+VRC_INTERVALS = ["1m", "5m"]
 
 
 def log_blocklist(cluster):
@@ -106,10 +107,13 @@ def configure_rbd_mirroring(cluster, peer_info):
         context=cluster,
     )
 
-    print("Creating VolumeReplicationClass")
-    template = drenv.template("start-data/vrc-sample.yaml")
-    yaml = template.substitute(cluster=cluster, scname="rook-ceph-block")
-    kubectl.apply("--filename=-", input=yaml, context=cluster)
+    for interval in VRC_INTERVALS:
+        print(f"Creating VolumeReplicationClass vrc-{interval}")
+        template = drenv.template("start-data/vrc.yaml")
+        yaml = template.substitute(
+            cluster=cluster, scname="rook-ceph-block", interval=interval
+        )
+        kubectl.apply("--filename=-", input=yaml, context=cluster)
 
     print(f"Apply rbd mirror to cluster '{cluster}'")
     kubectl.apply("--kustomize=start-data", context=cluster)

--- a/test/addons/rbd-mirror/start-data/vgrc.yaml
+++ b/test/addons/rbd-mirror/start-data/vgrc.yaml
@@ -3,15 +3,17 @@
 
 ---
 apiVersion: replication.storage.openshift.io/v1alpha1
-kind: VolumeReplicationClass
+kind: VolumeGroupReplicationClass
 metadata:
-  name: vrc-sample
+  name: vgrc-$interval
   labels:
     ramendr.openshift.io/storageid: $scname-$cluster-1
     ramendr.openshift.io/replicationid: rook-ceph-replication-1
 spec:
   provisioner: rook-ceph.rbd.csi.ceph.com
   parameters:
-    replication.storage.openshift.io/replication-secret-name: rook-csi-rbd-provisioner
-    replication.storage.openshift.io/replication-secret-namespace: rook-ceph
-    schedulingInterval: 1m
+    clusterID: rook-ceph
+    pool: $pool
+    replication.storage.openshift.io/group-replication-secret-name: rook-csi-rbd-provisioner
+    replication.storage.openshift.io/group-replication-secret-namespace: rook-ceph
+    schedulingInterval: $interval

--- a/test/addons/rbd-mirror/start-data/vrc.yaml
+++ b/test/addons/rbd-mirror/start-data/vrc.yaml
@@ -3,17 +3,15 @@
 
 ---
 apiVersion: replication.storage.openshift.io/v1alpha1
-kind: VolumeGroupReplicationClass
+kind: VolumeReplicationClass
 metadata:
-  name: vgrc-sample
+  name: vrc-$interval
   labels:
     ramendr.openshift.io/storageid: $scname-$cluster-1
     ramendr.openshift.io/replicationid: rook-ceph-replication-1
 spec:
   provisioner: rook-ceph.rbd.csi.ceph.com
   parameters:
-    clusterID: rook-ceph
-    pool: $pool
-    replication.storage.openshift.io/group-replication-secret-name: rook-csi-rbd-provisioner
-    replication.storage.openshift.io/group-replication-secret-namespace: rook-ceph
-    schedulingInterval: 1m
+    replication.storage.openshift.io/replication-secret-name: rook-csi-rbd-provisioner
+    replication.storage.openshift.io/replication-secret-namespace: rook-ceph
+    schedulingInterval: $interval

--- a/test/addons/rbd-mirror/test
+++ b/test/addons/rbd-mirror/test
@@ -12,6 +12,7 @@ from drenv import kubectl
 
 POOL_NAME = "replicapool"
 PVC_NAME = "rbd-pvc"
+VR_NAME = "vr-1m"
 
 
 def rbd(*args, cluster=None):
@@ -55,7 +56,7 @@ def rbd_mirror_image_status(cluster, image):
 
 
 def test_volume_replication(primary, secondary):
-    print(f"Deploying pvc {PVC_NAME} and vr vr-sample in cluster '{primary}'")
+    print(f"Deploying pvc {PVC_NAME} and vr {VR_NAME} in cluster '{primary}'")
     kubectl.apply("--kustomize=test-data", context=primary)
 
     print(f"Waiting until pvc {PVC_NAME} is bound in cluster '{primary}'")
@@ -67,18 +68,18 @@ def test_volume_replication(primary, secondary):
         context=primary,
     )
 
-    print(f"Waiting until vr vr-sample is completed in cluster '{primary}'")
+    print(f"Waiting until vr {VR_NAME} is completed in cluster '{primary}'")
     kubectl.wait(
-        "volumereplication/vr-sample",
+        f"volumereplication/{VR_NAME}",
         "--for=condition=Completed",
         "--namespace=rook-ceph",
         "--timeout=300s",
         context=primary,
     )
 
-    print(f"Waiting until vr vr-sample state is primary in cluster '{primary}'")
+    print(f"Waiting until vr {VR_NAME} state is primary in cluster '{primary}'")
     kubectl.wait(
-        "volumereplication/vr-sample",
+        f"volumereplication/{VR_NAME}",
         "--for=jsonpath={.status.state}=Primary",
         "--namespace=rook-ceph",
         "--timeout=300s",
@@ -116,9 +117,9 @@ def test_volume_replication(primary, secondary):
     else:
         raise RuntimeError(f"Timeout waiting for image {rbd_image}")
 
-    print(f"vr vr-sample info on primary cluster '{primary}'")
+    print(f"vr {VR_NAME} info on primary cluster '{primary}'")
     kubectl.get(
-        "volumereplication/vr-sample",
+        f"volumereplication/{VR_NAME}",
         "--output=yaml",
         "--namespace=rook-ceph",
         context=primary,
@@ -128,7 +129,7 @@ def test_volume_replication(primary, secondary):
     image_status = rbd_mirror_image_status(primary, rbd_image)
     print(json.dumps(image_status, indent=2))
 
-    print(f"Deleting pvc {PVC_NAME} and vr vr-sample in primary cluster '{primary}'")
+    print(f"Deleting pvc {PVC_NAME} and vr {VR_NAME} in primary cluster '{primary}'")
     kubectl.delete("--kustomize=test-data", context=primary)
 
     print(f"Replication from cluster '{primary}' to cluster '{secondary}' succeeded")

--- a/test/addons/rbd-mirror/test-data/kustomization.yaml
+++ b/test/addons/rbd-mirror/test-data/kustomization.yaml
@@ -3,7 +3,7 @@
 
 ---
 resources:
-- vr-sample.yaml
+- vr-1m.yaml
 - rbd-pvc.yaml
 
 namespace: rook-ceph

--- a/test/addons/rbd-mirror/test-data/vgr-1m.yaml
+++ b/test/addons/rbd-mirror/test-data/vgr-1m.yaml
@@ -5,9 +5,9 @@
 apiVersion: replication.storage.openshift.io/v1alpha1
 kind: VolumeGroupReplication
 metadata:
-  name: vgr-sample
+  name: vgr-1m
 spec:
-  volumeGroupReplicationClassName: vgrc-sample
+  volumeGroupReplicationClassName: vgrc-1m
   replicationState: primary
   source:
     selector:

--- a/test/addons/rbd-mirror/test-data/vr-1m.yaml
+++ b/test/addons/rbd-mirror/test-data/vr-1m.yaml
@@ -5,9 +5,9 @@
 apiVersion: replication.storage.openshift.io/v1alpha1
 kind: VolumeReplication
 metadata:
-  name: vr-sample
+  name: vr-1m
 spec:
-  volumeReplicationClass: vrc-sample
+  volumeReplicationClass: vrc-1m
   replicationState: primary
   dataSource:
     kind: PersistentVolumeClaim


### PR DESCRIPTION
- Add support for creating multiple DRPolicies for easier testing with different scheduling intervals. Both 1m and 5m DRPolicies are now created using a template.
- Update e2e configs to use updated 1m drpolicy name.

```
ramendev config test/envs/regional-dr.yaml
2025-10-08 21:20:58,499 INFO    [ramendev] Starting config
2025-10-08 21:20:58,762 INFO    [ramendev] Creating ramen s3 secrets in cluster 'hub'
2025-10-08 21:20:58,954 INFO    [ramendev] Updating ramen config map in cluster 'hub'
2025-10-08 21:20:59,057 INFO    [ramendev] Creating dr-clusters for regional-dr
2025-10-08 21:20:59,871 INFO    [ramendev] Creating dr-policy-1m for regional-dr
2025-10-08 21:20:59,947 INFO    [ramendev] Creating dr-policy-5m for regional-dr
2025-10-08 21:21:00,027 INFO    [ramendev] Waiting until s3 secrets are propagated to managed clusters
2025-10-08 21:21:00,376 INFO    [ramendev] Waiting until DRClusters report phase
2025-10-08 21:21:00,454 INFO    [ramendev] Waiting until DRClusters phase is available
2025-10-08 21:21:00,697 INFO    [ramendev] Waiting until dr-policy-1m is validated
2025-10-08 21:21:00,837 INFO    [ramendev] Waiting until dr-policy-5m is validated
2025-10-08 21:21:00,977 INFO    [ramendev] Creating ramen-ops managedclustersetbinding in cluster 'hub'
2025-10-08 21:21:01,058 INFO    [ramendev] Finished config in 2.56 seconds
```

```
kubectl get drpolicy --context hub
NAME           AGE
dr-policy-1m   48s
dr-policy-5m   48s
```

drpolicies:

```
- apiVersion: ramendr.openshift.io/v1alpha1
  kind: DRPolicy
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"ramendr.openshift.io/v1alpha1","kind":"DRPolicy","metadata":{"annotations":{},"name":"dr-policy-1m"},"spec":{"drClusters":["dr1","dr2"],"replicationClassSelector":{},"schedulingInterval":"1m","volumeSnapshotClassSelector":{}}}
    creationTimestamp: "2025-10-08T15:50:14Z"
    finalizers:
    - drpolicies.ramendr.openshift.io/ramen
    generation: 2
    labels:
      cluster.open-cluster-management.io/backup: ramen
    name: dr-policy-1m
    resourceVersion: "5135"
    uid: 6f44d666-7d25-4981-8a9d-dcb34db4acc3
  spec:
    drClusters:
    - dr1
    - dr2
    replicationClassSelector: {}
    schedulingInterval: 1m
    volumeGroupSnapshotClassSelector: {}
    volumeSnapshotClassSelector: {}
  status:
    async:
      peerClasses:
      - clusterIDs:
        - c4c0d007-6e5a-44d5-bcfd-a7964e61cc73
        - b5a684ae-7967-4fb5-9607-4d78bf8ab482
        replicationID: rook-ceph-replication-1
        storageClassName: rook-ceph-block
        storageID:
        - rook-ceph-block-dr1-1
        - rook-ceph-block-dr2-1
      - clusterIDs:
        - c4c0d007-6e5a-44d5-bcfd-a7964e61cc73
        - b5a684ae-7967-4fb5-9607-4d78bf8ab482
        storageClassName: rook-cephfs-fs1
        storageID:
        - rook-cephfs-fs1-dr1-1
        - rook-cephfs-fs1-dr2-1
    conditions:
    - lastTransitionTime: "2025-10-08T15:50:15Z"
      message: drpolicy validated
      observedGeneration: 2
      reason: Succeeded
      status: "True"
      type: Validated
    sync: {}
- apiVersion: ramendr.openshift.io/v1alpha1
  kind: DRPolicy
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"ramendr.openshift.io/v1alpha1","kind":"DRPolicy","metadata":{"annotations":{},"name":"dr-policy-5m"},"spec":{"drClusters":["dr1","dr2"],"replicationClassSelector":{},"schedulingInterval":"5m","volumeSnapshotClassSelector":{}}}
    creationTimestamp: "2025-10-08T15:50:14Z"
    finalizers:
    - drpolicies.ramendr.openshift.io/ramen
    generation: 2
    labels:
      cluster.open-cluster-management.io/backup: ramen
    name: dr-policy-5m
    resourceVersion: "5229"
    uid: 49a5a027-dc37-4a38-8458-9301f1cd704f
  spec:
    drClusters:
    - dr1
    - dr2
    replicationClassSelector: {}
    schedulingInterval: 5m
    volumeGroupSnapshotClassSelector: {}
    volumeSnapshotClassSelector: {}
  status:
    async:
      peerClasses:
      - clusterIDs:
        - c4c0d007-6e5a-44d5-bcfd-a7964e61cc73
        - b5a684ae-7967-4fb5-9607-4d78bf8ab482
        replicationID: rook-ceph-replication-1
        storageClassName: rook-ceph-block
        storageID:
        - rook-ceph-block-dr1-1
        - rook-ceph-block-dr2-1
      - clusterIDs:
        - c4c0d007-6e5a-44d5-bcfd-a7964e61cc73
        - b5a684ae-7967-4fb5-9607-4d78bf8ab482
        storageClassName: rook-cephfs-fs1
        storageID:
        - rook-cephfs-fs1-dr1-1
        - rook-cephfs-fs1-dr2-1
    conditions:
    - lastTransitionTime: "2025-10-08T15:50:15Z"
      message: drpolicy validated
      observedGeneration: 2
      reason: Succeeded
      status: "True"
      type: Validated
    sync: {}
```

Fixes #2118 