### PR TITLE
Filter out VM Prime PVCs from protected PVC list by unsetting VM label selector on prime PVC

### DIFF
--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -307,6 +307,7 @@ rules:
   - list
   - watch
   - patch
+  - update
   - delete
 - apiGroups:
   - kubevirt.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -248,11 +248,12 @@ rules:
   resources:
   - virtualmachines
   verbs:
-  - delete
   - get
   - list
-  - patch
   - watch
+  - patch
+  - update
+  - delete
 - apiGroups:
   - multicluster.x-k8s.io
   resources:

--- a/internal/controller/cephfscg/cghandler.go
+++ b/internal/controller/cephfscg/cghandler.go
@@ -200,8 +200,13 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupSource(
 		namespaces = *c.instance.Spec.ProtectedNamespaces
 	}
 
+	recipeName := ""
+	if c.instance.Spec.KubeObjectProtection != nil && c.instance.Spec.KubeObjectProtection.RecipeRef != nil {
+		recipeName = c.instance.Spec.KubeObjectProtection.RecipeRef.Name
+	}
+
 	volumeGroupSnapshotClassName, err := util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(c.ctx, c.Client,
-		c.volumeGroupSnapshotClassSelector, *c.volumeGroupSnapshotSource, namespaces, c.logger)
+		c.volumeGroupSnapshotClassSelector, *c.volumeGroupSnapshotSource, namespaces, c.logger, recipeName)
 	if err != nil {
 		log.Error(err, "Failed to get VGSClass name")
 		// If final sync is requested, ensure final sync cleanup is run regardless of the error

--- a/internal/controller/util/cephfs_cg.go
+++ b/internal/controller/util/cephfs_cg.go
@@ -104,13 +104,14 @@ func GetVolumeGroupSnapshotClassFromPVCsStorageClass(
 	pvcsConsistencyGroupSelector metav1.LabelSelector,
 	namespace []string,
 	logger logr.Logger,
+	recipeName string,
 ) (string, error) {
 	volumeGroupSnapshotClasses, err := GetVolumeGroupSnapshotClasses(ctx, k8sClient, volumeGroupSnapshotClassSelector)
 	if err != nil {
 		return "", err
 	}
 
-	pvcs, err := ListPVCsByPVCSelector(ctx, k8sClient, logger, pvcsConsistencyGroupSelector, namespace, false)
+	pvcs, err := ListPVCsByPVCSelector(ctx, k8sClient, logger, pvcsConsistencyGroupSelector, namespace, false, recipeName)
 	if err != nil {
 		return "", err
 	}

--- a/internal/controller/util/cephfs_cg_test.go
+++ b/internal/controller/util/cephfs_cg_test.go
@@ -251,7 +251,8 @@ var _ = Describe("CephfsCg", func() {
 		Describe("GetVolumeGroupSnapshotClassFromPVCsStorageClass", func() {
 			It("Should be failed", func() {
 				volumeGroupSnapshotClassName, err := util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(
-					context.Background(), k8sClient, metav1.LabelSelector{}, metav1.LabelSelector{}, []string{"default"}, testLogger)
+					context.Background(), k8sClient, metav1.LabelSelector{}, metav1.LabelSelector{},
+					[]string{"default"}, testLogger, "")
 				Expect(volumeGroupSnapshotClassName).To(Equal(""))
 				Expect(err).NotTo(BeNil())
 				Expect(err.Error()).To(ContainSubstring("unable to find matching volumegroupsnapshotclass for storage provisioner"))
@@ -269,26 +270,29 @@ var _ = Describe("CephfsCg", func() {
 					volumeGroupSnapshotClassName, err := util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(
 						context.Background(), k8sClient,
 						metav1.LabelSelector{MatchLabels: map[string]string{"test": "testxxxx"}},
-						metav1.LabelSelector{}, []string{"default"}, testLogger)
+						metav1.LabelSelector{}, []string{"default"}, testLogger, "")
 					Expect(volumeGroupSnapshotClassName).To(Equal(""))
 					Expect(err).NotTo(BeNil())
 
 					volumeGroupSnapshotClassName, err = util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(
 						context.Background(), k8sClient,
 						metav1.LabelSelector{MatchLabels: map[string]string{"test": "test"}},
-						metav1.LabelSelector{MatchLabels: map[string]string{"test": "test"}}, []string{"default"}, testLogger)
+						metav1.LabelSelector{MatchLabels: map[string]string{"test": "test"}}, []string{"default"},
+						testLogger, "")
 					Expect(volumeGroupSnapshotClassName).To(Equal(""))
 					Expect(err).NotTo(BeNil())
 
 					volumeGroupSnapshotClassName, err = util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(
-						context.Background(), k8sClient, metav1.LabelSelector{}, metav1.LabelSelector{}, []string{"default"}, testLogger)
+						context.Background(), k8sClient, metav1.LabelSelector{}, metav1.LabelSelector{}, []string{"default"},
+						testLogger, "")
 					Expect(volumeGroupSnapshotClassName).To(Equal("vgsc"))
 					Expect(err).To(BeNil())
 
 					volumeGroupSnapshotClassName, err = util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(
 						context.Background(), k8sClient,
 						metav1.LabelSelector{MatchLabels: map[string]string{"test": "test"}},
-						metav1.LabelSelector{MatchLabels: map[string]string{"testpvc": "testpvc"}}, []string{"default"}, testLogger)
+						metav1.LabelSelector{MatchLabels: map[string]string{"testpvc": "testpvc"}}, []string{"default"},
+						testLogger, "")
 					Expect(volumeGroupSnapshotClassName).To(Equal("vgsc"))
 					Expect(err).To(BeNil())
 				})

--- a/internal/controller/util/pvcs_util_test.go
+++ b/internal/controller/util/pvcs_util_test.go
@@ -91,7 +91,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should list all PVCs when VolSync is disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					true /* Volsync Disabled */)
+					true /* Volsync Disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(pvcCount))
@@ -106,7 +106,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should filter out VolSync PVCs when VolSync is not disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					false /* Volsync NOT disabled */)
+					false /* Volsync NOT disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(pvcCount - 2)) // 2 PVCs are VolSync PVCs
@@ -127,7 +127,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should list matching PVCs when VolSync is disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					true /* Volsync Disabled */)
+					true /* Volsync Disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(3))
@@ -141,7 +141,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should list matching PVCs and filter out VolSync PVCs when VolSync is not disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					false /* Volsync NOT Disabled */)
+					false /* Volsync NOT Disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(1))
@@ -162,7 +162,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should list matching PVCs when VolSync is disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					true /* Volsync Disabled */)
+					true /* Volsync Disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(2))
@@ -175,7 +175,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should list matching PVCs and filter out VolSync PVCs when VolSync is not disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					false /* Volsync NOT Disabled */)
+					false /* Volsync NOT Disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(1))
@@ -203,7 +203,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should list matching PVCs when VolSync is disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					true /* Volsync Disabled */)
+					true /* Volsync Disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(2))
@@ -216,7 +216,7 @@ var _ = Describe("PVCS_Util", func() {
 			It("Should list matching PVCs and filter out VolSync PVCs when VolSync is not disabled", func() {
 				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
 					[]string{testNamespace.GetName()},
-					false /* Volsync NOT Disabled */)
+					false /* Volsync NOT Disabled */, "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(1))

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -399,7 +399,7 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=list;watch
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods/exec,verbs=create
-// +kubebuilder:rbac:groups="kubevirt.io",resources=virtualmachines,verbs=get;list;watch;patch;delete
+// +kubebuilder:rbac:groups="kubevirt.io",resources=virtualmachines,verbs=get;list;watch;update;delete
 // +kubebuilder:rbac:groups="kubevirt.io",resources=virtualmachineinstances,verbs=get;list;watch
 // +kubebuilder:rbac:groups="cdi.kubevirt.io",resources=datavolumes,verbs=get;list;watch
 
