### PR TITLE
Adding watch RBAC to backupstoragelocations

### DIFF
--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -260,6 +260,7 @@ rules:
   - velero.io
   resources:
   - backups
+  - backupstoragelocations
   - restores
   verbs:
   - create
@@ -277,18 +278,6 @@ rules:
   - restores/status
   verbs:
   - get
-- apiGroups:
-  - velero.io
-  resources:
-  - backupstoragelocations
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
 - apiGroups:
   - volsync.backube
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -375,6 +375,7 @@ rules:
   - velero.io
   resources:
   - backups
+  - backupstoragelocations
   - restores
   verbs:
   - create
@@ -392,18 +393,6 @@ rules:
   - restores/status
   verbs:
   - get
-- apiGroups:
-  - velero.io
-  resources:
-  - backupstoragelocations
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
 - apiGroups:
   - view.open-cluster-management.io
   resources:

--- a/internal/controller/kubeobjects/velero/requests.go
+++ b/internal/controller/kubeobjects/velero/requests.go
@@ -4,7 +4,7 @@
 //nolint:lll
 // +kubebuilder:rbac:groups=velero.io,resources=backups,verbs=create;delete;deletecollection;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=velero.io,resources=backups/status,verbs=get
-// +kubebuilder:rbac:groups=velero.io,resources=backupstoragelocations,verbs=create;delete;deletecollection;get;list;patch;update
+// +kubebuilder:rbac:groups=velero.io,resources=backupstoragelocations,verbs=create;delete;deletecollection;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=velero.io,resources=restores,verbs=create;delete;deletecollection;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=velero.io,resources=restores/status,verbs=get
 


### PR DESCRIPTION
Getting following error in ramen pod logs:
`"error": "backupstoragelocations.velero.io is forbidden: User \"system:serviceaccount:openshift-dr-system:ramen-dr-cluster-operator\" cannot watch resource \"backupstoragelocations\" in API group \"velero.io\" at the cluster scope"`

Fixes: DFBUGS-4365