### PR TITLE
e2e: update workload interface

### DIFF
--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -6,6 +6,7 @@ package types
 import (
 	"context"
 
+	recipe "github.com/ramendr/recipe/api/v1alpha1"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,6 +58,7 @@ type Deployer interface {
 	WaitForResourcesDelete(TestContext) error
 }
 
+// nolint:interfacebloat
 type Workload interface {
 	// Can differ based on the workload, hence part of the Workload interface
 	Kustomize() string
@@ -71,6 +73,10 @@ type Workload interface {
 	// GetLabelSelector returns the labelSelector to used for selecting the resources.
 	// This value is made use during preparation of hooks used in recipe.
 	GetLabelSelector() *metav1.LabelSelector
+	// GetChecks returns the check hook to be executed based on workload and given namespace.
+	GetChecks(string) []*recipe.Check
+	// GetOperations returns the exec hook to be executed based on workload and given namespace.
+	GetOperations(string) []*recipe.Operation
 	Health(ctx TestContext, cluster *Cluster) error
 	Status(ctx TestContext) ([]WorkloadStatus, error)
 }

--- a/e2e/workloads/deploy.go
+++ b/e2e/workloads/deploy.go
@@ -6,6 +6,7 @@ package workloads
 import (
 	"fmt"
 
+	recipe "github.com/ramendr/recipe/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -65,6 +66,24 @@ func (w Deployment) GetSelectResource() string {
 
 func (w Deployment) GetLabelSelector() *metav1.LabelSelector {
 	return &metav1.LabelSelector{MatchLabels: map[string]string{"appname": deploymentAppName}}
+}
+
+func (w Deployment) GetChecks(namespace string) []*recipe.Check {
+	return []*recipe.Check{
+		{
+			Name:      "check-replicas",
+			Condition: "{$.spec.replicas} == {$.status.readyReplicas}",
+		},
+	}
+}
+
+func (w Deployment) GetOperations(namespace string) []*recipe.Operation {
+	return []*recipe.Operation{
+		{
+			Name:    "ls",
+			Command: "/bin/sh -c ls",
+		},
+	}
 }
 
 func (w Deployment) Kustomize() string {

--- a/e2e/workloads/vm.go
+++ b/e2e/workloads/vm.go
@@ -6,6 +6,7 @@ package workloads
 import (
 	"fmt"
 
+	recipe "github.com/ramendr/recipe/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,6 +60,16 @@ func (w *VM) GetSelectResource() string {
 
 func (w *VM) GetLabelSelector() *metav1.LabelSelector {
 	return &metav1.LabelSelector{MatchLabels: map[string]string{"appname": vmAppName}}
+}
+
+// TODO: To be implemented according to the VM workload
+func (w *VM) GetChecks(namespace string) []*recipe.Check {
+	return nil
+}
+
+// TODO: To be implemented according to the VM workload
+func (w *VM) GetOperations(namespace string) []*recipe.Operation {
+	return nil
 }
 
 func (w *VM) Kustomize() string {


### PR DESCRIPTION
As the workloads are responsible for the resources that are deployed, GetCheckHook and GetExecHook functions are introduced which can be implemented as per the workload type i.e., deployment or vm or any other resource in the future.