### PR TITLE
volsync: use copyMethod Direct to match Ramen config

### DIFF
--- a/test/addons/volsync/rd/base/rd.yaml
+++ b/test/addons/volsync/rd/base/rd.yaml
@@ -8,10 +8,9 @@ metadata:
   name: busybox-dst
 spec:
   rsyncTLS:
-    copyMethod: Snapshot
+    copyMethod: Direct
     destinationPVC: volsync-pvc
     storageClassName: STORAGE_CLASS
-    volumeSnapshotClassName: VOLUME_SNAPSHOT_CLASS
     moverSecurityContext:
       runAsUser: 10000
       runAsGroup: 10000

--- a/test/addons/volsync/rd/block/kustomization.yaml
+++ b/test/addons/volsync/rd/block/kustomization.yaml
@@ -28,6 +28,3 @@ patches:
       - op: replace
         path: /spec/rsyncTLS/storageClassName
         value: rook-ceph-block
-      - op: replace
-        path: /spec/rsyncTLS/volumeSnapshotClassName
-        value: csi-rbdplugin-snapclass

--- a/test/addons/volsync/rd/file/kustomization.yaml
+++ b/test/addons/volsync/rd/file/kustomization.yaml
@@ -28,6 +28,3 @@ patches:
       - op: replace
         path: /spec/rsyncTLS/storageClassName
         value: rook-cephfs-fs1
-      - op: replace
-        path: /spec/rsyncTLS/volumeSnapshotClassName
-        value: csi-cephfsplugin-snapclass

--- a/test/addons/volsync/rs/block/rs.yaml
+++ b/test/addons/volsync/rs/block/rs.yaml
@@ -13,8 +13,7 @@ spec:
   rsyncTLS:
     keySecret: volsync-rsync-tls-busybox-dst-block
     address: volsync-rsync-tls-dst-busybox-dst.volsync-test-block.svc.clusterset.local
-    copyMethod: Snapshot
-    volumeSnapshotClassName: csi-rbdplugin-snapclass
+    copyMethod: Direct
     moverSecurityContext:
       runAsUser: 10000
       runAsGroup: 10000

--- a/test/addons/volsync/rs/file/rs.yaml
+++ b/test/addons/volsync/rs/file/rs.yaml
@@ -13,8 +13,7 @@ spec:
   rsyncTLS:
     keySecret: volsync-rsync-tls-busybox-dst-file
     address: volsync-rsync-tls-dst-busybox-dst.volsync-test-file.svc.clusterset.local
-    copyMethod: Snapshot
-    volumeSnapshotClassName: csi-cephfsplugin-snapclass
+    copyMethod: Direct
     moverSecurityContext:
       runAsUser: 10000
       runAsGroup: 10000


### PR DESCRIPTION
The volsync addon test uses copyMethod: Snapshot, but Ramen configures
volsync with copyMethod: Direct. This mismatch causes a ~10% flaky
test failure due to a race condition in volsync snapshot cleanup.

When using copyMethod: Snapshot, volsync creates a VolumeSnapshot
after replication completes, but signals completion (lastManualSync)
before the snapshot is ready. If test teardown deletes the namespace
during the ~100ms window before the snapshot becomes ready, the
snapshot's volumesnapshot-bound-protection finalizer blocks namespace
deletion indefinitely, causing the 120s kubectl wait timeout.

Change all ReplicationDestination and ReplicationSource resources to
use copyMethod: Direct, aligning the test with Ramen's production
configuration. With Direct copy no VolumeSnapshots are created, so
the finalizer deadlock cannot occur.

## Test results

**No volsync addon failures in 300 runs.**

### Stats

| System         | Runs | Failures | Rate % |
|----------------|------|----------|--------|
| Linux          |  100 |       12 |    88% |
| macOS (M1 Pro) |  100 |        2 |    98% |
| macOS (M2 Max) |  100 |        3 |    97% |

### Failures (Linux)

| Count | Addon | Error Type | Runs |
|------:|-------|------------|------|
| 6 | ocm-cluster | unknown | 010, 031, 044, 049, 070, 077 |
| 6 | rbd-mirror | timeout | 011, 060, 062, 072, 090, 092 |

### Failures (macOS M1 Pro)

| Count | Addon | Error Type | Runs |
|------:|-------|------------|------|
| 2 | ocm-cluster | timeout | 000, 042 |

### Failures (macOS M2 Max)

| Count | Addon | Error Type | Runs |
|------:|-------|------------|------|
| 1 | ocm-cluster | unknown | 053 |
| 1 | minio | bucket_creation | 080 |
| 1 | ocm-cluster | timeout | 093 |

---

Fixes #2410