### PR TITLE
hooks: add support for job and cronjobs

### DIFF
--- a/internal/controller/hooks/exec_hook.go
+++ b/internal/controller/hooks/exec_hook.go
@@ -57,6 +57,13 @@ func (e ExecHook) Execute(log logr.Logger) error {
 		return fmt.Errorf("error getting pods for exec hook: %w", err)
 	}
 
+	// If no pods are found return an error.
+	// This will cause the controller to retry until pods become available
+	if len(execPods) == 0 {
+		return fmt.Errorf("no running pods found for exec hook %s in namespace %s with selectResource %s",
+			e.Hook.Name, e.Hook.Namespace, e.Hook.SelectResource)
+	}
+
 	inverseOp := e.Hook.Op.InverseOp
 
 	failedPod, err := e.executeCommands(execPods, log)

--- a/internal/controller/hooks/exec_hook_test.go
+++ b/internal/controller/hooks/exec_hook_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,173 +18,6 @@ import (
 	"github.com/ramendr/ramen/internal/controller/hooks"
 	"github.com/ramendr/ramen/internal/controller/kubeobjects"
 )
-
-func setup(t *testing.T) client.Client {
-	t.Helper()
-
-	scheme := runtime.NewScheme()
-	err := corev1.AddToScheme(scheme)
-	assert.NoError(t, err)
-	err = appsv1.AddToScheme(scheme)
-	assert.NoError(t, err)
-
-	// nolint:errcheck
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
-		WithIndex(&corev1.Pod{}, "metadata.name", func(obj client.Object) []string {
-			return []string{obj.(*corev1.Pod).Name}
-		}).Build()
-	assert.NotNil(t, fakeClient)
-
-	return fakeClient
-}
-
-func getPodSpec(name string) *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: "test-ns",
-			Labels: map[string]string{
-				"appname": "busybox",
-			},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:  "test-container",
-					Image: "test-image",
-				},
-			},
-		},
-	}
-}
-
-func getOpHookSpec() *kubeobjects.HookSpec {
-	return &kubeobjects.HookSpec{
-		Name:      "test",
-		Namespace: "test-ns",
-		Type:      "exec",
-		Op: kubeobjects.Operation{
-			Command: "echo hello",
-			Name:    "exec-hook",
-		},
-	}
-}
-
-func getRS() *appsv1.ReplicaSet {
-	return &appsv1.ReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-rs",
-			Namespace: "test-ns",
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "apps/v1",
-					Kind:       "Deployment",
-					Name:       "test-deployment",
-					UID:        "test-uid",
-				},
-			},
-		},
-	}
-}
-
-func getDaemonSet(name, namespace string, labels map[string]string) *appsv1.DaemonSet {
-	if labels == nil {
-		labels = map[string]string{"appname": "busybox"}
-	}
-
-	return &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels:    labels,
-		},
-		Spec: appsv1.DaemonSetSpec{
-			Selector: &metav1.LabelSelector{MatchLabels: labels},
-		},
-		Status: appsv1.DaemonSetStatus{
-			NumberReady: 1,
-		},
-	}
-}
-
-func getPodOwnedByDaemonSet(podName, namespace, daemonSetName, daemonSetUID string) *corev1.Pod {
-	controllerTrue := true
-
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: namespace,
-			Labels:    map[string]string{"appname": "busybox"},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "apps/v1",
-					Kind:       "DaemonSet",
-					Name:       daemonSetName,
-					UID:        types.UID(daemonSetUID),
-					Controller: &controllerTrue,
-				},
-			},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{Name: "test-container", Image: "test-image"},
-			},
-		},
-		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
-		},
-	}
-}
-
-func getStatefulSet(name, namespace string, replicas int32, labels map[string]string) *appsv1.StatefulSet {
-	if labels == nil {
-		labels = map[string]string{"appname": "busybox"}
-	}
-
-	return &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels:    labels,
-		},
-		Spec: appsv1.StatefulSetSpec{
-			Replicas: &replicas,
-			Selector: &metav1.LabelSelector{MatchLabels: labels},
-		},
-		Status: appsv1.StatefulSetStatus{
-			ReadyReplicas: replicas,
-		},
-	}
-}
-
-func getPodOwnedByStatefulSet(podName, namespace, statefulSetName, statefulSetUID string) *corev1.Pod {
-	controllerTrue := true
-
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: namespace,
-			Labels:    map[string]string{"appname": "busybox"},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "apps/v1",
-					Kind:       "StatefulSet",
-					Name:       statefulSetName,
-					UID:        types.UID(statefulSetUID),
-					Controller: &controllerTrue,
-				},
-			},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{Name: "test-container", Image: "test-image"},
-			},
-		},
-		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
-		},
-	}
-}
 
 func TestExecuteWithNoSelector(t *testing.T) {
 	fakeClient := setup(t)
@@ -420,6 +254,7 @@ func TestGetPodsForDaemonSetAllPods(t *testing.T) {
 	assert.Contains(t, names, "test-ds-pod-2")
 }
 
+//nolint:dupl // mirrors TestGetPodsForJobWithLabelSelectorSinglePod; both test single-pod label-selector path for different resource types
 func TestGetPodsForStatefulSetWithLabelSelector(t *testing.T) {
 	fakeClient := setup(t)
 	ss := getStatefulSet("test-ss", "test-ns", 1, map[string]string{"appname": "busybox"})
@@ -492,4 +327,721 @@ func TestGetPodsForStatefulSetAllPods(t *testing.T) {
 	names := []string{pods[0].PodName, pods[1].PodName}
 	assert.Contains(t, names, "test-ss-0")
 	assert.Contains(t, names, "test-ss-1")
+}
+
+// ---------------------------------------------------------------------------
+// Job helpers
+// ---------------------------------------------------------------------------
+
+//nolint:unparam // name and namespace are kept as params to mirror the pattern of getDaemonSet/getStatefulSet
+func getJob(name, namespace string, activeCount int32, labels map[string]string) *batchv1.Job {
+	if labels == nil {
+		labels = map[string]string{"appname": "busybox"}
+	}
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: batchv1.JobSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "test-container", Image: "test-image"},
+					},
+				},
+			},
+		},
+		Status: batchv1.JobStatus{
+			Active: activeCount,
+		},
+	}
+}
+
+//nolint:unparam // namespace is kept as a param to mirror getPodOwnedByDaemonSet/getPodOwnedByStatefulSet
+func getPodOwnedByJob(podName, namespace, jobName, jobUID string) *corev1.Pod {
+	controllerTrue := true
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			Labels:    map[string]string{"appname": "busybox"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "batch/v1",
+					Kind:       "Job",
+					Name:       jobName,
+					UID:        types.UID(jobUID),
+					Controller: &controllerTrue,
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "test-container", Image: "test-image"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CronJob helpers
+// ---------------------------------------------------------------------------
+
+//nolint:unparam // name and namespace are kept as params to mirror getDaemonSet/getStatefulSet
+func getCronJob(name, namespace string, labels map[string]string) *batchv1.CronJob {
+	if labels == nil {
+		labels = map[string]string{"appname": "busybox"}
+	}
+
+	return &batchv1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule: "*/1 * * * *",
+			JobTemplate: batchv1.JobTemplateSpec{
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "test-container", Image: "test-image"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+//nolint:unparam // namespace is kept as a param for consistency with other owned-resource helpers
+func getJobOwnedByCronJob(jobName, namespace, cronJobName, cronJobUID string, activeCount int32) *batchv1.Job {
+	controllerTrue := true
+
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "batch/v1",
+					Kind:       "CronJob",
+					Name:       cronJobName,
+					UID:        types.UID(cronJobUID),
+					Controller: &controllerTrue,
+				},
+			},
+		},
+		Status: batchv1.JobStatus{
+			Active: activeCount,
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Job tests
+// ---------------------------------------------------------------------------
+
+//nolint:dupl // mirrors TestGetPodsForStatefulSetWithLabelSelector; both test single-pod label-selector path for different resource types
+func TestGetPodsForJobWithLabelSelectorSinglePod(t *testing.T) {
+	fakeClient := setup(t)
+
+	job := getJob("test-job", "test-ns", 1, map[string]string{"appname": "busybox"})
+	err := fakeClient.Create(context.Background(), job)
+	assert.NoError(t, err)
+
+	pod := getPodOwnedByJob("test-job-pod", "test-ns", "test-job", "job-uid")
+	err = fakeClient.Create(context.Background(), pod)
+	assert.NoError(t, err)
+
+	hookSpec := getOpHookSpec()
+	hookSpec.SelectResource = "job"
+	hookSpec.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"appname": "busybox"},
+	}
+	hookSpec.SinglePodOnly = true
+
+	eHook := hooks.ExecHook{
+		Hook:   hookSpec,
+		Reader: fakeClient,
+		Scheme: fakeClient.Scheme(),
+	}
+	log := zap.New(zap.UseDevMode(true))
+
+	lister := hooks.NewPodLister(eHook)
+	pods, err := lister.GetPods(log)
+	assert.NoError(t, err)
+	assert.Len(t, pods, 1)
+	assert.Equal(t, hooks.ExecPodSpec{
+		PodName:   "test-job-pod",
+		Namespace: "test-ns",
+		Command:   []string{"echo", "hello"},
+		Container: "test-container",
+	}, pods[0])
+}
+
+func TestGetPodsForJobAllPods(t *testing.T) {
+	fakeClient := setup(t)
+
+	job := getJob("test-job", "test-ns", 2, map[string]string{"appname": "busybox"})
+	err := fakeClient.Create(context.Background(), job)
+	assert.NoError(t, err)
+
+	pod1 := getPodOwnedByJob("test-job-pod-1", "test-ns", "test-job", "job-uid")
+	err = fakeClient.Create(context.Background(), pod1)
+	assert.NoError(t, err)
+
+	pod2 := getPodOwnedByJob("test-job-pod-2", "test-ns", "test-job", "job-uid")
+	err = fakeClient.Create(context.Background(), pod2)
+	assert.NoError(t, err)
+
+	hookSpec := getOpHookSpec()
+	hookSpec.SelectResource = "job"
+	hookSpec.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"appname": "busybox"},
+	}
+	hookSpec.SinglePodOnly = false
+
+	eHook := hooks.ExecHook{
+		Hook:   hookSpec,
+		Reader: fakeClient,
+		Scheme: fakeClient.Scheme(),
+	}
+	log := zap.New(zap.UseDevMode(true))
+
+	lister := hooks.NewPodLister(eHook)
+	pods, err := lister.GetPods(log)
+	assert.NoError(t, err)
+	assert.Len(t, pods, 2)
+
+	names := []string{pods[0].PodName, pods[1].PodName}
+	assert.Contains(t, names, "test-job-pod-1")
+	assert.Contains(t, names, "test-job-pod-2")
+}
+
+func TestGetPodsForJobNoActivePods(t *testing.T) {
+	fakeClient := setup(t)
+
+	// Job with Active=0 but pod still Running; pod should be returned since it's actually running.
+	// The Job status field may not be updated yet, but if the pod is Running, we should execute on it.
+	job := getJob("test-job", "test-ns", 0, map[string]string{"appname": "busybox"})
+	err := fakeClient.Create(context.Background(), job)
+	assert.NoError(t, err)
+
+	pod := getPodOwnedByJob("test-job-pod", "test-ns", "test-job", "job-uid")
+	err = fakeClient.Create(context.Background(), pod)
+	assert.NoError(t, err)
+
+	hookSpec := getOpHookSpec()
+	hookSpec.SelectResource = "job"
+	hookSpec.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"appname": "busybox"},
+	}
+	hookSpec.SinglePodOnly = true
+
+	eHook := hooks.ExecHook{
+		Hook:   hookSpec,
+		Reader: fakeClient,
+		Scheme: fakeClient.Scheme(),
+	}
+	log := zap.New(zap.UseDevMode(true))
+
+	lister := hooks.NewPodLister(eHook)
+	pods, err := lister.GetPods(log)
+	assert.NoError(t, err)
+	// Pod is Running, so it should be returned even if Job.Status.Active is 0
+	assert.Len(t, pods, 1)
+	assert.Equal(t, "test-job-pod", pods[0].PodName)
+}
+
+func TestGetPodsForJobWithCompletedPods(t *testing.T) {
+	fakeClient := setup(t)
+
+	// Job with Active=0 and pod in Succeeded state; no pods should be returned.
+	job := getJob("test-job", "test-ns", 0, map[string]string{"appname": "busybox"})
+	err := fakeClient.Create(context.Background(), job)
+	assert.NoError(t, err)
+
+	pod := getPodOwnedByJob("test-job-pod", "test-ns", "test-job", "job-uid")
+	// Set pod to Succeeded state (truly completed)
+	pod.Status.Phase = corev1.PodSucceeded
+	err = fakeClient.Create(context.Background(), pod)
+	assert.NoError(t, err)
+
+	hookSpec := getOpHookSpec()
+	hookSpec.SelectResource = "job"
+	hookSpec.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"appname": "busybox"},
+	}
+	hookSpec.SinglePodOnly = true
+
+	eHook := hooks.ExecHook{
+		Hook:   hookSpec,
+		Reader: fakeClient,
+		Scheme: fakeClient.Scheme(),
+	}
+	log := zap.New(zap.UseDevMode(true))
+
+	lister := hooks.NewPodLister(eHook)
+	pods, err := lister.GetPods(log)
+	assert.NoError(t, err)
+	// Pod is Succeeded, so it should NOT be returned
+	assert.Len(t, pods, 0)
+}
+
+func TestExecHookFailsWhenNoPodsFound(t *testing.T) {
+	fakeClient := setup(t)
+
+	// Job exists but has no running pods
+	job := getJob("test-job", "test-ns", 0, map[string]string{"appname": "busybox"})
+	err := fakeClient.Create(context.Background(), job)
+	assert.NoError(t, err)
+
+	hookSpec := getOpHookSpec()
+	hookSpec.SelectResource = "job"
+	hookSpec.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"appname": "busybox"},
+	}
+	hookSpec.SinglePodOnly = true
+	hookSpec.SkipHookIfNotPresent = false // Should fail when no pods found
+
+	eHook := hooks.ExecHook{
+		Hook:   hookSpec,
+		Reader: fakeClient,
+		Scheme: fakeClient.Scheme(),
+	}
+	log := zap.New(zap.UseDevMode(true))
+
+	// Execute should fail because no running pods are found
+	err = eHook.Execute(log)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no running pods found")
+}
+
+func TestExecHookSkipsWhenNoPodsFoundAndSkipFlagSet(t *testing.T) {
+	fakeClient := setup(t)
+
+	// Job exists but has no running pods
+	job := getJob("test-job", "test-ns", 0, map[string]string{"appname": "busybox"})
+	err := fakeClient.Create(context.Background(), job)
+	assert.NoError(t, err)
+
+	hookSpec := getOpHookSpec()
+	hookSpec.SelectResource = "job"
+	hookSpec.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"appname": "busybox"},
+	}
+	hookSpec.SinglePodOnly = true
+	hookSpec.SkipHookIfNotPresent = true // Should skip when no pods found
+
+	eHook := hooks.ExecHook{
+		Hook:   hookSpec,
+		Reader: fakeClient,
+		Scheme: fakeClient.Scheme(),
+	}
+	log := zap.New(zap.UseDevMode(true))
+
+	// Execute should succeed (skip) because skipHookIfNotPresent is true
+	err = eHook.Execute(log)
+	assert.Error(t, err)
+}
+
+func TestGetPodsForJobWithNameSelector(t *testing.T) {
+	fakeClient := setup(t)
+
+	job := getJob("test-job", "test-ns", 1, nil)
+	err := fakeClient.Create(context.Background(), job)
+	assert.NoError(t, err)
+
+	pod := getPodOwnedByJob("test-job-pod", "test-ns", "test-job", "job-uid")
+	err = fakeClient.Create(context.Background(), pod)
+	assert.NoError(t, err)
+
+	hookSpec := getOpHookSpec()
+	hookSpec.SelectResource = "job"
+	hookSpec.NameSelector = "test-job"
+
+	eHook := hooks.ExecHook{
+		Hook:   hookSpec,
+		Reader: fakeClient,
+		Scheme: fakeClient.Scheme(),
+	}
+	log := zap.New(zap.UseDevMode(true))
+
+	lister := hooks.NewPodLister(eHook)
+	pods, err := lister.GetPods(log)
+	assert.NoError(t, err)
+	assert.Len(t, pods, 1)
+	assert.Equal(t, "test-job-pod", pods[0].PodName)
+}
+
+// ---------------------------------------------------------------------------
+// CronJob tests
+// ---------------------------------------------------------------------------
+
+func TestGetPodsForCronJobWithLabelSelectorSinglePod(t *testing.T) {
+	fakeClient := setup(t)
+
+	cj := getCronJob("test-cj", "test-ns", map[string]string{"appname": "busybox"})
+	err := fakeClient.Create(context.Background(), cj)
+	assert.NoError(t, err)
+
+	job := getJobOwnedByCronJob("test-cj-job", "test-ns", "test-cj", "cj-uid", 1)
+	err = fakeClient.Create(context.Background(), job)
+	assert.NoError(t, err)
+
+	pod := getPodOwnedByJob("test-cj-pod", "test-ns", "test-cj-job", "job-uid")
+	err = fakeClient.Create(context.Background(), pod)
+	assert.NoError(t, err)
+
+	hookSpec := getOpHookSpec()
+	hookSpec.SelectResource = "cronjob"
+	hookSpec.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"appname": "busybox"},
+	}
+	hookSpec.SinglePodOnly = true
+
+	eHook := hooks.ExecHook{
+		Hook:   hookSpec,
+		Reader: fakeClient,
+		Scheme: fakeClient.Scheme(),
+	}
+	log := zap.New(zap.UseDevMode(true))
+
+	lister := hooks.NewPodLister(eHook)
+	pods, err := lister.GetPods(log)
+	assert.NoError(t, err)
+	assert.Len(t, pods, 1)
+	assert.Equal(t, hooks.ExecPodSpec{
+		PodName:   "test-cj-pod",
+		Namespace: "test-ns",
+		Command:   []string{"echo", "hello"},
+		Container: "test-container",
+	}, pods[0])
+}
+
+func TestGetPodsForCronJobAllPods(t *testing.T) {
+	fakeClient := setup(t)
+
+	cj := getCronJob("test-cj", "test-ns", map[string]string{"appname": "busybox"})
+	err := fakeClient.Create(context.Background(), cj)
+	assert.NoError(t, err)
+
+	job := getJobOwnedByCronJob("test-cj-job", "test-ns", "test-cj", "cj-uid", 2)
+	err = fakeClient.Create(context.Background(), job)
+	assert.NoError(t, err)
+
+	pod1 := getPodOwnedByJob("test-cj-pod-1", "test-ns", "test-cj-job", "job-uid")
+	err = fakeClient.Create(context.Background(), pod1)
+	assert.NoError(t, err)
+
+	pod2 := getPodOwnedByJob("test-cj-pod-2", "test-ns", "test-cj-job", "job-uid")
+	err = fakeClient.Create(context.Background(), pod2)
+	assert.NoError(t, err)
+
+	hookSpec := getOpHookSpec()
+	hookSpec.SelectResource = "cronjob"
+	hookSpec.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"appname": "busybox"},
+	}
+	hookSpec.SinglePodOnly = false
+
+	eHook := hooks.ExecHook{
+		Hook:   hookSpec,
+		Reader: fakeClient,
+		Scheme: fakeClient.Scheme(),
+	}
+	log := zap.New(zap.UseDevMode(true))
+
+	lister := hooks.NewPodLister(eHook)
+	pods, err := lister.GetPods(log)
+	assert.NoError(t, err)
+	assert.Len(t, pods, 2)
+
+	names := []string{pods[0].PodName, pods[1].PodName}
+	assert.Contains(t, names, "test-cj-pod-1")
+	assert.Contains(t, names, "test-cj-pod-2")
+}
+
+func TestGetPodsForCronJobNoActiveJobs(t *testing.T) {
+	fakeClient := setup(t)
+
+	cj := getCronJob("test-cj", "test-ns", map[string]string{"appname": "busybox"})
+	err := fakeClient.Create(context.Background(), cj)
+	assert.NoError(t, err)
+
+	// Job owned by the CronJob but with Active=0 (completed).
+	job := getJobOwnedByCronJob("test-cj-job", "test-ns", "test-cj", "cj-uid", 0)
+	err = fakeClient.Create(context.Background(), job)
+	assert.NoError(t, err)
+
+	hookSpec := getOpHookSpec()
+	hookSpec.SelectResource = "cronjob"
+	hookSpec.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"appname": "busybox"},
+	}
+	hookSpec.SinglePodOnly = true
+
+	eHook := hooks.ExecHook{
+		Hook:   hookSpec,
+		Reader: fakeClient,
+		Scheme: fakeClient.Scheme(),
+	}
+	log := zap.New(zap.UseDevMode(true))
+
+	lister := hooks.NewPodLister(eHook)
+	pods, err := lister.GetPods(log)
+	assert.NoError(t, err)
+	assert.Len(t, pods, 0)
+}
+
+func TestGetPodsForCronJobWithNameSelector(t *testing.T) {
+	fakeClient := setup(t)
+
+	cj := getCronJob("test-cj", "test-ns", nil)
+	err := fakeClient.Create(context.Background(), cj)
+	assert.NoError(t, err)
+
+	job := getJobOwnedByCronJob("test-cj-job", "test-ns", "test-cj", "cj-uid", 1)
+	err = fakeClient.Create(context.Background(), job)
+	assert.NoError(t, err)
+
+	pod := getPodOwnedByJob("test-cj-pod", "test-ns", "test-cj-job", "job-uid")
+	err = fakeClient.Create(context.Background(), pod)
+	assert.NoError(t, err)
+
+	hookSpec := getOpHookSpec()
+	hookSpec.SelectResource = "cronjob"
+	hookSpec.NameSelector = "test-cj"
+
+	eHook := hooks.ExecHook{
+		Hook:   hookSpec,
+		Reader: fakeClient,
+		Scheme: fakeClient.Scheme(),
+	}
+	log := zap.New(zap.UseDevMode(true))
+
+	lister := hooks.NewPodLister(eHook)
+	pods, err := lister.GetPods(log)
+	assert.NoError(t, err)
+	assert.Len(t, pods, 1)
+	assert.Equal(t, "test-cj-pod", pods[0].PodName)
+}
+
+func TestIsPodOwnedByJob(t *testing.T) {
+	pod := getPodSpec("test-pod")
+	pod.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion: "batch/v1",
+			Kind:       "Job",
+			Name:       "test-job",
+			UID:        "test-uid",
+		},
+	}
+	pod.Status = corev1.PodStatus{Phase: corev1.PodRunning}
+
+	// Controller flag not set — should be false.
+	assert.False(t, hooks.IsPodOwnedByJob(pod, "test-job"))
+
+	isController := true
+	pod.OwnerReferences[0].Controller = &isController
+	assert.True(t, hooks.IsPodOwnedByJob(pod, "test-job"))
+
+	// Wrong job name — should be false.
+	assert.False(t, hooks.IsPodOwnedByJob(pod, "other-job"))
+}
+
+func TestIsJobOwnedByCronJob(t *testing.T) {
+	job := getJobOwnedByCronJob("test-job", "test-ns", "test-cj", "cj-uid", 1)
+
+	assert.True(t, hooks.IsJobOwnedByCronJob(job, "test-cj"))
+	assert.False(t, hooks.IsJobOwnedByCronJob(job, "other-cj"))
+
+	// Controller flag not set — should be false.
+	job.OwnerReferences[0].Controller = nil
+	assert.False(t, hooks.IsJobOwnedByCronJob(job, "test-cj"))
+}
+
+// ---------------------------------------------------------------------------
+// Helper functions
+// ---------------------------------------------------------------------------
+
+func setup(t *testing.T) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	err := corev1.AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = appsv1.AddToScheme(scheme)
+	assert.NoError(t, err)
+	err = batchv1.AddToScheme(scheme)
+	assert.NoError(t, err)
+
+	// nolint:errcheck
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithIndex(&corev1.Pod{}, "metadata.name", func(obj client.Object) []string {
+			return []string{obj.(*corev1.Pod).Name}
+		}).Build()
+	assert.NotNil(t, fakeClient)
+
+	return fakeClient
+}
+
+func getPodSpec(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				"appname": "busybox",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:  "test-container",
+					Image: "test-image",
+				},
+			},
+		},
+	}
+}
+
+func getOpHookSpec() *kubeobjects.HookSpec {
+	return &kubeobjects.HookSpec{
+		Name:      "test",
+		Namespace: "test-ns",
+		Type:      "exec",
+		Op: kubeobjects.Operation{
+			Command: "echo hello",
+			Name:    "exec-hook",
+		},
+	}
+}
+
+func getRS() *appsv1.ReplicaSet {
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rs",
+			Namespace: "test-ns",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "test-deployment",
+					UID:        "test-uid",
+				},
+			},
+		},
+	}
+}
+
+func getDaemonSet(name, namespace string, labels map[string]string) *appsv1.DaemonSet {
+	if labels == nil {
+		labels = map[string]string{"appname": "busybox"}
+	}
+
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+		},
+		Status: appsv1.DaemonSetStatus{
+			NumberReady: 1,
+		},
+	}
+}
+
+func getPodOwnedByDaemonSet(podName, namespace, daemonSetName, daemonSetUID string) *corev1.Pod {
+	controllerTrue := true
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			Labels:    map[string]string{"appname": "busybox"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "DaemonSet",
+					Name:       daemonSetName,
+					UID:        types.UID(daemonSetUID),
+					Controller: &controllerTrue,
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "test-container", Image: "test-image"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+}
+
+func getStatefulSet(name, namespace string, replicas int32, labels map[string]string) *appsv1.StatefulSet {
+	if labels == nil {
+		labels = map[string]string{"appname": "busybox"}
+	}
+
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: replicas,
+		},
+	}
+}
+
+func getPodOwnedByStatefulSet(podName, namespace, statefulSetName, statefulSetUID string) *corev1.Pod {
+	controllerTrue := true
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+			Labels:    map[string]string{"appname": "busybox"},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "apps/v1",
+					Kind:       "StatefulSet",
+					Name:       statefulSetName,
+					UID:        types.UID(statefulSetUID),
+					Controller: &controllerTrue,
+				},
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "test-container", Image: "test-image"},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
 }

