### PR TITLE
kubectl: Enforce timeout in wait, delete, and rollout

### DIFF
--- a/test/addons/argocd/start
+++ b/test/addons/argocd/start
@@ -32,7 +32,6 @@ def wait_for_deployments(cluster):
         "--all",
         "--for=condition=Available",
         "--namespace=argocd",
-        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/argocd/test
+++ b/test/addons/argocd/test
@@ -52,7 +52,7 @@ def wait_until_busybox_is_healthy(hub, cluster):
         f"busybox-{cluster}",
         "--for=jsonpath={.status.health.status}=Healthy",
         "--namespace=argocd",
-        "--timeout=120s",
+        timeout=120,
         context=hub,
     )
 
@@ -99,7 +99,7 @@ def wait_until_busybox_is_deleted(hub, cluster):
         f"busybox-{cluster}",
         "--for=delete",
         "--namespace=argocd",
-        "--timeout=60s",
+        timeout=60,
         context=hub,
     )
     print(f"Waiting until namespace argocd-test is deleted in cluster {cluster}")
@@ -107,7 +107,7 @@ def wait_until_busybox_is_deleted(hub, cluster):
         "ns",
         "argocd-test",
         "--for=delete",
-        "--timeout=60s",
+        timeout=60,
         context=cluster,
     )
 

--- a/test/addons/cdi/start
+++ b/test/addons/cdi/start
@@ -22,7 +22,6 @@ def deploy(cluster):
         "status",
         "deploy/cdi-operator",
         f"--namespace={NAMESPACE}",
-        "--timeout=300s",
         context=cluster,
     )
 
@@ -37,7 +36,6 @@ def wait(cluster):
         "cdi.cdi.kubevirt.io/cdi",
         "--for=condition=available",
         f"--namespace={NAMESPACE}",
-        "--timeout=300s",
         context=cluster,
     )
     print("Waiting until cdi cr finished progressing")
@@ -45,7 +43,6 @@ def wait(cluster):
         "cdi.cdi.kubevirt.io/cdi",
         "--for=condition=progressing=False",
         f"--namespace={NAMESPACE}",
-        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/cdi/test
+++ b/test/addons/cdi/test
@@ -20,7 +20,7 @@ def test(cluster):
     kubectl.wait(
         "pvc/test-pvc",
         "--for=jsonpath={.status.phase}=Bound",
-        "--timeout=120s",
+        timeout=120,
         context=cluster,
     )
 
@@ -28,7 +28,7 @@ def test(cluster):
     kubectl.wait(
         "dv/test-dv",
         "--for=condition=Bound",
-        "--timeout=120s",
+        timeout=120,
         context=cluster,
     )
 
@@ -36,7 +36,7 @@ def test(cluster):
     kubectl.wait(
         "pvc/test-dv",
         "--for=jsonpath={.status.phase}=Bound",
-        "--timeout=120s",
+        timeout=120,
         context=cluster,
     )
 

--- a/test/addons/csi-addons/start
+++ b/test/addons/csi-addons/start
@@ -22,7 +22,6 @@ def wait(cluster):
         "status",
         "deploy/csi-addons-controller-manager",
         "--namespace=csi-addons-system",
-        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/demo/start
+++ b/test/addons/demo/start
@@ -28,7 +28,7 @@ print("Waiting until deployment is rolled out")
 kubectl.rollout(
     "status",
     "deployment",
-    "--timeout=120s",
+    timeout=120,
     context=cluster,
 )
 
@@ -37,7 +37,7 @@ kubectl.rollout(
     "status",
     "ingress",
     "--namespace=ingress-nginx",
-    "--timeout=120s",
+    timeout=120,
     context=cluster,
 )
 

--- a/test/addons/example/start
+++ b/test/addons/example/start
@@ -22,7 +22,7 @@ print("Waiting until example deployment is rolled out")
 kubectl.rollout(
     "status",
     "deploy/example-deployment",
-    "--timeout=180s",
+    timeout=180,
     context=cluster,
 )
 
@@ -31,6 +31,6 @@ kubectl.wait(
     "pod",
     "--selector=app=example",
     "--for=condition=Ready",
-    "--timeout=180s",
+    timeout=180,
     context=cluster,
 )

