### PR TITLE
e2e: add interface to get recipe

### DIFF
--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -4,6 +4,7 @@
 package deployers
 
 import (
+	recipe "github.com/ramendr/recipe/api/v1alpha1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/ramendr/ramen/e2e/config"
@@ -133,6 +134,11 @@ func (a ApplicationSet) GetNamespace(ctx types.TestContext) string {
 
 func (a ApplicationSet) IsDiscovered() bool {
 	return false
+}
+
+// GetRecipe returns nil as ApplicationSet deployer does not use Recipe.
+func (a ApplicationSet) GetRecipe(ctx types.TestContext) (*recipe.Recipe, error) {
+	return nil, nil
 }
 
 func init() {

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -4,6 +4,7 @@
 package deployers
 
 import (
+	recipe "github.com/ramendr/recipe/api/v1alpha1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	subscriptionv1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/apps/v1"
 
@@ -149,6 +150,11 @@ func (s Subscription) WaitForResourcesDelete(ctx types.TestContext) error {
 
 func (s Subscription) IsDiscovered() bool {
 	return false
+}
+
+// GetRecipe returns nil as Subscription deployer does not use Recipe.
+func (s Subscription) GetRecipe(ctx types.TestContext) (*recipe.Recipe, error) {
+	return nil, nil
 }
 
 func init() {

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -56,6 +56,10 @@ type Deployer interface {
 	DeleteResources(TestContext) error
 	// WaitForResourcesDelete waits for all workload resources to be deleted
 	WaitForResourcesDelete(TestContext) error
+
+	// GetRecipe returns the recipe if the deployer is configured to use one.
+	// Returns nil if the deployer is not configured to use a recipe.
+	GetRecipe(TestContext) (*recipe.Recipe, error)
 }
 
 // nolint:interfacebloat


### PR DESCRIPTION
Updating Deployer interface to add method GetRecipe which will be useful when working with DR actions. 
GetRecipe will try to generate the recipe if configured to do so. It will return error if recipe generation is to be done and fails for some reason. Recipe will be initialised in the first call and thereafter a copy of same will be re-used.
GetRecipe is applicable for Discovered Apps. For other types of deployers, (nil, nil) will be returned.