### PR TITLE
Filter out VM Prime PVCs from protected PVC list by unsetting VM label selector on prime PVC

### DIFF
--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -305,6 +305,25 @@ rules:
   verbs:
   - get
   - list
+  - watch
+  - patch
+  - delete
+- apiGroups:
+  - kubevirt.io
+  resources:
+  - virtualmachineinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cdi.kubevirt.io
+  resources:
+  - datavolumes
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -238,11 +238,20 @@ rules:
 - apiGroups:
   - kubevirt.io
   resources:
+  - virtualmachineinstances
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubevirt.io
+  resources:
   - virtualmachines
   verbs:
   - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - multicluster.x-k8s.io

--- a/internal/controller/cephfscg/cghandler.go
+++ b/internal/controller/cephfscg/cghandler.go
@@ -200,8 +200,12 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupSource(
 		namespaces = *c.instance.Spec.ProtectedNamespaces
 	}
 
+	recipeName := ""
+	if c.instance.Spec.KubeObjectProtection != nil && c.instance.Spec.KubeObjectProtection.RecipeRef != nil {
+		recipeName = c.instance.Spec.KubeObjectProtection.RecipeRef.Name
+	}
 	volumeGroupSnapshotClassName, err := util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(c.ctx, c.Client,
-		c.volumeGroupSnapshotClassSelector, *c.volumeGroupSnapshotSource, namespaces, c.logger)
+		c.volumeGroupSnapshotClassSelector, *c.volumeGroupSnapshotSource, namespaces, c.logger, recipeName)
 	if err != nil {
 		log.Error(err, "Failed to get VGSClass name")
 		// If final sync is requested, ensure final sync cleanup is run regardless of the error

--- a/internal/controller/util/cephfs_cg.go
+++ b/internal/controller/util/cephfs_cg.go
@@ -104,13 +104,14 @@ func GetVolumeGroupSnapshotClassFromPVCsStorageClass(
 	pvcsConsistencyGroupSelector metav1.LabelSelector,
 	namespace []string,
 	logger logr.Logger,
+	recipeName string,
 ) (string, error) {
 	volumeGroupSnapshotClasses, err := GetVolumeGroupSnapshotClasses(ctx, k8sClient, volumeGroupSnapshotClassSelector)
 	if err != nil {
 		return "", err
 	}
 
-	pvcs, err := ListPVCsByPVCSelector(ctx, k8sClient, logger, pvcsConsistencyGroupSelector, namespace, false)
+	pvcs, err := ListPVCsByPVCSelector(ctx, k8sClient, logger, pvcsConsistencyGroupSelector, namespace, false, recipeName)
 	if err != nil {
 		return "", err
 	}

--- a/internal/controller/util/cephfs_cg_test.go
+++ b/internal/controller/util/cephfs_cg_test.go
@@ -251,7 +251,8 @@ var _ = Describe("CephfsCg", func() {
 		Describe("GetVolumeGroupSnapshotClassFromPVCsStorageClass", func() {
 			It("Should be failed", func() {
 				volumeGroupSnapshotClassName, err := util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(
-					context.Background(), k8sClient, metav1.LabelSelector{}, metav1.LabelSelector{}, []string{"default"}, testLogger)
+					context.Background(), k8sClient, metav1.LabelSelector{}, metav1.LabelSelector{},
+					[]string{"default"}, testLogger, "")
 				Expect(volumeGroupSnapshotClassName).To(Equal(""))
 				Expect(err).NotTo(BeNil())
 				Expect(err.Error()).To(ContainSubstring("unable to find matching volumegroupsnapshotclass for storage provisioner"))
@@ -269,26 +270,29 @@ var _ = Describe("CephfsCg", func() {
 					volumeGroupSnapshotClassName, err := util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(
 						context.Background(), k8sClient,
 						metav1.LabelSelector{MatchLabels: map[string]string{"test": "testxxxx"}},
-						metav1.LabelSelector{}, []string{"default"}, testLogger)
+						metav1.LabelSelector{}, []string{"default"}, testLogger, "")
 					Expect(volumeGroupSnapshotClassName).To(Equal(""))
 					Expect(err).NotTo(BeNil())
 
 					volumeGroupSnapshotClassName, err = util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(
 						context.Background(), k8sClient,
 						metav1.LabelSelector{MatchLabels: map[string]string{"test": "test"}},
-						metav1.LabelSelector{MatchLabels: map[string]string{"test": "test"}}, []string{"default"}, testLogger)
+						metav1.LabelSelector{MatchLabels: map[string]string{"test": "test"}}, []string{"default"},
+						testLogger, "")
 					Expect(volumeGroupSnapshotClassName).To(Equal(""))
 					Expect(err).NotTo(BeNil())
 
 					volumeGroupSnapshotClassName, err = util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(
-						context.Background(), k8sClient, metav1.LabelSelector{}, metav1.LabelSelector{}, []string{"default"}, testLogger)
+						context.Background(), k8sClient, metav1.LabelSelector{}, metav1.LabelSelector{}, []string{"default"},
+						testLogger, "")
 					Expect(volumeGroupSnapshotClassName).To(Equal("vgsc"))
 					Expect(err).To(BeNil())
 
 					volumeGroupSnapshotClassName, err = util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(
 						context.Background(), k8sClient,
 						metav1.LabelSelector{MatchLabels: map[string]string{"test": "test"}},
-						metav1.LabelSelector{MatchLabels: map[string]string{"testpvc": "testpvc"}}, []string{"default"}, testLogger)
+						metav1.LabelSelector{MatchLabels: map[string]string{"testpvc": "testpvc"}}, []string{"default"},
+						testLogger, "")
 					Expect(volumeGroupSnapshotClassName).To(Equal("vgsc"))
 					Expect(err).To(BeNil())
 				})

--- a/internal/controller/util/pvcs_util_test.go
+++ b/internal/controller/util/pvcs_util_test.go
@@ -91,7 +91,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should list all PVCs when VolSync is disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					true /* Volsync Disabled */)
+					true /* Volsync Disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(pvcCount))
@@ -106,7 +106,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should filter out VolSync PVCs when VolSync is not disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					false /* Volsync NOT disabled */)
+					false /* Volsync NOT disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(pvcCount - 2)) // 2 PVCs are VolSync PVCs
@@ -127,7 +127,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should list matching PVCs when VolSync is disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					true /* Volsync Disabled */)
+					true /* Volsync Disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(3))
@@ -141,7 +141,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should list matching PVCs and filter out VolSync PVCs when VolSync is not disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					false /* Volsync NOT Disabled */)
+					false /* Volsync NOT Disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(1))
@@ -162,7 +162,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should list matching PVCs when VolSync is disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					true /* Volsync Disabled */)
+					true /* Volsync Disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(2))
@@ -175,7 +175,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should list matching PVCs and filter out VolSync PVCs when VolSync is not disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					false /* Volsync NOT Disabled */)
+					false /* Volsync NOT Disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(1))
@@ -203,7 +203,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should list matching PVCs when VolSync is disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					true /* Volsync Disabled */)
+					true /* Volsync Disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(2))
@@ -216,7 +216,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should list matching PVCs and filter out VolSync PVCs when VolSync is not disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					false /* Volsync NOT Disabled */)
+					false /* Volsync NOT Disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(1))

--- a/internal/controller/util/vm_util.go
+++ b/internal/controller/util/vm_util.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -64,37 +65,27 @@ func ListVMsByVMNamespace(
 	log logr.Logger,
 	vmNamespaceList []string,
 	vmList []string,
-) ([]string, error) {
-	var foundVMList []string
-
-	var notFoundErr error
-
-	foundVM := &virtv1.VirtualMachine{}
+) ([]virtv1.VirtualMachine, error) {
+	var foundVMs []virtv1.VirtualMachine
 
 	for _, ns := range vmNamespaceList {
 		for _, vm := range vmList {
+			foundVM := &virtv1.VirtualMachine{}
+
 			vmLookUp := types.NamespacedName{Namespace: ns, Name: vm}
 			if err := apiReader.Get(ctx, vmLookUp, foundVM); err != nil {
-				if !k8serrors.IsNotFound(err) {
-					return nil, err
+				if k8serrors.IsNotFound(err) {
+					continue
 				}
 
-				if notFoundErr == nil {
-					notFoundErr = err
-				}
-
-				continue
+				return nil, err
 			}
 
-			foundVMList = append(foundVMList, foundVM.Name)
+			foundVMs = append(foundVMs, *foundVM.DeepCopy())
 		}
 	}
 
-	if len(foundVMList) > 0 {
-		return foundVMList, nil
-	}
-
-	return nil, notFoundErr
+	return foundVMs, nil
 }
 
 // IsVMDeletionInProgress returns true if any listed KubeVirt VM within the given protected NS is in deletion state.
@@ -104,29 +95,23 @@ func IsVMDeletionInProgress(ctx context.Context,
 	vmList []string,
 	vmNamespaceList []string,
 	log logr.Logger,
-) bool {
-	log.Info("Checking if VirtualMachines are being deleted",
-		"vmCount", len(vmList),
-		"vmNames", vmList)
+) ([]virtv1.VirtualMachine, bool, error) {
+	foundVMs, err := ListVMsByVMNamespace(ctx, k8sclient,
+		log, vmNamespaceList, vmList)
+	if err != nil {
+		// Skip and requeue for Get API errors
+		return nil, true, err
+	}
 
-	foundVM := &virtv1.VirtualMachine{}
+	for _, vm := range foundVMs {
+		if ResourceIsDeleted(&vm) {
+			log.Info("VM deletion is in progress", "VM", vm.Name)
 
-	for _, ns := range vmNamespaceList {
-		for _, vm := range vmList {
-			vmLookUp := types.NamespacedName{Namespace: ns, Name: vm}
-			if err := k8sclient.Get(ctx, vmLookUp, foundVM); err != nil {
-				// Continuing with remaining list of VMs as the current one might already have been deleted
-				continue
-			}
-
-			if !foundVM.GetDeletionTimestamp().IsZero() {
-				// Deletion of vm has been requested
-				return true
-			}
+			return foundVMs, true, nil
 		}
 	}
 
-	return false
+	return foundVMs, false, nil
 }
 
 // DeleteVMs deletes the given KubeVirt VMs across the provided namespaces.
@@ -134,62 +119,207 @@ func IsVMDeletionInProgress(ctx context.Context,
 func DeleteVMs(
 	ctx context.Context,
 	k8sclient client.Client,
-	vmList []string,
-	vmNamespaceList []string,
+	foundVMs []virtv1.VirtualMachine,
 	log logr.Logger,
 ) error {
-	for _, ns := range vmNamespaceList {
-		for _, vmName := range vmList {
-			vm := &virtv1.VirtualMachine{}
-			key := client.ObjectKey{Name: vmName, Namespace: ns}
+	for _, vm := range foundVMs {
+		ns := vm.GetNamespace()
 
-			if err := k8sclient.Get(ctx, key, vm); err != nil {
-				log.Error(err, "Failed to get VM", "namespace", ns, "name", vmName)
+		vmName := vm.GetName()
 
-				return fmt.Errorf("failed to get VM %s/%s: %w", ns, vmName, err)
-			}
+		if err := k8sclient.Delete(ctx, &vm); err != nil {
+			log.Error(err, "Failed to delete VM", "namespace", ns, "name", vmName)
 
-			if err := k8sclient.Delete(ctx, vm); err != nil {
-				log.Error(err, "Failed to delete VM", "namespace", ns, "name", vmName)
-
-				return fmt.Errorf("failed to delete VM %s/%s: %w", ns, vmName, err)
-			}
-
-			log.Info("Deleted VM successfully", "namespace", ns, "name", vmName)
+			return fmt.Errorf("failed to delete VM %s/%s: %w", ns, vmName, err)
 		}
+
+		log.Info("Deleted VM successfully", "namespace", ns, "name", vmName)
 	}
 
 	return nil
 }
 
-// IsOwnedByVM recursively traverses ownerReferences until it finds a VirtualMachine.
-func IsOwnedByVM(ctx context.Context, c client.Client, obj client.Object,
-	owners []metav1.OwnerReference, log logr.Logger) (string, error) {
+// TODO: Merge this function with IsPVCInUseByPod to avoid duplication.
+// Both functions perform similar checks, so refactor them into a single reusable utility.
+// This requires careful handling to ensure compatibility and correctness across all call sites.
+func IsUsedByVirtLauncherPod(ctx context.Context, c client.Client, obj client.Object,
+	log logr.Logger,
+) (client.Object, error) {
+	// Patch PVC only if its not exclusively owned by any controller
+	podList := &corev1.PodList{}
+	pvcName := obj.GetName()
+	pvcNamespace := obj.GetNamespace()
 
-	for _, owner := range owners {
-		if owner.Kind == KindVirtualMachine && owner.APIVersion == KubeVirtAPIVersion {
-			return owner.Name, nil // Found VM root
-		}
+	err := c.List(ctx, podList, client.MatchingFields{PodVolumePVCClaimIndexName: pvcName},
+		client.InNamespace(pvcNamespace))
+	if err != nil {
+		log.Error(err, "error getting pods list from protected namespace", "namespace", pvcNamespace)
 
-		// Fetch only metadata of the owner
-		ownerMeta := &metav1.PartialObjectMetadata{}
-		ownerMeta.SetGroupVersionKind(schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind))
+		return nil, err
+	}
 
-		if err := c.Get(ctx, client.ObjectKey{Namespace: obj.GetNamespace(), Name: owner.Name}, ownerMeta); err != nil {
-			log.Info("Failed to fetch owner", "error", err)
-			continue // skip if not found
-		}
+	if len(podList.Items) == 0 {
+		log.Info("Not is use by any pod")
 
-		// Continue traversal with the owner
-		// Recursively check its ownerReferences
-		obj = ownerMeta
-		nestedOwners := obj.GetOwnerReferences()
-		if len(nestedOwners) > 0 {
-			vmName, err := IsOwnedByVM(ctx, c, obj, nestedOwners, log)
-			if err == nil {
-				return vmName, nil
-			}
+		return nil, nil
+	}
+
+	var vmName client.Object
+	for _, pod := range podList.Items {
+		vmName, err = IsOwnedByVM(ctx, c, &pod, log)
+		if err != nil {
+			// If not owned by this pod continue to check on the next pod(PV shared across VMs?)
+			continue
 		}
 	}
-	return "", fmt.Errorf("no VM owner found")
+
+	if vmName == nil {
+		return nil, nil
+	}
+
+	log.Info("Got the VM owning the PVC", "PVC", pvcName,
+		"set to owned by VM", vmName.GetName(), "VM kind", vmName.GetObjectKind())
+
+	return vmName, nil
+}
+
+// This allows VM to declare as owner of PVC and has a dependency on the object without specifying it as a controller.
+func UpdatePvcWithVMOwnerRef(
+	ctx context.Context,
+	c client.Client,
+	ownerVM client.Object,
+	pvcName, pvcNamespace string,
+	log logr.Logger,
+) error {
+	pvcLookupKey := types.NamespacedName{Namespace: pvcNamespace, Name: pvcName}
+
+	pvc := &corev1.PersistentVolumeClaim{}
+	if err := c.Get(ctx, pvcLookupKey, pvc); err != nil {
+		log.Error(err, "Failed to get PVC", "namespace", pvcNamespace, "PVCname", pvcName)
+
+		return err
+	}
+
+	needsUpdate, err := AddOwnerReference(pvc, ownerVM, c.Scheme())
+	if err != nil {
+		return fmt.Errorf("failed to add owner reference: %w", err)
+	}
+
+	if !needsUpdate {
+		log.Info("PVC already has the desired owner reference; no update needed",
+			"PVC name", pvc.GetName(), "Owned by VM", ownerVM.GetName())
+
+		return nil
+	}
+
+	if err := c.Update(ctx, pvc); err != nil {
+		log.Error(err, "Failed to update PVC with owner reference",
+			"namespace", pvcNamespace, "PVCname", pvcName)
+
+		return fmt.Errorf("failed to update PVC with owner reference: %w", err)
+	}
+
+	log.Info("Successfully updated PVC with owner reference to VM",
+		"PVC name", pvc.GetName(), "Owned by VM", ownerVM.GetName())
+
+	return nil
+}
+
+type item struct {
+	ns    string
+	owner metav1.OwnerReference
+}
+
+func getStackOfOwners(obj client.Object) []item {
+	owners := obj.GetOwnerReferences()
+	ownerNS := obj.GetNamespace()
+
+	stack := make([]item, 0, len(owners))
+	for _, o := range owners {
+		stack = append(stack, item{ns: ownerNS, owner: o})
+	}
+
+	return stack
+}
+
+// IsOwnedByVM walks the owner chain and returns the VM metadata object if found.
+// It prefers KubeVirt VM owners (kind=VirtualMachine, apigroup starts with kubevirt.io/)
+// Assuming all the owners are from same namespace
+// Typical KubeVirt ownership depth (PVC→DV→VM or PVC→VMI→VM or virt-launcher-pod->VMI->VM)
+func IsOwnedByVM(
+	ctx context.Context,
+	c client.Client,
+	obj client.Object,
+	log logr.Logger,
+) (client.Object, error) {
+	stack := getStackOfOwners(obj)
+
+	for len(stack) > 0 {
+		cur := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		// If this owner is a KubeVirt VM, return it
+		if isKubeVirtVM(cur.owner) {
+			vmMeta, err := fetchPartialMeta(ctx, c, cur.ns, cur.owner)
+			if err != nil {
+				log.Info("Failed to fetch VM owner ", "gvk",
+					gvkString(cur.owner), "name", cur.owner.Name, "err", err)
+
+				continue
+			}
+
+			if vmMeta.GetUID() == cur.owner.UID {
+				return vmMeta, nil
+			}
+
+			continue
+		}
+
+		// Try fetching only the owner's metadata
+		ownerMeta, err := fetchPartialMeta(ctx, c, cur.ns, cur.owner)
+		if err != nil {
+			log.Info("Failed to fetch owner ", "gvk",
+				gvkString(cur.owner), "name", cur.owner.Name, "err", err)
+
+			continue
+		}
+
+		if ownerMeta.GetUID() != cur.owner.UID {
+			// UID mismatch; skip
+			continue
+		}
+
+		// Otherwise, enqueue its parents (same namespace assumption for KubeVirt chain)
+		nestedOwners := ownerMeta.GetOwnerReferences()
+		for _, nestedOwner := range nestedOwners {
+			stack = append(stack, item{ns: cur.ns, owner: nestedOwner})
+		}
+	}
+
+	return nil, fmt.Errorf("no VM found in ownership chain")
+}
+
+func isKubeVirtVM(o metav1.OwnerReference) bool {
+	return o.Kind == KindVirtualMachine && o.APIVersion == KubeVirtAPIVersion
+}
+
+// Fetch only metadata of the owner
+func fetchPartialMeta(
+	ctx context.Context,
+	c client.Client,
+	ns string,
+	o metav1.OwnerReference,
+) (*metav1.PartialObjectMetadata, error) {
+	objMeta := &metav1.PartialObjectMetadata{}
+	objMeta.SetGroupVersionKind(schema.FromAPIVersionAndKind(o.APIVersion, o.Kind))
+
+	if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: o.Name}, objMeta); err != nil {
+		return nil, err
+	}
+
+	return objMeta, nil
+}
+
+func gvkString(o metav1.OwnerReference) string {
+	return o.APIVersion + "/" + o.Kind
 }

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
+	virtv1 "kubevirt.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -397,7 +399,8 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=list;watch
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods/exec,verbs=create
-// +kubebuilder:rbac:groups="kubevirt.io",resources=virtualmachines,verbs=get;list;watch;delete
+// +kubebuilder:rbac:groups="kubevirt.io",resources=virtualmachines,verbs=get;list;watch;patch;delete
+// +kubebuilder:rbac:groups="kubevirt.io",resources=virtualmachineinstances,verbs=get;list;watch
 // +kubebuilder:rbac:groups="cdi.kubevirt.io",resources=datavolumes,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
@@ -690,10 +693,15 @@ func (v *VRGInstance) listPVCsOwnedByVrg() (*corev1.PersistentVolumeClaimList, e
 
 func (v *VRGInstance) listPVCsByPVCSelector(labelSelector metav1.LabelSelector,
 ) (*corev1.PersistentVolumeClaimList, error) {
+	recipeName := ""
+	if v.recipeElements.RecipeWithParams != nil {
+		recipeName = v.recipeElements.RecipeWithParams.Name
+	}
 	return util.ListPVCsByPVCSelector(v.ctx, v.reconciler.Client, v.log,
 		labelSelector,
 		v.recipeElements.PvcSelector.NamespaceNames,
 		v.instance.Spec.VolSync.Disabled,
+		recipeName,
 	)
 }
 
@@ -1698,34 +1706,7 @@ func (v *VRGInstance) processAsSecondary() ctrl.Result {
 func (v *VRGInstance) reconcileAsSecondary() ctrl.Result {
 	result := ctrl.Result{}
 
-	if v.isVMRecipeProtection() {
-		v.log.Info("Checking VM cleanup and cross-cluster resource conflicts",
-			"name", v.instance.GetName(),
-			"namespace", v.instance.GetNamespace(),
-			"recipeName", "vm-recipe")
-
-		if err := v.validateVMsForStandaloneProtection(); err != nil {
-			result.Requeue = true
-		}
-
-		if !result.Requeue {
-			v.log.Info("VRG status observed",
-				"name", v.instance.GetName(),
-				"namespace", v.instance.GetNamespace(),
-				"replicationState", v.instance.Spec.ReplicationState,
-				"statusState", v.instance.Status.State,
-				"generation", v.instance.GetGeneration(),
-				"resourceVersion", v.instance.GetResourceVersion(),
-			)
-
-			if v.ShouldCleanupVMForSecondary() {
-				v.log.Info("Requeuing until VM cleanup is complete")
-
-				result.Requeue = true
-			}
-		}
-	}
-
+	result.Requeue = v.HandleSecondaryConflictsAndCleanup() || result.Requeue
 	result.Requeue = v.reconcileVolSyncAsSecondary() || result.Requeue
 	result.Requeue = v.reconcileVolRepsAsSecondary() || result.Requeue
 
@@ -1850,8 +1831,6 @@ func (v *VRGInstance) updateVRGStatus(result ctrl.Result) ctrl.Result {
 	}
 
 	v.updateStatusState()
-
-	result.Requeue = v.instance.Status.State == ramendrv1alpha1.UnknownState
 
 	v.instance.Status.ObservedGeneration = v.instance.Generation
 
@@ -2503,22 +2482,29 @@ func (v *VRGInstance) CheckForVMConflictOnSecondary() error {
 }
 
 func (v *VRGInstance) CheckForVMNameConflictOnSecondary(vmNamespaceList, vmList []string) error {
-	var foundVMs []string
+	foundVMs, err := util.ListVMsByVMNamespace(v.ctx, v.reconciler.Client,
+		v.log, vmNamespaceList, vmList)
+	if err != nil {
+		return err
+	}
 
-	var err error
-	if foundVMs, err = util.ListVMsByVMNamespace(v.ctx, v.reconciler.APIReader,
-		v.log, vmNamespaceList, vmList); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return fmt.Errorf("failed to lookup virtualmachine resources, check rbacs")
-		}
-
+	if len(foundVMs) == 0 {
 		return nil
 	}
 
-	v.log.Info(fmt.Sprintf("found conflicting VM[%v] on secondary", foundVMs))
+	v.log.Info("found conflicting VMs on secondary", "foundVMs", vmNamesString(foundVMs))
 
 	return fmt.Errorf("protected VMs on the primary cluster share names with VMs on " +
 		"the secondary site, which may impact failover or recovery")
+}
+
+func vmNamesString(vms []virtv1.VirtualMachine) string {
+	names := make([]string, len(vms))
+	for i := range vms {
+		names[i] = vms[i].Name
+	}
+
+	return strings.Join(names, ", ")
 }
 
 func (v *VRGInstance) aggregateVRGNoClusterDataConflictCondition() *metav1.Condition {

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -18,6 +18,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	virtv1 "kubevirt.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -246,7 +247,8 @@ func (v *VRGInstance) isPVCReadyForSecondary(pvc *corev1.PersistentVolumeClaim, 
 
 	// If PVC is not being deleted, it is not ready for Secondary, unless action is failover
 	if v.instance.Spec.Action != ramendrv1alpha1.VRGActionFailover && !rmnutil.ResourceIsDeleted(pvc) {
-		log.Info("VolumeReplication cannot become Secondary, as its PersistentVolumeClaim is not marked for deletion")
+		log.Info("VolumeReplication cannot become Secondary, as its PersistentVolumeClaim is not marked for deletion",
+			"pvc", pvc.Name)
 
 		msg := "unable to transition to Secondary as PVC is not deleted"
 		v.updatePVCDataReadyCondition(pvc.Namespace, pvc.Name, VRGConditionReasonProgressing, msg)
@@ -2889,13 +2891,60 @@ func PruneAnnotations(annotations map[string]string) map[string]string {
 	return result
 }
 
-func (v *VRGInstance) ShouldCleanupVMForSecondary() bool {
-	if !v.IsDRActionInProgress() {
-		v.log.Info("Skip VM cleanup; reconcile as secondary")
+// Checks and requeues reconciler of VM resource cleanup.
+func (v *VRGInstance) HandleSecondaryConflictsAndCleanup() bool {
+	if !v.isVMRecipeProtection() {
+		return false
+	}
+
+	v.log.Info("Checking VM cleanup and cross-cluster resource conflicts",
+		"recipeName", "vm-recipe")
+
+	if v.isResourceConflict() {
+		v.log.Info("Conflict detected; blocking resource cleanup until resolution")
 
 		return false
 	}
 
+	v.log.Info("VRG status observed",
+		"replicationState", v.instance.Spec.ReplicationState,
+		"statusState", v.instance.Status.State,
+		"generation", v.instance.GetGeneration(),
+		"resourceVersion", v.instance.GetResourceVersion(),
+	)
+
+	if !v.IsDRActionInProgress() {
+		v.log.Info("Skip resource cleanup; reconcile as secondary")
+
+		return false
+	}
+
+	if v.ShouldCleanupVMForSecondary() {
+		v.log.Info("Requeuing until VM cleanup is complete")
+
+		return true
+	}
+
+	return false
+}
+
+// Checks if there are conflicting protected resources across managed clusters
+func (v *VRGInstance) isResourceConflict() bool {
+	if err := v.validateVMsForStandaloneProtection(); err != nil {
+		return true
+	}
+
+	return false
+}
+
+//  1. If VM resource cleanup is in progress, requeue for reconciliation
+//  2. If protected VMs are not found in protected NS, consider VM cleanup complete
+//  3. Validates if all protected VMs owns PVCs from the lis tof all the protected volumes directly or indirectly
+//     a) VM manifest has references to PVC through DataVolumeTemplate or DataVolume
+//     b) VM instance pod - virt-launcher-xxx is using the PVC, whose lifecycle management is independent of VM
+//  4. for step 3(b) VM ownership is set on the respective PVCs
+//  5. Deletes the VM using cascade foreground deletion API
+func (v *VRGInstance) ShouldCleanupVMForSecondary() bool {
 	v.log.Info(
 		"DR action progressing",
 		"component", "VRGController",
@@ -2908,81 +2957,271 @@ func (v *VRGInstance) ShouldCleanupVMForSecondary() bool {
 
 	vmNamespaceList := v.instance.Spec.KubeObjectProtection.RecipeParameters[recipecore.ProtectedVMNamespace]
 	vmList := v.instance.Spec.KubeObjectProtection.RecipeParameters[recipecore.VMList]
-	var foundVMs []string
-	var err error
-	if len(vmList) > 0 {
-		if rmnutil.IsVMDeletionInProgress(v.ctx, v.reconciler.Client, vmList, vmNamespaceList, v.log) {
-			v.log.Info("VM deletion is in progress, skipping ownerreferences check")
 
-			return true
-		}
-
-		foundVMs, err = rmnutil.ListVMsByVMNamespace(v.ctx, v.reconciler.APIReader,
-			v.log, vmNamespaceList, vmList)
-		if len(foundVMs) == 0 || err != nil {
-			v.log.Info(
-				"No VirtualMachines found for cleanup; deletion appears complete",
-				"vmList", vmList,
-				"namespaceList", vmNamespaceList,
-			)
-
-			return false
-		}
-	}
-
-	if v.IsAllProtectedPVCsOwnedByProtectedVMs(foundVMs) {
-		v.log.Info("all protected PVCs have ownerreferences to protected list of VMs")
-		// Cleanup VM resources
-		err := rmnutil.DeleteVMs(v.ctx, v.reconciler.Client, vmList, vmNamespaceList, v.log)
-		if err != nil {
-			v.log.Error(err, "Failed to delete VMs",
-				"vmList", vmList,
-			)
-
-			return false
-		}
-
+	foundVMs, yes := v.skipVMCleanupVerificationCheck()
+	if yes { // VM cleanup is in progress
 		return true
 	}
 
-	v.log.Info("not all protected PVCs have ownerReferences to the protected list of VMs")
+	if len(foundVMs) == 0 && !yes { // VM cleanup complete
+		v.log.Info(
+			"No VirtualMachines found for cleanup; deletion appears complete",
+			"vmList", vmList,
+			"namespaceList", vmNamespaceList,
+		)
 
-	return false
+		return false
+	}
+
+	// Proceed to verify if VMs are eligibile for auto-cleanup
+
+	yes = v.validatePVCOwnershipOnVMs()
+	if !yes {
+		v.log.Info("VMs not eligible for automated cleanup")
+
+		return yes
+	}
+
+	v.log.Info("Proceed to cleanup VM resources")
+	// Cleanup VM resources
+	err := rmnutil.DeleteVMs(v.ctx, v.reconciler.Client, foundVMs, v.log)
+	if err != nil { // Requeue and retry
+		v.log.Error(err, "Failed to delete VMs",
+			"vmList", vmList,
+		)
+
+		// return false
+	}
+
+	return true
+
+	// return false
 }
 
-func (v *VRGInstance) IsAllProtectedPVCsOwnedByProtectedVMs(foundVMs []string) bool {
-	yes := true
-	vmList := v.instance.Spec.KubeObjectProtection.RecipeParameters[recipecore.VMList]
+// pvcProcessResult captures the decision for a single PVC.
+type pvcProcessResult struct {
+	vm    *metav1.PartialObjectMetadata
+	skip  bool // manual cleanup required; abort overall cleanup
+	retry bool // transient error; request requeue
+}
 
-	allPVCs := make([]corev1.PersistentVolumeClaim, 0, len(v.volRepPVCs)+len(v.volSyncPVCs))
-	allPVCs = append(allPVCs, v.volRepPVCs...)
-	allPVCs = append(allPVCs, v.volSyncPVCs...)
+// ValidatePVCOwnershipOnVMs ensures PVCs used by protected VMs carry VM OwnerReferences,
+// or decides to skip/retry cleanup based on current state.
+func (v *VRGInstance) validatePVCOwnershipOnVMs() bool {
+	protectedPVCs := v.collectProtectedPVCs()
+	protectedVMs := v.instance.Spec.KubeObjectProtection.RecipeParameters[recipecore.VMList]
+	protectedVMSet := toSet(protectedVMs)
 
-	for idx := range allPVCs {
-		pvc := &allPVCs[idx]
-		log := logWithPvcName(v.log, pvc)
+	// Map PVC name → VM for patching later
+	pvcToVM := make(map[string]*metav1.PartialObjectMetadata)
 
-		vmName, err := rmnutil.IsOwnedByVM(v.ctx, v.reconciler.Client, pvc, pvc.OwnerReferences, log)
-		if err != nil {
-			log.Error(err, "Skipping cleanup",
-				"pvc", pvc.Name,
-				"vm", vmName,
-				"reason", "invalid ownerReferences",
-				"action", "manual cleanup required")
-			return false
+	var (
+		skipCleanup  bool
+		retryCleanup bool
+	)
+
+	for i := range protectedPVCs {
+		if rmnutil.ResourceIsDeleted(&protectedPVCs[i]) {
+			// skip validation if pvc is already in terminating state
+			continue
 		}
 
-		v.log.Info("PVC is owned by VM", "pvc", pvc.Name, "vm", vmName)
+		res := v.verifyVMPVCOwnershipAndUsage(&protectedPVCs[i], protectedVMSet)
+		if res.skip {
+			skipCleanup = true
 
-		if !slices.Contains(vmList, vmName) {
-			v.log.Info("PVC is owned by a VM that is not in the protected VM list",
-				"pvc", pvc.Name,
-				"vm", vmName,
-				"protectedVMs", vmList)
+			break
+		}
 
-			return false
+		if res.retry {
+			retryCleanup = true
+
+			break
+		}
+
+		if res.vm != nil {
+			pvcToVM[protectedPVCs[i].Name] = res.vm
 		}
 	}
 
-	return yes
+	// If any PVC cannot be associated → skip cleanup
+	if skipCleanup || len(pvcToVM) == 0 {
+		return false
+	}
+
+	// Patch PVCs outside the loop
+	if v.patchPVCsOwnerRefs(pvcToVM) {
+		retryCleanup = true
+	}
+	// return true if no retry needed, return false if retry required
+	return !retryCleanup
+}
+
+// collectProtectedPVCs merges volRepPVCs and volSyncPVCs.
+func (v *VRGInstance) collectProtectedPVCs() []corev1.PersistentVolumeClaim {
+	p := make([]corev1.PersistentVolumeClaim, 0, len(v.volRepPVCs)+len(v.volSyncPVCs))
+	p = append(p, v.volRepPVCs...)
+	p = append(p, v.volSyncPVCs...)
+
+	return p
+}
+
+// verifyVMPVCOwnershipAndUsage decides what to do with a single PVC:
+// - If it already has an OwnerReference, validate it.
+// - Else, check if used by virt-launcher, and whether VM is protected.
+// Returns mapping info or flags indicating skip/retry.
+func (v *VRGInstance) verifyVMPVCOwnershipAndUsage(
+	pvc *corev1.PersistentVolumeClaim,
+	protectedVMSet map[string]struct{},
+) pvcProcessResult {
+	log := logWithPvcName(v.log, pvc)
+
+	if len(pvc.OwnerReferences) > 0 {
+		return v.handleExistingOwnerRef(pvc, log)
+	}
+
+	vm, decision := v.resolveOwnerFromVirtLauncher(pvc, log)
+	if decision.skip || decision.retry || vm == nil {
+		return decision
+	}
+
+	// 3) Ensure VM is among protected VMs; else skip cleanup.
+	if !v.isProtectedVM(vm.GetName(), protectedVMSet) {
+		log.Info("Skipping cleanup, PVC not used by protected VM", "pvc", pvc.Name, "vm", vm.GetName())
+
+		return pvcProcessResult{skip: true}
+	}
+
+	// 4) Success: return VM metadata for patching.
+	pom, ok := vm.(*metav1.PartialObjectMetadata)
+	if !ok {
+		log.Info("VirtualMachine(VM) map function received non-VM resource")
+
+		return pvcProcessResult{}
+	}
+
+	return pvcProcessResult{vm: pom}
+}
+
+// handleExistingOwnerRef validates PVC ownerReferences chain and returns skip on invalid.
+func (v *VRGInstance) handleExistingOwnerRef(
+	pvc *corev1.PersistentVolumeClaim,
+	log logr.Logger,
+) pvcProcessResult {
+	vm, err := rmnutil.IsOwnedByVM(v.ctx, v.reconciler.Client, pvc, log)
+	if err != nil {
+		log.Error(err, "Skipping cleanup", "pvc", pvc.Name,
+			"reason", "invalid ownerReferences", "action", "manual cleanup required")
+
+		return pvcProcessResult{skip: true}
+	}
+
+	log.Info("Continue with cleanup",
+		"pvc", pvc.GetName(),
+		"ownedByVM", vm.GetName(),
+		"ownerReferences", pvc.OwnerReferences)
+
+	// Already valid; no patching needed
+	pom, ok := vm.(*metav1.PartialObjectMetadata)
+	if !ok {
+		log.Info("VirtualMachine(VM) map function received non-VM resource")
+
+		return pvcProcessResult{}
+	}
+
+	return pvcProcessResult{vm: pom}
+}
+
+// resolveOwnerFromVirtLauncher tries to map PVC usage to a virt-launcher pod's VM.
+func (v *VRGInstance) resolveOwnerFromVirtLauncher(
+	pvc *corev1.PersistentVolumeClaim,
+	log logr.Logger,
+) (client.Object, pvcProcessResult) {
+	ownerVMMetadata, err := rmnutil.IsUsedByVirtLauncherPod(v.ctx, v.reconciler.Client, pvc, log)
+	if err != nil {
+		// Transient resolution error → ask for retry
+		return nil, pvcProcessResult{retry: true}
+	}
+
+	if ownerVMMetadata == nil {
+		// No virt-launcher usage found → manual cleanup
+		return nil, pvcProcessResult{skip: true}
+	}
+
+	// Ensure the reported object is a VM PartialObjectMetadata
+	vm, ok := ownerVMMetadata.(*metav1.PartialObjectMetadata)
+	if !ok {
+		log.Info("VirtualMachine(VM) map function received non-VM resource")
+
+		return nil, pvcProcessResult{}
+	}
+
+	return vm, pvcProcessResult{}
+}
+
+// isProtectedVM checks membership in the protected set.
+func (v *VRGInstance) isProtectedVM(vmName string, protectedVMSet map[string]struct{}) bool {
+	_, ok := protectedVMSet[vmName]
+
+	return ok
+}
+
+// patchPVCsOwnerRefs applies VM OwnerReference to PVCs and returns true if any patch failed.
+func (v *VRGInstance) patchPVCsOwnerRefs(pvcToVM map[string]*metav1.PartialObjectMetadata) bool {
+	var patchError bool
+
+	for pvcName, vm := range pvcToVM {
+		err := rmnutil.UpdatePvcWithVMOwnerRef(v.ctx, v.reconciler.Client, vm, pvcName, vm.Namespace, v.log)
+		if err != nil {
+			v.log.Error(err, "Failed to patch PVC owner reference",
+				"pvcName", pvcName,
+				"vm", vm.GetName())
+
+			patchError = true
+		}
+	}
+
+	return patchError
+}
+
+func toSet(items []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(items))
+	for _, it := range items {
+		m[it] = struct{}{}
+	}
+
+	return m
+}
+
+// skip VM cleanup if cleanup is already in progress or cleanup just completed.
+// Returns TRUE to skip further validation and requeue for reconcile
+// Rerurns FALSE to proceed further with VM GarbageCollection process
+// Returns empty VM array list and FALSE if VM GC is complete and no need to requeue for reconcile
+func (v *VRGInstance) skipVMCleanupVerificationCheck() ([]virtv1.VirtualMachine, bool) {
+	vmNamespaceList := v.instance.Spec.KubeObjectProtection.RecipeParameters[recipecore.ProtectedVMNamespace]
+	vmList := v.instance.Spec.KubeObjectProtection.RecipeParameters[recipecore.VMList]
+
+	var foundVMs []virtv1.VirtualMachine
+
+	if len(vmList) == 0 {
+		v.log.V(1).Info("no protected VMs specified. Skipping VM garbage collection processing")
+
+		return nil, true
+	}
+
+	foundVMs, yes, err := rmnutil.IsVMDeletionInProgress(v.ctx, v.reconciler.Client, vmList, vmNamespaceList, v.log)
+	if err != nil {
+		// Skip and requeue for Get API errors
+		v.log.V(1).Error(err, "Failed to list VMs")
+
+		return foundVMs, true
+	}
+
+	if yes { // skip and requeue as deletion is already in progress
+		v.log.Info("VM deletion is in progress, skipping ownerreferences check")
+
+		return foundVMs, true
+	}
+
+	return foundVMs, false
 }


### PR DESCRIPTION
##### What caused the problem
VM Prime PVCs were being incorrectly included in the protected PVC list because the default Ramen VM label selector was still present on these temporary PVCs.
The Ramen VRG reconciler uses label selectors to identify resources (VMs and PVCs) for protection. After a VM is enrolled for DR:

**Upstream**: This label selector is added on the VM and its resources by the user.
**Downstream:** The default label is added to the VirtualMachine CR by the ODF UI console to mark it as protected.

This mechanism allows Ramen to pseudo-own resources and manage subsets of VMs in a namespace.
However, during restore or relocation workflows, temporary PVCs (Prime PVCs) created for VolumeImportSource/DataVolume inherit this label. If PV adoption succeeds but the Prime PVC retains Ramen finalizers and the VM label selector, it is not garbage-collected and gets treated as a protected resource.
This leads to:

- PVC duplication and VolumeReplication sprawl during multiple DR actions (relocate/failover).
- Unnecessary storage consumption and bandwidth usage during sync.


How it’s fixed

- Added logic to filter out VM Prime PVCs from the protected PVC list.
- When a temporary importer PVC is detected, unset the VM label selector to ensure it is automatically dropped and not considered for protection.

Impact

- Prevents accidental protection of temporary PVCs.
- Reduces risk of restore failures and dangling resources.
- Optimizes DR workflows by avoiding unnecessary storage and replication overhead.

Fixes: [2353](https://github.com/RamenDR/ramen/issues/2353)
Updated RBAC permissions on VirtualMachine CRD to use the 'update' verb instead of 'patch' for label modifications.