--- a/test/addons/external-snapshotter/start
+++ b/test/addons/external-snapshotter/start
@@ -29,7 +29,6 @@ def wait(cluster):
         "status",
         "deploy/snapshot-controller",
         "--namespace=kube-system",
-        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/kubevirt/start
+++ b/test/addons/kubevirt/start
@@ -22,7 +22,6 @@ def deploy(cluster):
         "status",
         "deploy/virt-operator",
         f"--namespace={NAMESPACE}",
-        "--timeout=300s",
         context=cluster,
     )
 
@@ -37,7 +36,6 @@ def wait(cluster):
         "kubevirt.kubevirt.io/kubevirt",
         "--for=condition=available",
         f"--namespace={NAMESPACE}",
-        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/kubevirt/test
+++ b/test/addons/kubevirt/test
@@ -40,7 +40,7 @@ def wait_until_vm_is_ready(cluster):
         "vm/testvm",
         "--for=condition=ready",
         f"--namespace={NAMESPACE}",
-        "--timeout=180s",
+        timeout=180,
         context=cluster,
     )
 

--- a/test/addons/minio/start
+++ b/test/addons/minio/start
@@ -30,7 +30,6 @@ def wait(cluster):
         "status",
         "deployment/minio",
         "--namespace=minio",
-        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/ocm-cluster/start
+++ b/test/addons/ocm-cluster/start
@@ -74,7 +74,6 @@ def wait(cluster):
             "status",
             deployment,
             f"--namespace={ADDONS_NAMESPACE}",
-            "--timeout=300s",
             context=cluster,
         )
 
@@ -96,7 +95,6 @@ def wait_for_hub(hub):
                 "status",
                 deployment,
                 f"--namespace={namespace}",
-                "--timeout=300s",
                 context=hub,
             )
 
@@ -146,7 +144,7 @@ def wait_for_managed_cluster(cluster, hub):
     kubectl.wait(
         f"managedcluster/{cluster}",
         "--for=jsonpath={.spec.hubAcceptsClient}=true",
-        "--timeout=60s",
+        timeout=60,
         context=hub,
     )
 
@@ -159,7 +157,7 @@ def wait_for_managed_cluster(cluster, hub):
         kubectl.wait(
             f"managedcluster/{cluster}",
             f"--for=condition={condition}",
-            "--timeout=60s",
+            timeout=60,
             context=hub,
         )
 

--- a/test/addons/ocm-cluster/test
+++ b/test/addons/ocm-cluster/test
@@ -21,7 +21,7 @@ def wait_for_work(cluster, hub):
         "manifestwork/example-manifestwork",
         "--for=condition=applied",
         f"--namespace={cluster}",
-        "--timeout=120s",
+        timeout=120,
         context=hub,
     )
 
@@ -32,7 +32,7 @@ def wait_for_deployment(cluster, hub):
         "manifestwork/example-manifestwork",
         "--for=condition=available",
         f"--namespace={cluster}",
-        "--timeout=120s",
+        timeout=120,
         context=hub,
     )
 
@@ -40,8 +40,8 @@ def wait_for_deployment(cluster, hub):
     kubectl.wait(
         "deploy/example-deployment",
         "--for=condition=available",
-        "--timeout=120s",
         "--namespace=default",
+        timeout=120,
         context=cluster,
     )
 
@@ -57,7 +57,7 @@ def wait_for_delete_work(cluster, hub):
         "manifestwork/example-manifestwork",
         "--for=delete",
         f"--namespace={cluster}",
-        "--timeout=120s",
+        timeout=120,
         context=hub,
     )
 
@@ -67,7 +67,7 @@ def wait_for_delete_deployment(cluster):
     kubectl.wait(
         "deploy/example-deployment",
         "--for=delete",
-        "--timeout=120s",
+        timeout=120,
         context=cluster,
     )
 

--- a/test/addons/ocm-controller/start
+++ b/test/addons/ocm-controller/start
@@ -22,7 +22,6 @@ def wait(cluster):
         "status",
         "deploy/ocm-controller",
         "--namespace=open-cluster-management",
-        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/ocm-hub/start
+++ b/test/addons/ocm-hub/start
@@ -77,7 +77,6 @@ def wait(cluster):
                 "status",
                 deployment,
                 f"--namespace={ns}",
