### PR TITLE
Validate kubevirt-velero-plugin is enabled to ensure VM resource protection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,9 @@ test-vrg-vs: generate manifests envtest ## Run VolumeReplicationGroupVolSync tes
 test-vrg-recipe: generate manifests envtest ## Run VolumeReplicationGroupRecipe tests.
 	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupRecipe
 
+test-vrg-vmrecipe: generate manifests envtest
+	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus VolumeReplicationGroupVMRecipe
+
 test-vrg-kubeobjects: generate manifests envtest ## Run VolumeReplicationGroupKubeObjects tests.
 	 go test ./internal/controller -coverprofile cover.out  -ginkgo.focus VRG_KubeObjectProtection
 

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -1404,9 +1404,6 @@ func (r *DRPlacementControlReconciler) updateResourceCondition(
 		ProtectedPVCs:   extractProtectedPVCNames(vrg),
 	}
 
-	drpc.Status.ResourceConditions.Conditions = assignConditionsWithConflictCheck(
-		vrgs, vrg, VRGConditionTypeNoClusterDataConflict)
-
 	if vrg.Status.PVCGroups != nil {
 		drpc.Status.ResourceConditions.ResourceMeta.PVCGroups = vrg.Status.PVCGroups
 	}
@@ -1421,7 +1418,7 @@ func (r *DRPlacementControlReconciler) updateResourceCondition(
 		drpc.Status.LastKubeObjectProtectionTime = &vrg.Status.KubeObjectProtection.CaptureToRecoverFrom.EndTime
 	}
 
-	updateDRPCProtectedCondition(drpc, vrg, clusterName)
+	updateDRPCProtectedCondition(drpc, vrg, clusterName, vrgs)
 }
 
 // getVRG retrieves a VRG either from the provided map or fetches it from the managed cluster/S3 store.
@@ -1480,85 +1477,6 @@ func extractProtectedPVCNames(vrg *rmn.VolumeReplicationGroup) []string {
 	}
 
 	return protectedPVCs
-}
-
-// findConflictCondition selects the appropriate condition from VRGs based on the conflict type.
-func findConflictCondition(vrgs map[string]*rmn.VolumeReplicationGroup, conflictType string) *metav1.Condition {
-	var selectedCondition *metav1.Condition
-
-	for _, vrg := range vrgs {
-		condition := meta.FindStatusCondition(vrg.Status.Conditions, conflictType)
-		if condition != nil && condition.Status == metav1.ConditionFalse {
-			// Prioritize primary VRG's condition if available
-			if isVRGPrimary(vrg) {
-				return condition // Exit early if primary VRG condition is found
-			}
-
-			// Assign the first non-primary VRG's condition if no primary found yet
-			if selectedCondition == nil {
-				selectedCondition = condition
-			}
-		}
-	}
-
-	return selectedCondition
-}
-
-// assignConditionsWithConflictCheck assigns conditions from a given VRG while prioritizing conflict conditions.
-func assignConditionsWithConflictCheck(vrgs map[string]*rmn.VolumeReplicationGroup,
-	vrg *rmn.VolumeReplicationGroup, conflictType string,
-) []metav1.Condition {
-	conditions := &vrg.Status.Conditions
-	conflictCondition := findConflictCondition(vrgs, conflictType)
-
-	// Ensure the conflict condition is present in the conditions list
-	if conflictCondition != nil {
-		setConflictStatusCondition(conditions, *conflictCondition)
-	}
-
-	return *conditions
-}
-
-func setConflictStatusCondition(existingConditions *[]metav1.Condition,
-	newCondition metav1.Condition,
-) metav1.Condition {
-	if existingConditions == nil {
-		existingConditions = &[]metav1.Condition{}
-	}
-
-	existingCondition := rmnutil.FindCondition(*existingConditions, newCondition.Type)
-	if existingCondition == nil {
-		newCondition.LastTransitionTime = metav1.NewTime(time.Now())
-		*existingConditions = append(*existingConditions, newCondition)
-
-		return newCondition
-	}
-
-	if existingCondition.Status != newCondition.Status ||
-		existingCondition.Reason != newCondition.Reason {
-		existingCondition.Status = newCondition.Status
-		existingCondition.Reason = newCondition.Reason
-		existingCondition.LastTransitionTime = metav1.NewTime(time.Now())
-	}
-
-	defaultValue := "none"
-	if newCondition.Reason == "" {
-		newCondition.Reason = defaultValue
-	}
-
-	if newCondition.Message == "" {
-		newCondition.Message = defaultValue
-	}
-
-	existingCondition.Reason = newCondition.Reason
-	existingCondition.Message = newCondition.Message
-	// TODO: Why not update lastTranTime if the above change?
-
-	if existingCondition.ObservedGeneration != newCondition.ObservedGeneration {
-		existingCondition.LastTransitionTime = metav1.NewTime(time.Now())
-	}
-
-	return *existingCondition
 }
 
 // clusterForVRGStatus determines which cluster's VRG should be inspected for status updates to DRPC

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -579,6 +579,16 @@ func (v *VRGInstance) processVRG() ctrl.Result {
 
 	v.log.Info("Recipe", "elements", v.recipeElements)
 
+	if err := recipeVMBackupValidate(v.ctx, v.reconciler.Client, v.recipeElements,
+		*v.instance, *v.ramenConfig, v.log); err != nil {
+		return v.invalid(
+			err,
+			"Velero misconfiguration detected; disaster recovery for the VM workload will not succeed. "+
+				"Verify Velero configuration and enable the required plugins",
+			false,
+		)
+	}
+
 	if err := v.updatePVCList(); err != nil {
 		return v.invalid(err, "Failed to process list of PVCs to protect", true)
 	}


### PR DESCRIPTION
This PR introduces validation logic to ensure that the kubevirt-velero-plugin is properly enabled and configured in the Velero deployment for Disaster Recovery (DR) protection of VirtualMachines using the internal recipe vm-recipe. The plugin is essential for enabling backup and restore operations for KubeVirt-managed VirtualMachines (VMs), DataVolumes (DVs), PersistentVolumeClaims (PVCs), and associated resources.

Key changes:
1. Added checks to confirm that the kubevirt-velero-plugin is present and correctly configured in Velero.
2. Introduced unit tests to validate the correctness of the new logic.
3. Added a new test rule in the Makefile to run tests specific to the vm-recipe.

Fixes: [2313](https://github.com/RamenDR/ramen/issues/2313)