### PR TITLE
Use groupID for VGR name if cg label is empty

### DIFF
--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -886,6 +886,7 @@ func (v *VRGInstance) pvcUnprotectVolRep(pvc corev1.PersistentVolumeClaim, log l
 	v.pvcStatusDeleteIfPresent(pvc.Namespace, pvc.Name, log)
 }
 
+//nolint:funlen,gocognit,cyclop
 func (v *VRGInstance) pvcsUnprotectVolRep(pvcs []corev1.PersistentVolumeClaim) {
 	groupPVCs := make(map[types.NamespacedName][]*corev1.PersistentVolumeClaim)
 
@@ -914,6 +915,17 @@ func (v *VRGInstance) pvcsUnprotectVolRep(pvcs []corev1.PersistentVolumeClaim) {
 		}
 
 		if cg, ok := v.isCGEnabled(pvc); ok {
+			if cg == "" {
+				grID, err := v.getVGRClassReplicationID(pvc)
+				if err != nil {
+					v.requeue()
+
+					continue
+				}
+
+				cg = grID
+			}
+
 			vgrName := rmnutil.CreateVGRName(cg, v.instance.Name)
 			vgrNamespacedName := types.NamespacedName{Name: vgrName, Namespace: pvc.Namespace}
 


### PR DESCRIPTION
When a workload is deleted, we clear the consistency-group label on it's PVCs.
On the next reconcile, we try to build the VolumeGroupReplication (VGR) name from that label—but it’s already empty.
That makes us fail to find an existing VGR and call reconcileMissingVGR function, which “unprotects” PVCs, because it thinks the VGR is missing.
As a result, the VGR itself never gets deleted.

Fix in this PR: If the PVC’s consistency label is already cleared, find the group replication ID from the PVC's StorageClass and use that to construct the VGR name. This lets the controller find and clean up the existing VGR correctly.

Fixes: https://issues.redhat.com/browse/DFBUGS-4346