### PR TITLE
rook-cluster: Fix csi-addons dependency and wait

### DIFF
--- a/test/addons/csi-addons/start
+++ b/test/addons/csi-addons/start
@@ -17,10 +17,12 @@ def deploy(cluster):
 
 
 def wait(cluster):
-    print("Waiting until csi-addons-controller-manager is rolled out")
+    print(
+        "Waiting until deployment 'csi-addons-system/csi-addons-controller-manager' is rolled out"
+    )
     kubectl.rollout(
         "status",
-        "deploy/csi-addons-controller-manager",
+        "deployment/csi-addons-controller-manager",
         "--namespace=csi-addons-system",
         context=cluster,
     )

--- a/test/addons/rook-cluster/start
+++ b/test/addons/rook-cluster/start
@@ -6,16 +6,44 @@
 import json
 import os
 import sys
+import time
 
 import yaml
 
 import drenv
+from drenv import commands
 from drenv import kubectl
 from drenv import cache
 
 # The ceph, and ceph-csi iamges are very large (500m each), using larger
 # timeout to avoid timeouts with flaky network.
 TIMEOUT = 600
+
+# CSI driver components created by the rook operator as part of the
+# CephCluster reconciliation.
+CSI_COMPONENTS = [
+    {"kind": "daemonset", "name": "csi-rbdplugin"},
+    {"kind": "daemonset", "name": "csi-cephfsplugin"},
+    {"kind": "deployment", "name": "csi-rbdplugin-provisioner"},
+    {"kind": "deployment", "name": "csi-cephfsplugin-provisioner"},
+]
+
+CSIADDONS_TIMEOUT = 300
+CSIADDONS_ATTEMPTS = 3
+
+# CSIAddonsNode resources are created by the csi-addons sidecar in the CSI
+# driver pods. The sidecar registers the node after the pod is ready.
+# The csi-addons CRD must be deployed before rook-cluster so the sidecar
+# can register as soon as the pod starts.
+#
+# Without these resources, the VolumeReplication controller cannot find the
+# CSI driver's replication client, causing VR reconciliation to fail with
+# "no leader for the ControllerService".
+CSIADDONS_NODES = [
+    "daemonset-csi-rbdplugin",
+    "deployment-csi-rbdplugin-provisioner",
+    "deployment-csi-cephfsplugin-provisioner",
+]
 
 
 def deploy(cluster):
@@ -48,6 +76,68 @@ def wait(cluster):
     )
     info = {"ceph cluster status": json.loads(out)}
     print(yaml.dump(info, sort_keys=False))
+
+    for comp in CSI_COMPONENTS:
+        print(f"Waiting until {comp['kind']} 'rook-ceph/{comp['name']}' is rolled out")
+        kubectl.rollout(
+            "status",
+            f"{comp['kind']}/{comp['name']}",
+            "--namespace=rook-ceph",
+            context=cluster,
+        )
+
+    wait_for_csiaddons_nodes(cluster)
+
+
+def wait_for_csiaddons_nodes(cluster):
+    """
+    Wait for CSIAddonsNode resources to report status.state=Connected.
+
+    The csi-addons sidecar deletes and recreates the CSIAddonsNode resource
+    when the CSI driver pod restarts. This can cause kubectl wait to fail
+    with NotFound if the resource is deleted between the wait_for and
+    kubectl.wait calls. We retry to handle this race.
+    """
+    deadline = time.monotonic() + CSIADDONS_TIMEOUT
+
+    for suffix in CSIADDONS_NODES:
+        name = f"{cluster}-rook-ceph-{suffix}"
+        resource = f"csiaddonsnodes.csiaddons.openshift.io/{name}"
+
+        for attempt in range(1, CSIADDONS_ATTEMPTS + 1):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise RuntimeError(f"Timeout waiting for {resource}")
+
+            print(f"Waiting until '{resource}' status.state is not empty")
+            drenv.wait_for(
+                resource,
+                output="jsonpath={.status.state}",
+                namespace="rook-ceph",
+                timeout=remaining,
+                profile=cluster,
+            )
+
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise RuntimeError(f"Timeout waiting for {resource}")
+
+            print(f"Waiting until '{resource}' status.state is Connected")
+            try:
+                kubectl.wait(
+                    resource,
+                    "--for=jsonpath={.status.state}=Connected",
+                    "--namespace=rook-ceph",
+                    timeout=remaining,
+                    context=cluster,
+                )
+                break
+            except commands.Error:
+                if attempt == CSIADDONS_ATTEMPTS:
+                    raise
+                print(
+                    f"Retrying wait for '{resource}' ({attempt}/{CSIADDONS_ATTEMPTS})"
+                )
 
 
 if len(sys.argv) != 2:

