### PR TITLE
envs: Minimize regional dr vm memory

### DIFF
--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -22,7 +22,7 @@ templates:
           device_ownership_from_security_context: true
     network: "$network"
     cpus: 4
-    memory: "8g"
+    memory: "7g"
     extra_disks: 1
     disk_size: "50g"
     workers:
@@ -48,7 +48,7 @@ templates:
     container_runtime: containerd
     network: "$network"
     cpus: 2
-    memory: "6g"
+    memory: "5g"
     workers:
       - addons:
           - name: ocm-hub


### PR DESCRIPTION
Since we moved to minikube on macOS we increased vm memory by 2 GiB. This creates too much memory pressure on developer machine, running many memory hungry applications (Chrome, Cursor, VScode, Slack, Teams). Lets give them back 3 GiB. The clusters should work fine with 1 GiB extra memory.

## Testing

- [ ] Stress test on macOS
- [ ] Stress test on Linux
- [ ] Testing ramenctl test runs

## Issues

Tested in CI in this PR and in #2408 - we had 2 CI failures in the e2e run out of 4. Unlikely to be random failure.

Failed runs:
- https://github.com/RamenDR/ramen/actions/runs/22117056315/attempts/1
- https://github.com/RamenDR/ramen/actions/runs/22116946455/attempts/1

Successful runs:
- https://github.com/RamenDR/ramen/actions/runs/22117056315/attempts/2
- https://github.com/RamenDR/ramen/actions/runs/22117056315/attempts/3
- https://github.com/RamenDR/ramen/actions/runs/22116946455/attempts/2
