### PR TITLE
drenv: Update external-snapshotter to v8.3

### DIFF
--- a/test/addons/external-snapshotter/cache
+++ b/test/addons/external-snapshotter/cache
@@ -7,5 +7,5 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh("crds", "addons/external-snapshotter-crds-8.2.yaml")
-cache.refresh("controller", "addons/external-snapshotter-controller-8.2.yaml")
+cache.refresh("crds", "addons/external-snapshotter-crds-8.3.yaml")
+cache.refresh("controller", "addons/external-snapshotter-controller-8.3.yaml")

--- a/test/addons/external-snapshotter/controller/kustomization.yaml
+++ b/test/addons/external-snapshotter/controller/kustomization.yaml
@@ -1,7 +1,7 @@
 ---
 resources:
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
 namespace: kube-system
 patches:
   # Enable volume group replication support

--- a/test/addons/external-snapshotter/crds/kustomization.yaml
+++ b/test/addons/external-snapshotter/crds/kustomization.yaml
@@ -1,8 +1,8 @@
 ---
 resources:
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml

--- a/test/addons/external-snapshotter/start
+++ b/test/addons/external-snapshotter/start
@@ -12,14 +12,14 @@ from drenv import cache
 
 def deploy(cluster):
     print("Deploying crds")
-    path = cache.get("crds", "addons/external-snapshotter-crds-8.2.yaml")
+    path = cache.get("crds", "addons/external-snapshotter-crds-8.3.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
     print("Waiting until crds are established")
     kubectl.wait("--for=condition=established", "--filename", path, context=cluster)
 
     print("Deploying snapshot-controller")
-    path = cache.get("controller", "addons/external-snapshotter-controller-8.2.yaml")
+    path = cache.get("controller", "addons/external-snapshotter-controller-8.3.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
 


### PR DESCRIPTION
We always want to test with latest versions. Hopefully this version can fix the random failure to delete volsync snapshot that we see in the CI.