-                "--timeout=300s",
                 context=cluster,
             )
 

--- a/test/addons/olm/start
+++ b/test/addons/olm/start
@@ -58,7 +58,6 @@ def wait(cluster):
         "csv/packageserver",
         f"--namespace={NAMESPACE}",
         "--for=jsonpath={.status.phase}=Succeeded",
-        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/rbd-mirror/start
+++ b/test/addons/rbd-mirror/start
@@ -131,7 +131,6 @@ def wait_until_rbd_mirror_is_ready(cluster):
         "cephrbdmirror/my-rbd-mirror",
         "--for=jsonpath={.status.phase}=Ready",
         "--namespace=rook-ceph",
-        "--timeout=300s",
         context=cluster,
     )
     status = kubectl.get(
@@ -222,7 +221,7 @@ def restart_rbd_mirror_daemon(cluster):
         "status",
         deploy,
         "--namespace=rook-ceph",
-        "--timeout=120s",
+        timeout=120,
         context=cluster,
     )
 

--- a/test/addons/rbd-mirror/test
+++ b/test/addons/rbd-mirror/test
@@ -64,7 +64,6 @@ def test_volume_replication(primary, secondary):
         f"pvc/{PVC_NAME}",
         "--for=jsonpath={.status.phase}=Bound",
         "--namespace=rook-ceph",
-        "--timeout=300s",
         context=primary,
     )
 
@@ -73,7 +72,6 @@ def test_volume_replication(primary, secondary):
         f"volumereplication/{VR_NAME}",
         "--for=condition=Completed",
         "--namespace=rook-ceph",
-        "--timeout=300s",
         context=primary,
     )
 
@@ -82,7 +80,6 @@ def test_volume_replication(primary, secondary):
         f"volumereplication/{VR_NAME}",
         "--for=jsonpath={.status.state}=Primary",
         "--namespace=rook-ceph",
-        "--timeout=300s",
         context=primary,
     )
 

--- a/test/addons/rook-cephfs/start
+++ b/test/addons/rook-cephfs/start
@@ -50,7 +50,6 @@ def wait(cluster):
             f"cephfilesystem/{file_system}",
             "--for=jsonpath={.status.phase}=Ready",
             "--namespace=rook-ceph",
-            "--timeout=300s",
             context=cluster,
         )
 

--- a/test/addons/rook-cephfs/test
+++ b/test/addons/rook-cephfs/test
@@ -26,7 +26,6 @@ def test_provisioning(cluster):
         f"pvc/{PVC_NAME}",
         "--for=jsonpath={.status.phase}=Bound",
         f"--namespace={NAMESPACE}",
-        "--timeout=300s",
         context=cluster,
     )
 
@@ -35,7 +34,6 @@ def test_provisioning(cluster):
         f"volumesnapshot/{SNAP_NAME}",
         "--for=jsonpath={.status.readyToUse}=true",
         f"--namespace={NAMESPACE}",
-        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/rook-cluster/start
+++ b/test/addons/rook-cluster/start
@@ -36,7 +36,7 @@ def wait(cluster):
         "cephcluster/my-cluster",
         "--for=jsonpath={.status.phase}=Ready",
         "--namespace=rook-ceph",
-        f"--timeout={TIMEOUT}s",
+        timeout=TIMEOUT,
         context=cluster,
     )
 

--- a/test/addons/rook-operator/start
+++ b/test/addons/rook-operator/start
@@ -23,7 +23,7 @@ def wait(cluster):
         "deploy/rook-ceph-operator",
         "--namespace=rook-ceph",
         # We had random timeout with 300s.
-        "--timeout=600s",
+        timeout=600,
         context=cluster,
     )
 
@@ -33,7 +33,6 @@ def wait(cluster):
         "--for=jsonpath={.status.phase}=Running",
         "--namespace=rook-ceph",
         "--selector=app=rook-ceph-operator",
-        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/rook-pool/start
+++ b/test/addons/rook-pool/start
@@ -54,7 +54,6 @@ def wait(cluster):
         "cephblockpool/replicapool",
         "--for=jsonpath={.status.phase}=Ready",
         "--namespace=rook-ceph",
-        "--timeout=300s",
         context=cluster,
     )
 
