### PR TITLE
Update csi-addons and rook-operator kustomizations/scripts

### DIFF
--- a/test/addons/csi-addons/cache
+++ b/test/addons/csi-addons/cache
@@ -7,4 +7,4 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh(".", "addons/csi-addons-latest-1.yaml")
+cache.refresh(".", "addons/csi-addons-latest-5.yaml")

--- a/test/addons/csi-addons/kustomization.yaml
+++ b/test/addons/csi-addons/kustomization.yaml
@@ -3,15 +3,12 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Using commit ea75ddad8c2294e5686d97ccfedd071a25bea3a6 from kubernetes-csi-addons,
-# which was the latest commit at the time of writing.
-# The image digest sha256:527fad57b39117318de60021b8d74e48be2194850495db72083cf8bdd030f32e
-# corresponds to the latest quay.io/csiaddons/k8s-controller image at the same time.
 ---
 resources:
-  - https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/ea75ddad8c2294e5686d97ccfedd071a25bea3a6/deploy/controller/crds.yaml
-  - https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/ea75ddad8c2294e5686d97ccfedd071a25bea3a6/deploy/controller/rbac.yaml
-  - https://raw.githubusercontent.com/csi-addons/kubernetes-csi-addons/ea75ddad8c2294e5686d97ccfedd071a25bea3a6/deploy/controller/setup-controller.yaml
+  - https://raw.githubusercontent.com/Nikhil-Ladha/kubernetes-csi-addons/refs/heads/cg-support/deploy/controller/crds.yaml
+  - https://raw.githubusercontent.com/Nikhil-Ladha/kubernetes-csi-addons/refs/heads/cg-support/deploy/controller/rbac.yaml
+  - https://raw.githubusercontent.com/Nikhil-Ladha/kubernetes-csi-addons/refs/heads/cg-support/deploy/controller/setup-controller.yaml
 images:
   - name: quay.io/csiaddons/k8s-controller
-    digest: sha256:527fad57b39117318de60021b8d74e48be2194850495db72083cf8bdd030f32e
+    newName: quay.io/nladha/csiaddons-controller
+    newTag: cg

--- a/test/addons/csi-addons/start
+++ b/test/addons/csi-addons/start
@@ -12,7 +12,7 @@ from drenv import cache
 
 def deploy(cluster):
     print("Deploying csi addon for volume replication")
-    path = cache.get(".", "addons/csi-addons-latest-1.yaml")
+    path = cache.get(".", "addons/csi-addons-latest-5.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
 

--- a/test/addons/rook-operator/cache
+++ b/test/addons/rook-operator/cache
@@ -7,4 +7,4 @@ import os
 from drenv import cache
 
 os.chdir(os.path.dirname(__file__))
-cache.refresh(".", "addons/rook-operator-1.18-1.yaml")
+cache.refresh(".", "addons/rook-operator-1.18-5.yaml")

--- a/test/addons/rook-operator/kustomization.yaml
+++ b/test/addons/rook-operator/kustomization.yaml
@@ -47,8 +47,5 @@ patches:
                 env:
                   - name: ROOK_DISABLE_ADMISSION_CONTROLLER
                     value: 'true'
-                  # Using quay.io/csiaddons/k8s-sidecar image
-                  # with digest sha256:66a7257319284294181b7a3ba639d0706ea8b12783997d17056132021e9e13d7,
-                  # which was the latest image available at the time of writing.
                   - name: ROOK_CSIADDONS_IMAGE
-                    value: quay.io/csiaddons/k8s-sidecar@sha256:66a7257319284294181b7a3ba639d0706ea8b12783997d17056132021e9e13d7
+                    value: quay.io/nladha/csiaddons-sidecar:cg

--- a/test/addons/rook-operator/start
+++ b/test/addons/rook-operator/start
@@ -12,7 +12,7 @@ from drenv import cache
 
 def deploy(cluster):
     print("Deploying rook ceph operator")
-    path = cache.get(".", "addons/rook-operator-1.18-1.yaml")
+    path = cache.get(".", "addons/rook-operator-1.18-5.yaml")
     kubectl.apply("--filename", path, context=cluster)
 
 


### PR DESCRIPTION
Instead of using quay.io/csiaddons/k8s-controller and quay.io/csiaddons/k8s-sidecar with specific digests, use proprietary images