### PR TITLE
Fix NetworkFence MCV resource name loookup

### DIFF
--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -1099,7 +1099,7 @@ func (u *drclusterInstance) fenceClusterOnCluster(peerCluster *ramen.DRCluster,
 	annotations := make(map[string]string)
 	annotations[DRClusterNameAnnotation] = u.object.Name
 
-	nf, err := u.reconciler.MCVGetter.GetNFFromManagedCluster(u.object.Name,
+	nf, err := u.reconciler.MCVGetter.GetNFFromManagedCluster(u.object.Name, networkFenceClassName,
 		u.object.Namespace, peerCluster.Name, annotations)
 	if err != nil {
 		// dont update the status or conditions. Return requeue, nil as
@@ -1173,7 +1173,7 @@ func (u *drclusterInstance) unfenceClusterOnCluster(peerCluster *ramen.DRCluster
 	annotations := make(map[string]string)
 	annotations[DRClusterNameAnnotation] = u.object.Name
 
-	nf, err := u.reconciler.MCVGetter.GetNFFromManagedCluster(u.object.Name,
+	nf, err := u.reconciler.MCVGetter.GetNFFromManagedCluster(u.object.Name, networkFenceClassName,
 		u.object.Namespace, peerCluster.Name, annotations)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/internal/controller/drcluster_controller_test.go
+++ b/internal/controller/drcluster_controller_test.go
@@ -108,8 +108,8 @@ func generateNFC() *csiaddonsv1alpha1.NetworkFenceClass {
 	return nfc
 }
 
-func (f FakeMCVGetter) GetNFFromManagedCluster(resourceName, resourceNamespace, managedCluster string,
-	annotations map[string]string,
+func (f FakeMCVGetter) GetNFFromManagedCluster(resourceName, networkFenceClass, resourceNamespace,
+	managedCluster string, annotations map[string]string,
 ) (*csiaddonsv1alpha1.NetworkFence, error) {
 	nfStatus := csiaddonsv1alpha1.NetworkFenceStatus{
 		Result:  csiaddonsv1alpha1.FencingOperationResultSucceeded,

--- a/internal/controller/util/mcv_util.go
+++ b/internal/controller/util/mcv_util.go
@@ -28,6 +28,10 @@ import (
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
 )
 
+const (
+	NetworkFencePrefix = "network-fence"
+)
+
 //nolint:interfacebloat
 type ManagedClusterViewGetter interface {
 	GetVRGFromManagedCluster(
@@ -35,7 +39,7 @@ type ManagedClusterViewGetter interface {
 		annotations map[string]string) (*rmn.VolumeReplicationGroup, error)
 
 	GetNFFromManagedCluster(
-		resourceName, resourceNamespace, managedCluster string,
+		resourceName, networkFenceClassName, resourceNamespace, managedCluster string,
 		annotations map[string]string) (*csiaddonsv1alpha1.NetworkFence, error)
 
 	GetMModeFromManagedCluster(
@@ -160,13 +164,18 @@ func (m ManagedClusterViewGetterImpl) GetVRGFromManagedCluster(resourceName, res
 	return vrg, err
 }
 
-func (m ManagedClusterViewGetterImpl) GetNFFromManagedCluster(resourceName, resourceNamespace, managedCluster string,
-	annotations map[string]string,
+func (m ManagedClusterViewGetterImpl) GetNFFromManagedCluster(targetCluster, networkFenceClassName,
+	resourceNamespace, managedCluster string, annotations map[string]string,
 ) (*csiaddonsv1alpha1.NetworkFence, error) {
 	nf := &csiaddonsv1alpha1.NetworkFence{}
 
+	resourceName := strings.Join([]string{NetworkFencePrefix, targetCluster}, "-")
+	if networkFenceClassName != "" {
+		resourceName = strings.Join([]string{NetworkFencePrefix, networkFenceClassName, targetCluster}, "-")
+	}
+
 	err := m.getResourceFromManagedCluster(
-		"network-fence-"+resourceName,
+		resourceName,
 		resourceNamespace,
 		managedCluster,
 		annotations,


### PR DESCRIPTION
Construct GetNFFromManagedCluster MCV resource name from NFClass when a NetworkFenceClass is in use; otherwise use the base name. Update all callers and tests to pass networkFenceClassName.