### PR TITLE
fix: preserve PVC annotations during cephfs volume failover/relocate

### DIFF
--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -2643,3 +2643,47 @@ func (v *VRGInstance) validateSecondaryPVCConflictForVolRep() *metav1.Condition 
 
 	return nil
 }
+
+// pruneAnnotations takes a map of annotations and removes the annotations where the key start with:
+//   - pv.kubernetes.io
+//   - replication.storage.openshift.io
+//   - volumereplicationgroups.ramendr.openshift.io
+//   - volsync.backube
+//   - apps.open-cluster-management.io && key == ACMAppSubDoNotDeleteAnnotation
+//
+// Parameters:
+//
+//	annotations: the map of annotations to prune
+//
+// Returns:
+//
+//	a new map containing only the remaining annotations
+func PruneAnnotations(annotations map[string]string) map[string]string {
+	if annotations == nil {
+		return map[string]string{}
+	}
+
+	result := make(map[string]string)
+
+	for key, value := range annotations {
+		switch {
+		case strings.HasPrefix(key, "pv.kubernetes.io"):
+			continue
+		case strings.HasPrefix(key, "volume.kubernetes.io"):
+			continue
+		case strings.HasPrefix(key, "replication.storage.openshift.io"):
+			continue
+		case strings.HasPrefix(key, "volumereplicationgroups.ramendr.openshift.io"):
+			continue
+		case strings.HasPrefix(key, "volsync.backube"):
+			continue
+		case strings.HasPrefix(key, "apps.open-cluster-management.io") &&
+			key == volsync.ACMAppSubDoNotDeleteAnnotation:
+			continue
+		}
+
+		result[key] = value
+	}
+
+	return result
+}

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -2854,43 +2854,6 @@ func (v *VRGInstance) aggregateVolRepClusterDataProtectedCondition() *metav1.Con
 	return newVRGClusterDataProtectedCondition(v.instance.Generation, msg)
 }
 
-// pruneAnnotations takes a map of annotations and removes the annotations where the key start with:
-//   - pv.kubernetes.io
-//   - replication.storage.openshift.io
-//   - volumereplicationgroups.ramendr.openshift.io
-//
-// Parameters:
-//
-//	annotations: the map of annotations to prune
-//
-// Returns:
-//
-//	a new map containing only the remaining annotations
-func PruneAnnotations(annotations map[string]string) map[string]string {
-	if annotations == nil {
-		return map[string]string{}
-	}
-
-	result := make(map[string]string)
-
-	for key, value := range annotations {
-		switch {
-		case strings.HasPrefix(key, "pv.kubernetes.io"):
-			continue
-		case strings.HasPrefix(key, "replication.storage.openshift.io"):
-			continue
-		case strings.HasPrefix(key, "volumereplicationgroups.ramendr.openshift.io"):
-			continue
-		case strings.HasPrefix(key, "volsync.backube"):
-			continue
-		}
-
-		result[key] = value
-	}
-
-	return result
-}
-
 // Checks and requeues reconciler of VM resource cleanup.
 func (v *VRGInstance) HandleSecondaryConflictsAndCleanup() bool {
 	if !v.isVMRecipeProtection() {

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -262,7 +262,7 @@ func (v *VRGInstance) buildProtectedPVCForPVC(pvc corev1.PersistentVolumeClaim) 
 		Namespace:          pvc.Namespace,
 		ProtectedByVolSync: true,
 		StorageClassName:   pvc.Spec.StorageClassName,
-		Annotations:        protectedPVCAnnotations(pvc),
+		Annotations:        PruneAnnotations(pvc.GetAnnotations()),
 		Labels:             pvc.Labels,
 		AccessModes:        pvc.Spec.AccessModes,
 		Resources:          pvc.Spec.Resources,
@@ -798,25 +798,6 @@ func (v VRGInstance) isVolSyncProtectedPVCConditionReady(conType string) bool {
 	}
 
 	return ready
-}
-
-// protectedPVCAnnotations return the annotations that we must propagate to the
-// destination cluster:
-//   - apps.open-cluster-management.io/* - required to make the protected PVC
-//     owned by OCM when DR is disabled. Copy all annnotations except the
-//     special "do-not-delete" annotation, used only on the source cluster
-//     during relocate.
-func protectedPVCAnnotations(pvc corev1.PersistentVolumeClaim) map[string]string {
-	res := map[string]string{}
-
-	for key, value := range pvc.Annotations {
-		if strings.HasPrefix(key, "apps.open-cluster-management.io/") &&
-			key != volsync.ACMAppSubDoNotDeleteAnnotation {
-			res[key] = value
-		}
-	}
-
-	return res
 }
 
 func (v *VRGInstance) isPVCDeletedForUnprotection(pvc *corev1.PersistentVolumeClaim) bool {

--- a/internal/controller/vrg_volsync_test.go
+++ b/internal/controller/vrg_volsync_test.go
@@ -140,6 +140,7 @@ var _ = Describe("VolumeReplicationGroupVolSyncController", func() {
 					volsync.ACMAppSubDoNotDeleteAnnotation:                 volsync.ACMAppSubDoNotDeleteAnnotationVal,
 					"pv.kubernetes.io/bind-completed":                      "yes",
 					"volume.kubernetes.io/storage-provisioner":             "provisioner",
+					"any-other-annotation":                                 "any-value",
 				}
 
 				JustBeforeEach(func() {
@@ -190,6 +191,10 @@ var _ = Describe("VolumeReplicationGroupVolSyncController", func() {
 							"apps.open-cluster-management.io/hosting-subscription", "sub-name"))
 						Expect(vsPvc.Annotations).To(HaveKeyWithValue(
 							"apps.open-cluster-management.io/reconcile-option", "merge"))
+
+						// Any other annotations are also progagated.
+						Expect(vsPvc.Annotations).To(HaveKeyWithValue(
+							"any-other-annotation", "any-value"))
 
 						// Except the do-no-delete annotion
 						Expect(vsPvc.Annotations).NotTo(HaveKey(volsync.ACMAppSubDoNotDeleteAnnotation))


### PR DESCRIPTION
For cephfs volumes, PVC annotations were not being transferred to the destination cluster, causing applications like PostgreSQL to fail on the target side after successful failover/relocation.

This commit ensures that all PVC annotations are properly copied from the source cluster to the destination cluster. This preserves critical metadata required by applications and storage provisioners to function correctly after action change.

Fixes: https://issues.redhat.com/browse/DFBUGS-4945