@@ -63,7 +62,6 @@ def wait(cluster):
         "cephblockpool/replicapool",
         "--for=jsonpath={.status.info.rbdMirrorBootstrapPeerSecretName}=pool-peer-token-replicapool",
         "--namespace=rook-ceph",
-        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/rook-toolbox/start
+++ b/test/addons/rook-toolbox/start
@@ -23,7 +23,6 @@ def wait(cluster):
         "status",
         "deploy/rook-ceph-tools",
         "--namespace=rook-ceph",
-        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/submariner/start
+++ b/test/addons/submariner/start
@@ -107,7 +107,7 @@ def wait_for_deployments(cluster, names, namespace):
             "status",
             deployment,
             f"--namespace={namespace}",
-            "--timeout=180s",
+            timeout=180,
             context=cluster,
         )
 

--- a/test/addons/submariner/test
+++ b/test/addons/submariner/test
@@ -99,7 +99,6 @@ def wait_for_service(cluster, namespace):
         f"deploy/{SERVICE}",
         "--for=condition=Available",
         f"--namespace={namespace}",
-        "--timeout=300s",
         context=cluster,
     )
 
@@ -110,7 +109,6 @@ def wait_for_pod(cluster, namespace):
         "pod/test",
         "--for=condition=Ready",
         f"--namespace={namespace}",
-        "--timeout=300s",
         context=cluster,
     )
 
@@ -131,7 +129,7 @@ def wait_for_service_export(cluster, namespace):
         f"serviceexports/{SERVICE}",
         "--for=condition=Ready",
         f"--namespace={namespace}",
-        "--timeout=120s",
+        timeout=120,
         context=cluster,
     )
     exports = kubectl.describe(

--- a/test/addons/velero/test
+++ b/test/addons/velero/test
@@ -23,7 +23,7 @@ def test(cluster):
         "status",
         "deploy/nginx-deployment",
         "--namespace=nginx-example",
-        "--timeout=180s",
+        timeout=180,
         context=cluster,
     )
 
@@ -46,7 +46,7 @@ def test(cluster):
         "status",
         "deploy/nginx-deployment",
         "--namespace=nginx-example",
-        "--timeout=120s",
+        timeout=120,
         context=cluster,
     )
 

--- a/test/addons/volsync/start
+++ b/test/addons/volsync/start
@@ -52,7 +52,6 @@ def wait_for_deployment(cluster):
         "status",
         f"deploy/{DEPLOYMENT}",
         f"--namespace={NAMESPACE}",
-        "--timeout=300s",
         context=cluster,
     )
 

--- a/test/addons/volsync/test
+++ b/test/addons/volsync/test
@@ -44,7 +44,7 @@ def wait_for_application(cluster, variant):
         "status",
         f"deploy/{DEPLOY}",
         f"--namespace={NAMESPACE}-{variant}",
-        "--timeout=120s",
+        timeout=120,
         context=cluster,
     )
 
@@ -58,7 +58,7 @@ def wait_for_replication_destination(cluster, variant):
         "replicationdestination/busybox-dst",
         "--for=condition=Synchronizing=True",
         f"--namespace={NAMESPACE}-{variant}",
-        "--timeout=120s",
+        timeout=120,
         context=cluster,
     )
 
@@ -110,7 +110,7 @@ def setup_replication_service(cluster1, cluster2, variant):
         f"serviceexports/{VOLSYNC_SERVICE}",
         "--for=condition=Ready",
         f"--namespace={NAMESPACE}-{variant}",
-        "--timeout=120s",
+        timeout=120,
         context=cluster2,
     )
 
@@ -158,7 +158,7 @@ def run_replication(cluster, variant):
         "replicationsource/busybox-src",
         "--for=jsonpath={.status.lastManualSync}=replication-1",
         f"--namespace={NAMESPACE}-{variant}",
-        "--timeout=120s",
+        timeout=120,
         context=cluster,
     )
     out = kubectl.get(
@@ -224,7 +224,7 @@ def teardown(cluster1, cluster2, variant):
             "ns",
             f"{NAMESPACE}-{variant}",
             "--for=delete",
-            "--timeout=120s",
+            timeout=120,
             context=cluster,
         )
 

