### PR TITLE
e2e: move base context to diff package

### DIFF
--- a/e2e/app/context.go
+++ b/e2e/app/context.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package app
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/ramendr/ramen/e2e/config"
+	"github.com/ramendr/ramen/e2e/types"
+)
+
+// Context implements types.Context for sharing the log, env, and config with all code.
+type Context struct {
+	log    *zap.SugaredLogger
+	env    *types.Env
+	config *config.Config
+	ctx    context.Context
+}
+
+func NewContext(ctx context.Context, config *config.Config, env *types.Env, log *zap.SugaredLogger) *Context {
+	return &Context{
+		log:    log,
+		env:    env,
+		config: config,
+		ctx:    ctx,
+	}
+}
+
+func (c *Context) Logger() *zap.SugaredLogger {
+	return c.log
+}
+
+func (c *Context) Config() *config.Config {
+	return c.config
+}
+
+func (c *Context) Env() *types.Env {
+	return c.env
+}
+
+func (c *Context) Context() context.Context {
+	return c.ctx
+}
+
+// WithTimeout returns a derived context with a deadline. Call cancel to release resources associated with the context
+// as soon as the operation running in the context complete.
+func (c Context) WithTimeout(d time.Duration) (*Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(c.ctx, d)
+	c.ctx = ctx //nolint:revive
+
+	return &c, cancel
+}

--- a/e2e/dr_test.go
+++ b/e2e/dr_test.go
@@ -16,18 +16,18 @@ import (
 )
 
 func TestDR(dt *testing.T) {
-	t := test.WithLog(dt, Ctx.log)
+	t := test.WithLog(dt, Ctx.Logger())
 	t.Parallel()
 
-	if len(Ctx.config.Tests) == 0 {
+	if len(Ctx.Config().Tests) == 0 {
 		t.Fatal("No tests found in the configuration file")
 	}
 
-	if err := validate.TestConfig(&Ctx); err != nil {
+	if err := validate.TestConfig(Ctx); err != nil {
 		t.Fatal(err.Error())
 	}
 
-	if err := util.EnsureChannel(&Ctx); err != nil {
+	if err := util.EnsureChannel(Ctx); err != nil {
 		t.Fatalf("Failed to ensure channel: %s", err)
 	}
 
@@ -40,16 +40,16 @@ func TestDR(dt *testing.T) {
 		}
 	})
 
-	pvcSpecs := config.PVCSpecsMap(Ctx.config)
-	deploySpecs := config.DeployersMap(Ctx.config)
+	pvcSpecs := config.PVCSpecsMap(Ctx.Config())
+	deploySpecs := config.DeployersMap(Ctx.Config())
 
-	for _, tc := range Ctx.config.Tests {
+	for _, tc := range Ctx.Config().Tests {
 		pvcSpec, ok := pvcSpecs[tc.PVCSpec]
 		if !ok {
 			panic("unknown pvcSpec")
 		}
 
-		workload, err := workloads.New(tc.Workload, Ctx.config.Repo.Branch, pvcSpec)
+		workload, err := workloads.New(tc.Workload, Ctx.Config().Repo.Branch, pvcSpec)
 		if err != nil {
 			panic(err)
 		}
@@ -64,7 +64,7 @@ func TestDR(dt *testing.T) {
 			panic(err)
 		}
 
-		ctx := test.NewContext(&Ctx, workload, deployer)
+		ctx := test.NewContext(Ctx, workload, deployer)
 		t.Run(ctx.Name(), func(dt *testing.T) {
 			t := test.WithLog(dt, ctx.Logger())
 			t.Parallel()

--- a/e2e/validation_test.go
+++ b/e2e/validation_test.go
@@ -14,7 +14,7 @@ func TestValidation(dt *testing.T) {
 	t := test.WithLog(dt, Ctx.Logger())
 	t.Parallel()
 
-	if err := validate.TestConfig(&Ctx); err != nil {
+	if err := validate.TestConfig(Ctx); err != nil {
 		t.Fatal(err.Error())
 	}
 
@@ -24,7 +24,7 @@ func TestValidation(dt *testing.T) {
 		t := test.WithLog(dt, Ctx.Logger())
 		t.Parallel()
 
-		err := validate.RamenHubOperator(&Ctx, env.Hub)
+		err := validate.RamenHubOperator(Ctx, env.Hub)
 		if err != nil {
 			t.Fatalf("Failed to validate hub cluster %q: %s", env.Hub.Name, err)
 		}
@@ -33,7 +33,7 @@ func TestValidation(dt *testing.T) {
 		t := test.WithLog(dt, Ctx.Logger())
 		t.Parallel()
 
-		err := validate.RamenDRClusterOperator(&Ctx, env.C1)
+		err := validate.RamenDRClusterOperator(Ctx, env.C1)
 		if err != nil {
 			t.Fatalf("Failed to validate dr cluster %q: %s", env.C1.Name, err)
 		}
@@ -42,7 +42,7 @@ func TestValidation(dt *testing.T) {
 		t := test.WithLog(dt, Ctx.Logger())
 		t.Parallel()
 
-		err := validate.RamenDRClusterOperator(&Ctx, env.C2)
+		err := validate.RamenDRClusterOperator(Ctx, env.C2)
 		if err != nil {
 			t.Fatalf("Failed to validate dr cluster %q: %s", env.C2.Name, err)
 		}


### PR DESCRIPTION
main_test was implementing Context defined within TestContext struct. Moved to a package app, so that it can be re-used. 