### PR TITLE
Set DRPC.status.Progression During Ongoing VM Resource Cleanup on Target Managed Cluster

### DIFF
--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -100,6 +100,7 @@ const (
 	ProgressionCreatingMW                          = ProgressionStatus("CreatingMW")
 	ProgressionUpdatingPlRule                      = ProgressionStatus("UpdatingPlRule")
 	ProgressionWaitForReadiness                    = ProgressionStatus("WaitForReadiness")
+	ProgressionCleanupReadiness                    = ProgressionStatus("CleanupReadiness")
 	ProgressionCleaningUp                          = ProgressionStatus("Cleaning Up")
 	ProgressionWaitOnUserToCleanUp                 = ProgressionStatus("WaitOnUserToCleanUp")
 	ProgressionCheckingFailoverPrerequisites       = ProgressionStatus("CheckingFailoverPrerequisites")

--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -307,6 +307,7 @@ rules:
   - list
   - watch
   - patch
+  - update
   - delete
 - apiGroups:
   - kubevirt.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -252,6 +252,7 @@ rules:
   - get
   - list
   - patch
+  - update
   - watch
 - apiGroups:
   - multicluster.x-k8s.io

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -985,6 +985,18 @@ func (v *VRGInstance) aggregateVolSyncClusterDataConflictCondition() *metav1.Con
 	return noClusterDataConflictCondition
 }
 
+func (v *VRGInstance) aggregateVolSyncAutoCleanupCondition() *metav1.Condition {
+	autoCleanupCondition := &metav1.Condition{
+		Status:             metav1.ConditionFalse,
+		Type:               VRGConditionTypeAutoCleanup,
+		Reason:             VRGConditionReasonUnused,
+		ObservedGeneration: v.instance.Generation,
+		Message:            "Automated cleanup not applicable for VolSync scheme.",
+	}
+
+	return autoCleanupCondition
+}
+
 func (v *VRGInstance) getCGLablelFromPVC(pvc *corev1.PersistentVolumeClaim, finalSync bool) (string, bool) {
 	cgLabelVal, ok := pvc.Labels[util.ConsistencyGroupLabel]
 	if ok && cgLabelVal != "" {


### PR DESCRIPTION
[Design Doc for the feature](https://docs.google.com/document/d/1GCuv4pCRnMD0TuvXNvs4qSs-pnhpXQ0KUR7Ixnrg0hA/edit?tab=t.0)
Fixes two things:

1. Updated RBAC permissions on VirtualMachine CRD to use the 'update' verb instead of 'patch' for ownerReference modifications.
2. This change updates the Disaster Recovery Placement Control (DRPC) controller logic to set the status.Progression field appropriately when VM resource cleanup is in progress on the target managed cluster.

Added ```cleanupReadiness``` state to perform pre-cleanup validation for VM/PVC resources on the target managed cluster.

If validation succeeds:

DRPC status.Progression transitions to ```Cleaning Up``` while VRG reconciles and completes resource cleanup.

If validation fails:

DRPC status.Progression is updated to ```WaitForUserToCleanup```, indicating manual intervention is required.

Introduced a new condition named AutoCleanup in VRG status with the following Reasons:

AttemptingAutoCleanup – Indicates the controller is trying to automatically clean up VM/PVC resources.
AutoCleanupNotFeasible – Validation failed; automatic cleanup cannot proceed.
AutoCleanupCompleted – Automatic cleanup finished successfully.

This condition complements the new cleanupReadiness state and provides granular visibility into the auto-cleanup workflow.