### PR TITLE
ramendev: Use kubectl timeout= keyword argument

### DIFF
--- a/ramendev/ramendev/config.py
+++ b/ramendev/ramendev/config.py
@@ -119,8 +119,8 @@ def wait_for_secret_propagation(hub, clusters, args):
         kubectl.wait(
             f"policy/{policy}",
             "--for=jsonpath={.status.compliant}=Compliant",
-            "--timeout=60s",
             f"--namespace={cluster}",
+            timeout=60,
             context=hub,
             log=command.debug,
         )

--- a/ramendev/ramendev/deploy.py
+++ b/ramendev/ramendev/deploy.py
@@ -77,7 +77,7 @@ def deploy(args, cluster, deploy_type, platform="", timeout=120):
         "status",
         f"deploy/{deploy}",
         f"--namespace={args.ramen_namespace}",
-        f"--timeout={timeout}s",
+        timeout=timeout,
         context=cluster,
         log=command.debug,
     )


### PR DESCRIPTION
Use the timeout= keyword argument added in commit a24393ac ("kubectl: Add default timeout to wait, delete, and rollout") instead of passing "--timeout" as a string argument.

This ensures the timeout is handled consistently by the kubectl module and benefits from the default timeout enforcement.

Without this change we run with 2 --timeout arguments (one added by ramen dev, one by kubectl.rollout():

```
drenv.commands.Error: command failed:
  command:
  - kubectl
  - rollout
  - --context
  - hub
  - status
  - deploy/ramen-hub-operator
  - --namespace=ramen-system
  - --timeout=120s
  - --timeout
  - 300.0s
  exitcode: 1
  error: 'error: timed out waiting for the condition'
```