--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -57,7 +57,7 @@ def test_rollout(tmpenv, capsys):
     kubectl.rollout(
         "status",
         "deploy/example-deployment",
-        f"--timeout={TIMEOUT}s",
+        timeout=TIMEOUT,
         context=tmpenv.profile,
     )
     out, err = capsys.readouterr()
@@ -68,7 +68,7 @@ def test_wait(tmpenv, capsys):
     kubectl.wait(
         "deploy/example-deployment",
         "--for=condition=available",
-        f"--timeout={TIMEOUT}s",
+        timeout=TIMEOUT,
         context=tmpenv.profile,
     )
     out, err = capsys.readouterr()

--- a/test/drenv/test.py
+++ b/test/drenv/test.py
@@ -212,8 +212,8 @@ def lookup_cluster():
     kubectl.wait(
         placement,
         "--for=condition=PlacementSatisfied",
-        "--timeout=60s",
         f"--namespace={config['namespace']}",
+        timeout=60,
         context=env["hub"],
         log=debug,
     )
@@ -303,7 +303,6 @@ def wait_for_drpc_phase(phase):
         drpc,
         f"--for=jsonpath={{.status.phase}}={phase}",
         f"--namespace={config['namespace']}",
-        "--timeout=300s",
         context=env["hub"],
         log=debug,
     )
@@ -323,7 +322,7 @@ def wait_until_drpc_is_stable(timeout=300):
         drpc,
         "--for=condition=Available",
         f"--namespace={config['namespace']}",
-        f"--timeout={timeout}s",
+        timeout=timeout,
         context=env["hub"],
         log=debug,
     )
@@ -333,7 +332,7 @@ def wait_until_drpc_is_stable(timeout=300):
         drpc,
         "--for=condition=PeerReady",
         f"--namespace={config['namespace']}",
-        f"--timeout={timeout}s",
+        timeout=timeout,
         context=env["hub"],
         log=debug,
     )


### PR DESCRIPTION
## Problem

A kubectl delete command in the submariner addon had no `--timeout` flag
and got stuck for 4 hours, wasting CI time. kubectl wait, delete, and
rollout commands can block indefinitely when a condition is never met or
a resource is never deleted.

## Challenge

Timeouts were passed as `--timeout=Ns` strings in `*args`, making it
impossible to enforce that every call has a timeout. It was too easy to
forget to add `--timeout`, and there was no way to provide a default.

## Solution

Add a timeout parameter (default 300 seconds) to `kubectl.wait()`,
`kubectl.delete()`, and `kubectl.rollout()`. The timeout is always injected
by `_watch()`, ensuring every call has a timeout. Callers can override
with `timeout=N` when the default is not appropriate.

Commands that previously had no timeout may now fail earlier with the
default 300s timeout. We can tune the timeout later if we find issues.

## Changes

- Add DEFAULT_TIMEOUT = 300 in kubectl.py
- Add timeout parameter to _watch(), wait(), delete(), and rollout()
- Remove --timeout=300s from callers using the default timeout
- Replace --timeout=Ns with timeout=N for callers using non-default
  timeouts:
  - timeout=60: argocd/test, ocm-cluster/start
  - timeout=120: argocd/test, cdi/test, demo/start, ocm-cluster/test,
    rbd-mirror/start, velero/test, volsync/test, test.py
  - timeout=180: example/start, kubevirt/test, submariner/start,
    velero/test
  - timeout=600: rook-cluster/start, rook-operator/start

## Commands that previously had no timeout

These commands had no timeout and use now the default timeout:

- submariner/test: kubectl.delete --wait=true (caused the 4h hang)
- submariner/test: kubectl.wait for deploy, pod
- olm/start: kubectl.wait, kubectl.rollout for operators
- ocm-cluster/test: kubectl.delete for manifestwork
- external-snapshotter/start: kubectl.wait for CRDs
- odf-external-snapshotter/start: kubectl.wait for CRDs
- kubevirt/test: kubectl.delete --kustomize=vm
- rbd-mirror/test: kubectl.delete --kustomize=test-data
- rook-cephfs/test: kubectl.delete --kustomize provision-test
- cdi/test: kubectl.delete --kustomize=pvc, --kustomize=dv
- velero/test: kubectl.delete namespace, --filename
- volsync/test: kubectl.delete --filename rs.yaml