### PR TITLE
e2e: update Workload interface

### DIFF
--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ramendr/ramen/e2e/config"
@@ -64,6 +65,12 @@ type Workload interface {
 	GetAppName() string
 	GetPath() string
 	GetBranch() string
+	// GetSelectResource returns the hook.selectResource of workload used. It can be either "deployment"
+	//  or "pod" or "statefulset" or any resource with the format "<apigroup>/<apiversion>/<kindplural>"
+	GetSelectResource() string
+	// GetLabelSelector returns the labelSelector to used for selecting the resources.
+	// This value is made use during preparation of hooks used in recipe.
+	GetLabelSelector() *metav1.LabelSelector
 	Health(ctx TestContext, cluster *Cluster) error
 	Status(ctx TestContext) ([]WorkloadStatus, error)
 }

--- a/e2e/workloads/deploy.go
+++ b/e2e/workloads/deploy.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/ramendr/ramen/e2e/config"
@@ -16,10 +17,11 @@ import (
 )
 
 const (
-	deploymentName    = "deploy"
-	deploymentAppName = "busybox"
-	deploymentPath    = "workloads/deployment/base"
-	deploymentPVCName = "busybox-pvc"
+	deploymentName           = "deploy"
+	deploymentAppName        = "busybox"
+	deploymentPath           = "workloads/deployment/base"
+	deploymentPVCName        = "busybox-pvc"
+	deploymentSelectResource = "deployment"
 
 	//nolint:lll
 	// deploymentMinimumReplicasAvailable is added in a deployment when it has its minimum replicas required available.
@@ -55,6 +57,14 @@ func (w Deployment) GetPath() string {
 
 func (w Deployment) GetBranch() string {
 	return w.Branch
+}
+
+func (w Deployment) GetSelectResource() string {
+	return deploymentSelectResource
+}
+
+func (w Deployment) GetLabelSelector() *metav1.LabelSelector {
+	return &metav1.LabelSelector{MatchLabels: map[string]string{"appname": deploymentAppName}}
 }
 
 func (w Deployment) Kustomize() string {

--- a/e2e/workloads/vm.go
+++ b/e2e/workloads/vm.go
@@ -8,6 +8,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	virtv1 "kubevirt.io/api/core/v1"
 
@@ -50,6 +51,14 @@ func (w *VM) GetPath() string {
 
 func (w *VM) GetBranch() string {
 	return w.Branch
+}
+
+func (w *VM) GetSelectResource() string {
+	return "kubevirt.io/v1/virtualmachines"
+}
+
+func (w *VM) GetLabelSelector() *metav1.LabelSelector {
+	return &metav1.LabelSelector{MatchLabels: map[string]string{"appname": vmAppName}}
 }
 
 func (w *VM) Kustomize() string {


### PR DESCRIPTION
Add GetSelectResource() and GetLabelName() to the Workload. 
Recipe have check hooks and exec hooks supported. Check hooks are for checking/validating conditions of the mentioned resources and given condition. Similarly for exec hooks, the specified commands are executed on the pod(s).

hook.selectResourceType can have values pod, deployment, statefulset or any custom resource in the format `<apiGroup>/<apiVersion>/<resourceNamePlural>`. Currently, supported workload is of type deployment in e2e. 

This PR will be used in https://github.com/RamenDR/ramen/pull/2223 