### PR TITLE
Add mitigation to delay VolumeGroupSnapshot creation for newly created PVCs

### DIFF
--- a/hack/fakes/fake_volume_group_source_handler.go
+++ b/hack/fakes/fake_volume_group_source_handler.go
@@ -46,11 +46,13 @@ type FakeVolumeGroupSourceHandler struct {
 	}
 	createOrUpdateReplicationSourceForRestoredPVCsReturns struct {
 		result1 []*v1.ObjectReference
-		result2 error
+		result2 bool
+		result3 error
 	}
 	createOrUpdateReplicationSourceForRestoredPVCsReturnsOnCall map[int]struct {
 		result1 []*v1.ObjectReference
-		result2 error
+		result2 bool
+		result3 error
 	}
 	CreateOrUpdateVolumeGroupSnapshotStub        func(context.Context, v1a.Object) (bool, error)
 	createOrUpdateVolumeGroupSnapshotMutex       sync.RWMutex
@@ -59,10 +61,12 @@ type FakeVolumeGroupSourceHandler struct {
 		arg2 v1a.Object
 	}
 	createOrUpdateVolumeGroupSnapshotReturns struct {
-		result1 error
+		result1 bool
+		result2 error
 	}
 	createOrUpdateVolumeGroupSnapshotReturnsOnCall map[int]struct {
-		result1 error
+		result1 bool
+		result2 error
 	}
 	RestoreVolumesFromVolumeGroupSnapshotStub        func(context.Context, v1a.Object) ([]cephfscg.RestoredPVC, error)
 	restoreVolumesFromVolumeGroupSnapshotMutex       sync.RWMutex
@@ -76,6 +80,19 @@ type FakeVolumeGroupSourceHandler struct {
 	}
 	restoreVolumesFromVolumeGroupSnapshotReturnsOnCall map[int]struct {
 		result1 []cephfscg.RestoredPVC
+		result2 error
+	}
+	WaitIfPVCTooNewStub        func(context.Context) (bool, error)
+	waitIfPVCTooNewMutex       sync.RWMutex
+	waitIfPVCTooNewArgsForCall []struct {
+		arg1 context.Context
+	}
+	waitIfPVCTooNewReturns struct {
+		result1 bool
+		result2 error
+	}
+	waitIfPVCTooNewReturnsOnCall map[int]struct {
+		result1 bool
 		result2 error
 	}
 	invocations      map[string][][]interface{}
@@ -235,9 +252,9 @@ func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRest
 		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
-		return ret.result1, false, ret.result2
+		return ret.result1, ret.result2, ret.result3
 	}
