### PR TITLE
e2e: move log file from test to app package

### DIFF
--- a/e2e/app/log.go
+++ b/e2e/app/log.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: The RamenDR authors
 // SPDX-License-Identifier: Apache-2.0
 
-package test
+package app
 
 import (
 	"os"

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/deployers"
 	"github.com/ramendr/ramen/e2e/env"
-	"github.com/ramendr/ramen/e2e/test"
 	"github.com/ramendr/ramen/e2e/util"
 	"github.com/ramendr/ramen/e2e/workloads"
 )
@@ -37,7 +36,7 @@ func testMain(m *testing.M) int {
 	flag.StringVar(&logFile, "logfile", "ramen-e2e.log", "e2e log file")
 	flag.Parse()
 
-	log, err := test.CreateLogger(logFile)
+	log, err := app.CreateLogger(logFile)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
As the log creation binds more to application, moving log from test package to app package.