### PR TITLE
Add helper function to print unified diff

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -7,6 +7,7 @@ go 1.24.0
 toolchain go1.24.5
 
 require (
+	github.com/aymanbagabas/go-udiff v0.3.1
 	github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929
 	github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567
 	github.com/spf13/viper v1.19.0

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -4,6 +4,8 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
+github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=

--- a/e2e/helpers/helpers.go
+++ b/e2e/helpers/helpers.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+// package helpers provides testing helper functions.
+package helpers
+
+import (
+	"testing"
+
+	"github.com/aymanbagabas/go-udiff"
+	"sigs.k8s.io/yaml"
+)
+
+func MarshalYAML(t *testing.T, a any) string {
+	t.Helper()
+
+	data, err := yaml.Marshal(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return string(data)
+}
+
+func UnifiedDiff(t *testing.T, expected, actual any) string {
+	t.Helper()
+
+	expectedString := marshal(t, expected)
+	actualString := marshal(t, actual)
+
+	return udiff.Unified("expected", "actual", expectedString, actualString)
+}
+
+func marshal(t *testing.T, obj any) string {
+	t.Helper()
+
+	if s, ok := obj.(string); ok {
+		return s
+	}
+
+	return MarshalYAML(t, obj)
+}

--- a/e2e/helpers/helpers_test.go
+++ b/e2e/helpers/helpers_test.go
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package helpers_test
+
+import (
+	"testing"
+
+	"github.com/ramendr/ramen/e2e/config"
+	"github.com/ramendr/ramen/e2e/helpers"
+)
+
+func TestUnifiedDiff(t *testing.T) {
+	t.Run("strings", func(t *testing.T) {
+		a := `line 1
+line 2
+`
+		b := `line 1
+modified
+`
+		actualDiff := helpers.UnifiedDiff(t, a, b)
+
+		expectedDiff := `--- expected
++++ actual
+@@ -1,2 +1,2 @@
+ line 1
+-line 2
++modified
+`
+		if actualDiff != expectedDiff {
+			t.Fatalf("expected:\n%s\ngot:\n%s", expectedDiff, actualDiff)
+		}
+	})
+
+	t.Run("equal objects", func(t *testing.T) {
+		a := config.PVCSpec{
+			Name:             "rbd",
+			StorageClassName: "rbd-ceph-block",
+			AccessModes:      "ReadWriteOnce",
+		}
+		b := a
+
+		actualDiff := helpers.UnifiedDiff(t, a, b)
+
+		expectedDiff := ""
+
+		if actualDiff != expectedDiff {
+			t.Fatalf("expected:\n%s\ngot:\n%s", expectedDiff, actualDiff)
+		}
+	})
+
+	t.Run("different objects", func(t *testing.T) {
+		a := config.PVCSpec{
+			Name:             "rbd",
+			StorageClassName: "rbd-ceph-block",
+			AccessModes:      "ReadWriteOnce",
+		}
+		b := a
+		b.StorageClassName = "rbd-cephfs"
+
+		actualDiff := helpers.UnifiedDiff(t, a, b)
+
+		expectedDiff := `--- expected
++++ actual
+@@ -1,3 +1,3 @@
+ accessModes: ReadWriteOnce
+ name: rbd
+-storageClassName: rbd-ceph-block
++storageClassName: rbd-cephfs
+`
+
+		if actualDiff != expectedDiff {
+			t.Fatalf("expected:\n%s\ngot:\n%s", expectedDiff, actualDiff)
+		}
+	})
+
+	t.Run("nill", func(t *testing.T) {
+		a := config.PVCSpec{
+			Name:             "rbd",
+			StorageClassName: "rbd-ceph-block",
+			AccessModes:      "ReadWriteOnce",
+		}
+		actualDiff := helpers.UnifiedDiff(t, &a, nil)
+
+		expectedDiff := `--- expected
++++ actual
+@@ -1,3 +1 @@
+-accessModes: ReadWriteOnce
+-name: rbd
+-storageClassName: rbd-ceph-block
++null
+`
+		if actualDiff != expectedDiff {
+			t.Fatalf("expected:\n%s\ngot:\n%s", expectedDiff, actualDiff)
+		}
+	})
+}


### PR DESCRIPTION
When recipe generation tests are run, unified diff will help finding
the exact differences and fixing the issues. Hence, adding the implementation
and also minimal tests for the same.

This will be consumed in https://github.com/RamenDR/ramen/pull/2223