### PR TITLE
kubectl: fix rollout timeout for non-status subcommands

### DIFF
--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -139,11 +139,16 @@ def delete(*args, input=None, timeout=DEFAULT_TIMEOUT, context=None, log=print):
     _watch("delete", *args, input=input, timeout=timeout, context=context, log=log)
 
 
-def rollout(*args, timeout=DEFAULT_TIMEOUT, context=None, log=print):
+def rollout(command, *args, timeout=None, context=None, log=print):
     """
-    Run kubectl rollout ... logging progress messages.
+    Run kubectl rollout command ... logging progress messages.
+
+    Only the "status" subcommand supports --timeout. If timeout is not
+    specified for "status", DEFAULT_TIMEOUT is used.
     """
-    _watch("rollout", *args, timeout=timeout, context=context, log=log)
+    if command == "status":
+        timeout = timeout or DEFAULT_TIMEOUT
+    _watch("rollout", command, *args, timeout=timeout, context=context, log=log)
 
 
 def wait(*args, timeout=DEFAULT_TIMEOUT, context=None, log=print):


### PR DESCRIPTION
The rollout() function passed --timeout to all kubectl rollout subcommands, but only "status" supports it. This caused failures when restarting deployments:

    kubectl rollout restart deployment.apps/klusterlet \
        --namespace=open-cluster-management --timeout 300s
    error: unknown flag: --timeout

Make "command" an explicit parameter instead of packing it into *args, and apply the default timeout only for "status". If a caller mistakenly passes a timeout to another subcommand, the flag is forwarded to kubectl which will fail, exposing the caller bug.