### PR TITLE
drenv: Fix disable port forwarding with lima 2.0

### DIFF
--- a/test/drenv/providers/lima/k8s.yaml
+++ b/test/drenv/providers/lima/k8s.yaml
@@ -31,6 +31,7 @@ portForwards:
   - ignore: true
     proto: any
     guestIP: "0.0.0.0"
+    guestIPMustBeZero: false
 
 param:
   # If set, allow acess to local insecure registry and use it as image


### PR DESCRIPTION
lima 2.0 changed the required configuration to disable port forwarding, breaking our k8s template[1]. Add the new required option `guestIPMustBeZero: false` to disable port forwarding.

[1] https://github.com/lima-vm/lima/issues/4403