### PR TITLE
ci: Update kind to Kubernetes 1.35.1

### DIFF
--- a/.github/workflows/ramen.yaml
+++ b/.github/workflows/ramen.yaml
@@ -159,11 +159,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes_version: ["1.29.1"]
+        kubernetes_version: ["1.35.1"]
         include:
-          - kubernetes_version: "1.29.1"
-            kind_image: "1.29.1@sha256:a0cc28af37cf39b019e2b448c54d1a3f789de32536cb5a5db61a49623e527144"
-            kind_version: "v0.21.0"
+          - kubernetes_version: "1.35.1"
+            kind_image: "1.35.1@sha256:05d7bcdefbda08b4e038f644c4df690cdac3fba8b06f8289f30e10026720a1ab"
+            kind_version: "v0.31.0"
     env:
       KUBERNETES_VERSION: ${{ matrix.kubernetes_version }}
       KIND_VERSION: ${{ matrix.kind_version }}

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -5,8 +5,8 @@
 
 set -e -o pipefail
 
-KIND_IMAGE="${KIND_IMAGE:-1.29.1@sha256:a0cc28af37cf39b019e2b448c54d1a3f789de32536cb5a5db61a49623e527144}"
-KIND_VERSION="${KIND_VERSION:-v0.21.0}"
+KIND_IMAGE="${KIND_IMAGE:-1.35.1@sha256:05d7bcdefbda08b4e038f644c4df690cdac3fba8b06f8289f30e10026720a1ab}"
+KIND_VERSION="${KIND_VERSION:-v0.31.0}"
 KIND_DIR="$(mktemp -d --tmpdir kind-XXXXXX)"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-"$(basename "${KIND_DIR}" | tr "[:upper:]" "[:lower:]")"}"
 rmdir "${KIND_DIR}"


### PR DESCRIPTION
We were using 10 versions old kind (0.21) instead of current (0.31.0) and unsupported 6 versions old Kubernetes (1.29.1) instead of current (1.35.1).

Update to latest versions, matching latest minikube.