### PR TITLE
drenv: Update flannel version to v0.27.0

### DIFF
--- a/test/drenv/providers/lima/k8s.yaml
+++ b/test/drenv/providers/lima/k8s.yaml
@@ -182,7 +182,7 @@ provision:
       kubectl scale deploy coredns -n kube-system --replicas=1
 
       # Installing a Pod network add-on
-      kubectl apply -f https://github.com/flannel-io/flannel/releases/download/v0.24.0/kube-flannel.yml
+      kubectl apply -f https://github.com/flannel-io/flannel/releases/download/v0.27.0/kube-flannel.yml
 
       # Control plane node isolation
       kubectl taint nodes --all node-role.kubernetes.io/control-plane-


### PR DESCRIPTION
Update flannel CNI plugin version from v0.24.0 to v0.27.0 to align with upstream Lima changes. 

Resolves #1704

- [ ] Test 