### PR TITLE
e2e: updating interfaces of the deployers

### DIFF
--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -141,6 +141,11 @@ func (a ApplicationSet) GetRecipe(ctx types.TestContext) (*recipe.Recipe, error)
 	return nil, nil
 }
 
+// GetConfig returns the deployer configuration used by the ApplicationSet deployer.
+func (a ApplicationSet) GetConfig() *config.Deployer {
+	return &a.DeployerSpec
+}
+
 func init() {
 	register("appset", NewApplicationSet)
 }

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -140,6 +140,11 @@ func (d *DiscoveredApp) GetRecipe(ctx types.TestContext) (*recipe.Recipe, error)
 	return d.recipe, nil
 }
 
+// GetConfig returns the deployer configuration used by the DiscoveredApp deployer.
+func (d DiscoveredApp) GetConfig() *config.Deployer {
+	return &d.DeployerSpec
+}
+
 func (d DiscoveredApp) shouldGenerateRecipe() bool {
 	return d.DeployerSpec.Recipe != nil && d.DeployerSpec.Recipe.Type == "generate"
 }

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -157,6 +157,11 @@ func (s Subscription) GetRecipe(ctx types.TestContext) (*recipe.Recipe, error) {
 	return nil, nil
 }
 
+// GetConfig returns the deployer configuration used by the Subscription deployer.
+func (s Subscription) GetConfig() *config.Deployer {
+	return &s.DeployerSpec
+}
+
 func init() {
 	register("subscr", NewSubscription)
 }

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -60,6 +60,9 @@ type Deployer interface {
 	// GetRecipe returns the recipe if the deployer is configured to use one.
 	// Returns nil if the deployer is not configured to use a recipe.
 	GetRecipe(TestContext) (*recipe.Recipe, error)
+
+	// GetConfig returns the deployer configuration used by the deployer
+	GetConfig() *config.Deployer
 }
 
 // nolint:interfacebloat


### PR DESCRIPTION
This PR will:
1. correct the return values of the GetName for the various deployers.
2. Add new interface GetConfig, to get the deployer config which can be used later in the test runs.