### PR TITLE
Add CephFS ConsistencyGroup support for PVC deselection

### DIFF
--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1099,19 +1099,10 @@ func (v *VRGInstance) separatePVCUsingPeerClassAndSC(peerClasses []ramendrv1alph
 //nolint:gocognit,cyclop
 func (v *VRGInstance) separateAsyncPVCs(pvcList *corev1.PersistentVolumeClaimList) error {
 	peerClasses := v.instance.Spec.Async.PeerClasses
-	deletedPVCCount := 0
 
 	for idx := range pvcList.Items {
 		pvc := &pvcList.Items[idx]
 		scName := pvc.Spec.StorageClassName
-
-		if util.ResourceIsDeleted(pvc) {
-			deletedPVCCount++
-
-			v.log.Info("Skipping PVC marked for deletion", "pvc", pvc.Name, "namespace", pvc.Namespace)
-
-			continue
-		}
 
 		storageClass, err := v.validateAndGetStorageClass(scName, pvc)
 		if err != nil {
@@ -1131,7 +1122,7 @@ func (v *VRGInstance) separateAsyncPVCs(pvcList *corev1.PersistentVolumeClaimLis
 	v.log.Info(fmt.Sprintf("Found %d PVCs targeted for VolRep and %d targeted for VolSync",
 		len(v.volRepPVCs), len(v.volSyncPVCs)))
 
-	if len(pvcList.Items) != (len(v.volRepPVCs) + len(v.volSyncPVCs) + deletedPVCCount) {
+	if len(pvcList.Items) != (len(v.volRepPVCs) + len(v.volSyncPVCs)) {
 		return fmt.Errorf("no PVCs are procted")
 	}
 


### PR DESCRIPTION
Add CephFS ConsistencyGroup support for PVC deselection

-Clean up separation flow for better readability
-Restore function signature to align with original design
-No functional behavior change intended

Fix: [DFBUGS-3963](https://issues.redhat.com/browse/DFBUGS-3963)

Signed-off-by: kumarsgoyal <kumar.sgoyal@gmail.com>