--- a/internal/controller/hooks/exec_pod_lister.go
+++ b/internal/controller/hooks/exec_pod_lister.go
@@ -8,7 +8,7 @@ import (
 )
 
 // PodLister interface abstracts pod discovery based on SelectResource type.
-// Each implementation handles a specific resource type (pod, deployment, statefulset, daemonset).
+// Each implementation handles a specific resource type (pod, deployment, statefulset, daemonset, job, cronjob).
 type PodLister interface {
 	GetPods(log logr.Logger) ([]ExecPodSpec, error)
 }
@@ -22,6 +22,10 @@ func NewPodLister(e ExecHook) PodLister {
 		return &StatefulSetPodLister{ExecHook: e}
 	case "daemonset":
 		return &DaemonSetPodLister{ExecHook: e}
+	case "job":
+		return &JobPodLister{ExecHook: e}
+	case "cronjob":
+		return &CronJobPodLister{ExecHook: e}
 	default: // "pod" or ""
 		return &DirectPodLister{ExecHook: e}
 	}

--- a/internal/controller/hooks/exec_pod_lister_cronjob.go
+++ b/internal/controller/hooks/exec_pod_lister_cronjob.go
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CronJobPodLister handles pod discovery when SelectResource is "cronjob".
+// It finds CronJobs, then their active child Jobs, then the pods owned by those Jobs.
+type CronJobPodLister struct {
+	ExecHook
+}
+
+// GetPods returns pods from CronJobs matching the selector criteria.
+// When SinglePodOnly is true, it returns one active pod per CronJob (from its first active Job).
+// When SinglePodOnly is false, it returns all active pods from all active Jobs of all matched CronJobs.
+func (l *CronJobPodLister) GetPods(log logr.Logger) ([]ExecPodSpec, error) {
+	cronJobs, err := l.getCronJobs(log)
+	if err != nil {
+		return nil, err
+	}
+
+	if l.Hook.SinglePodOnly {
+		return l.getOneActivePodPerCronJob(cronJobs, log)
+	}
+
+	return l.getAllActivePodsFromCronJobs(cronJobs, log)
+}
+
+//nolint:dupl // getJobs mirrors this structure; both use label/name selectors.
+func (l *CronJobPodLister) getCronJobs(log logr.Logger) ([]batchv1.CronJob, error) {
+	cronJobList := &batchv1.CronJobList{}
+	cronJobs := make([]batchv1.CronJob, 0)
+
+	if l.Hook.LabelSelector != nil {
+		err := getResourcesUsingLabelSelector(l.Reader, l.Hook, cronJobList)
+		if err != nil {
+			return cronJobs, err
+		}
+
+		cronJobs = append(cronJobs, cronJobList.Items...)
+
+		log.Info("cronjobs count obtained using label selector", "hook", l.Hook.Name,
+			"labelSelector", l.Hook.LabelSelector, "selectResource", l.Hook.SelectResource,
+			"cronJobCount", len(cronJobs))
+	}
+
+	if l.Hook.NameSelector != "" {
+		selectorType, objs, err := getResourcesUsingNameSelector(l.Reader, l.Hook, cronJobList)
+		if err != nil {
+			return cronJobs, err
+		}
+
+		for _, obj := range objs {
+			cj, ok := obj.(*batchv1.CronJob)
+			if ok {
+				cronJobs = append(cronJobs, *cj)
+			}
+		}
+
+		log.Info("cronjobs count obtained using name selector", "hook", l.Hook.Name,
+			"nameSelector", l.Hook.NameSelector, "selectorType", selectorType,
+			"selectResource", l.Hook.SelectResource, "cronJobCount", len(cronJobs))
+	}
+
+	return cronJobs, nil
+}
+
+// getActiveJobsForCronJob returns all Jobs owned by the given CronJob.
+// Note: We don't check job.Status.Active here because it may not be updated yet.
+// Instead, we rely on listActivePodsForJob to find actually running pods.
+func (l *CronJobPodLister) getActiveJobsForCronJob(cronJob *batchv1.CronJob) ([]batchv1.Job, error) {
+	jobList := &batchv1.JobList{}
+
+	err := l.Reader.List(context.Background(), jobList, client.InNamespace(cronJob.Namespace))
+	if err != nil {
+		return nil, fmt.Errorf("error listing jobs for cronjob %s: %w", cronJob.Name, err)
+	}
+
+	jobs := make([]batchv1.Job, 0)
+
+	for i := range jobList.Items {
+		job := &jobList.Items[i]
+		if IsJobOwnedByCronJob(job, cronJob.Name) {
+			jobs = append(jobs, *job)
+		}
+	}
+
+	return jobs, nil
+}
+
+func (l *CronJobPodLister) getOneActivePodPerCronJob(
+	cronJobs []batchv1.CronJob, log logr.Logger,
+) ([]ExecPodSpec, error) {
+	execPods := make([]ExecPodSpec, 0)
+
+	for _, cronJob := range cronJobs {
+		activeJobs, err := l.getActiveJobsForCronJob(&cronJob)
+		if err != nil {
+			return execPods, err
+		}
+
+		if len(activeJobs) == 0 {
+			log.Info("no active jobs found for cronjob", "cronjob", cronJob.Name, "namespace", cronJob.Namespace)
+
+			continue
+		}
+
+		cmd, err := covertCommandToStringArray(l.Hook.Op.Command)
+		if err != nil {
+			return execPods, fmt.Errorf("error converting command to string array: %w", err)
+		}
+
+		// Use the first active Job; SinglePodOnly semantics: one pod is sufficient.
+		job := &activeJobs[0]
+
+		pods, err := listActivePodsForJob(context.Background(), l.Reader, job, cmd, l.Hook.Op.Container)
+		if err != nil {
+			return execPods, fmt.Errorf("error listing pods for job %s: %w", job.Name, err)
+		}
+
+		if len(pods) > 0 {
+			execPods = append(execPods, pods[0])
+		}
+	}
+
+	return execPods, nil
+}
+
+func (l *CronJobPodLister) getAllActivePodsFromCronJobs(
+	cronJobs []batchv1.CronJob, log logr.Logger,
+) ([]ExecPodSpec, error) {
+	execPods := make([]ExecPodSpec, 0)
+
+	cmd, err := covertCommandToStringArray(l.Hook.Op.Command)
+	if err != nil {
+		return execPods, fmt.Errorf("error converting command to string array: %w", err)
+	}
+
+	log.V(1).Info("getAllActivePodsFromCronJobs", "cronJobCount", len(cronJobs))
+
+	for _, cronJob := range cronJobs {
+		activeJobs, err := l.getActiveJobsForCronJob(&cronJob)
+		if err != nil {
+			return execPods, err
+		}
+
+		for i := range activeJobs {
+			job := &activeJobs[i]
+
+			pods, err := listActivePodsForJob(context.Background(), l.Reader, job, cmd, l.Hook.Op.Container)
+			if err != nil {
+				return execPods, fmt.Errorf("error listing pods for job %s: %w", job.Name, err)
+			}
+
+			execPods = append(execPods, pods...)
+		}
+	}
+
+	return execPods, nil
+}

