### PR TITLE
Improve logging in VolumeReplicationGroup controller

### DIFF
--- a/internal/controller/util/pvcs_util.go
+++ b/internal/controller/util/pvcs_util.go
@@ -81,8 +81,6 @@ func ListPVCsByPVCSelector(
 		updatedPVCSelector = updatedPVCSelector.Add(*notCreatedByRamen)
 	}
 
-	logger.Info("Fetching PersistentVolumeClaims", "pvcSelector", updatedPVCSelector)
-
 	listOptions := []client.ListOption{
 		client.MatchingLabelsSelector{
 			Selector: updatedPVCSelector,
@@ -96,8 +94,6 @@ func ListPVCsByPVCSelector(
 		return nil, fmt.Errorf("failed to list PersistentVolumeClaims, %w", err)
 	}
 
-	logger.Info(fmt.Sprintf("Found %d PVCs using label selector %v", len(pvcList.Items), updatedPVCSelector))
-
 	var pvcs []corev1.PersistentVolumeClaim
 
 	for _, pvc := range pvcList.Items {
@@ -106,7 +102,8 @@ func ListPVCsByPVCSelector(
 		}
 	}
 
-	logger.Info(fmt.Sprintf("Returning %d PVCs in namespace(s) %v", len(pvcs), namespaces))
+	logger.Info(fmt.Sprintf("Found %d PVCs using label selector %v in namespace(s) %v",
+		len(pvcs), updatedPVCSelector, namespaces))
 
 	pvcList.Items = pvcs
 

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -226,7 +226,8 @@ func pvcPredicateFunc() predicate.Funcs {
 	pvcPredicate := predicate.Funcs{
 		// NOTE: Create predicate is retained, to help with logging the event
 		CreateFunc: func(e event.CreateEvent) bool {
-			log.Info("Create event for PersistentVolumeClaim")
+			o := e.Object
+			log.Info("Create event for PVC", "namespace", o.GetNamespace(), "name", o.GetName())
 
 			return true
 		},
@@ -245,13 +246,13 @@ func pvcPredicateFunc() predicate.Funcs {
 				return false
 			}
 
-			log.Info("Update event for PersistentVolumeClaim")
+			log.Info("Update event for PVC", "namespace", oldPVC.GetNamespace(), "name", oldPVC.GetName())
 
 			return updateEventDecision(oldPVC, newPVC, log)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			o := e.Object
-			log.Info("PVC Delete", "namespace", o.GetNamespace(), "name", o.GetName())
+			log.Info("Delete event for PVC", "namespace", o.GetNamespace(), "name", o.GetName())
 
 			return true
 		},

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1070,8 +1070,6 @@ func (v *VRGInstance) validateSyncPVCs(pvcList *corev1.PersistentVolumeClaimList
 }
 
 func (v *VRGInstance) separatePVCsUsingOnlySC(storageClass *storagev1.StorageClass, pvc *corev1.PersistentVolumeClaim) {
-	v.log.Info("separating PVC using only sc provisioner")
-
 	replicationClassMatchFound := false
 
 	pvcEnabledForVolSync := util.IsPVCMarkedForVolSync(v.instance.GetAnnotations())
@@ -1097,8 +1095,6 @@ func (v *VRGInstance) separatePVCsUsingOnlySC(storageClass *storagev1.StorageCla
 func (v *VRGInstance) separatePVCUsingPeerClassAndSC(peerClasses []ramendrv1alpha1.PeerClass,
 	storageClass *storagev1.StorageClass, pvc *corev1.PersistentVolumeClaim,
 ) error {
-	v.log.Info("separate PVC using peerClasses")
-
 	peerClass, err := v.findPeerClassMatchingSC(storageClass, peerClasses, pvc)
 	if err != nil {
 		return err

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -2070,13 +2070,11 @@ func (v *VRGInstance) updateProtectedCGsForVolRep(pvcGroups *[]ramendrv1alpha1.G
 }
 
 func (v *VRGInstance) logAndSetConditions(conditionName string, subconditions ...*metav1.Condition) {
-	msg := fmt.Sprintf("merging %s condition", conditionName)
-	v.log.Info(msg, "subconditions", subconditions)
 	finalCondition := util.MergeConditions(util.SetStatusCondition,
 		&v.instance.Status.Conditions,
 		[]string{VRGConditionReasonUnused},
 		subconditions...)
-	msg = fmt.Sprintf("updated %s status to %s", conditionName, finalCondition.Status)
+	msg := fmt.Sprintf("updated %s status to %s", conditionName, finalCondition.Status)
 	v.log.Info(msg, "finalCondition", finalCondition)
 }
 

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -383,8 +383,6 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 		// this. If not found, then reconcile request would not be sent
 		selector, err := metav1.LabelSelectorAsSelector(&pvcSelector.LabelSelector)
 		if err != nil {
-			log1.Error(err, "Failed to get the label selector from VolumeReplicationGroup")
-
 			continue
 		}
 
@@ -2351,8 +2349,6 @@ func (r *VolumeReplicationGroupReconciler) VGRMapFunc(ctx context.Context, obj c
 
 	vgr, ok := obj.(*volrep.VolumeGroupReplication)
 	if !ok {
-		log.Info("map function received non-vgr resource")
-
 		return []reconcile.Request{}
 	}
 
@@ -2462,8 +2458,6 @@ func (r *VolumeReplicationGroupReconciler) VRMapFunc(ctx context.Context, obj cl
 
 	vr, ok := obj.(*volrep.VolumeReplication)
 	if !ok {
-		log.Info("map function received non-vr resource")
-
 		return []reconcile.Request{}
 	}
 
@@ -2476,8 +2470,6 @@ func (r *VolumeReplicationGroupReconciler) RDMapFunc(ctx context.Context, obj cl
 
 	rd, ok := obj.(*volsyncv1alpha1.ReplicationDestination)
 	if !ok {
-		log.Info("map function received not a replication destination resource")
-
 		return []reconcile.Request{}
 	}
 
@@ -2490,8 +2482,6 @@ func (r *VolumeReplicationGroupReconciler) RSMapFunc(ctx context.Context, obj cl
 
 	rs, ok := obj.(*volsyncv1alpha1.ReplicationSource)
 	if !ok {
-		log.Info("map function received not a replication source resource")
-
 		return []reconcile.Request{}
 	}
 
@@ -2504,8 +2494,6 @@ func (r *VolumeReplicationGroupReconciler) RGDMapFunc(ctx context.Context, obj c
 
 	rgd, ok := obj.(*ramendrv1alpha1.ReplicationGroupDestination)
 	if !ok {
-		log.Info("map function received not a replication group destination resource")
-
 		return []reconcile.Request{}
 	}
 
@@ -2518,8 +2506,6 @@ func (r *VolumeReplicationGroupReconciler) RGSMapFunc(ctx context.Context, obj c
 
 	rgs, ok := obj.(*ramendrv1alpha1.ReplicationGroupSource)
 	if !ok {
-		log.Info("map function received not a replication group source resource")
-
 		return []reconcile.Request{}
 	}
 

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -231,7 +231,8 @@ func pvcPredicateFunc() predicate.Funcs {
 	pvcPredicate := predicate.Funcs{
 		// NOTE: Create predicate is retained, to help with logging the event
 		CreateFunc: func(e event.CreateEvent) bool {
-			log.Info("Create event for PersistentVolumeClaim")
+			o := e.Object
+			log.Info("Create event for PVC", "namespace", o.GetNamespace(), "name", o.GetName())
 
 			return true
 		},
@@ -250,13 +251,13 @@ func pvcPredicateFunc() predicate.Funcs {
 				return false
 			}
 
-			log.Info("Update event for PersistentVolumeClaim")
+			log.Info("Update event for PVC", "namespace", oldPVC.GetNamespace(), "name", oldPVC.GetName())
 
 			return updateEventDecision(oldPVC, newPVC, log)
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			o := e.Object
-			log.Info("PVC Delete", "namespace", o.GetNamespace(), "name", o.GetName())
+			log.Info("Delete event for PVC", "namespace", o.GetNamespace(), "name", o.GetName())
 
 			return true
 		},

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -2097,13 +2097,11 @@ func (v *VRGInstance) updateProtectedCGsForVolRep(pvcGroups *[]ramendrv1alpha1.G
 }
 
 func (v *VRGInstance) logAndSetConditions(conditionName string, subconditions ...*metav1.Condition) {
-	msg := fmt.Sprintf("merging %s condition", conditionName)
-	v.log.Info(msg, "subconditions", subconditions)
 	finalCondition := util.MergeConditions(util.SetStatusCondition,
 		&v.instance.Status.Conditions,
 		[]string{VRGConditionReasonUnused},
 		subconditions...)
-	msg = fmt.Sprintf("updated %s status to %s", conditionName, finalCondition.Status)
+	msg := fmt.Sprintf("updated %s status to %s", conditionName, finalCondition.Status)
 	v.log.Info(msg, "finalCondition", finalCondition)
 }
 

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1076,8 +1076,6 @@ func (v *VRGInstance) validateSyncPVCs(pvcList *corev1.PersistentVolumeClaimList
 }
 
 func (v *VRGInstance) separatePVCsUsingOnlySC(storageClass *storagev1.StorageClass, pvc *corev1.PersistentVolumeClaim) {
-	v.log.Info("separating PVC using only sc provisioner")
-
 	replicationClassMatchFound := false
 
 	pvcEnabledForVolSync := util.IsPVCMarkedForVolSync(v.instance.GetAnnotations())
@@ -1103,8 +1101,6 @@ func (v *VRGInstance) separatePVCsUsingOnlySC(storageClass *storagev1.StorageCla
 func (v *VRGInstance) separatePVCUsingPeerClassAndSC(peerClasses []ramendrv1alpha1.PeerClass,
 	storageClass *storagev1.StorageClass, pvc *corev1.PersistentVolumeClaim,
 ) error {
-	v.log.Info("separate PVC using peerClasses")
-
 	peerClass, err := v.findPeerClassMatchingSC(storageClass, peerClasses, pvc)
 	if err != nil {
 		return err

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -388,8 +388,6 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 		// this. If not found, then reconcile request would not be sent
 		selector, err := metav1.LabelSelectorAsSelector(&pvcSelector.LabelSelector)
 		if err != nil {
-			log1.Error(err, "Failed to get the label selector from VolumeReplicationGroup")
-
 			continue
 		}
 
@@ -2378,8 +2376,6 @@ func (r *VolumeReplicationGroupReconciler) VGRMapFunc(ctx context.Context, obj c
 
 	vgr, ok := obj.(*volrep.VolumeGroupReplication)
 	if !ok {
-		log.Info("map function received non-vgr resource")
-
 		return []reconcile.Request{}
 	}
 
@@ -2489,8 +2485,6 @@ func (r *VolumeReplicationGroupReconciler) VRMapFunc(ctx context.Context, obj cl
 
 	vr, ok := obj.(*volrep.VolumeReplication)
 	if !ok {
-		log.Info("map function received non-vr resource")
-
 		return []reconcile.Request{}
 	}
 
@@ -2503,8 +2497,6 @@ func (r *VolumeReplicationGroupReconciler) RDMapFunc(ctx context.Context, obj cl
 
 	rd, ok := obj.(*volsyncv1alpha1.ReplicationDestination)
 	if !ok {
-		log.Info("map function received not a replication destination resource")
-
 		return []reconcile.Request{}
 	}
 
@@ -2517,8 +2509,6 @@ func (r *VolumeReplicationGroupReconciler) RSMapFunc(ctx context.Context, obj cl
 
 	rs, ok := obj.(*volsyncv1alpha1.ReplicationSource)
 	if !ok {
-		log.Info("map function received not a replication source resource")
-
 		return []reconcile.Request{}
 	}
 
@@ -2531,8 +2521,6 @@ func (r *VolumeReplicationGroupReconciler) RGDMapFunc(ctx context.Context, obj c
 
 	rgd, ok := obj.(*ramendrv1alpha1.ReplicationGroupDestination)
 	if !ok {
-		log.Info("map function received not a replication group destination resource")
-
 		return []reconcile.Request{}
 	}
 
@@ -2545,8 +2533,6 @@ func (r *VolumeReplicationGroupReconciler) RGSMapFunc(ctx context.Context, obj c
 
 	rgs, ok := obj.(*ramendrv1alpha1.ReplicationGroupSource)
 	if !ok {
-		log.Info("map function received not a replication group source resource")
-
 		return []reconcile.Request{}
 	}
 

--- a/internal/controller/vrg_status_pvcs.go
+++ b/internal/controller/vrg_status_pvcs.go
@@ -67,8 +67,6 @@ func (v *VRGInstance) vrgStatusPvcNamespacesSetIfUnset() {
 		log := v.log.WithValues("PVC", pvc.Name)
 
 		if pvc.Namespace != "" {
-			log.V(1).Info("VRG status PVC namespace set already", "namespace", pvc.Namespace)
-
 			continue
 		}
 

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -1692,9 +1692,6 @@ func (v *VRGInstance) selectVolumeReplicationClass(
 
 		return nil, fmt.Errorf("no %s found to match provisioner and schedule", objType)
 	case 1:
-		v.log.Info(fmt.Sprintf("Found %s that matches provisioner and schedule %s/%s", objType,
-			storageClass.Provisioner, v.instance.Spec.Async.SchedulingInterval))
-
 		return matchingReplicationClassList[0], nil
 	}
 

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -1696,9 +1696,6 @@ func (v *VRGInstance) selectVolumeReplicationClass(
 
 		return nil, fmt.Errorf("no %s found to match provisioner and schedule", objType)
 	case 1:
-		v.log.Info(fmt.Sprintf("Found %s that matches provisioner and schedule %s/%s", objType,
-			storageClass.Provisioner, v.instance.Spec.Async.SchedulingInterval))
-
 		return matchingReplicationClassList[0], nil
 	}
 


### PR DESCRIPTION
Remove noisy/non-informative logs, add context to critical log entries, and log at a higher scope than PVC to avoid repeated lines.