### PR TITLE
Fix autocleanup status update for non-VM and CephFS workloads

### DIFF
--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -600,6 +600,8 @@ func (v *VRGInstance) processVRG() ctrl.Result {
 		return v.dataError(err, "Failed to add finalizer to VolumeReplicationGroup", true)
 	}
 
+	v.updateVRGAutoCleanupCondition()
+
 	switch {
 	case v.instance.Spec.ReplicationState == ramendrv1alpha1.Primary:
 		return v.processAsPrimary()
@@ -2040,6 +2042,34 @@ func (v *VRGInstance) updateVRGDataReadyCondition() {
 	)
 }
 
+func (v *VRGInstance) updateVRGAutoCleanupCondition() {
+	switch {
+	case !v.isDiscoveredApp():
+		// gitOps managed apps
+		setVRGAutoCleanupCondition(&v.instance.Status.Conditions, v.instance.Generation,
+			metav1.ConditionFalse, VRGConditionReasonUnused,
+			"Automated Cleanup not applicable: GitOps manages the application's resource lifecycle.")
+	case !v.isVMRecipeProtection():
+		// all other discovered apps protection except vm-recipe
+		setVRGAutoCleanupCondition(&v.instance.Status.Conditions, v.instance.Generation,
+			metav1.ConditionFalse, VRGConditionReasonUnused,
+			"Automated cleanup is not supported for this application's protection configuration.")
+	case len(v.volSyncPVCs) > 0:
+		// discovered app with cephfs volumes
+		setVRGAutoCleanupCondition(&v.instance.Status.Conditions, v.instance.Generation,
+			metav1.ConditionFalse, VRGConditionReasonUnused,
+			"Automated cleanup not applicable for VMs with volumes protected by VolSync.")
+	default:
+		// discovered app with vm-recipe
+		if !v.IsDRActionInProgress() {
+			// no DR action progressing
+			setVRGAutoCleanupCondition(&v.instance.Status.Conditions, v.instance.Generation,
+				metav1.ConditionTrue, VRGConditionReasonUnused,
+				"Automated cleanup is supported, but no DR action is in progress and no cleanup is currently required.")
+		}
+	}
+}
+
 // updateVRGConditions updates three summary conditions VRGConditionTypeDataReady,
 // VRGConditionTypeClusterDataProtected and VRGConditionDataProtected at the VRG
 // level based on the corresponding PVC level conditions in the VRG:
@@ -2047,18 +2077,12 @@ func (v *VRGInstance) updateVRGDataReadyCondition() {
 // The VRGConditionTypeClusterDataReady summary condition is not a PVC level
 // condition and is updated elsewhere.
 func (v *VRGInstance) updateVRGConditions() {
-	var (
-		volSyncDataProtected, volSyncClusterDataProtected, volSyncClusterDataConflict *metav1.Condition
-		volSyncAutoCleanup                                                            *metav1.Condition
-	)
+	var volSyncDataProtected, volSyncClusterDataProtected, volSyncClusterDataConflict *metav1.Condition
 
 	if v.instance.Spec.Sync == nil {
 		volSyncDataProtected, volSyncClusterDataProtected = v.aggregateVolSyncDataProtectedConditions()
 
 		volSyncClusterDataConflict = v.aggregateVolSyncClusterDataConflictCondition()
-		if len(v.volSyncPVCs) > 0 {
-			volSyncAutoCleanup = v.aggregateVolSyncAutoCleanupCondition()
-		}
 	}
 
 	v.updateVRGDataReadyCondition()
@@ -2077,7 +2101,7 @@ func (v *VRGInstance) updateVRGConditions() {
 		v.aggregateVRGNoClusterDataConflictCondition(),
 	)
 
-	v.logAndSetConditions(VRGConditionTypeAutoCleanup, volSyncAutoCleanup,
+	v.logAndSetConditions(VRGConditionTypeAutoCleanup,
 		v.aggregateVRGAutoCleanupCondition())
 
 	v.updateVRGLastGroupSyncTime()
@@ -2753,4 +2777,8 @@ func (v *VRGInstance) aggregateVRGAutoCleanupCondition() *metav1.Condition {
 	}
 
 	return &desired
+}
+
+func (v *VRGInstance) isDiscoveredApp() bool {
+	return v.instance.Spec.ProtectedNamespaces != nil && len(*v.instance.Spec.ProtectedNamespaces) > 0
 }

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -987,18 +987,6 @@ func (v *VRGInstance) aggregateVolSyncClusterDataConflictCondition() *metav1.Con
 	return noClusterDataConflictCondition
 }
 
-func (v *VRGInstance) aggregateVolSyncAutoCleanupCondition() *metav1.Condition {
-	autoCleanupCondition := &metav1.Condition{
-		Status:             metav1.ConditionFalse,
-		Type:               VRGConditionTypeAutoCleanup,
-		Reason:             VRGConditionReasonUnused,
-		ObservedGeneration: v.instance.Generation,
-		Message:            "Automated cleanup not applicable for VolSync scheme.",
-	}
-
-	return autoCleanupCondition
-}
-
 func (v *VRGInstance) getCGLablelFromPVC(pvc *corev1.PersistentVolumeClaim, finalSync bool) (string, bool) {
 	cgLabelVal, ok := pvc.Labels[util.ConsistencyGroupLabel]
 	if ok && cgLabelVal != "" {


### PR DESCRIPTION
This PR fixes incorrect status updates for the AutoCleanup condition in VRGInstance.updateVRGAutoCleanupCondition().
It ensures the condition is False/Unused for:

Non-discovered (GitOps-managed) apps
Discovered apps not using VM recipe protection
Discovered apps with VolSync-protected (CephFS) volumes

For discovered apps with VM recipe protection and no DR action in progress, the condition is now set to True/Unused with a clear message indicating cleanup is supported but not required.

### Behaviour Matrix


App Type / State | AutoCleanup Condition | Reason/Message
-- | -- | --
GitOps-managed app (not discovered) | False (Unused) | “Automated Cleanup not applicable: GitOps manages the application's lifecycle.”
Discovered app, not VM recipe protection | False (Unused) | “Automated cleanup is not supported for this application's protection config.”
Discovered app with VolSync/CephFS volumes | False (Unused) | “Automated cleanup not applicable for VMs with volumes protected by VolSync.”
Discovered app with VM recipe, no DR in progress | True (Unused) | “Supported, but no DR action in progress; no cleanup currently required.”
Discovered app with VM recipe, DR in progress | True (Progressing/NotFeasible/Completed) | There is no change in this PR with respect to this.

