### PR TITLE
drenv: Remove unrecognized feature gate

### DIFF
--- a/test/drenv/providers/lima/k8s.yaml
+++ b/test/drenv/providers/lima/k8s.yaml
@@ -169,8 +169,6 @@ provision:
       kind: KubeletConfiguration
       apiVersion: kubelet.config.k8s.io/v1beta1
       cgroupDriver: systemd
-      featureGates:
-        StatefulSetAutoDeletePVC: true
       EOF
 
       # We ignore NumCPU preflight error for running a minimal cluster in

--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -25,8 +25,6 @@ templates:
     memory: "6g"
     extra_disks: 1
     disk_size: "50g"
-    feature_gates:
-      - StatefulSetAutoDeletePVC=true
     workers:
       - addons:
           - name: rook-operator


### PR DESCRIPTION
We use StatefulSetAutoDeletePVC feature gate which is not needed since
Kubernetes 1.32[1]. With kubernetes 1.35 (minikube 1.38 default) using
this feature gate cause the kubelet to fail.

Example error in the guest:

    Jan 29 22:34:00 minikube kubelet[3520]: Flag --feature-gates has been deprecated, This parameter
    should be set via the config file specified by the Kubelet's --config flag. See
    https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/ for more information.

    Jan 29 22:34:00 minikube kubelet[3520]: E0129 22:34:00.120213 3520 run.go:72] "command failed"
    err="failed to set feature gates from initial flags-based config: unrecognized feature gate:
    StatefulSetAutoDeletePVC"

    Jan 29 22:34:00 minikube systemd[1]: kubelet.service: Main process exited, code=exited,
    status=1/FAILURE

The --feature-gate flag is also deprecated, but it still works. This
should be fixed in minkube to pass the feature gates using the kubelet
configuration file[2].

Example failed runs without this change:
- https://github.com/RamenDR/ramen/actions/runs/21600699291/job/62245605382
- https://github.com/RamenDR/ramen/actions/runs/21593242184/job/62218561744
- https://github.com/RamenDR/ramen/actions/runs/21592423421/job/62215707675

Example successful runs with this change:
- https://github.com/RamenDR/ramen/actions/runs/21595301856/job/62230788288
- https://github.com/RamenDR/ramen/actions/runs/21594474495/job/62223004699
- https://github.com/RamenDR/ramen/actions/runs/21573717531/job/62157143443

[1] https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
[2] https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/
