### PR TITLE
Set DRPC status progression for discovered VM cleanup during relocate and failover operations

### DIFF
--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -100,6 +100,7 @@ const (
 	ProgressionCreatingMW                          = ProgressionStatus("CreatingMW")
 	ProgressionUpdatingPlRule                      = ProgressionStatus("UpdatingPlRule")
 	ProgressionWaitForReadiness                    = ProgressionStatus("WaitForReadiness")
+	ProgressionCleanupReadiness                    = ProgressionStatus("CleanupReadiness")
 	ProgressionCleaningUp                          = ProgressionStatus("Cleaning Up")
 	ProgressionWaitOnUserToCleanUp                 = ProgressionStatus("WaitOnUserToCleanUp")
 	ProgressionCheckingFailoverPrerequisites       = ProgressionStatus("CheckingFailoverPrerequisites")

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -238,11 +238,20 @@ rules:
 - apiGroups:
   - kubevirt.io
   resources:
+  - virtualmachineinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubevirt.io
+  resources:
   - virtualmachines
   verbs:
   - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - multicluster.x-k8s.io

--- a/internal/controller/util/vm_util.go
+++ b/internal/controller/util/vm_util.go
@@ -3,21 +3,24 @@ package util
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	virtv1 "kubevirt.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/ramendr/ramen/internal/controller/core"
 )
 
 const (
-	KindVirtualMachine = "VirtualMachine"
-	KubeVirtAPIVersion = "kubevirt.io/v1"
+	KindVirtualMachine       = "VirtualMachine"
+	KubeVirtAPIVersionPrefix = "kubevirt.io/" // prefix match on group; version follows (e.g., v1)
 )
 
 func ListVMsByLabelSelector(
@@ -64,37 +67,38 @@ func ListVMsByVMNamespace(
 	log logr.Logger,
 	vmNamespaceList []string,
 	vmList []string,
-) ([]string, error) {
-	var foundVMList []string
-
-	var notFoundErr error
-
-	foundVM := &virtv1.VirtualMachine{}
+) ([]virtv1.VirtualMachine, error) {
+	var foundVMs []virtv1.VirtualMachine
+	// Set to track seen (ns, name) pairs
+	seen := make(map[string]struct{}, len(vmNamespaceList)*len(vmList))
 
 	for _, ns := range vmNamespaceList {
 		for _, vm := range vmList {
-			vmLookUp := types.NamespacedName{Namespace: ns, Name: vm}
-			if err := apiReader.Get(ctx, vmLookUp, foundVM); err != nil {
-				if !k8serrors.IsNotFound(err) {
-					return nil, err
-				}
-
-				if notFoundErr == nil {
-					notFoundErr = err
-				}
-
+			foundVM := &virtv1.VirtualMachine{}
+			key := ns + "/" + vm
+			// Skip if we've already successfully added this (ns, name) pair
+			if _, already := seen[key]; already {
+				// Skip duplicates of the same (namespace, name)
 				continue
 			}
 
-			foundVMList = append(foundVMList, foundVM.Name)
+			vmLookUp := types.NamespacedName{Namespace: ns, Name: vm}
+			if err := apiReader.Get(ctx, vmLookUp, foundVM); err != nil {
+				if k8serrors.IsNotFound(err) {
+					continue
+				}
+
+				return nil, err
+			}
+
+			// Mark as seen only when it actually exists, to verify duplicate entries in the input spec
+			seen[key] = struct{}{}
+
+			foundVMs = append(foundVMs, *foundVM.DeepCopy())
 		}
 	}
 
-	if len(foundVMList) > 0 {
-		return foundVMList, nil
-	}
-
-	return nil, notFoundErr
+	return foundVMs, nil
 }
 
 // IsVMDeletionInProgress returns true if any listed KubeVirt VM within the given protected NS is in deletion state.
@@ -105,24 +109,18 @@ func IsVMDeletionInProgress(ctx context.Context,
 	vmNamespaceList []string,
 	log logr.Logger,
 ) bool {
-	log.Info("Checking if VirtualMachines are being deleted",
-		"vmCount", len(vmList),
-		"vmNames", vmList)
+	foundVMs, err := ListVMsByVMNamespace(ctx, k8sclient,
+		log, vmNamespaceList, vmList)
+	if err != nil {
+		// Skip and requeue for Get API errors
+		return true
+	}
 
-	foundVM := &virtv1.VirtualMachine{}
+	for _, vm := range foundVMs {
+		if !vm.GetDeletionTimestamp().IsZero() {
+			log.Info("VM deletion is in progress", "VM", vm)
 
-	for _, ns := range vmNamespaceList {
-		for _, vm := range vmList {
-			vmLookUp := types.NamespacedName{Namespace: ns, Name: vm}
-			if err := k8sclient.Get(ctx, vmLookUp, foundVM); err != nil {
-				// Continuing with remaining list of VMs as the current one might already have been deleted
-				continue
-			}
-
-			if !foundVM.GetDeletionTimestamp().IsZero() {
-				// Deletion of vm has been requested
-				return true
-			}
+			return true
 		}
 	}
 
@@ -134,62 +132,202 @@ func IsVMDeletionInProgress(ctx context.Context,
 func DeleteVMs(
 	ctx context.Context,
 	k8sclient client.Client,
+	foundVMs []virtv1.VirtualMachine,
 	vmList []string,
 	vmNamespaceList []string,
 	log logr.Logger,
 ) error {
-	for _, ns := range vmNamespaceList {
-		for _, vmName := range vmList {
-			vm := &virtv1.VirtualMachine{}
-			key := client.ObjectKey{Name: vmName, Namespace: ns}
+	for _, vm := range foundVMs {
+		ns := vm.GetNamespace()
 
-			if err := k8sclient.Get(ctx, key, vm); err != nil {
-				log.Error(err, "Failed to get VM", "namespace", ns, "name", vmName)
+		vmName := vm.GetName()
 
-				return fmt.Errorf("failed to get VM %s/%s: %w", ns, vmName, err)
-			}
+		// Foreground deletion option
+		deleteOpts := &client.DeleteOptions{
+			GracePeriodSeconds: nil,
+			PropagationPolicy: func() *metav1.DeletionPropagation {
+				p := metav1.DeletePropagationForeground
 
-			if err := k8sclient.Delete(ctx, vm); err != nil {
-				log.Error(err, "Failed to delete VM", "namespace", ns, "name", vmName)
-
-				return fmt.Errorf("failed to delete VM %s/%s: %w", ns, vmName, err)
-			}
-
-			log.Info("Deleted VM successfully", "namespace", ns, "name", vmName)
+				return &p
+			}(),
 		}
+		if err := k8sclient.Delete(ctx, &vm, deleteOpts); err != nil {
+			log.Error(err, "Failed to delete VM", "namespace", ns, "name", vmName)
+
+			return fmt.Errorf("failed to delete VM %s/%s: %w", ns, vmName, err)
+		}
+
+		log.Info("Deleted VMs successfully", "from namespace", ns, "VM name", vmName)
 	}
 
 	return nil
 }
 
-// IsOwnedByVM recursively traverses ownerReferences until it finds a VirtualMachine.
-func IsOwnedByVM(ctx context.Context, c client.Client, obj client.Object,
-	owners []metav1.OwnerReference, log logr.Logger) (string, error) {
+func IsUsedByVirtLauncherPod(ctx context.Context, c client.Client, obj client.Object,
+	log logr.Logger,
+) (client.Object, error) {
+	// skip checking if virt-launcher pod is using the PVC when ownerrefences is >0,
+	// as PVC may be managed by cdi.kubevirt.io controller or any user application controller.
+	if len(obj.GetOwnerReferences()) > 0 {
+		return nil, nil
+	}
+	// Patch PVC only if its not exclusively owned by any controller
+	// Get the Pod
+	podList := &corev1.PodList{}
+	pvcName := obj.GetName()
+	pvcNamespace := obj.GetNamespace()
 
-	for _, owner := range owners {
-		if owner.Kind == KindVirtualMachine && owner.APIVersion == KubeVirtAPIVersion {
-			return owner.Name, nil // Found VM root
-		}
+	err := c.List(ctx, podList, client.MatchingFields{PodVolumePVCClaimIndexName: pvcName},
+		client.InNamespace(pvcNamespace))
+	if err != nil {
+		log.Error(err, "error getting pods list from protected namespace", "namespace", pvcNamespace)
 
-		// Fetch only metadata of the owner
-		ownerMeta := &metav1.PartialObjectMetadata{}
-		ownerMeta.SetGroupVersionKind(schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind))
+		return nil, err
+	}
 
-		if err := c.Get(ctx, client.ObjectKey{Namespace: obj.GetNamespace(), Name: owner.Name}, ownerMeta); err != nil {
-			log.Info("Failed to fetch owner", "error", err)
-			continue // skip if not found
-		}
+	if len(podList.Items) == 0 {
+		log.Info("Not is use by any pod")
 
-		// Continue traversal with the owner
-		// Recursively check its ownerReferences
-		obj = ownerMeta
-		nestedOwners := obj.GetOwnerReferences()
-		if len(nestedOwners) > 0 {
-			vmName, err := IsOwnedByVM(ctx, c, obj, nestedOwners, log)
-			if err == nil {
+		return nil, nil
+	}
+
+	for _, pod := range podList.Items {
+		for _, vol := range pod.Spec.Volumes {
+			if vol.PersistentVolumeClaim != nil && vol.PersistentVolumeClaim.ClaimName == pvcName {
+				vmName, err := IsOwnedByVM(ctx, c, &pod, log)
+				if err != nil {
+					log.Error(err, "Skipping cleanup",
+						"pod", pod.Name,
+						"vm", vmName,
+						"reason", "invalid ownerReferences",
+						"action", "manual cleanup required")
+
+					return nil, nil
+				}
+
+				log.Info("Got the VM owning the PVC", "PVC", pvcName,
+					"set to owned by VM", vmName.GetName(), "VM kind", vmName.GetObjectKind())
+
 				return vmName, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("no VM owner found")
+
+	return nil, nil
+}
+
+// This allows VM to declare as owner of PVC and has a dependency on the object without specifying it as a controller.
+func PatchPvcWithVMOwnerRef(ctx context.Context, c client.Client, ownerVM client.Object,
+	pvcName, pvcNamespace string, log logr.Logger,
+) error {
+	pvcLookupKey := types.NamespacedName{Namespace: pvcNamespace, Name: pvcName}
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	if err := c.Get(ctx, pvcLookupKey, pvc); err != nil {
+		log.Error(err, "Failed to get PVC", "namespace", pvcNamespace, "PVCname", pvcName)
+
+		return err
+	}
+
+	// 1. Capture the original state of the PVC before modification
+	// It's crucial to create a deep copy to represent the *unmodified* base for the patch calculation
+	pvcOriginal := pvc.DeepCopy()
+
+	// 2. Add the OwnerReference to the local in-memory PVC object
+	// This mutates the 'pvc' object in place
+	err := controllerutil.SetOwnerReference(ownerVM, pvc, c.Scheme())
+	if err != nil {
+		return fmt.Errorf("failed to add owner reference: %w", err)
+	}
+
+	// 3. Use the client.Patch helper to calculate the difference (the patch)
+	// between 'pvcOriginal' and the now-modified 'pvc' object.
+	// We specifically use client.MergeFrom to generate a MergePatch payload.
+	patch := client.MergeFrom(pvcOriginal)
+
+	// 4. Execute the Patch API call
+	// This sends only the 'metadata.ownerReferences' change to the Kubernetes API server
+	if err := c.Patch(ctx, pvc, patch); err != nil {
+		return fmt.Errorf("failed to patch PVC with owner reference: %w", err)
+	}
+
+	log.Info("Successfully patched PVC with owner reference to VM",
+		"PVC name", pvc.GetName(), "Owned by VM", ownerVM.GetName())
+
+	return nil
+}
+
+// IsOwnedByVM walks the owner chain and returns the VM metadata object if found.
+// It prefers KubeVirt VM owners (kind=VirtualMachine, apigroup starts with kubevirt.io/)
+// Assuming all the owners are from same namespace
+// Typical KubeVirt ownership depth (PVC→DV→VM or PVC→VMI→VM or virt-launcher-pod->VMI->VM)
+func IsOwnedByVM(
+	ctx context.Context,
+	c client.Client,
+	obj client.Object,
+	log logr.Logger,
+) (client.Object, error) {
+	owners := obj.GetOwnerReferences()
+	// Breadth-first/flat traversal to reduce cognitive complexity
+	type queued struct {
+		ns    string
+		owner metav1.OwnerReference
+	}
+
+	q := make([]queued, 0, len(owners))
+	for _, o := range owners {
+		q = append(q, queued{ns: obj.GetNamespace(), owner: o})
+	}
+
+	for len(q) > 0 {
+		cur := q[0]
+		q = q[1:]
+
+		// Try fetching only the owner's metadata
+		ownerMeta, err := fetchPartialMeta(ctx, c, cur.ns, cur.owner)
+		if err != nil {
+			log.Info("Failed to fetch owner", "gvk", cur.owner.APIVersion+"/"+cur.owner.Kind, "name", cur.owner.Name, "err", err)
+
+			continue
+		}
+
+		if ownerMeta.GetUID() != cur.owner.UID {
+			// UID mismatch; skip
+			continue
+		}
+
+		// If this owner is a KubeVirt VM, return it
+		if isKubeVirtVM(cur.owner) {
+			return ownerMeta, nil
+		}
+
+		// Otherwise, enqueue its parents (same namespace assumption for KubeVirt chain)
+		nestedOwners := ownerMeta.GetOwnerReferences()
+		for _, nestedOwner := range nestedOwners {
+			q = append(q, queued{ns: cur.ns, owner: nestedOwner})
+		}
+	}
+
+	return nil, fmt.Errorf("no VM owner found")
+}
+
+func isKubeVirtVM(o metav1.OwnerReference) bool {
+	return o.Kind == KindVirtualMachine && strings.HasPrefix(o.APIVersion, KubeVirtAPIVersionPrefix)
+}
+
+// Fetch only metadata of the owner
+func fetchPartialMeta(
+	ctx context.Context,
+	c client.Client,
+	ns string,
+	o metav1.OwnerReference,
+) (*metav1.PartialObjectMetadata, error) {
+	objMeta := &metav1.PartialObjectMetadata{}
+	objMeta.SetGroupVersionKind(schema.FromAPIVersionAndKind(o.APIVersion, o.Kind))
+
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: o.Name}, objMeta); err != nil {
+		return nil, err
+	}
+
+	return objMeta, nil
 }

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
+	virtv1 "kubevirt.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -397,7 +399,8 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=list;watch
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods/exec,verbs=create
-// +kubebuilder:rbac:groups="kubevirt.io",resources=virtualmachines,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups="kubevirt.io",resources=virtualmachines,verbs=get;list;watch;patch;delete
+// +kubebuilder:rbac:groups="kubevirt.io",resources=virtualmachineinstances,verbs=get;list;watch
 // +kubebuilder:rbac:groups="cdi.kubevirt.io",resources=datavolumes,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -1698,34 +1701,7 @@ func (v *VRGInstance) processAsSecondary() ctrl.Result {
 func (v *VRGInstance) reconcileAsSecondary() ctrl.Result {
 	result := ctrl.Result{}
 
-	if v.isVMRecipeProtection() {
-		v.log.Info("Checking VM cleanup and cross-cluster resource conflicts",
-			"name", v.instance.GetName(),
-			"namespace", v.instance.GetNamespace(),
-			"recipeName", "vm-recipe")
-
-		if err := v.validateVMsForStandaloneProtection(); err != nil {
-			result.Requeue = true
-		}
-
-		if !result.Requeue {
-			v.log.Info("VRG status observed",
-				"name", v.instance.GetName(),
-				"namespace", v.instance.GetNamespace(),
-				"replicationState", v.instance.Spec.ReplicationState,
-				"statusState", v.instance.Status.State,
-				"generation", v.instance.GetGeneration(),
-				"resourceVersion", v.instance.GetResourceVersion(),
-			)
-
-			if v.ShouldCleanupVMForSecondary() {
-				v.log.Info("Requeuing until VM cleanup is complete")
-
-				result.Requeue = true
-			}
-		}
-	}
-
+	result.Requeue = v.ShouldCleanupForSecondary()
 	result.Requeue = v.reconcileVolSyncAsSecondary() || result.Requeue
 	result.Requeue = v.reconcileVolRepsAsSecondary() || result.Requeue
 
@@ -2503,22 +2479,29 @@ func (v *VRGInstance) CheckForVMConflictOnSecondary() error {
 }
 
 func (v *VRGInstance) CheckForVMNameConflictOnSecondary(vmNamespaceList, vmList []string) error {
-	var foundVMs []string
+	foundVMs, err := util.ListVMsByVMNamespace(v.ctx, v.reconciler.APIReader,
+		v.log, vmNamespaceList, vmList)
+	if err != nil {
+		return err
+	}
 
-	var err error
-	if foundVMs, err = util.ListVMsByVMNamespace(v.ctx, v.reconciler.APIReader,
-		v.log, vmNamespaceList, vmList); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return fmt.Errorf("failed to lookup virtualmachine resources, check rbacs")
-		}
-
+	if len(foundVMs) == 0 {
 		return nil
 	}
 
-	v.log.Info(fmt.Sprintf("found conflicting VM[%v] on secondary", foundVMs))
+	v.log.Info("found conflicting VMs on secondary", "foundVMs", vmNamesString(foundVMs))
 
 	return fmt.Errorf("protected VMs on the primary cluster share names with VMs on " +
 		"the secondary site, which may impact failover or recovery")
+}
+
+func vmNamesString(vms []virtv1.VirtualMachine) string {
+	names := make([]string, len(vms))
+	for i := range vms {
+		names[i] = vms[i].Name
+	}
+
+	return strings.Join(names, ", ")
 }
 
 func (v *VRGInstance) aggregateVRGNoClusterDataConflictCondition() *metav1.Condition {


### PR DESCRIPTION
Enhances DRPC status reporting by reflecting the cleanup progression of discovered VMs from the managed cluster during relocate and failover operations. This provides users with clear visibility into the cleanup process and its current stage.

Test results for relocate: 
```
# oc get drpc vm-dvt-dr -n ramen-ops -o json -w | jq .status.progression
"Completed"
"Completed"
"PreparingFinalSync"
"CleanupReadiness"
"CleanupReadiness"
"Cleaning Up"
"WaitingForResourceRestore"
"WaitForReadiness"
"WaitForReadiness"
"Completed"
"Completed"
"Completed"
# oc get drpc -A
NAMESPACE   NAME           AGE   PREFERREDCLUSTER   FAILOVERCLUSTER   DESIREDSTATE   CURRENTSTATE
ramen-ops   vm-dvt-dr      33h   dr2                dr1               Relocate       Relocated
```

Test result for Failover:
```
# oc get drpc vm-dvt-dr -n ramen-ops -o json -w | jq .status.progression
"Completed"
"Completed"
"Completed"
"Completed"
"WaitingForResourceRestore"
"WaitForReadiness"
"WaitForReadiness"
"WaitForReadiness"
"Cleaning Up"
"Cleaning Up"
"Completed"
"Completed"
"Completed"
"Completed"
"Completed"
"Completed"
# oc get drpc -A
NAMESPACE   NAME           AGE   PREFERREDCLUSTER   FAILOVERCLUSTER   DESIREDSTATE   CURRENTSTATE
ramen-ops   vm-dvt-dr      32h   dr2                dr1               Failover       FailedOver
```