-	return fakeReturns.result1, false, fakeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVCsCallCount() int {
@@ -259,30 +276,33 @@ func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRest
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVCsReturns(result1 []*v1.ObjectReference, result2 error) {
+func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVCsReturns(result1 []*v1.ObjectReference, result2 bool, result3 error) {
 	fake.createOrUpdateReplicationSourceForRestoredPVCsMutex.Lock()
 	defer fake.createOrUpdateReplicationSourceForRestoredPVCsMutex.Unlock()
 	fake.CreateOrUpdateReplicationSourceForRestoredPVCsStub = nil
 	fake.createOrUpdateReplicationSourceForRestoredPVCsReturns = struct {
 		result1 []*v1.ObjectReference
-		result2 error
-	}{result1, result2}
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVCsReturnsOnCall(i int, result1 []*v1.ObjectReference, result2 error) {
+func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVCsReturnsOnCall(i int, result1 []*v1.ObjectReference, result2 bool, result3 error) {
 	fake.createOrUpdateReplicationSourceForRestoredPVCsMutex.Lock()
 	defer fake.createOrUpdateReplicationSourceForRestoredPVCsMutex.Unlock()
 	fake.CreateOrUpdateReplicationSourceForRestoredPVCsStub = nil
 	if fake.createOrUpdateReplicationSourceForRestoredPVCsReturnsOnCall == nil {
 		fake.createOrUpdateReplicationSourceForRestoredPVCsReturnsOnCall = make(map[int]struct {
 			result1 []*v1.ObjectReference
-			result2 error
+			result2 bool
+			result3 error
 		})
 	}
 	fake.createOrUpdateReplicationSourceForRestoredPVCsReturnsOnCall[i] = struct {
 		result1 []*v1.ObjectReference
-		result2 error
-	}{result1, result2}
+		result2 bool
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshot(arg1 context.Context, arg2 v1a.Object) (bool, error) {
@@ -300,9 +320,9 @@ func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshot(arg1
 		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return false, ret.result1
+		return ret.result1, ret.result2
 	}
-	return false, fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshotCallCount() int {
@@ -324,27 +344,30 @@ func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshotArgsF
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshotReturns(result1 error) {
+func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshotReturns(result1 bool, result2 error) {
 	fake.createOrUpdateVolumeGroupSnapshotMutex.Lock()
 	defer fake.createOrUpdateVolumeGroupSnapshotMutex.Unlock()
 	fake.CreateOrUpdateVolumeGroupSnapshotStub = nil
 	fake.createOrUpdateVolumeGroupSnapshotReturns = struct {
-		result1 error
-	}{result1}
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshotReturnsOnCall(i int, result1 error) {
+func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshotReturnsOnCall(i int, result1 bool, result2 error) {
 	fake.createOrUpdateVolumeGroupSnapshotMutex.Lock()
 	defer fake.createOrUpdateVolumeGroupSnapshotMutex.Unlock()
 	fake.CreateOrUpdateVolumeGroupSnapshotStub = nil
 	if fake.createOrUpdateVolumeGroupSnapshotReturnsOnCall == nil {
 		fake.createOrUpdateVolumeGroupSnapshotReturnsOnCall = make(map[int]struct {
-			result1 error
+			result1 bool
+			result2 error
 		})
 	}
 	fake.createOrUpdateVolumeGroupSnapshotReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeVolumeGroupSourceHandler) RestoreVolumesFromVolumeGroupSnapshot(arg1 context.Context, arg2 v1a.Object) ([]cephfscg.RestoredPVC, error) {
@@ -412,19 +435,73 @@ func (fake *FakeVolumeGroupSourceHandler) RestoreVolumesFromVolumeGroupSnapshotR
 	}{result1, result2}
 }
 
+func (fake *FakeVolumeGroupSourceHandler) WaitIfPVCTooNew(arg1 context.Context) (bool, error) {
+	fake.waitIfPVCTooNewMutex.Lock()
+	ret, specificReturn := fake.waitIfPVCTooNewReturnsOnCall[len(fake.waitIfPVCTooNewArgsForCall)]
+	fake.waitIfPVCTooNewArgsForCall = append(fake.waitIfPVCTooNewArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.WaitIfPVCTooNewStub
+	fakeReturns := fake.waitIfPVCTooNewReturns
+	fake.recordInvocation("WaitIfPVCTooNew", []interface{}{arg1})
+	fake.waitIfPVCTooNewMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeVolumeGroupSourceHandler) WaitIfPVCTooNewCallCount() int {
+	fake.waitIfPVCTooNewMutex.RLock()
+	defer fake.waitIfPVCTooNewMutex.RUnlock()
+	return len(fake.waitIfPVCTooNewArgsForCall)
+}
+
+func (fake *FakeVolumeGroupSourceHandler) WaitIfPVCTooNewCalls(stub func(context.Context) (bool, error)) {
+	fake.waitIfPVCTooNewMutex.Lock()
+	defer fake.waitIfPVCTooNewMutex.Unlock()
+	fake.WaitIfPVCTooNewStub = stub
+}
+
+func (fake *FakeVolumeGroupSourceHandler) WaitIfPVCTooNewArgsForCall(i int) context.Context {
+	fake.waitIfPVCTooNewMutex.RLock()
+	defer fake.waitIfPVCTooNewMutex.RUnlock()
+	argsForCall := fake.waitIfPVCTooNewArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeVolumeGroupSourceHandler) WaitIfPVCTooNewReturns(result1 bool, result2 error) {
+	fake.waitIfPVCTooNewMutex.Lock()
+	defer fake.waitIfPVCTooNewMutex.Unlock()
+	fake.WaitIfPVCTooNewStub = nil
+	fake.waitIfPVCTooNewReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeVolumeGroupSourceHandler) WaitIfPVCTooNewReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.waitIfPVCTooNewMutex.Lock()
+	defer fake.waitIfPVCTooNewMutex.Unlock()
+	fake.WaitIfPVCTooNewStub = nil
+	if fake.waitIfPVCTooNewReturnsOnCall == nil {
+		fake.waitIfPVCTooNewReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.waitIfPVCTooNewReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeVolumeGroupSourceHandler) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.checkReplicationSourceForRestoredPVCsCompletedMutex.RLock()
-	defer fake.checkReplicationSourceForRestoredPVCsCompletedMutex.RUnlock()
-	fake.cleanVolumeGroupSnapshotMutex.RLock()
-	defer fake.cleanVolumeGroupSnapshotMutex.RUnlock()
-	fake.createOrUpdateReplicationSourceForRestoredPVCsMutex.RLock()
-	defer fake.createOrUpdateReplicationSourceForRestoredPVCsMutex.RUnlock()
-	fake.createOrUpdateVolumeGroupSnapshotMutex.RLock()
-	defer fake.createOrUpdateVolumeGroupSnapshotMutex.RUnlock()
-	fake.restoreVolumesFromVolumeGroupSnapshotMutex.RLock()
-	defer fake.restoreVolumesFromVolumeGroupSnapshotMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
This change introduces a mitigation to reduce snapshot failures caused by `SELinux labeling` issues on newly created PVCs.

When a `VolumeGroupSnapshot` is created too soon after the app PVCs are provisioned, the PVCs may not yet be mounted by a Pod(s), meaning SELinux labels might not be fully applied. As a result, snapshots could capture incorrect labels, which can later cause "**access denied**" errors when restoring read-only (ROX) PVCs.

To reduce the likelihood of this issue, the new logic checks each PVC’s creation timestamp and waits until the PVC is at least one minute old before proceeding with snapshot creation. This waiting period increases the chance that the PVC has been mounted and labeled correctly.

**Notes:**
1. This is a mitigation, not a complete solution.
2. The issue is more commonly observed in QE environments where application deployment and DR protection happen simultaneously.
3. In typical customer environments, where the application is deployed and verified before DR protection is applied, this condition is less likely to occur.
4. We could eliminate this by waiting for all PVCs to be used (mounted) before creating the snapshot, but that would mean we would not be able to protect unused PVCs (e.g. those created but only mounted sometime in the future).

**Fixes:** 
   1. https://issues.redhat.com/browse/DFBUGS-4231