### PR TITLE
Fix flaky VRG test by waiting for deletion to complete

### DIFF
--- a/internal/controller/vrg_recipe_test.go
+++ b/internal/controller/vrg_recipe_test.go
@@ -250,7 +250,7 @@ var _ = Describe("VolumeReplicationGroupRecipe", func() {
 	}
 	vrgDelete := func() {
 		Expect(k8sClient.Delete(ctx, vrg)).To(Succeed())
-		Eventually(vrgGet, time.Second*10, time.Millisecond*100).Should(MatchError(k8serrors.NewNotFound(
+		Eventually(vrgGet).WithTimeout(10 * time.Second).Should(MatchError(k8serrors.NewNotFound(
 			schema.GroupResource{
 				Group:    ramen.GroupVersion.Group,
 				Resource: "volumereplicationgroups",


### PR DESCRIPTION
This PR updates the VolumeReplicationGroupRecipe Controller test to wait for VRG deletion to complete, addressing flakiness observed in the test.

Fixes #2294