--- a/internal/controller/hooks/exec_pod_lister_job.go
+++ b/internal/controller/hooks/exec_pod_lister_job.go
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// JobPodLister handles pod discovery when SelectResource is "job".
+// It finds Jobs and returns pods owned by those Jobs that are currently active (Running).
+type JobPodLister struct {
+	ExecHook
+}
+
+// GetPods returns pods from Jobs matching the selector criteria.
+// When SinglePodOnly is true, it returns one active pod per Job.
+// When SinglePodOnly is false, it returns all active pods from all matched Jobs.
+func (l *JobPodLister) GetPods(log logr.Logger) ([]ExecPodSpec, error) {
+	jobs, err := l.getJobs(log)
+	if err != nil {
+		return nil, err
+	}
+
+	if l.Hook.SinglePodOnly {
+		return l.getOneActivePodPerJob(jobs, log)
+	}
+
+	return l.getAllActivePodsFromJobs(jobs, log)
+}
+
+//nolint:dupl // getCronJobs and getStatefulSets mirror this structure; all use label/name selectors for different resource types
+func (l *JobPodLister) getJobs(log logr.Logger) ([]batchv1.Job, error) {
+	jobList := &batchv1.JobList{}
+	jobs := make([]batchv1.Job, 0)
+
+	if l.Hook.LabelSelector != nil {
+		err := getResourcesUsingLabelSelector(l.Reader, l.Hook, jobList)
+		if err != nil {
+			return jobs, err
+		}
+
+		jobs = append(jobs, jobList.Items...)
+
+		log.Info("jobs count obtained using label selector", "hook", l.Hook.Name,
+			"labelSelector", l.Hook.LabelSelector, "selectResource", l.Hook.SelectResource,
+			"jobCount", len(jobs))
+	}
+
+	if l.Hook.NameSelector != "" {
+		selectorType, objs, err := getResourcesUsingNameSelector(l.Reader, l.Hook, jobList)
+		if err != nil {
+			return jobs, err
+		}
+
+		for _, obj := range objs {
+			j, ok := obj.(*batchv1.Job)
+			if ok {
+				jobs = append(jobs, *j)
+			}
+		}
+
+		log.Info("jobs count obtained using name selector", "hook", l.Hook.Name,
+			"nameSelector", l.Hook.NameSelector, "selectorType", selectorType,
+			"selectResource", l.Hook.SelectResource, "jobCount", len(jobs))
+	}
+
+	return jobs, nil
+}
+
+func (l *JobPodLister) getOneActivePodPerJob(jobs []batchv1.Job, log logr.Logger) ([]ExecPodSpec, error) {
+	execPods := make([]ExecPodSpec, 0)
+
+	for _, job := range jobs {
+		pod, err := l.getFirstActivePodForJob(&job)
+		if err != nil {
+			return execPods, fmt.Errorf("error getting active pod for job %s: %w", job.Name, err)
+		}
+
+		if pod == nil {
+			log.Info("no active pod found for job", "job", job.Name, "namespace", job.Namespace)
+
+			continue
+		}
+
+		cmd, err := covertCommandToStringArray(l.Hook.Op.Command)
+		if err != nil {
+			return execPods, fmt.Errorf("error converting command to string array: %w", err)
+		}
+
+		execPods = append(execPods, getExecPodSpec(l.Hook.Op.Container, cmd, pod))
+	}
+
+	return execPods, nil
+}
+
+func (l *JobPodLister) getAllActivePodsFromJobs(jobs []batchv1.Job, log logr.Logger) ([]ExecPodSpec, error) {
+	execPods := make([]ExecPodSpec, 0)
+
+	cmd, err := covertCommandToStringArray(l.Hook.Op.Command)
+	if err != nil {
+		return execPods, fmt.Errorf("error converting command to string array: %w", err)
+	}
+
+	log.V(1).Info("getAllActivePodsFromJobs", "jobCount", len(jobs))
+
+	for _, job := range jobs {
+		pods, err := listActivePodsForJob(context.Background(), l.Reader, &job, cmd, l.Hook.Op.Container)
+		if err != nil {
+			return execPods, fmt.Errorf("error listing pods for job %s: %w", job.Name, err)
+		}
+
+		execPods = append(execPods, pods...)
+	}
+
+	return execPods, nil
+}
+
+func (l *JobPodLister) getFirstActivePodForJob(job *batchv1.Job) (*corev1.Pod, error) {
+	podList := &corev1.PodList{}
+
+	err := l.Reader.List(context.Background(), podList, client.InNamespace(job.Namespace))
+	if err != nil {
+		return nil, fmt.Errorf("error listing pods: %w", err)
+	}
+
+	totalPods := len(podList.Items)
+	jobOwnedPods := 0
+	runningPods := 0
+
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+
+		// Check if pod is owned by this job (for logging purposes)
+		for _, ownerRef := range pod.OwnerReferences {
+			if isOwnerCorrect(&ownerRef, job.Name, "Job") {
+				jobOwnedPods++
+
+				if pod.Status.Phase == corev1.PodRunning {
+					runningPods++
+				}
+
+				break
+			}
+		}
+
+		if IsPodOwnedByJob(pod, job.Name) {
+			return pod, nil
+		}
+	}
+
+	// Log details when no pod is found
+	log := logr.FromContextOrDiscard(context.Background())
+	log.V(1).Info("getFirstActivePodForJob - no running pod found",
+		"job", job.Name,
+		"namespace", job.Namespace,
+		"totalPodsInNamespace", totalPods,
+		"jobOwnedPods", jobOwnedPods,
+		"runningJobPods", runningPods)
+
+	return nil, nil
+}
+
+// listActivePodsForJob lists all Running pods owned by the given Job.
+func listActivePodsForJob(
+	ctx context.Context,
+	reader client.Reader,
+	job *batchv1.Job,
+	cmd []string,
+	container string,
+) ([]ExecPodSpec, error) {
+	podList := &corev1.PodList{}
+
+	err := reader.List(ctx, podList, client.InNamespace(job.Namespace))
+	if err != nil {
+		return nil, fmt.Errorf("error listing pods: %w", err)
+	}
+
+	execPods := make([]ExecPodSpec, 0)
+	totalPods := len(podList.Items)
+	jobOwnedPods := 0
+	runningPods := 0
+	completedPods := 0
+
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+
+		// Check if pod is owned by this job (regardless of phase)
+		isOwnedByJob := false
+
+		for _, ownerRef := range pod.OwnerReferences {
+			if isOwnerCorrect(&ownerRef, job.Name, "Job") {
+				isOwnedByJob = true
+				jobOwnedPods++
+
+				break
+			}
+		}
+
+		if isOwnedByJob {
+			switch pod.Status.Phase {
+			case corev1.PodRunning:
+				runningPods++
+
+				execPods = append(execPods, getExecPodSpec(container, cmd, pod))
+			case corev1.PodSucceeded, corev1.PodFailed:
+				completedPods++
+			case corev1.PodPending, corev1.PodUnknown:
+				// Pod is not ready yet, don't count it
+			}
+		}
+	}
+
+	logJobPodDetails(ctx, job.Name, job.Namespace, totalPods, jobOwnedPods, runningPods, completedPods, len(execPods))
+
+	return execPods, nil
+}
+
+// logJobPodDetails logs diagnostic information about job pods.
+func logJobPodDetails(
+	ctx context.Context, jobName, namespace string,
+	totalPods, jobOwnedPods, runningPods, completedPods, execPodsReturned int,
+) {
+	log := logr.FromContextOrDiscard(ctx)
+
+	// Always log at INFO level when no running pods found to help debugging
+	if runningPods == 0 && jobOwnedPods > 0 {
+		if completedPods > 0 {
+			log.Info("listActivePodsForJob - job completed, no running pods",
+				"job", jobName,
+				"namespace", namespace,
+				"totalPodsInNamespace", totalPods,
+				"jobOwnedPods", jobOwnedPods,
+				"completedPods", completedPods,
+				"runningJobPods", runningPods)
+		} else {
+			log.Info("listActivePodsForJob - pods exist but not running yet",
+				"job", jobName,
+				"namespace", namespace,
+				"totalPodsInNamespace", totalPods,
+				"jobOwnedPods", jobOwnedPods,
+				"runningJobPods", runningPods)
+		}
+	} else {
+		log.V(1).Info("listActivePodsForJob details",
+			"job", jobName,
+			"namespace", namespace,
+			"totalPodsInNamespace", totalPods,
+			"jobOwnedPods", jobOwnedPods,
+			"runningJobPods", runningPods,
+			"completedPods", completedPods,
+			"execPodsReturned", execPodsReturned)
+	}
+}
+
+// IsPodOwnedByJob checks if a pod is owned by the specified Job and is running.
+func IsPodOwnedByJob(pod *corev1.Pod, jobName string) bool {
+	for _, ownerRef := range pod.OwnerReferences {
+		if isOwnerCorrect(&ownerRef, jobName, "Job") && pod.Status.Phase == corev1.PodRunning {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsJobOwnedByCronJob checks if a Job is owned by the specified CronJob.
+func IsJobOwnedByCronJob(job *batchv1.Job, cronJobName string) bool {
+	for _, ownerRef := range job.OwnerReferences {
+		if isOwnerCorrect(&ownerRef, cronJobName, "CronJob") {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/controller/hooks/hooks_util.go
+++ b/internal/controller/hooks/hooks_util.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
 package hooks
 
 import (
@@ -6,6 +9,7 @@ import (
 	"regexp"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -85,6 +89,10 @@ func getFilteredObjectsBasedOnTypeAndNameSelector(objList client.ObjectList, nam
 		objs = filterStatefulSets(v.Items, nameSelector)
 	case *appsv1.DaemonSetList:
 		objs = filterDaemonSets(v.Items, nameSelector)
+	case *batchv1.JobList:
+		objs = filterJobs(v.Items, nameSelector)
+	case *batchv1.CronJobList:
+		objs = filterCronJobs(v.Items, nameSelector)
 	}
 
 	return objs
@@ -107,6 +115,14 @@ func filterPods(objs []corev1.Pod, nameSelector string) []client.Object {
 }
 
 func filterUnstructuredObjects(objs []unstructured.Unstructured, nameSelector string) []client.Object {
+	return filterObjectsSameAsNameSelector(toPointerSlice(objs), nameSelector)
+}
+
+func filterJobs(objs []batchv1.Job, nameSelector string) []client.Object {
+	return filterObjectsSameAsNameSelector(toPointerSlice(objs), nameSelector)
+}
+
+func filterCronJobs(objs []batchv1.CronJob, nameSelector string) []client.Object {
 	return filterObjectsSameAsNameSelector(toPointerSlice(objs), nameSelector)
 }
 
@@ -149,6 +165,14 @@ func getObjectsBasedOnType(objList client.ObjectList) []client.Object {
 		for _, ds := range v.Items {
 			objs = append(objs, &ds)
 		}
+	case *batchv1.JobList:
+		for _, j := range v.Items {
+			objs = append(objs, &j)
+		}
+	case *batchv1.CronJobList:
+		for _, cj := range v.Items {
+			objs = append(objs, &cj)
+		}
 	}
 
 	return objs
@@ -174,6 +198,10 @@ func getObjectsBasedOnTypeAndRegex(objList client.ObjectList, nameSelector strin
 		objs = getMatchingStatefulSets(v, re)
 	case *appsv1.DaemonSetList:
 		objs = getMatchingDaemonSets(v, re)
+	case *batchv1.JobList:
+		objs = getMatchingJobs(v, re)
+	case *batchv1.CronJobList:
+		objs = getMatchingCronJobs(v, re)
 	}
 
 	return objs
@@ -269,6 +297,14 @@ func getMatchingStatefulSets(ssList *appsv1.StatefulSetList, re *regexp.Regexp) 
 
 func getMatchingDaemonSets(dsList *appsv1.DaemonSetList, re *regexp.Regexp) []client.Object {
 	return getRegexMatchingObjects(toPointerSlice(dsList.Items), re)
+}
+
+func getMatchingJobs(jList *batchv1.JobList, re *regexp.Regexp) []client.Object {
+	return getRegexMatchingObjects(toPointerSlice(jList.Items), re)
+}
+
+func getMatchingCronJobs(cjList *batchv1.CronJobList, re *regexp.Regexp) []client.Object {
+	return getRegexMatchingObjects(toPointerSlice(cjList.Items), re)
 }
 
 func getRegexMatchingObjects[T client.Object](items []T, re *regexp.Regexp) []client.Object {


### PR DESCRIPTION
As of now, for exec hooks, deployments, daemonsets, statefulsets and pods are supported. Job and CronJob support is being added through this PR.

Assisted by AI