### PR TITLE
pvc: handle unmounted pvcs without annotations

### DIFF
--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -48,8 +48,6 @@ const (
 	VRGOwnerNamespaceLabel string = "volumereplicationgroups-owner-namespace"
 
 	MarkForDeletion = "ramendr.io/marked-for-deletion"
-
-	PVCMountedAnnotation = "ramendr.openshift.io/mounted"
 )
 
 type ResourceUpdater struct {


### PR DESCRIPTION
This PR will handle the unmounted PVCs without making use of annotation. And also if moverConfig is provided in DRPC, then mount job will not be created using ramen.

Fixes #2431 