### PR TITLE
Validate resource conflict irrespective of requeue status

### DIFF
--- a/api/v1alpha1/ramenconfig_types.go
+++ b/api/v1alpha1/ramenconfig_types.go
@@ -57,7 +57,9 @@ type S3StoreProfile struct {
 	// https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
 	S3Bucket string `json:"s3Bucket"`
 
-	// S3 compatible endpoint of the object store of this S3 profile
+	// S3CompatibleEndpoint is the object store endpoint for this S3 profile.
+	// If the scheme is not specified, "https://" is assumed. Using "http://"
+	// is insecure and should be used for testing purposes only.
 	S3CompatibleEndpoint string `json:"s3CompatibleEndpoint"`
 
 	// S3 Region; the AWS go client SDK does not have a default region; hence,

--- a/internal/controller/s3utils.go
+++ b/internal/controller/s3utils.go
@@ -140,7 +140,6 @@ func (s3ObjectStoreGetter) ObjectStore(ctx context.Context,
 			string(secretAccessKey), ""),
 		Endpoint:         aws.String(s3Endpoint),
 		Region:           aws.String(s3Region),
-		DisableSSL:       aws.Bool(true),
 		S3ForcePathStyle: aws.Bool(true),
 	})
 	if err != nil {

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1678,7 +1678,7 @@ func (v *VRGInstance) reconcileAsSecondary() ctrl.Result {
 		v.instance.Status.Conditions = []metav1.Condition{}
 	}
 
-	if !result.Requeue && v.isVMRecipeProtection() {
+	if v.isVMRecipeProtection() {
 		if err := v.validateVMsForStandaloneProtection(); err != nil {
 			result.Requeue = true
 		}


### PR DESCRIPTION
This PR introduces logic to validate resource conflicts across peer clusters prior to stopping reconciliation of the secondary VolumeReplicationGroup (VRG)—such as overlapping PVC or VM—are detected and handled gracefully before reconciliation is paused.