### PR TITLE
e2e: Simplify INFO logs

### DIFF
--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -30,8 +30,7 @@ func (a ApplicationSet) Deploy(ctx types.TestContext) error {
 	// Deploys the application on the first DR cluster (c1).
 	cluster := ctx.Env().C1
 
-	log.Infof("Deploying applicationset app \"%s/%s\" in cluster %q",
-		ctx.AppNamespace(), ctx.Workload().GetAppName(), cluster.Name)
+	log.Infof("Deploying in cluster %q", cluster.Name)
 
 	if err := util.CreateNamespaceOnMangedClusters(ctx, ctx.AppNamespace()); err != nil {
 		return err
@@ -74,10 +73,9 @@ func (a ApplicationSet) Undeploy(ctx types.TestContext) error {
 		}
 
 		log.Debugf("Could not retrieve the cluster name: %s", err)
-		log.Infof("Undeploying applicationset app \"%s/%s\"", ctx.AppNamespace(), ctx.Workload().GetAppName())
+		log.Info("Undeploying")
 	} else {
-		log.Infof("Undeploying applicationset app \"%s/%s\" in cluster %q",
-			ctx.AppNamespace(), ctx.Workload().GetAppName(), cluster.Name)
+		log.Infof("Undeploying from cluster %q", cluster.Name)
 	}
 
 	if err := a.DeleteResources(ctx); err != nil {

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -41,7 +41,7 @@ func (d DiscoveredApp) Deploy(ctx types.TestContext) error {
 		return err
 	}
 
-	log.Infof("Deploying discovered app \"%s/%s\" in cluster %q", appNamespace, ctx.Workload().GetAppName(), cluster.Name)
+	log.Infof("Deploying in cluster %q", cluster.Name)
 
 	if err := util.CreateNamespaceOnMangedClusters(ctx, appNamespace); err != nil {
 		return err
@@ -83,10 +83,7 @@ func (d DiscoveredApp) Deploy(ctx types.TestContext) error {
 // Undeploy deletes the workload from the managed clusters.
 func (d DiscoveredApp) Undeploy(ctx types.TestContext) error {
 	log := ctx.Logger()
-	appNamespace := ctx.AppNamespace()
-
-	log.Infof("Undeploying discovered app \"%s/%s\" in clusters %q and %q",
-		appNamespace, ctx.Workload().GetAppName(), ctx.Env().C1.Name, ctx.Env().C2.Name)
+	log.Infof("Undeploying from clusters %q and %q", ctx.Env().C1.Name, ctx.Env().C2.Name)
 
 	if err := d.DeleteResources(ctx); err != nil {
 		return err

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -47,8 +47,7 @@ func (s Subscription) Deploy(ctx types.TestContext) error {
 	// Deploys the application on the first DR cluster (c1).
 	cluster := ctx.Env().C1
 
-	log.Infof("Deploying subscription app \"%s/%s\" in cluster %q",
-		ctx.AppNamespace(), ctx.Workload().GetAppName(), cluster.Name)
+	log.Infof("Deploying in cluster %q", cluster.Name)
 
 	// create subscription namespace
 	err := util.CreateNamespace(ctx, ctx.Env().Hub, managementNamespace)
@@ -102,10 +101,9 @@ func (s Subscription) Undeploy(ctx types.TestContext) error {
 		}
 
 		log.Debugf("Could not retrieve the cluster name: %s", err)
-		log.Infof("Undeploying subscription app \"%s/%s\"", ctx.AppNamespace(), ctx.Workload().GetAppName())
+		log.Info("Undeploying")
 	} else {
-		log.Infof("Undeploying subscription app \"%s/%s\" in cluster %q",
-			ctx.AppNamespace(), ctx.Workload().GetAppName(), cluster.Name)
+		log.Infof("Undeploying from cluster %q", cluster.Name)
 	}
 
 	if err := s.DeleteResources(ctx); err != nil {

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -47,7 +47,7 @@ func EnableProtection(ctx types.TestContext) error {
 		return err
 	}
 
-	log.Infof("Protecting workload \"%s/%s\" in cluster %q", appNamespace, appname, cluster.Name)
+	log.Infof("Protecting workload in cluster %q", cluster.Name)
 
 	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		placement, err := util.GetPlacement(ctx, managementNamespace, placementName)
@@ -114,10 +114,9 @@ func DisableProtection(ctx types.TestContext) error {
 		}
 
 		log.Debugf("Could not retrieve the cluster name: %s", err)
-		log.Infof("Unprotecting workload \"%s/%s\"", appNamespace, ctx.Workload().GetAppName())
+		log.Info("Unprotecting workload")
 	} else {
-		log.Infof("Unprotecting workload \"%s/%s\" in cluster %q",
-			appNamespace, ctx.Workload().GetAppName(), cluster.Name)
+		log.Infof("Unprotecting workload in cluster %q", cluster.Name)
 	}
 
 	if err := annotateDRPCDoNotDeletePVC(ctx, name); err != nil {
@@ -163,8 +162,7 @@ func Failover(ctx types.TestContext) error {
 		return err
 	}
 
-	log.Infof("Failing over workload \"%s/%s\" from cluster %q to cluster %q",
-		ctx.AppNamespace(), ctx.Workload().GetAppName(), currentCluster.Name, targetCluster.Name)
+	log.Infof("Failing over workload from cluster %q to cluster %q", currentCluster.Name, targetCluster.Name)
 
 	err = failoverRelocate(ctx, ramen.ActionFailover, ramen.FailedOver, currentCluster, targetCluster)
 	if err != nil {
@@ -196,8 +194,7 @@ func Relocate(ctx types.TestContext) error {
 		return err
 	}
 
-	log.Infof("Relocating workload \"%s/%s\" from cluster %q to cluster %q",
-		ctx.AppNamespace(), ctx.Workload().GetAppName(), currentCluster.Name, targetCluster.Name)
+	log.Infof("Relocating workload from cluster %q to cluster %q", currentCluster.Name, targetCluster.Name)
 
 	err = failoverRelocate(ctx, ramen.ActionRelocate, ramen.Relocated, currentCluster, targetCluster)
 	if err != nil {
@@ -220,10 +217,9 @@ func Purge(ctx types.TestContext) error {
 			return err
 		}
 
-		log.Infof("Purging workload \"%s/%s\"", ctx.AppNamespace(), ctx.Workload().GetAppName())
+		log.Info("Purging workload")
 	} else {
-		log.Infof("Purging workload \"%s/%s\" in cluster %q",
-			ctx.AppNamespace(), ctx.Workload().GetAppName(), cluster.Name)
+		log.Infof("Purging workload in cluster %q", cluster.Name)
 	}
 
 	if err := deleteProtectionResources(ctx); err != nil {

--- a/e2e/dractions/disapp.go
+++ b/e2e/dractions/disapp.go
@@ -31,7 +31,7 @@ func EnableProtectionDiscoveredApps(ctx types.TestContext) error {
 		return err
 	}
 
-	log.Infof("Protecting workload \"%s/%s\" in cluster %q", appNamespace, appname, cluster.Name)
+	log.Infof("Protecting workload in cluster %q", cluster.Name)
 
 	// create placement
 	if err := createPlacementManagedByRamen(ctx, placementName, managementNamespace); err != nil {


### PR DESCRIPTION
Previously the logs repeated the namespace and deployment name, and were too long and hard to follow. Remove the namespace/name from the log to make them similar to ramenctl progress logs.

The namespace and name should be available in DEBUG logs. We log a detailed debug log for every change in the system.

## Logs before

```console
2025-12-14T01:23:05.624+0200	INFO	appset-deploy-rbd	Deploying applicationset app "test-appset-deploy-rbd/busybox" in cluster "dr1"
2025-12-14T01:23:25.763+0200	INFO	appset-deploy-rbd	Workload deployed
2025-12-14T01:23:25.770+0200	INFO	appset-deploy-rbd	Protecting workload "test-appset-deploy-rbd/busybox" in cluster "dr1"
2025-12-14T01:25:00.986+0200	INFO	appset-deploy-rbd	Workload protected
2025-12-14T01:25:00.997+0200	INFO	appset-deploy-rbd	Failing over workload "test-appset-deploy-rbd/busybox" from cluster "dr1" to cluster "dr2"
2025-12-14T01:28:26.370+0200	INFO	appset-deploy-rbd	Workload failed over
2025-12-14T01:28:26.383+0200	INFO	appset-deploy-rbd	Relocating workload "test-appset-deploy-rbd/busybox" from cluster "dr2" to cluster "dr1"
2025-12-14T01:31:31.661+0200	INFO	appset-deploy-rbd	Workload relocated
2025-12-14T01:31:31.675+0200	INFO	appset-deploy-rbd	Unprotecting workload "test-appset-deploy-rbd/busybox" in cluster "dr1"
2025-12-14T01:32:27.077+0200	INFO	appset-deploy-rbd	Workload unprotected
2025-12-14T01:32:27.088+0200	INFO	appset-deploy-rbd	Undeploying applicationset app "test-appset-deploy-rbd/busybox" in cluster "dr1"
2025-12-14T01:32:33.180+0200	INFO	appset-deploy-rbd	Workload undeployed
```

## Logs after

```console
2025-12-14T02:11:46.843+0200	INFO	appset-deploy-rbd	Deploying in cluster "dr1"
2025-12-14T02:12:01.990+0200	INFO	appset-deploy-rbd	Workload deployed
2025-12-14T02:12:02.085+0200	INFO	appset-deploy-rbd	Protecting workload in cluster "dr1"
2025-12-14T02:13:37.397+0200	INFO	appset-deploy-rbd	Workload protected
2025-12-14T02:13:37.418+0200	INFO	appset-deploy-rbd	Failing over workload from cluster "dr1" to cluster "dr2"
2025-12-14T02:19:34.384+0200	INFO	appset-deploy-rbd	Workload failed over
2025-12-14T02:19:34.398+0200	INFO	appset-deploy-rbd	Relocating workload from cluster "dr2" to cluster "dr1"
2025-12-14T02:23:14.836+0200	INFO	appset-deploy-rbd	Workload relocated
2025-12-14T02:23:14.845+0200	INFO	appset-deploy-rbd	Unprotecting workload in cluster "dr1"
2025-12-14T02:24:04.217+0200	INFO	appset-deploy-rbd	Workload unprotected
2025-12-14T02:24:04.231+0200	INFO	appset-deploy-rbd	Undeploying from cluster "dr1"
2025-12-14T02:24:10.472+0200	INFO	appset-deploy-rbd	Workload undeployed
```