### PR TITLE
ci: Run e2e-daily on all self-hosted runners

### DIFF
--- a/.github/workflows/e2e-daily.yaml
+++ b/.github/workflows/e2e-daily.yaml
@@ -15,9 +15,14 @@ on:
 
 jobs:
   refresh-cache:
-    runs-on: [self-hosted, e2e-rdr]
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - e2e-rdr-2
+          - e2e-rdr-3
+    runs-on: ${{ matrix.runner }}
     if: github.repository == 'RamenDR/ramen'
-
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -37,7 +42,13 @@ jobs:
             drenv cache envs/regional-dr.yaml
 
   prune-images:
-    runs-on: [self-hosted, e2e-rdr]
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - e2e-rdr-2
+          - e2e-rdr-3
+    runs-on: ${{ matrix.runner }}
     if: github.repository == 'RamenDR/ramen'
     steps:
       - name: Prune images


### PR DESCRIPTION
The current job runs on a random self-hosted runner every day. Fix it to run on all self-hosted runners every day, so we refresh the cache and prune images every day.

Example run started using workflow_dispatch on the test branch:
https://github.com/RamenDR/ramen/actions/runs/18383046230

<img width="364" height="217" alt="Screenshot 2025-10-09 at 20 02 42" src="https://github.com/user-attachments/assets/f576724b-6dfd-4513-8568-74f040d82200" />

Our self-hosted runners:
https://github.com/RamenDR/ramen/actions/runners?tab=self-hosted