@@ -693,10 +693,16 @@ func (v *VRGInstance) listPVCsOwnedByVrg() (*corev1.PersistentVolumeClaimList, e
 
 func (v *VRGInstance) listPVCsByPVCSelector(labelSelector metav1.LabelSelector,
 ) (*corev1.PersistentVolumeClaimList, error) {
+	recipeName := ""
+	if v.recipeElements.RecipeWithParams != nil {
+		recipeName = v.recipeElements.RecipeWithParams.Name
+	}
+
 	return util.ListPVCsByPVCSelector(v.ctx, v.reconciler.Client, v.log,
 		labelSelector,
 		v.recipeElements.PvcSelector.NamespaceNames,
 		v.instance.Spec.VolSync.Disabled,
+		recipeName,
 	)
 }
 


### PR DESCRIPTION
#### What caused the problem
VM Prime PVCs were being incorrectly included in the protected PVC list because the default Ramen VM label selector was still present on these temporary PVCs.
The Ramen VRG reconciler uses label selectors to identify resources (VMs and PVCs) for protection. After a VM is enrolled for DR:

**Upstream**: This label selector is added on the VM and its resources by the user.
**Downstream:** The default label is added to the VirtualMachine CR by the ODF UI console to mark it as protected.

This mechanism allows Ramen to pseudo-own resources and manage subsets of VMs in a namespace.
However, during restore or relocation workflows, temporary PVCs (Prime PVCs) created for VolumeImportSource/DataVolume inherit this label. If PV adoption succeeds but the Prime PVC retains Ramen finalizers and the VM label selector, it is not garbage-collected and gets treated as a protected resource.
This leads to:

- PVC duplication and VolumeReplication sprawl during multiple DR actions (relocate/failover).
- Unnecessary storage consumption and bandwidth usage during sync.


How it’s fixed

- Added logic to filter out VM Prime PVCs from the protected PVC list.
- When a temporary importer PVC is detected, unset the VM label selector to ensure it is automatically dropped and not considered for protection.

Impact

- Prevents accidental protection of temporary PVCs.
- Reduces risk of restore failures and dangling resources.
- Optimizes DR workflows by avoiding unnecessary storage and replication overhead.

Fixes: [2353](https://github.com/RamenDR/ramen/issues/2353)
Updated RBAC permissions on VirtualMachine CRD to use the 'update' verb instead of 'patch' for ownerReference modifications.