### PR TITLE
Fix panic using nil RGS in CreateOrUpdateReplicationGroupSource function

### DIFF
--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -223,8 +223,10 @@ func (v *VRGInstance) reconcilePVCAsVolSyncPrimary(pvc corev1.PersistentVolumeCl
 
 		setVRGConditionTypeVolSyncRepSourceSetupComplete(&protectedPVC.Conditions, v.instance.Generation, "Ready")
 
-		protectedPVC.LastSyncTime = rgs.Status.LastSyncTime
-		protectedPVC.LastSyncDuration = rgs.Status.LastSyncDuration
+		if rgs != nil {
+			protectedPVC.LastSyncTime = rgs.Status.LastSyncTime
+			protectedPVC.LastSyncDuration = rgs.Status.LastSyncDuration
+		}
 
 		return v.instance.Spec.RunFinalSync && !finalSyncComplete
 	}


### PR DESCRIPTION
When we requeuing to allow temporary PVCs for final sync to be setup, ReplicationGroupSource, returned from CreateOrUpdateReplicationGroupSource function was nil, that caused panic.