### PR TITLE
When there are no protected CG, clear PVCGroups in VRG status

### DIFF
--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1836,6 +1836,8 @@ func (v *VRGInstance) updateVRGStatus(result ctrl.Result) ctrl.Result {
 
 	if len(pvcGroups) > 0 {
 		v.instance.Status.PVCGroups = pvcGroups
+	} else {
+		v.instance.Status.PVCGroups = nil
 	}
 
 	v.updateStatusState()


### PR DESCRIPTION
While testing Failover/Relocation, I noticed that when all protected PVCs are removed from the secondary VRG, status.PVCGroups is not cleared. It keeps the previous value instead of being null/empty, which makes the VRG status misleading.

This PR explicitly sets status.PVCGroups = nil when there are no PVC groups, so the VRG YAML reflects the actual state.