### PR TITLE
ci: Fix black format to comply with recent black 26.1.0

### DIFF
--- a/test/addons/velero/test
+++ b/test/addons/velero/test
@@ -11,7 +11,6 @@ import time
 from drenv import kubectl
 from drenv import commands
 
-
 BACKUP = "nginx-backup"
 
 

--- a/test/drenv/test.py
+++ b/test/drenv/test.py
@@ -13,7 +13,6 @@ from drenv import kubectl
 from . import ramen
 from . import yaml
 
-
 workdir = None
 env = None
 config = None


### PR DESCRIPTION
Recent ci runs are failing with black [26.1.0](https://github.com/RamenDR/ramen/actions/runs/21137481064/job/60782981507).
Run `make black-reformat` to comply with black 26.1.0 which enforces one blank line after imports.

See:
- https://black.readthedocs.io/en/stable/change_log.html#id1
- https://github.com/psf/black/pull/4489

Older ci run passs(with [black  25.12.0](https://github.com/RamenDR/ramen/actions/runs/21061274850/job/60567958945
)): 