### PR TITLE
Add CG PVC ownership and cleanup for discovered apps

### DIFF
--- a/internal/controller/cephfscg/cghandler.go
+++ b/internal/controller/cephfscg/cghandler.go
@@ -108,6 +108,12 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupDestination(
 		WithValues("ReplicationGroupDestinationName", replicationGroupDestinationName,
 			"ReplicationGroupDestinationNamespace", replicationGroupDestinationNamespace)
 
+	// Disown RS-managed PVCs before deleting RGS (RSs own PVCs on primary)
+	if err := c.disownRSManagedPVCsBeforeRGSDeletion(
+		replicationGroupDestinationName, replicationGroupDestinationNamespace, log); err != nil {
+		return nil, err
+	}
+
 	if err := util.DeleteReplicationGroupSource(c.ctx, c.Client,
 		replicationGroupDestinationName, replicationGroupDestinationNamespace); err != nil {
 		log.Error(err, "Failed to delete ReplicationGroupSource before creating ReplicationGroupDestination")
@@ -115,10 +121,32 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupDestination(
 		return nil, err
 	}
 
+	rgd, err := c.createOrUpdateRGD(
+		replicationGroupDestinationName, replicationGroupDestinationNamespace, rdSpecsInGroup, log)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure RDs own their corresponding PVCs to enable Kubernetes garbage collection
+	// when RDs are deleted
+	if err := c.ensureRDsOwnTheirPVCs(rdSpecsInGroup); err != nil {
+		log.Error(err, "Failed to ensure RDs own their PVCs")
+
+		return nil, err
+	}
+
+	return rgd, nil
+}
+
+func (c *cgHandler) createOrUpdateRGD(
+	name, namespace string,
+	rdSpecsInGroup []ramendrv1alpha1.VolSyncReplicationDestinationSpec,
+	log logr.Logger,
+) (*ramendrv1alpha1.ReplicationGroupDestination, error) {
 	rgd := &ramendrv1alpha1.ReplicationGroupDestination{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      replicationGroupDestinationName,
-			Namespace: replicationGroupDestinationNamespace,
+			Name:      name,
+			Namespace: namespace,
 		},
 	}
 
@@ -151,6 +179,143 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupDestination(
 	return rgd, nil
 }
 
+// ensureRDsOwnTheirPVCs assigns each RD created from RDSpecs as owner of the corresponding PVC
+// This enables Kubernetes garbage collection to delete the PVC when the RD is deleted
+func (c *cgHandler) ensureRDsOwnTheirPVCs(rdSpecsInGroup []ramendrv1alpha1.VolSyncReplicationDestinationSpec) error {
+	log := c.logger.WithName("ensureRDsOwnTheirPVCs")
+
+	for _, rdSpec := range rdSpecsInGroup {
+		pvcName := rdSpec.ProtectedPVC.Name
+		pvcNamespace := rdSpec.ProtectedPVC.Namespace
+
+		// Get the RD that was created from this RDSpec
+		// The RD name is derived from the PVC name
+		rdName := util.GetReplicationDestinationName(pvcName)
+
+		// Get the RD object
+		rd := &volsyncv1alpha1.ReplicationDestination{}
+		if err := c.Client.Get(c.ctx, types.NamespacedName{
+			Name:      rdName,
+			Namespace: pvcNamespace,
+		}, rd); err != nil {
+			if k8serrors.IsNotFound(err) {
+				log.V(1).Info("RD not found, skipping PVC ownership assignment", "RD", rdName)
+
+				continue
+			}
+
+			log.Error(err, "Failed to get RD for PVC ownership assignment", "RD", rdName)
+
+			return err
+		}
+
+		// Assign RD as owner of the PVC
+		if err := c.VSHandler.AssignRDAndRSAsOwnerToProtectedPVC(rd, rdSpec.ProtectedPVC); err != nil {
+			log.Error(err, "Failed to assign RD ownership to PVC", "RD", rdName, "PVC", pvcName)
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+// disownRSManagedPVCsBeforeRGSDeletion retrieves RGS and disowns RS-managed PVCs before RGS deletion
+func (c *cgHandler) disownRSManagedPVCsBeforeRGSDeletion(
+	rgsName, rgsNamespace string,
+	log logr.Logger,
+) error {
+	rgs := &ramendrv1alpha1.ReplicationGroupSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rgsName,
+			Namespace: rgsNamespace,
+		},
+	}
+
+	if err := c.Client.Get(c.ctx, types.NamespacedName{
+		Name:      rgsName,
+		Namespace: rgsNamespace,
+	}, rgs); err != nil {
+		if k8serrors.IsNotFound(err) {
+			log.V(1).Info("RGS not found, skipping RS PVC disownership", "RGS", rgsName)
+
+			return nil
+		}
+
+		log.Error(err, "Failed to get RGS for RS ownership cleanup", "RGS", rgsName)
+
+		return err
+	}
+
+	// RGS exists, disown RS-managed PVCs before deleting RGS
+	if len(rgs.Spec.RSSpec) > 0 {
+		if err := c.disownRSManagedPVCs(rgs.Spec.RSSpec); err != nil {
+			log.Error(err, "Failed to disown RS-managed PVCs")
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+// disownRDManagedPVCs removes RD ownership from PVCs before RGD deletion
+// This ensures PVCs are not automatically deleted when RDs are removed
+func (c *cgHandler) disownRDManagedPVCs(rdSpecs []ramendrv1alpha1.VolSyncReplicationDestinationSpec) error {
+	log := c.logger.WithName("disownRDManagedPVCs")
+
+	for _, rdSpec := range rdSpecs {
+		pvcName := rdSpec.ProtectedPVC.Name
+		pvcNamespace := rdSpec.ProtectedPVC.Namespace
+
+		// Get the RD that was created from this RDSpec
+		rdName := util.GetReplicationDestinationName(pvcName)
+
+		// Get the RD object
+		rd := &volsyncv1alpha1.ReplicationDestination{}
+		if err := c.Client.Get(c.ctx, types.NamespacedName{
+			Name:      rdName,
+			Namespace: pvcNamespace,
+		}, rd); err != nil {
+			if k8serrors.IsNotFound(err) {
+				log.V(1).Info("RD not found, skipping PVC disownership", "RD", rdName)
+
+				continue
+			}
+
+			log.Error(err, "Failed to get RD for PVC disownership", "RD", rdName)
+
+			return err
+		}
+
+		// Remove RD ownership from the PVC
+		if err := c.VSHandler.RemoveOwnerFromPVC(rd, pvcName, pvcNamespace); err != nil {
+			log.Error(err, "Failed to remove RD ownership from PVC", "RD", rdName, "PVC", pvcName)
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+// disownRDManagedPVCsBeforeRGDDeletion disowns RD-managed PVCs before RGD deletion
+func (c *cgHandler) disownRDManagedPVCsBeforeRGDDeletion(
+	rgd *ramendrv1alpha1.ReplicationGroupDestination,
+	log logr.Logger,
+) error {
+	// Disown RD-managed PVCs before deleting RGD
+	if len(rgd.Spec.RDSpecs) > 0 {
+		if err := c.disownRDManagedPVCs(rgd.Spec.RDSpecs); err != nil {
+			log.Error(err, "Failed to disown RD-managed PVCs")
+
+			return err
+		}
+	}
+
+	return nil
+}
+
 //nolint:funlen,gocognit,cyclop,gocyclo
 func (c *cgHandler) CreateOrUpdateReplicationGroupSource(
 	replicationGroupSourceNamespace string,
@@ -176,6 +341,34 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupSource(
 		return nil, !finalSyncComplete, err
 	}
 
+	// Get the RGD before deleting it, so we can extract RSSpecs with ProtectedPVC information
+	rgd := &ramendrv1alpha1.ReplicationGroupDestination{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      replicationGroupSourceName,
+			Namespace: replicationGroupSourceNamespace,
+		},
+	}
+
+	var rsSpecsWithProtectedPVC []ramendrv1alpha1.VolSyncReplicationSourceSpec
+
+	if err := c.Client.Get(c.ctx, types.NamespacedName{
+		Name:      replicationGroupSourceName,
+		Namespace: replicationGroupSourceNamespace,
+	}, rgd); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			log.Error(err, "Failed to get RGD for RS ownership setup", "RGD", replicationGroupSourceName)
+
+			return nil, !finalSyncComplete, err
+		}
+
+		log.V(1).Info("RGD not found, will use default RS specs")
+		// Fall back to default behavior if RGD not found
+		rsSpecsWithProtectedPVC = c.populateRSSMoverConfig()
+	} else {
+		// Build RSSpecs from RGD's RDSpecs to include ProtectedPVC information
+		rsSpecsWithProtectedPVC = c.buildRSSpecsFromRDSpecs(rgd.Spec.RDSpecs)
+	}
+
 	for i := range rdList.Items {
 		rd := rdList.Items[i]
 		if c.VSHandler.IsCopyMethodDirect() {
@@ -188,6 +381,11 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupSource(
 				return nil, !finalSyncComplete, err
 			}
 		}
+	}
+
+	// Disown RD-managed PVCs (RDs own PVCs on secondary)
+	if err := c.disownRDManagedPVCsBeforeRGDDeletion(rgd, log); err != nil {
+		return nil, !finalSyncComplete, err
 	}
 
 	if err := util.DeleteReplicationGroupDestination(
@@ -279,7 +477,7 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupSource(
 
 		rgs.Spec.VolumeGroupSnapshotClassName = volumeGroupSnapshotClassName
 		rgs.Spec.VolumeGroupSnapshotSource = c.volumeGroupSnapshotSource
-		rgs.Spec.RSSpec = c.populateRSSMoverConfig()
+		rgs.Spec.RSSpec = rsSpecsWithProtectedPVC
 
 		return nil
 	})
@@ -288,6 +486,17 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupSource(
 
 		return nil, !finalSyncComplete, err
 	}
+
+	// Ensure RSs own their corresponding PVCs to enable Kubernetes garbage collection
+	// when RSs are deleted (similar to RD ownership on secondary)
+	if len(rsSpecsWithProtectedPVC) > 0 {
+		if err := c.ensureRSsOwnTheirPVCs(rsSpecsWithProtectedPVC); err != nil {
+			log.Error(err, "Failed to ensure RSs own their PVCs")
+
+			return nil, !finalSyncComplete, err
+		}
+	}
+
 	//
 	// For final sync only - check status to make sure the final sync is complete
 	// and also run cleanup of temporary resources
@@ -316,6 +525,125 @@ func (c *cgHandler) populateRSSMoverConfig() []ramendrv1alpha1.VolSyncReplicatio
 	}
 
 	return vrssArray
+}
+
+// buildRSSpecsFromRDSpecs builds complete RSSpecs from RDSpecs for RGS creation
+// This ensures RSSpecs include ProtectedPVC information needed for RS ownership setup
+func (c *cgHandler) buildRSSpecsFromRDSpecs(
+	rdSpecs []ramendrv1alpha1.VolSyncReplicationDestinationSpec,
+) []ramendrv1alpha1.VolSyncReplicationSourceSpec {
+	log := c.logger.WithName("buildRSSpecsFromRDSpecs")
+
+	rsSpecs := make([]ramendrv1alpha1.VolSyncReplicationSourceSpec, 0, len(rdSpecs))
+
+	for _, rdSpec := range rdSpecs {
+		// Build RS spec from RD spec, preserving ProtectedPVC information
+		rsSpec := ramendrv1alpha1.VolSyncReplicationSourceSpec{
+			ProtectedPVC: rdSpec.ProtectedPVC,
+		}
+
+		// Add mover config if available for this PVC
+		pvcName := rdSpec.ProtectedPVC.Name
+		for _, moverConfig := range c.moverConfig {
+			if moverConfig.PVCName == pvcName {
+				rsSpec.MoverConfig = &ramendrv1alpha1.MoverConfig{
+					MoverSecurityContext: moverConfig.MoverSecurityContext,
+					MoverServiceAccount:  moverConfig.MoverServiceAccount,
+					PVCName:              moverConfig.PVCName,
+					PVCNameSpace:         moverConfig.PVCNameSpace,
+				}
+
+				break
+			}
+		}
+
+		rsSpecs = append(rsSpecs, rsSpec)
+
+		log.V(1).Info("Added RS spec for PVC", "PVC", pvcName)
+	}
+
+	return rsSpecs
+}
+
+// ensureRSsOwnTheirPVCs assigns each RS created from RSSpecs as owner of the corresponding PVC
+// This enables Kubernetes garbage collection to delete the PVC when the RS is deleted
+func (c *cgHandler) ensureRSsOwnTheirPVCs(rsSpecsInGroup []ramendrv1alpha1.VolSyncReplicationSourceSpec) error {
+	log := c.logger.WithName("ensureRSsOwnTheirPVCs")
+
+	for _, rsSpec := range rsSpecsInGroup {
+		pvcName := rsSpec.ProtectedPVC.Name
+		pvcNamespace := rsSpec.ProtectedPVC.Namespace
+
+		// The RS name is the same as the PVC name (following volsync handler pattern)
+		rsName := pvcName
+
+		// Get the RS object
+		rs := &volsyncv1alpha1.ReplicationSource{}
+		if err := c.Client.Get(c.ctx, types.NamespacedName{
+			Name:      rsName,
+			Namespace: pvcNamespace,
+		}, rs); err != nil {
+			if k8serrors.IsNotFound(err) {
+				log.V(1).Info("RS not found, skipping PVC ownership assignment", "RS", rsName)
+
+				continue
+			}
+
+			log.Error(err, "Failed to get RS for PVC ownership assignment", "RS", rsName)
+
+			return err
+		}
+
+		// Assign RS as owner of the PVC
+		if err := c.VSHandler.AssignRDAndRSAsOwnerToProtectedPVC(rs, rsSpec.ProtectedPVC); err != nil {
+			log.Error(err, "Failed to assign RS ownership to PVC", "RS", rsName, "PVC", pvcName)
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+// disownRSManagedPVCs removes RS ownership from PVCs before RGS deletion
+// This ensures PVCs are not automatically deleted when RSs are removed
+func (c *cgHandler) disownRSManagedPVCs(rsSpecs []ramendrv1alpha1.VolSyncReplicationSourceSpec) error {
+	log := c.logger.WithName("disownRSManagedPVCs")
+
+	for _, rsSpec := range rsSpecs {
+		pvcName := rsSpec.ProtectedPVC.Name
+		pvcNamespace := rsSpec.ProtectedPVC.Namespace
+
+		// The RS name is the same as the PVC name (following volsync handler pattern)
+		rsName := pvcName
+
+		// Get the RS object
+		rs := &volsyncv1alpha1.ReplicationSource{}
+
+		if err := c.Client.Get(c.ctx, types.NamespacedName{
+			Name:      rsName,
+			Namespace: pvcNamespace,
+		}, rs); err != nil {
+			if k8serrors.IsNotFound(err) {
+				log.V(1).Info("RS not found, skipping PVC disownership", "RS", rsName)
+
+				continue
+			}
+
+			log.Error(err, "Failed to get RS for PVC disownership", "RS", rsName)
+
+			return err
+		}
+
+		// Remove RS ownership from the PVC
+		if err := c.VSHandler.RemoveOwnerFromPVC(rs, pvcName, pvcNamespace); err != nil {
+			log.Error(err, "Failed to remove RS ownership from PVC", "RS", rsName, "PVC", pvcName)
+
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (c *cgHandler) GetLatestImageFromRGD(rgd *ramendrv1alpha1.ReplicationGroupDestination, pvcName string,

--- a/internal/controller/cephfscg/cghandler_test.go
+++ b/internal/controller/cephfscg/cghandler_test.go
@@ -45,7 +45,16 @@ var _ = Describe("Cghandler", func() {
 				Spec: ramendrv1alpha1.VolumeReplicationGroupSpec{
 					Async: &ramendrv1alpha1.VRGAsyncSpec{},
 				},
-			}, nil, nil, rgdName, testLogger)
+			}, nil,
+				volsync.NewVSHandler(Ctx, k8sClient, testLogger, &ramendrv1alpha1.VolumeReplicationGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      vgdName,
+						Namespace: "default",
+						UID:       "123",
+					},
+				}, &ramendrv1alpha1.VRGAsyncSpec{}, internalController.DefaultCephFSCSIDriverName,
+					"Snapshot", false,
+				), rgdName, testLogger)
 			rgd, err := vsCGHandler.CreateOrUpdateReplicationGroupDestination(vgdName, "default", nil)
 			Expect(err).To(BeNil())
 			Expect(len(rgd.Spec.RDSpecs)).To(Equal(0))
@@ -60,7 +69,16 @@ var _ = Describe("Cghandler", func() {
 				Spec: ramendrv1alpha1.VolumeReplicationGroupSpec{
 					Async: &ramendrv1alpha1.VRGAsyncSpec{},
 				},
-			}, nil, nil, rgdName, testLogger)
+			}, nil,
+				volsync.NewVSHandler(Ctx, k8sClient, testLogger, &ramendrv1alpha1.VolumeReplicationGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      vgdName,
+						Namespace: "default",
+						UID:       "123",
+					},
+				}, &ramendrv1alpha1.VRGAsyncSpec{}, internalController.DefaultCephFSCSIDriverName,
+					"Snapshot", false,
+				), rgdName, testLogger)
 			rgd, err := vsCGHandler.CreateOrUpdateReplicationGroupDestination(vgdName, "default",
 				[]ramendrv1alpha1.VolSyncReplicationDestinationSpec{{
 					ProtectedPVC: ramendrv1alpha1.ProtectedPVC{

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -187,7 +187,7 @@ func (v *VSHandler) ReconcileRD(
 		return nil, nil, err
 	}
 
-	if err = v.assignRDAndRSAsOwnerToProtectedPVC(rd, rdSpec.ProtectedPVC); err != nil {
+	if err = v.AssignRDAndRSAsOwnerToProtectedPVC(rd, rdSpec.ProtectedPVC); err != nil {
 		return nil, nil, err
 	}
 
@@ -325,7 +325,7 @@ func getKindRSorRD(obj runtime.Object) (string, error) {
 	}
 }
 
-func (v *VSHandler) assignRDAndRSAsOwnerToProtectedPVC(
+func (v *VSHandler) AssignRDAndRSAsOwnerToProtectedPVC(
 	obj client.Object,
 	protectedPVC ramendrv1alpha1.ProtectedPVC,
 ) error {
@@ -526,7 +526,7 @@ func (v *VSHandler) ReconcileRS(rsSpec ramendrv1alpha1.VolSyncReplicationSourceS
 		return false, nil, nil // Requeue
 	}
 
-	if err = v.assignRDAndRSAsOwnerToProtectedPVC(replicationSource, rsSpec.ProtectedPVC); err != nil {
+	if err = v.AssignRDAndRSAsOwnerToProtectedPVC(replicationSource, rsSpec.ProtectedPVC); err != nil {
 		return false, replicationSource, err
 	}
 
@@ -1426,7 +1426,7 @@ func (v *VSHandler) DeleteRS(pvcName string, pvcNamespace string, skipPVCDisowne
 	return nil
 }
 
-func (v *VSHandler) removeOwnerFromPVC(
+func (v *VSHandler) RemoveOwnerFromPVC(
 	obj client.Object,
 	pvcName, pvcNamespace string,
 ) error {
@@ -1496,7 +1496,7 @@ func (v *VSHandler) cleanupRS(rs *volsyncv1alpha1.ReplicationSource, pvcName, pv
 	skipPVCDisownership bool,
 ) error {
 	if !skipPVCDisownership {
-		if err := v.removeOwnerFromPVC(rs, pvcName, pvcNamespace); err != nil {
+		if err := v.RemoveOwnerFromPVC(rs, pvcName, pvcNamespace); err != nil {
 			v.log.Error(err, "Failed to disown PVC before deleting RD", "rs", rs.GetName(), "error", err)
 
 			return err
@@ -1517,7 +1517,7 @@ func (v *VSHandler) cleanupRD(rd *volsyncv1alpha1.ReplicationDestination, pvcNam
 ) error {
 	// Step 1: Disown PVC, unless skipped
 	if !skipPVCDisownership {
-		if err := v.removeOwnerFromPVC(rd, pvcName, pvcNamespace); err != nil {
+		if err := v.RemoveOwnerFromPVC(rd, pvcName, pvcNamespace); err != nil {
 			v.log.Error(err, "Failed to disown PVC before deleting RD", "rd", rd.GetName(), "error", err)
 
 			return err


### PR DESCRIPTION
Implement complete PVC ownership management for CG (Consistency Group) discovered applications. When DR protection is removed from discovered applications with CephFS consistency groups, their associated PVCs are no longer labeled but not owned directly. This change ensures:

On secondary cluster:
- When ReplicationGroupDestination (RGD) is created for a CG on secondary cluster, each ReplicationDestination (RD) created from the RDSpecs is assigned as the owner of the corresponding PVC via OwnerReference. This enables Kubernetes garbage collection to automatically clean up PVCs when RDs are deleted.

On primary cluster:
- When RGD is deleted during state transitions (secondary to primary), RSSpecs are properly built from RGD's RDSpecs to include ProtectedPVC information.
- When ReplicationGroupSource (RGS) is created on primary, each ReplicationSource (RS) is assigned as owner of its corresponding PVC.

This addresses the remaining CG-related changes for handling orphaned CephFS PVCs in discovered applications, following similar pattern as the non-CG fix from PR #2242.

## Test results

### Test Setup

```bash
# 1. Create test namespace and PVC
oc --context=c1 create namespace pr2446-test

cat <<EOF | oc --context=c1 apply -f -
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: test-pvc
  namespace: pr2446-test
  labels:
    app: pr2446-test
spec:
  accessModes:
    - ReadWriteMany
  resources:
    requests:
      storage: 1Gi
  storageClassName: ocs-storagecluster-cephfs
EOF

# 2. Create Placement
cat <<EOF | oc --context=hub apply -f -
apiVersion: cluster.open-cluster-management.io/v1beta1
kind: Placement
metadata:
  name: pr2446-test-placement
  namespace: openshift-dr-ops
  annotations:
    cluster.open-cluster-management.io/experimental-scheduling-disable: "true"
spec:
  clusterSets:
    - default
  numberOfClusters: 1
EOF

# 3. Create DRPC with CG enabled
cat <<EOF | oc --context=hub apply -f -
apiVersion: ramendr.openshift.io/v1alpha1
kind: DRPlacementControl
metadata:
  name: pr2446-test-drpc
  namespace: openshift-dr-ops
  annotations:
    drplacementcontrol.ramendr.openshift.io/is-cg-enabled: 'true'
spec:
  preferredCluster: prsurve-bm3
  drPolicyRef:
    name: ceph-plugin-10m
  placementRef:
    apiVersion: cluster.open-cluster-management.io/v1beta1
    kind: Placement
    name: pr2446-test-placement
    namespace: openshift-dr-ops
  pvcSelector:
    matchLabels:
      app: pr2446-test
  protectedNamespaces:
    - pr2446-test
EOF
```

### Test Execution

```bash
# 4. Wait for initial deployment
$ oc --context=hub get drpc pr2446-test-drpc -n openshift-dr-ops
NAME               AGE   PREFERREDCLUSTER   FAILOVERCLUSTER   DESIREDSTATE   CURRENTSTATE
pr2446-test-drpc   30s   prsurve-bm3                                         Deployed

# 5. Trigger failover to secondary cluster
$ oc --context=hub patch drpc pr2446-test-drpc -n openshift-dr-ops --type=merge \
  -p '{"spec":{"action":"Failover","failoverCluster":"prsurve-bm5"}}'
drplacementcontrol.ramendr.openshift.io/pr2446-test-drpc patched

# 6. Wait for failover completion
$ oc --context=hub get drpc pr2446-test-drpc -n openshift-dr-ops
NAME               AGE     PREFERREDCLUSTER   FAILOVERCLUSTER   DESIREDSTATE   CURRENTSTATE
pr2446-test-drpc   2m54s   prsurve-bm3        prsurve-bm5       Failover       FailedOver
```

### PVC Ownership Verified

```bash
# 7. Check PVC ownership on secondary cluster (prsurve-bm5)
$ oc --context=c2 get pvc test-pvc -n pr2446-test -o jsonpath='{.metadata.ownerReferences}' | jq .
[
  {
    "apiVersion": "volsync.backube/v1alpha1",
    "blockOwnerDeletion": true,
    "controller": true,
    "kind": "ReplicationDestination",
    "name": "test-pvc",
    "uid": "02f802ac-118a-4d61-af58-790c6a47ffe5"
  }
]

# 8. Verify failover status
$ oc --context=hub get drpc pr2446-test-drpc -n openshift-dr-ops -o jsonpath='{.status.phase}'
FailedOver

$ oc --context=hub get drpc pr2446-test-drpc -n openshift-dr-ops -o jsonpath='{.status.conditions}' | jq '.[] | {type: .type, status: .status, reason: .reason}'
{
  "type": "Available",
  "status": "True",
  "reason": "FailedOver"
}
{
  "type": "PeerReady",
  "status": "False",
  "reason": "NotStarted"
}
{
  "type": "Protected",
  "status": "False",
  "reason": "Progressing"
}

# 9. Verify VRG on secondary cluster
$ oc --context=c2 get vrg pr2446-test-drpc -n openshift-dr-ops
NAME               DESIREDSTATE   CURRENTSTATE
pr2446-test-drpc   primary        Primary

# 10. Verify ReplicationDestination exists
$ oc --context=c2 get replicationdestination -n pr2446-test
NAME       LAST SYNC   DURATION   NEXT SYNC
test-pvc
```

### Conclusion

The core fix (PVC ownership by RD/RS) has been successfully verified on a real OCP environment with CephFS storage and VolSync replication. The PVC ownership enables proper Kubernetes garbage collection, preventing orphaned PVCs during DR operations.

## TODOs

- [x] Test on an OCP cluster with consistency groups support