### PR TITLE
drenv: Fix unneeded start delay

### DIFF
--- a/test/drenv/providers/lima/__init__.py
+++ b/test/drenv/providers/lima/__init__.py
@@ -67,7 +67,9 @@ def start(profile, verbose=False, timeout=None, local_registry=False):
     start = time.monotonic()
     logging.info("[%s] Starting lima cluster", profile["name"])
 
+    existing = True
     if not exists(profile):
+        existing = False
         _log_unsupported_options(profile)
         with tempfile.NamedTemporaryFile(
             prefix=f"drenv.lima.{profile['name']}.tmp",
@@ -84,7 +86,7 @@ def start(profile, verbose=False, timeout=None, local_registry=False):
     debug = partial(logging.debug, f"[{profile['name']}] %s")
     cluster.wait_until_ready(profile["name"], timeout=30, log=debug)
 
-    if vm["status"] == STOPPED:
+    if existing and vm["status"] == STOPPED:
         # We have random failures (e.g. ocm webooks) when starting a stopped
         # cluster. Until we find A better way, try to wait give the system
         # more time to become stable.


### PR DESCRIPTION
drenv: Fix unneeded start delay

When starting a stopped vm we have timeouts in webhooks, so we added a
15 seconds sleep before using the cluster in the lima provider start().
The implementation was wrong, always waiting 15 seconds after the
cluster is ready, before returning. Fix it to wait only when starting
stopped vm.

Testing shows that removing the sleep shortens the time until the
cluster is started, but the first deployment takes more time, since k8s
is not completely ready when the cluster is started.

## Example run vm - before

```console
% drenv start envs/vm.yaml --local-registry
2025-10-08 21:25:45,505 INFO    [vm] Starting environment
2025-10-08 21:25:45,528 INFO    [cluster] Starting lima cluster
2025-10-08 21:27:02,028 INFO    [cluster] Cluster started in 76.50 seconds
2025-10-08 21:27:02,030 INFO    [cluster/0] Running addons/example/start
2025-10-08 21:27:21,405 INFO    [cluster/0] addons/example/start completed in 19.37 seconds
2025-10-08 21:27:21,405 INFO    [cluster/0] Running addons/example/test
2025-10-08 21:27:21,542 INFO    [cluster/0] addons/example/test completed in 0.14 seconds
2025-10-08 21:27:21,543 INFO    [vm] Environment started in 96.04 seconds
```

## Example run vm - after

```console
% drenv start envs/vm.yaml --local-registry
2025-10-08 21:27:44,382 INFO    [vm] Starting environment
2025-10-08 21:27:44,405 INFO    [cluster] Starting lima cluster
2025-10-08 21:28:46,500 INFO    [cluster] Cluster started in 62.10 seconds
2025-10-08 21:28:46,501 INFO    [cluster/0] Running addons/example/start
2025-10-08 21:29:21,167 INFO    [cluster/0] addons/example/start completed in 34.67 seconds
2025-10-08 21:29:21,168 INFO    [cluster/0] Running addons/example/test
2025-10-08 21:29:21,309 INFO    [cluster/0] addons/example/test completed in 0.14 seconds
2025-10-08 21:29:21,310 INFO    [vm] Environment started in 96.93 seconds
```

To total time to start a cluster and install the example deployment
remain the same.

## Example run ocm - before

```console
% drenv start envs/ocm.yaml --local-registry
2025-10-08 22:04:31,997 INFO    [ocm] Starting environment
2025-10-08 22:04:32,024 INFO    [dr1] Starting lima cluster
2025-10-08 22:04:32,024 INFO    [hub] Starting lima cluster
2025-10-08 22:04:32,024 INFO    [dr2] Starting lima cluster
2025-10-08 22:05:55,983 INFO    [hub] Cluster started in 83.96 seconds
2025-10-08 22:05:55,985 INFO    [hub/0] Running addons/ocm-hub/start
2025-10-08 22:05:56,032 INFO    [dr1] Cluster started in 84.01 seconds
2025-10-08 22:05:56,034 INFO    [dr1/0] Running addons/ocm-cluster/start
2025-10-08 22:05:57,063 INFO    [dr2] Cluster started in 85.04 seconds
2025-10-08 22:05:57,063 INFO    [dr2/0] Running addons/ocm-cluster/start
2025-10-08 22:06:37,142 INFO    [hub/0] addons/ocm-hub/start completed in 41.16 seconds
2025-10-08 22:06:37,142 INFO    [hub/0] Running addons/ocm-controller/start
2025-10-08 22:06:48,347 INFO    [hub/0] addons/ocm-controller/start completed in 11.21 seconds
2025-10-08 22:08:08,546 INFO    [dr1/0] addons/ocm-cluster/start completed in 132.52 seconds
2025-10-08 22:08:08,546 INFO    [dr1/0] Running addons/ocm-cluster/test
2025-10-08 22:08:08,993 INFO    [dr2/0] addons/ocm-cluster/start completed in 131.94 seconds
2025-10-08 22:08:08,993 INFO    [dr2/0] Running addons/ocm-cluster/test
2025-10-08 22:08:13,091 INFO    [dr2/0] addons/ocm-cluster/test completed in 4.10 seconds
2025-10-08 22:08:14,582 INFO    [dr1/0] addons/ocm-cluster/test completed in 6.04 seconds
2025-10-08 22:08:14,583 INFO    [ocm] Environment started in 222.59 seconds
```

## Example run ocm - after

```console
% rm drenv.log; drenv start envs/ocm.yaml --local-registry
2025-10-08 22:52:42,566 INFO    [ocm] Starting environment
2025-10-08 22:52:42,592 INFO    [dr1] Starting lima cluster
2025-10-08 22:52:42,592 INFO    [dr2] Starting lima cluster
2025-10-08 22:52:42,593 INFO    [hub] Starting lima cluster
2025-10-08 22:53:49,340 INFO    [hub] Cluster started in 66.75 seconds
2025-10-08 22:53:49,341 INFO    [hub/0] Running addons/ocm-hub/start
2025-10-08 22:53:49,390 INFO    [dr1] Cluster started in 66.80 seconds
2025-10-08 22:53:49,390 INFO    [dr1/0] Running addons/ocm-cluster/start
2025-10-08 22:53:50,483 INFO    [dr2] Cluster started in 67.89 seconds
2025-10-08 22:53:50,483 INFO    [dr2/0] Running addons/ocm-cluster/start
2025-10-08 22:54:43,553 INFO    [hub/0] addons/ocm-hub/start completed in 54.21 seconds
2025-10-08 22:54:43,553 INFO    [hub/0] Running addons/ocm-controller/start
2025-10-08 22:54:52,894 INFO    [hub/0] addons/ocm-controller/start completed in 9.34 seconds
2025-10-08 22:56:02,998 INFO    [dr2/0] addons/ocm-cluster/start completed in 132.51 seconds
2025-10-08 22:56:02,998 INFO    [dr2/0] Running addons/ocm-cluster/test
2025-10-08 22:56:03,740 INFO    [dr1/0] addons/ocm-cluster/start completed in 134.35 seconds
2025-10-08 22:56:03,740 INFO    [dr1/0] Running addons/ocm-cluster/test
2025-10-08 22:56:07,002 INFO    [dr2/0] addons/ocm-cluster/test completed in 4.00 seconds
2025-10-08 22:56:07,809 INFO    [dr1/0] addons/ocm-cluster/test completed in 4.07 seconds
2025-10-08 22:56:07,809 INFO    [ocm] Environment started in 205.24 seconds
```

The total time was slightly lower but starting clusters is very noisy so
more runs are needed to tell if this is a real improvement.
