### PR TITLE
drenv: Increase default command timeout

### DIFF
--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -17,7 +17,7 @@ ERR = "err"
 
 # Default timeout for commands. Without a timeout commands can hang
 # indefinitely, wasting hours of CI time.
-_DEFAULT_TIMEOUT = 300
+_DEFAULT_TIMEOUT = 600
 
 Failure = collections.namedtuple("Failure", ["command", "exitcode", "error"])
 


### PR DESCRIPTION
Last stress test on Linux VM (similar to our e2e runners) shows that 4 runs of 500 failed with 300 seconds command timeout, before hitting timeouts in the actual addon. Issue also seen once in CI, and reported by Elena using a slower VM.

Increase the default timeout to 600 seconds to make drenv more reliable with slower machines.