### PR TITLE
S3 fencing to suspend old Primary from writing to S3.

### DIFF
--- a/internal/controller/s3utils_test.go
+++ b/internal/controller/s3utils_test.go
@@ -173,6 +173,27 @@ func (f *fakeObjectStorer) DeleteObjectsWithKeyPrefix(keyPrefix string) error {
 	return nil
 }
 
+func (f *fakeObjectStorer) CheckFailoverMarkerForVRG(pathPrefix string,
+	currentCluster string) (shouldSuspend bool,
+	failoverCluster string, err error,
+) {
+	return false, "", nil
+}
+
+func (f *fakeObjectStorer) CreateFailoverMarkerForVRG(pathPrefix string, marker controllers.S3FailoverMarker) error {
+	return nil
+}
+
+func (f *fakeObjectStorer) RemoveFailoverMarkerForVRG(pathPrefix, expectedCluster string, log logr.Logger) error {
+	return nil
+}
+
+func (f *fakeObjectStorer) UpdateFailoverMarkerPhase(pathPrefix, expectedCluster string,
+	phase controllers.FailoverPhase, log logr.Logger,
+) error {
+	return nil
+}
+
 var _ = Describe("FakeObjectStorer", func() {
 	var objectStorer controllers.ObjectStorer
 	object := "o"


### PR DESCRIPTION
Implements failover marker mechanism to coordinate S3 writes between clusters during DRAction failover operations. Prevents data corruption from concurrent writes by suspending old primary's S3 writes when failover marker is detected.

Key changes:
- Add failover marker creation/removal in DRPC
- Add marker check in VRG before S3 writes
- Add marker phase tracking (initiated/recovering/completed)

Tested the failover scenario with both clusters online, and it successfully prevented split‑brain.

Fixes: https://github.com/ramenDR/ramen/issues/250