### PR TITLE
ocm-cluster: Drop --wait from clusteradm join

### DIFF
--- a/test/addons/ocm-cluster/start
+++ b/test/addons/ocm-cluster/start
@@ -111,7 +111,6 @@ def join_cluster(cluster, hub):
         cluster_name=cluster,
         bundle_version=BUNDLE_VERSION,
         image_registry=IMAGE_REGISTRY,
-        wait=True,
         context=cluster,
     )
 
@@ -130,13 +129,16 @@ def label_cluster(cluster, hub):
 
 
 def wait_for_managed_cluster(cluster, hub):
-    # This takes less then a second, but sometimes it never complete, even if waiting 10 minutes.
+    # The managed cluster is created by the klusterlet deployed by
+    # clusteradm join. In stress testing, registration takes 16-53s on
+    # Linux CI (p95=45s) and 7-35s on macOS (p95=30s). Using 180s to
+    # cover slower environments.
     start = time.monotonic()
 
     print(f"Waiting until managed cluster '{cluster}' is created on the hub")
     drenv.wait_for(
         f"managedcluster/{cluster}",
-        timeout=60,
+        timeout=180,
         profile=hub,
     )
 

--- a/test/envs/regional-dr-kubevirt.yaml
+++ b/test/envs/regional-dr-kubevirt.yaml
@@ -37,9 +37,9 @@ templates:
           - name: ocm-cluster
             args: ["$name", "hub"]
           - name: recipe
+          - name: olm
       - addons:
           - name: csi-addons
-          - name: olm
           - name: minio
           - name: velero
           - name: kubevirt

--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -36,11 +36,11 @@ templates:
           - name: ocm-cluster
             args: ["$name", "hub"]
           - name: recipe
+          - name: olm
       - addons:
           - name: odf-external-snapshotter
           - name: external-snapshotter
           - name: csi-addons
-          - name: olm
           - name: minio
           - name: velero
   - name: "hub-cluster"


### PR DESCRIPTION
The --wait flag sets up a generic watch on the hub to track the
join progress. When two clusters join concurrently, events from
one join can confuse the other join's watch, causing either a ~5
minute timeout or an "unexpected watch event received" failure.

In baseline stress testing on Linux CI (100 runs, 198 concurrent
joins), 5% of joins hit the watch timeout bug (300-330s), and 2%
failed with "unexpected watch event received".

The wait_for_managed_cluster() function that follows the join
already waits for all the required conditions using kubectl wait
on the specific managed cluster resource, which is not affected
by concurrent joins. Removing --wait eliminates the redundant
generic watch and the issues it causes.

Increase the timeout for waiting for the managed cluster resource
from 60s to 180s, since we now wait for the klusterlet to register
instead of relying on clusteradm --wait.

Stress testing on Linux CI (seconds):

    Join to managed cluster registration:

                With --wait (100 runs)     Without --wait (73 runs)
    median                  40                          35
    p95                     99                          49
    max                    324                          57

    ocm-cluster/start completion:

                With --wait (100 runs)     Without --wait (73 runs)
    median                 184                         154
    p95                    228                         213
    max                    454                         262

Zero join-related failures or timeouts without --wait.

This shortens ocm-cluster step, so we can move olm to its worker.

## Addons durations before

<img width="2100" height="1680" alt="addons" src="https://github.com/user-attachments/assets/f9a22171-02ec-40d9-9818-73c6112f6294" />

## Addons durations after

<img width="2100" height="1680" alt="addons" src="https://github.com/user-attachments/assets/a42d4a16-822f-4a8a-bb71-349e25ae30b8" />
