### PR TITLE
e2e: Fix artifact collection when files are missing

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,6 +38,7 @@ jobs:
     - name: Setup drenv
       working-directory: test
       run: |
+        echo test/drenv.log >> "$GITHUB_WORKSPACE/artifacts.txt"
         source ../venv
         drenv setup envs/regional-dr.yaml
 
@@ -81,11 +82,15 @@ jobs:
 
     - name: Run e2e validation
       working-directory: e2e
-      run: ./run.sh -test.run TestValidation -logfile validation.log
+      run: |
+        echo e2e/validation.log >> "$GITHUB_WORKSPACE/artifacts.txt"
+        ./run.sh -test.run TestValidation -logfile validation.log
 
     - name: Run e2e dr tests
       working-directory: e2e
-      run: ./run.sh -test.run TestDR -logfile dr.log
+      run: |
+        echo e2e/dr.log >> "$GITHUB_WORKSPACE/artifacts.txt"
+        ./run.sh -test.run TestDR -logfile dr.log
 
     - name: Gather environment data
       if: always()
@@ -93,6 +98,7 @@ jobs:
       # Gathering typically takes less than 15 seconds.
       timeout-minutes: 3
       run: |
+        echo test/gather.rdr >> "$GITHUB_WORKSPACE/artifacts.txt"
         source ../venv
         drenv gather --directory gather.rdr envs/regional-dr.yaml
 
@@ -102,7 +108,12 @@ jobs:
     # https://github.com/actions/upload-artifact/issues/546
     - name: Archive artifacts
       if: always()
-      run: tar czf e2e.${{ env.BUILD_ID }}.tar.gz test/gather.rdr test/*.log e2e/*.log
+      run: |
+        tar --create \
+            --gzip \
+            --file e2e.${{ env.BUILD_ID }}.tar.gz \
+            --transform "s|^|e2e.${{ env.BUILD_ID }}/|" \
+            --files-from artifacts.txt
 
     - name: Upload artifacts
       if: always()


### PR DESCRIPTION
When the e2e test fails early, e2e/*.log files may not exist,
causing the tar command to fail:

    tar: e2e/*.log: Cannot stat: No such file or directory
    tar: Exiting with failure status due to previous errors

Instead of listing all artifact paths in the tar command, let
each step register its own artifacts in artifacts.txt. The
archive step just tars whatever was registered, with no need
to know about specific files.

Use tar --transform to always include a top-level directory in
the archive, so extraction is consistent regardless of the tool.