### PR TITLE
Introduce the dummy package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN go mod download
 
 # Copy the go source
 COPY cmd/main.go cmd/main.go
-COPY internal/controller/ internal/controller/
+COPY internal/ internal/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/main.go

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,7 +44,9 @@ import (
 	rmnutil "github.com/ramendr/ramen/internal/controller/util"
 	recipe "github.com/ramendr/recipe/api/v1alpha1"
 	virtv1 "kubevirt.io/api/core/v1"
+
 	// +kubebuilder:scaffold:imports
+	_ "github.com/ramendr/ramen/internal/dummy"
 )
 
 var (

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -52,7 +52,9 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
 	clrapiv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+
 	// +kubebuilder:scaffold:imports
+	_ "github.com/ramendr/ramen/internal/dummy"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to

--- a/internal/dummy/dummy.go
+++ b/internal/dummy/dummy.go
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+// package dummy is a workaround for golangci-lint gci formatter limitation. It
+// is used to provide a dummy import to preserve the special
+// `// +kubebuilder:scaffold:imports` comment:
+//
+//	import (
+//
+//		// +kubebuilder:scaffold:imports
+//		_ "github.com/ramendr/ramen/internal/dummy"
+//	)
+//
+// When the kubebuilder comment is before an import line it is not considered a
+// standalone comment and is preserved when gci reformat the imports.
+package dummy


### PR DESCRIPTION
package dummy is a workaround for golangci-lint gci formatter limitation. It is use to provide a dummy import to preserve the special `//+bubebuilder:scaffold:imports` comment:

```go
import (

    //+bubebuilder:scaffold:imports
    _ "github.com/ramendr/ramen/internal/dummy"
)
```

When the kubebuidler comment is before an import line it is not considered a standalone comment and is is preserved when gci reformat the imports.

## Example formatting with gci with this change

Example formatting with gci with this change (see #2299)

```diff
diff --git a/cmd/main.go b/cmd/main.go
index 490c64cf..b58adf5a 100644
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,14 +9,11 @@ import (
        "fmt"
        "os"
 
-       // Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-       // to ensure that exec-entrypoint and run can make use of them.
-       _ "k8s.io/client-go/plugin/pkg/client/auth"
-
        volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
        csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
        volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
        snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+       recipe "github.com/ramendr/recipe/api/v1alpha1"
        groupsnapv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
        plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
        velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -26,6 +23,10 @@ import (
        "k8s.io/apimachinery/pkg/runtime"
        utilruntime "k8s.io/apimachinery/pkg/util/runtime"
        clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+       // Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
+       // to ensure that exec-entrypoint and run can make use of them.
+       _ "k8s.io/client-go/plugin/pkg/client/auth"
+       virtv1 "kubevirt.io/api/core/v1"
        ocmv1 "open-cluster-management.io/api/cluster/v1"
        clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
        clrapiv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
@@ -38,13 +39,9 @@ import (
        "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
        ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
-
        controllers "github.com/ramendr/ramen/internal/controller"
        argocdv1alpha1hack "github.com/ramendr/ramen/internal/controller/argocd"
        rmnutil "github.com/ramendr/ramen/internal/controller/util"
-       recipe "github.com/ramendr/recipe/api/v1alpha1"
-       virtv1 "kubevirt.io/api/core/v1"
-
        // +kubebuilder:scaffold:imports
        _ "github.com/ramendr/ramen/internal/dummy"
 )
```

```diff
diff --git a/internal/controller/suite_test.go b/internal/controller/suite_test.go
index 05f46430..d043ba12 100644
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -10,17 +10,34 @@ import (
        "testing"
        "time"
 
+       volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+       csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
+       volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
        "github.com/go-logr/logr"
+       snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
        . "github.com/onsi/ginkgo/v2"
        . "github.com/onsi/gomega"
+       Recipe "github.com/ramendr/recipe/api/v1alpha1"
+       groupsnapv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
+       plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
+       velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
        "go.uber.org/zap/zapcore"
        corev1 "k8s.io/api/core/v1"
+       "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
        metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
        "k8s.io/apimachinery/pkg/types"
        "k8s.io/client-go/kubernetes/scheme"
        "k8s.io/client-go/rest"
        "k8s.io/client-go/util/workqueue"
        config "k8s.io/component-base/config/v1alpha1"
+       virtv1 "kubevirt.io/api/core/v1"
+       ocmclv1 "open-cluster-management.io/api/cluster/v1"
+       clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
+       clrapiv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+       ocmworkv1 "open-cluster-management.io/api/work/v1"
+       cpcv1 "open-cluster-management.io/config-policy-controller/api/v1"
+       gppv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
+       viewv1beta1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/view/v1beta1"
        ctrl "sigs.k8s.io/controller-runtime"
        "sigs.k8s.io/controller-runtime/pkg/client"
        "sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -29,30 +46,11 @@ import (
        "sigs.k8s.io/controller-runtime/pkg/manager"
        "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-       volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
-       csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
-       volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
-       snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
-       groupsnapv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
-       plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
-       virtv1 "kubevirt.io/api/core/v1"
-       ocmclv1 "open-cluster-management.io/api/cluster/v1"
-       ocmworkv1 "open-cluster-management.io/api/work/v1"
-       cpcv1 "open-cluster-management.io/config-policy-controller/api/v1"
-       gppv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
-       viewv1beta1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/view/v1beta1"
-
        ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
        ramencontrollers "github.com/ramendr/ramen/internal/controller"
        argocdv1alpha1hack "github.com/ramendr/ramen/internal/controller/argocd"
        testutils "github.com/ramendr/ramen/internal/controller/testutils"
        "github.com/ramendr/ramen/internal/controller/util"
-       Recipe "github.com/ramendr/recipe/api/v1alpha1"
-       velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
-       "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-       clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
-       clrapiv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
-
        // +kubebuilder:scaffold:imports
        _ "github.com/ramendr/ramen/internal/dummy"
 )
```