### PR TITLE
CI: More robust minikube and kubectl installation

### DIFF
--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -46,8 +46,9 @@ jobs:
 
       - name: Install minikube
         run: |
-          curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
-          sudo install minikube-linux-amd64 /usr/local/bin/minikube
+          curl --fail --silent --show-error --location --output minikube \
+              https://github.com/kubernetes/minikube/releases/latest/download/minikube-linux-amd64
+          sudo install minikube /usr/local/bin/
           minikube version
 
       - name: Install kubectl


### PR DESCRIPTION
# CI: More robust minikube and kubectl installation

Improves `.github/workflows/tools.yaml` so minikube and kubectl install reliably.

**Minikube:**
- Install from GitHub releases URL (recommended source).
- Fix curl to fail on errors instead of treating HTML error pages as the binary.

**Kubectl:**
- Get default Kubernetes version from minikube so kubectl always matches minikube; no workflow updates needed.
- Single curl for that version’s binary (URL is cached, fast); avoid flaky dl.k8s.io/release/stable.txt.
- Fix curl to fail on errors instead of treating HTML error pages as the binary.