### PR TITLE
Generate hash for longer PVC names in case of CG workloads

### DIFF
--- a/internal/controller/cephfscg/cghandler.go
+++ b/internal/controller/cephfscg/cghandler.go
@@ -378,7 +378,7 @@ func (c *cgHandler) DeleteLocalRDAndRS(rd *volsyncv1alpha1.ReplicationDestinatio
 
 	lrs := &volsyncv1alpha1.ReplicationSource{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getLocalReplicationName(rd.Name),
+			Name:      util.GetLocalReplicationName(rd.Name),
 			Namespace: rd.Namespace,
 		},
 	}
@@ -390,7 +390,7 @@ func (c *cgHandler) DeleteLocalRDAndRS(rd *volsyncv1alpha1.ReplicationDestinatio
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			return c.VSHandler.DeleteLocalRD(
-				getLocalReplicationName(rd.Name),
+				util.GetLocalReplicationName(rd.Name),
 				rd.Namespace,
 			)
 		}

--- a/internal/controller/cephfscg/replicationgroupdestination.go
+++ b/internal/controller/cephfscg/replicationgroupdestination.go
@@ -275,7 +275,7 @@ func (m *rgdMachine) CreateReplicationDestinations(
 
 	rd := &volsyncv1alpha1.ReplicationDestination{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getReplicationDestinationName(rdSpec.ProtectedPVC.Name),
+			Name:      util.GetReplicationDestinationName(rdSpec.ProtectedPVC.Name),
 			Namespace: m.ReplicationGroupDestination.Namespace,
 		},
 	}
@@ -311,7 +311,7 @@ func (m *rgdMachine) CreateReplicationDestinations(
 			return nil
 		}); err != nil {
 		m.Logger.Error(err, "Failed to create or update ReplicationDestination",
-			"ReplicationDestinationName", getReplicationDestinationName(rdSpec.ProtectedPVC.Name))
+			"ReplicationDestinationName", util.GetReplicationDestinationName(rdSpec.ProtectedPVC.Name))
 
 		return nil, fmt.Errorf("%w", err)
 	}

--- a/internal/controller/cephfscg/utils.go
+++ b/internal/controller/cephfscg/utils.go
@@ -21,36 +21,12 @@ func isFinalSyncComplete(replicationGroupSource *ramendrv1alpha1.ReplicationGrou
 	return replicationGroupSource.Status.LastManualSync == volsync.FinalSyncTriggerString
 }
 
-func getLocalReplicationName(pvcName string) string {
-	return pvcName + "-local" // Use PVC name as name plus -local for local RD and RS
-}
-
 func isLatestImageReady(latestImage *corev1.TypedLocalObjectReference) bool {
 	if latestImage == nil || latestImage.Name == "" || latestImage.Kind != volsync.VolumeSnapshotKind {
 		return false
 	}
 
 	return true
-}
-
-func getReplicationDestinationName(pvcName string) string {
-	return pvcName // Use PVC name as name of ReplicationDestination
-}
-
-// This is the remote service name that can be accessed from another cluster.  This assumes submariner and that
-// a ServiceExport is created for the service on the cluster that has the ReplicationDestination
-func getRemoteServiceNameForRDFromPVCName(pvcName, rdNamespace string) string {
-	return fmt.Sprintf("%s.%s.svc.clusterset.local", getLocalServiceNameForRDFromPVCName(pvcName), rdNamespace)
-}
-
-// Service name that VolSync will create locally in the same namespace as the ReplicationDestination
-func getLocalServiceNameForRDFromPVCName(pvcName string) string {
-	return getLocalServiceNameForRD(getReplicationDestinationName(pvcName))
-}
-
-func getLocalServiceNameForRD(rdName string) string {
-	// This is the name VolSync will use for the service
-	return fmt.Sprintf("volsync-rsync-tls-dst-%s", rdName)
 }
 
 // Copied from func (v *VSHandler) getStorageClass(

--- a/internal/controller/cephfscg/volumegroupsourcehandler.go
+++ b/internal/controller/cephfscg/volumegroupsourcehandler.go
@@ -541,7 +541,7 @@ func (h *volumeGroupSourceHandler) resolveRDService(
 	logger logr.Logger,
 ) (string, error) {
 	if isSubmarinerEnabled {
-		return getRemoteServiceNameForRDFromPVCName(originalPVCName, rsNS), nil
+		return util.GetRemoteServiceNameForRDFromPVCName(originalPVCName, rsNS), nil
 	}
 
 	logger.Info("Non submariner", "rsspec", vrg.Spec.VolSync.RSSpec)

--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -469,3 +469,27 @@ func GenerateCombinedName(name, storageID string) string {
 	// e.g. "nameHash.storageID"
 	return nameHash + labelSeparator + storageID
 }
+
+func GetReplicationDestinationName(pvcName string) string {
+	return pvcName // Use PVC name as name of ReplicationDestination
+}
+
+func GetLocalReplicationName(pvcName string) string {
+	return pvcName + "-local" // Use PVC name as name plus -local for local RD and RS
+}
+
+// Service name that VolSync will create locally in the same namespace as the ReplicationDestination
+func getLocalServiceNameForRDFromPVCName(pvcName string) string {
+	return GetLocalServiceNameForRD(GetReplicationDestinationName(pvcName))
+}
+
+func GetLocalServiceNameForRD(rdName string) string {
+	// This is the name VolSync will use for the service
+	return GetServiceName("volsync-rsync-tls-dst-", rdName)
+}
+
+// This is the remote service name that can be accessed from another cluster.  This assumes submariner and that
+// a ServiceExport is created for the service on the cluster that has the ReplicationDestination
+func GetRemoteServiceNameForRDFromPVCName(pvcName, rdNamespace string) string {
+	return fmt.Sprintf("%s.%s.svc.clusterset.local", getLocalServiceNameForRDFromPVCName(pvcName), rdNamespace)
+}

--- a/internal/controller/util/misc_test.go
+++ b/internal/controller/util/misc_test.go
@@ -44,4 +44,11 @@ var _ = Describe("misc", func() {
 	errs := validation.NameIsDNSSubdomain(validResourceName, false)
 
 	Expect(errs).To(BeEmpty(), "expected a valid DNS subdomain name, got errors: %v", errs)
+
+	shortenedPVCName := util.GetLocalServiceNameForRD("long-pvc-name-50-chars-00000000000000000000000000000000000000")
+
+	Expect(shortenedPVCName).Should(Equal("volsync-rsync-tls-dst-6e0c095d"))
+
+	originalPVCName := util.GetLocalServiceNameForRD("normal-pvc-name")
+	Expect(originalPVCName).Should(Equal("volsync-rsync-tls-dst-normal-pvc-name"))
 })


### PR DESCRIPTION
Scope:

1. Fixes the issue reported in [DFBUGS-5299](https://issues.redhat.com/browse/DFBUGS-5299) by generating hash for longer PVC names in case of CG workloads 
2. Also refactors the duplicate functions and moving them to misc.go 
3. Validate the fix and ensure no other tests are impacted