### PR TITLE
Remove PVC from protected list when VGR owner label is removed from it

### DIFF
--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -93,14 +93,6 @@ func (v *VRGInstance) reconcileVolGroupRepsAsSecondary(requeue *bool,
 
 		if v.undoPVCFinalizersAndPVRetentionForVGR(vgrNamespacedName, pvcs, log) {
 			*requeue = true
-
-			continue
-		}
-
-		for idx := range pvcs {
-			pvc := pvcs[idx]
-
-			v.pvcStatusDeleteIfPresent(pvc.Namespace, pvc.Name, log)
 		}
 	}
 }

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -205,11 +205,7 @@ func (v *VRGInstance) reconcileVolRepsAsSecondary() bool {
 
 		if v.undoPVCFinalizersAndPVRetention(pvc, log) {
 			requeue = true
-
-			continue
 		}
-
-		v.pvcStatusDeleteIfPresent(pvc.Namespace, pvc.Name, log)
 	}
 
 	v.reconcileVolGroupRepsAsSecondary(&requeue, groupPVCs)
@@ -565,6 +561,8 @@ func (v *VRGInstance) preparePVCForVRDeletion(pvc *corev1.PersistentVolumeClaim,
 			pvc.Namespace, pvc.Name, v.instance.Namespace, v.instance.Name, err)
 	}
 
+	v.pvcStatusDeleteIfPresent(pvc.Namespace, pvc.Name, log)
+
 	log1.Info("Deleted ramen annotations, labels, and finallizers from PersistentVolumeClaim",
 		"annotations", pvc.GetAnnotations(), "labels", pvc.GetLabels(), "finalizers", pvc.GetFinalizers())
 
@@ -877,12 +875,6 @@ func (v *VRGInstance) pvcUnprotectVolRep(pvc corev1.PersistentVolumeClaim, log l
 	} else {
 		v.pvcsUnprotectVolRep([]corev1.PersistentVolumeClaim{pvc})
 	}
-
-	if v.result.Requeue {
-		return
-	}
-
-	v.pvcStatusDeleteIfPresent(pvc.Namespace, pvc.Name, log)
 }
 
 //nolint:funlen,gocognit,cyclop


### PR DESCRIPTION
The problem: In the current pvcUnprotectVolRep implementation, we remove Ramen annotations/labels/finalizers (including owner label) from the PVC, but if Requeue flag is already true, we skip removing that PVC from the VRG’s ProtectedPVCs list. This leaves a stale entry that persists indefinitely. 

The fix: perform both steps together—once the owner label is gone, also remove the PVC from ProtectedPVCs so no orphans remain.