### PR TITLE
Ensure accurate resource conflict reporting in NoResourceConflict condition

### DIFF
--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -2467,10 +2467,16 @@ func (v *VRGInstance) IsDRActionInProgress() bool {
 	isRepStatePrimary := spec.ReplicationState == ramendrv1alpha1.Primary
 	switchedToPrimary := status.State == ramendrv1alpha1.PrimaryState
 
-	if (isRepStateSecondary && !switchedToSecondary) ||
-		(isRepStatePrimary && !switchedToPrimary) ||
-		v.instance.Generation != status.ObservedGeneration {
-		return true
+	if isRepStateSecondary {
+		if !switchedToSecondary || (v.instance.Generation != status.ObservedGeneration) {
+			return true
+		}
+	}
+
+	if isRepStatePrimary {
+		if !switchedToPrimary || (v.instance.Generation != status.ObservedGeneration) {
+			return true
+		}
 	}
 
 	return false


### PR DESCRIPTION
Correct IsDRActionInProgress() to avoid false “DR action in progress” when VRG spec/status are already in sync
This PR fixes an issue where IsDRActionInProgress() incorrectly reported that a DR action was in progress even when the Spec.ReplicationState and Status.State of the VRG were already aligned (and the action had effectively completed). The bug primarily surfaced on the secondary VRG, leading to misleading conflict checks and noisy/no-op DR flows.