--- a/test/envs/regional-dr-hubless.yaml
+++ b/test/envs/regional-dr-hubless.yaml
@@ -28,8 +28,8 @@ templates:
           - name: rook-pool
           - name: rook-cephfs
       - addons:
-          - name: external-snapshotter
           - name: csi-addons
+          - name: external-snapshotter
           - name: olm
           - name: minio
           - name: velero

--- a/test/envs/regional-dr-kubevirt.yaml
+++ b/test/envs/regional-dr-kubevirt.yaml
@@ -27,7 +27,6 @@ templates:
     disk_size: "50g"
     workers:
       - addons:
-          - name: external-snapshotter
           - name: rook-operator
           - name: rook-cluster
           - name: rook-toolbox
@@ -40,6 +39,7 @@ templates:
           - name: olm
       - addons:
           - name: csi-addons
+          - name: external-snapshotter
           - name: minio
           - name: velero
           - name: kubevirt

--- a/test/envs/regional-dr.yaml
+++ b/test/envs/regional-dr.yaml
@@ -38,9 +38,9 @@ templates:
           - name: recipe
           - name: olm
       - addons:
+          - name: csi-addons
           - name: odf-external-snapshotter
           - name: external-snapshotter
-          - name: csi-addons
           - name: minio
           - name: velero
   - name: "hub-cluster"

--- a/test/envs/rook.yaml
+++ b/test/envs/rook.yaml
@@ -22,8 +22,8 @@ templates:
           - name: rook-pool
           - name: rook-cephfs
       - addons:
-          - name: external-snapshotter
           - name: csi-addons
+          - name: external-snapshotter
 
 profiles:
   - name: "dr1"


### PR DESCRIPTION
rook-cluster: Fix csi-addons dependency and wait

The csi-addons sidecar in the rook CSI driver pods needs the
CSIAddonsNode CRD to register. When the sidecar starts before the CRD
exists, it retries on a ~164s interval, causing a bimodal distribution
in csi-addons/start time (17s vs 174-182s). If CSIAddonsNode resources
are missing, rbd-mirror/test becomes very slow or times out.

Fix by starting csi-addons first on its parallel worker. Since
rook-operator and csi-addons both take ~14s, and rook-cluster pods need
to pull a huge (1g) cephcsi image, the CRD is always installed before
rook-cluster creates the CSI driver pods.

In the kubevirt environment, also move external-snapshotter from the
rook worker to the parallel worker. The snapshot CRDs are only needed
by cdi, which starts well after external-snapshotter completes at ~54s
on its worker.

Wait for CSI driver components and CSIAddonsNode resources in
rook-cluster/start, since rook-cluster creates them:

- Wait for CSI driver daemonsets and deployments to roll out.

- Wait for CSIAddonsNode resources to report status.state=Connected.
  The wait_for step checks for non-empty .status.state before kubectl
  wait checks for the specific Connected value, matching the pattern
  used by other addons (rook-pool, rook-cluster, olm).

The CSIAddonsNode wait uses a retry loop because the csi-addons sidecar
deletes and recreates the resource when the CSI driver pod restarts.
This can cause kubectl wait to fail with NotFound between the wait_for
and kubectl wait calls. All attempts share a single 300s deadline to
bound the total wait time.