### PR TITLE
util: update create namespace manifest

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -2031,7 +2031,8 @@ func (d *DRPCInstance) ensureNamespaceManifestWork(homeCluster string) error {
 		annotations[DRPCNameAnnotation] = d.instance.Name
 		annotations[DRPCNamespaceAnnotation] = d.instance.Namespace
 
-		err := d.mwu.CreateOrUpdateNamespaceManifest(d.instance.Name, d.vrgNamespace, homeCluster, annotations)
+		err := d.mwu.CreateOrUpdateNamespaceManifest(d.instance.Name, d.vrgNamespace, homeCluster, annotations,
+			map[string]string{})
 		if err != nil {
 			return fmt.Errorf("failed to create namespace '%s' on cluster %s: %w", d.vrgNamespace, homeCluster, err)
 		}

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -2623,7 +2623,7 @@ func adoptOrphanVRG(
 	annotations[DRPCNamespaceAnnotation] = drpc.Namespace
 
 	// Adopt the namespace as well
-	err := mwu.CreateOrUpdateNamespaceManifest(drpc.Name, vrgNamespace, cluster, annotations)
+	err := mwu.CreateOrUpdateNamespaceManifest(drpc.Name, vrgNamespace, cluster, annotations, map[string]string{})
 	if err != nil {
 		log.Info("error creating namespace via ManifestWork during adoption", "error", err, "cluster", cluster)
 

--- a/internal/controller/util/mw_util.go
+++ b/internal/controller/util/mw_util.go
@@ -353,7 +353,7 @@ func (mwu *MWUtil) IsManifestApplied(cluster, mwType string) bool {
 // Namespace MW creation
 func (mwu *MWUtil) CreateOrUpdateNamespaceManifest(
 	name string, namespaceName string, managedClusterNamespace string,
-	annotations map[string]string,
+	annotations map[string]string, labels map[string]string,
 ) error {
 	manifest, err := mwu.GenerateManifest(Namespace(namespaceName))
 	if err != nil {
@@ -368,7 +368,7 @@ func (mwu *MWUtil) CreateOrUpdateNamespaceManifest(
 	manifestWork := mwu.newManifestWork(
 		mwName,
 		managedClusterNamespace,
-		map[string]string{},
+		labels,
 		manifests,
 		annotations)
 
@@ -637,7 +637,8 @@ func (mwu *MWUtil) DeleteNamespaceManifestWork(clusterName string, annotations m
 	// if not set, call CreateOrUpdateNamespaceManifest such that it is
 	// updated with the delete option
 	if mw.Spec.DeleteOption == nil {
-		err = mwu.CreateOrUpdateNamespaceManifest(mwu.InstName, mwu.TargetNamespace, clusterName, annotations)
+		err = mwu.CreateOrUpdateNamespaceManifest(mwu.InstName, mwu.TargetNamespace, clusterName, annotations,
+			map[string]string{})
 		if err != nil {
 			mwu.Log.Info("error creating namespace via ManifestWork", "error", err, "cluster", clusterName)
 


### PR DESCRIPTION
Currently, creation of manifest work for namespace was not accepting labels. So, adding changes to include the labels which will help for creating namespaces for discovered apps when being enrolled. 

These changes will be used in the future PR and the usage steps will be:
1. Get the list of namespaces to be created on cluster c2. [drpc.ProtectedNamespaces]
2. Create ManagedClusterView for namespace on the homeCluster.
3. Remove the annotations and other uids which need not be copied to other cluster.
4. Create ManifestWork(s) for the namespaces.