### PR TITLE
Add tests for single s3 store configurations

### DIFF
--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -126,6 +126,10 @@ type Test struct {
 	Workload string `json:"workload"`
 	Deployer string `json:"deployer"`
 	PVCSpec  string `json:"pvcSpec"`
+	// Group is an optional field to group related tests (e.g., "single-s3-store")
+	// Tests without a group are run by default in the main TestDR
+	// Tests with a group can be run selectively by dedicated test functions
+	Group string `json:"group,omitempty"`
 }
 
 // Config keeps configuration for e2e tests.

--- a/e2e/config/config_test.go
+++ b/e2e/config/config_test.go
@@ -45,6 +45,8 @@ func TestReadConfig(t *testing.T) {
 		Tests: []Test{
 			{Workload: "deploy", Deployer: "appset", PVCSpec: "rbd"},
 			{Workload: "deploy", Deployer: "appset", PVCSpec: "cephfs"},
+			{Workload: "deploy", Deployer: "disapp", PVCSpec: "rbd", Group: "single-s3-store"},
+			{Workload: "deploy", Deployer: "disapp", PVCSpec: "cephfs", Group: "single-s3-store"},
 		},
 		Channel: Channel{
 			Name:      "https-github-com-ramendr-ocm-ramen-samples-git",

--- a/e2e/config/testdata/test.yaml
+++ b/e2e/config/testdata/test.yaml
@@ -38,3 +38,13 @@ tests:
   - deployer: appset
     workload: deploy
     pvcspec: cephfs
+  # Tests for single S3 store configurations
+  # Discovered apps with RBD workload using S3 store for velero backups
+  - deployer: disapp
+    workload: deploy
+    pvcspec: rbd
+    group: single-s3-store
+  - deployer: disapp
+    workload: deploy
+    pvcspec: cephfs
+    group: single-s3-store

--- a/e2e/dr_test.go
+++ b/e2e/dr_test.go
@@ -43,7 +43,32 @@ func TestDR(dt *testing.T) {
 	pvcSpecs := config.PVCSpecsMap(Ctx.Config())
 	deploySpecs := config.DeployersMap(Ctx.Config())
 
-	for _, tc := range Ctx.Config().Tests {
+	ungroupedTests := filterUngroupedTests(Ctx.Config().Tests)
+	runTestCases(t, ungroupedTests, pvcSpecs, deploySpecs)
+}
+
+// filterUngroupedTests returns only tests without a group assignment.
+// Tests with a group are handled by dedicated test functions.
+func filterUngroupedTests(tests []config.Test) []config.Test {
+	var ungrouped []config.Test
+
+	for _, tc := range tests {
+		if tc.Group == "" {
+			ungrouped = append(ungrouped, tc)
+		}
+	}
+
+	return ungrouped
+}
+
+// runTestCases executes the provided test cases using the given specifications.
+func runTestCases(
+	t *test.T,
+	tests []config.Test,
+	pvcSpecs map[string]config.PVCSpec,
+	deploySpecs map[string]config.Deployer,
+) {
+	for _, tc := range tests {
 		pvcSpec, ok := pvcSpecs[tc.PVCSpec]
 		if !ok {
 			panic("unknown pvcSpec")

--- a/e2e/single_s3_store_test.go
+++ b/e2e/single_s3_store_test.go
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ramendr/ramen/e2e/config"
+	"github.com/ramendr/ramen/e2e/deployers"
+	"github.com/ramendr/ramen/e2e/test"
+	"github.com/ramendr/ramen/e2e/util"
+	"github.com/ramendr/ramen/e2e/validate"
+	"github.com/ramendr/ramen/e2e/workloads"
+)
+
+// TestSingleS3Store tests disaster recovery scenarios with a single S3 store
+// located on the hub cluster. This validates that RamenDR correctly handles
+// centralized S3 storage for both discovered apps and RBD workloads.
+//
+// This test runs tests marked with group "single-s3-store" from the configuration.
+// It can be used with any configuration file that includes tests with the
+// "single-s3-store" group (e.g., test.yaml, test-single-s3-store.yaml).
+func TestSingleS3Store(dt *testing.T) {
+	t := test.WithLog(dt, Ctx.Logger())
+	t.Parallel()
+
+	if err := setupTestEnvironment(); err != nil {
+		t.Fatalf("Failed to setup test environment: %s", err)
+	}
+
+	t.Cleanup(func() {
+		timedCtx, cancel := Ctx.WithTimeout(1 * time.Minute)
+		defer cancel()
+
+		if err := util.EnsureChannelDeleted(timedCtx); err != nil {
+			t.Fatalf("Failed to ensure channel deleted: %s", err)
+		}
+	})
+
+	singleS3Tests := filterSingleS3StoreTests(Ctx.Config().Tests)
+	if len(singleS3Tests) == 0 {
+		t.Skip("No single S3 store tests found in configuration")
+	}
+
+	runSingleS3StoreTests(t, singleS3Tests)
+}
+
+// setupTestEnvironment initializes the test environment with configuration validation
+// and channel setup.
+func setupTestEnvironment() error {
+	if len(Ctx.Config().Tests) == 0 {
+		return fmt.Errorf("no tests found in the configuration file")
+	}
+
+	if err := validate.TestConfig(Ctx); err != nil {
+		return err
+	}
+
+	return util.EnsureChannel(Ctx)
+}
+
+// runSingleS3StoreTests executes all single S3 store test cases.
+func runSingleS3StoreTests(t *test.T, singleS3Tests []config.Test) {
+	pvcSpecs := config.PVCSpecsMap(Ctx.Config())
+	deploySpecs := config.DeployersMap(Ctx.Config())
+
+	for _, tc := range singleS3Tests {
+		executeTestCase(t, tc, pvcSpecs, deploySpecs)
+	}
+}
+
+// executeTestCase runs a single test case with the given configuration.
+func executeTestCase(
+	t *test.T,
+	tc config.Test,
+	pvcSpecs map[string]config.PVCSpec,
+	deploySpecs map[string]config.Deployer,
+) {
+	pvcSpec, ok := pvcSpecs[tc.PVCSpec]
+	if !ok {
+		panic("unknown pvcSpec")
+	}
+
+	workload, err := workloads.New(tc.Workload, Ctx.Config().Repo.Branch, pvcSpec)
+	if err != nil {
+		panic(err)
+	}
+
+	deployerSpec, ok := deploySpecs[tc.Deployer]
+	if !ok {
+		panic("unknown deployer")
+	}
+
+	deployer, err := deployers.New(deployerSpec)
+	if err != nil {
+		panic(err)
+	}
+
+	ctx := test.NewContext(Ctx, workload, deployer)
+	t.Run(ctx.Name(), func(dt *testing.T) {
+		t := test.WithLog(dt, ctx.Logger())
+		t.Parallel()
+		runSingleS3StoreTestFlow(t, ctx)
+	})
+}
+
+// runSingleS3StoreTestFlow executes the standard DR workflow for single S3 store tests.
+// This validates:
+// - Deploy: Application deployment to primary cluster
+// - Enable: DR protection enablement using centralized S3 store
+// - Failover: Disaster failover with S3 backup restoration
+// - Relocate: Relocation back to primary cluster
+// - Disable: DR protection disablement
+// - Undeploy: Application cleanup
+func runSingleS3StoreTestFlow(t *test.T, ctx test.Context) {
+	t.Helper()
+
+	if err := ctx.Validate(); err != nil {
+		t.Skipf("Skip test: %s", err)
+	}
+
+	if !t.Run("Deploy", ctx.Deploy) {
+		t.FailNow()
+	}
+
+	if !t.Run("Enable", ctx.Enable) {
+		t.FailNow()
+	}
+
+	if !t.Run("Failover", ctx.Failover) {
+		t.FailNow()
+	}
+
+	if !t.Run("Relocate", ctx.Relocate) {
+		t.FailNow()
+	}
+
+	if !t.Run("Disable", ctx.Disable) {
+		t.FailNow()
+	}
+
+	if !t.Run("Undeploy", ctx.Undeploy) {
+		t.FailNow()
+	}
+}
+
+// filterSingleS3StoreTests filters test cases to include only those with
+// the "single-s3-store" group designation. This allows selective execution
+// of single S3 store tests separately from the main test suite to avoid
+// resource contention.
+func filterSingleS3StoreTests(tests []config.Test) []config.Test {
+	var filtered []config.Test
+
+	for _, test := range tests {
+		// Include tests marked with single-s3-store group
+		if test.Group == "single-s3-store" {
+			filtered = append(filtered, test)
+		}
+	}
+
+	return filtered
+}


### PR DESCRIPTION
Enables single S3 store testing and prevents CI timeouts through resource grouping.

- Add Group field to Test struct for selective test execution
- Refactor TestDR with extracted helpers to reduce complexity
- Use group filtering