### PR TITLE
s3utils: Remove DisableSSL option

### DIFF
--- a/api/v1alpha1/ramenconfig_types.go
+++ b/api/v1alpha1/ramenconfig_types.go
@@ -57,7 +57,9 @@ type S3StoreProfile struct {
 	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
 	S3Bucket string `json:"s3Bucket"`
 
-	// S3 compatible endpoint of the object store of this S3 profile
+	// S3CompatibleEndpoint is the object store endpoint for this S3 profile.
+	// If the scheme is not specified, "https://" is assumed. Using "http://"
+	// is insecure and should be used for testing purposes only.
 	S3CompatibleEndpoint string `json:"s3CompatibleEndpoint"`
 
 	// S3 Region; the AWS go client SDK does not have a default region; hence,

--- a/internal/controller/s3utils.go
+++ b/internal/controller/s3utils.go
@@ -140,7 +140,6 @@ func (s3ObjectStoreGetter) ObjectStore(ctx context.Context,
 			string(secretAccessKey), ""),
 		Endpoint:         aws.String(s3Endpoint),
 		Region:           aws.String(s3Region),
-		DisableSSL:       aws.Bool(true),
 		S3ForcePathStyle: aws.Bool(true),
 	})
 	if err != nil {


### PR DESCRIPTION
This option is poorly documented, confusing, and unneeded. Remove it and improve documentation of ramen config S3CompatibleEndpoint.

The DisableSSL option does not disable SSL and does not disable server certificate verification. The purpose of this option is to use "http://" by default if the endpoint does not specify a scheme. Without this option, "https://" is assumed. Users have no reason to specify an endpoint without a scheme, so this option is unneeded. It was removed in aws-sdk-go-v2.

Regardless of this option, both "https://" and "http://" scheme are supported, so this does not affect our testing environment using "http://".