### PR TITLE
Avoid PVC list loop for VGS class resolution

### DIFF
--- a/internal/controller/cephfscg/cghandler.go
+++ b/internal/controller/cephfscg/cghandler.go
@@ -64,6 +64,7 @@ type VSCGHandler interface {
 
 	CreateOrUpdateReplicationGroupSource(
 		replicationGroupSourceNamespace string,
+		storageClassName string,
 		runFinalSync bool,
 	) (*ramendrv1alpha1.ReplicationGroupSource, bool, error)
 
@@ -322,6 +323,7 @@ func (c *cgHandler) disownRDManagedPVCsBeforeRGDDeletion(
 //nolint:funlen,gocognit,cyclop,gocyclo
 func (c *cgHandler) CreateOrUpdateReplicationGroupSource(
 	replicationGroupSourceNamespace string,
+	storageClassName string,
 	runFinalSync bool,
 ) (*ramendrv1alpha1.ReplicationGroupSource, bool, error) {
 	replicationGroupSourceName := c.cgName
@@ -399,13 +401,8 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupSource(
 		return nil, !finalSyncComplete, err
 	}
 
-	namespaces := []string{c.instance.Namespace}
-	if c.instance.Spec.ProtectedNamespaces != nil && len(*c.instance.Spec.ProtectedNamespaces) != 0 {
-		namespaces = *c.instance.Spec.ProtectedNamespaces
-	}
-
 	volumeGroupSnapshotClassName, err := util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(c.ctx, c.Client,
-		c.volumeGroupSnapshotClassSelector, *c.volumeGroupSnapshotSource, namespaces, c.logger)
+		c.volumeGroupSnapshotClassSelector, storageClassName, c.logger)
 	if err != nil {
 		log.Error(err, "Failed to get VGSClass name")
 		// If final sync is requested, ensure final sync cleanup is run regardless of the error

--- a/internal/controller/cephfscg/cghandler_test.go
+++ b/internal/controller/cephfscg/cghandler_test.go
@@ -199,7 +199,7 @@ var _ = Describe("Cghandler", func() {
 					Async: &ramendrv1alpha1.VRGAsyncSpec{},
 				},
 			}, &metav1.LabelSelector{}, nil, rgsName, testLogger)
-			rgs, finalSync, err := vsCGHandler.CreateOrUpdateReplicationGroupSource("default", false)
+			rgs, finalSync, err := vsCGHandler.CreateOrUpdateReplicationGroupSource("default", "test", false)
 			Expect(err).To(BeNil())
 			Expect(finalSync).To(BeFalse())
 			Expect(rgs.Spec.Trigger.Schedule).NotTo(BeNil())

--- a/internal/controller/util/cephfs_cg_test.go
+++ b/internal/controller/util/cephfs_cg_test.go
@@ -251,45 +251,46 @@ var _ = Describe("CephfsCg", func() {
 		})
 		Describe("GetVolumeGroupSnapshotClassFromPVCsStorageClass", func() {
 			It("Should be failed", func() {
+				CreateSC(SCName, "testProvisioner1")
+
 				volumeGroupSnapshotClassName, err := util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(
-					context.Background(), k8sClient, metav1.LabelSelector{}, metav1.LabelSelector{}, []string{"default"}, testLogger)
+					context.Background(), k8sClient, metav1.LabelSelector{}, "test", testLogger)
 				Expect(volumeGroupSnapshotClassName).To(Equal(""))
 				Expect(err).NotTo(BeNil())
 				Expect(err.Error()).To(ContainSubstring("unable to find matching volumegroupsnapshotclass for storage provisioner"))
+				DeleteSC(SCName)
 			})
 			Context("There is pvc and storage class", func() {
 				BeforeEach(func() {
-					CreateSC(SCName)
-					CreatePVC(PVCName, SCName)
+					CreateSC(SCName, "testProvisioner")
 				})
 				AfterEach(func() {
-					DeletePVC(PVCName)
 					DeleteSC(SCName)
 				})
 				It("should be run as expected", func() {
 					volumeGroupSnapshotClassName, err := util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(
 						context.Background(), k8sClient,
 						metav1.LabelSelector{MatchLabels: map[string]string{"test": "testxxxx"}},
-						metav1.LabelSelector{}, []string{"default"}, testLogger)
+						"", testLogger)
 					Expect(volumeGroupSnapshotClassName).To(Equal(""))
 					Expect(err).NotTo(BeNil())
 
 					volumeGroupSnapshotClassName, err = util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(
 						context.Background(), k8sClient,
 						metav1.LabelSelector{MatchLabels: map[string]string{"test": "test"}},
-						metav1.LabelSelector{MatchLabels: map[string]string{"test": "test"}}, []string{"default"}, testLogger)
+						"testxxxx", testLogger)
 					Expect(volumeGroupSnapshotClassName).To(Equal(""))
 					Expect(err).NotTo(BeNil())
 
 					volumeGroupSnapshotClassName, err = util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(
-						context.Background(), k8sClient, metav1.LabelSelector{}, metav1.LabelSelector{}, []string{"default"}, testLogger)
+						context.Background(), k8sClient, metav1.LabelSelector{}, "test", testLogger)
 					Expect(volumeGroupSnapshotClassName).To(Equal("vgsc"))
 					Expect(err).To(BeNil())
 
 					volumeGroupSnapshotClassName, err = util.GetVolumeGroupSnapshotClassFromPVCsStorageClass(
 						context.Background(), k8sClient,
 						metav1.LabelSelector{MatchLabels: map[string]string{"test": "test"}},
-						metav1.LabelSelector{MatchLabels: map[string]string{"testpvc": "testpvc"}}, []string{"default"}, testLogger)
+						"test", testLogger)
 					Expect(volumeGroupSnapshotClassName).To(Equal("vgsc"))
 					Expect(err).To(BeNil())
 				})
@@ -302,38 +303,6 @@ var _ = Describe("CephfsCg", func() {
 				Expect(err).To(BeNil())
 				Expect(len(volumeGroupSnapshotClasses)).To(Equal(1))
 			})
-		})
-	})
-	Describe("VolumeGroupSnapshotClassMatchStorageProviders", func() {
-		It("Should be false", func() {
-			match := util.VolumeGroupSnapshotClassMatchStorageProviders(
-				groupsnapv1beta1.VolumeGroupSnapshotClass{
-					Driver: "test",
-				}, nil,
-			)
-			Expect(match).To(BeFalse())
-		})
-		It("Should be false", func() {
-			match := util.VolumeGroupSnapshotClassMatchStorageProviders(
-				groupsnapv1beta1.VolumeGroupSnapshotClass{
-					Driver: "test",
-				}, []string{"test1"},
-			)
-			Expect(match).To(BeFalse())
-		})
-		It("Should be false", func() {
-			match := util.VolumeGroupSnapshotClassMatchStorageProviders(
-				groupsnapv1beta1.VolumeGroupSnapshotClass{}, []string{"test1"},
-			)
-			Expect(match).To(BeFalse())
-		})
-		It("Should be true", func() {
-			match := util.VolumeGroupSnapshotClassMatchStorageProviders(
-				groupsnapv1beta1.VolumeGroupSnapshotClass{
-					Driver: "test",
-				}, []string{"test"},
-			)
-			Expect(match).To(BeTrue())
 		})
 	})
 
@@ -551,12 +520,12 @@ var (
 	SCName  = "test"
 )
 
-func CreateSC(scName string) {
+func CreateSC(scName string, provisioner string) {
 	sc := &storagev1.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: scName,
 		},
-		Provisioner: "testProvisioner",
+		Provisioner: provisioner,
 	}
 
 	Eventually(func() error {

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -236,7 +236,7 @@ func (v *VRGInstance) reconcilePVCAsVolSyncPrimary(pvc corev1.PersistentVolumeCl
 		)
 
 		rgs, finalSyncComplete, err := cephfsCGHandler.CreateOrUpdateReplicationGroupSource(
-			pvc.Namespace, v.instance.Spec.RunFinalSync,
+			pvc.Namespace, *pvc.Spec.StorageClassName, v.instance.Spec.RunFinalSync,
 		)
 		if err != nil {
 			v.log.Info("Failed to CreateOrUpdateReplicationGroupSource", "err", err)


### PR DESCRIPTION
Improvement: pass an additional parameter (the storage class name) to GetVolumeGroupSnapshotClassFromPVCsStorageClass to make it more efficient. With this parameter, we can avoid listing PVCs by label and iterating through them to determine the storage class provider name.