### PR TITLE
drpc: fix race condition

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -363,8 +363,6 @@ func (d *DRPCInstance) RunFailover() (bool, error) {
 	if d.vrgExistsAndPrimary(failoverCluster) {
 		d.updatePreferredDecision()
 		d.setDRState(rmn.FailedOver)
-		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
-			metav1.ConditionTrue, string(d.instance.Status.Phase), "Completed")
 
 		if err := d.ensureVRGManifestWork(failoverCluster); err != nil {
 			d.log.Info("Unable to ensure VRG ManifestWork on failover cluster")
@@ -381,6 +379,9 @@ func (d *DRPCInstance) RunFailover() (bool, error) {
 
 			return !done, nil
 		}
+
+		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
+			metav1.ConditionTrue, string(d.instance.Status.Phase), "Completed")
 
 		return d.ensureFailoverActionCompleted(failoverCluster)
 	} else if yes, err := d.mwExistsAndPlacementUpdated(failoverCluster); yes || err != nil {


### PR DESCRIPTION
Issue is seen when before failover is complete, Available condition is set to true, which results removal of maintenance mode before all the PVCs are promoted. Updating the Available condition after checkForReadiness gives positive result.