### PR TITLE
test/addons/rbd-mirror: run volume replication tests in parallel

### DIFF
--- a/test/addons/rbd-mirror/test
+++ b/test/addons/rbd-mirror/test
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import concurrent.futures
 import json
 import os
 import sys
@@ -156,5 +157,10 @@ os.chdir(os.path.dirname(__file__))
 cluster1 = sys.argv[1]
 cluster2 = sys.argv[2]
 
-test_volume_replication(cluster1, cluster2)
-test_volume_replication(cluster2, cluster1)
+with concurrent.futures.ThreadPoolExecutor() as e:
+    tests = [
+        e.submit(test_volume_replication, cluster1, cluster2),
+        e.submit(test_volume_replication, cluster2, cluster1),
+    ]
+    for t in concurrent.futures.as_completed(tests):
+        t.result()


### PR DESCRIPTION
Run replication from cluster1 to cluster2 and from cluster2 to cluster1 concurrently using ThreadPoolExecutor, like we do in the volsync addon test. This should cut the test time roughly in half since each test operates on a different primary cluster.

This change does not fix the linked issue, but this issue is not relevant now, since error will happen in rook-cluster/start. By the time we run rbd-mirror csi-addons sidecars are already connected.

## Test results - Linux

### Summary

- **Passed**: 98/100 (98.0%)
- **Failed**: 2/100
- **Total time**: 11h 25m
- **Time per run**: 6m 51s

### Timing (passed runs)

| Metric | Value |
|--------|-------|
| Mean | 6m 50s |
| Median | 6m 46s |
| Min | 6m 21s |
| Max | 7m 53s |
| Std Dev | 20s |
| p95 | 7m 27s |

### Failure Analysis

**2/100 runs failed (2.0%)**

| Count | Addon | Error Type | Runs |
|------:|-------|------------|------|
| 2 | rook-cluster | unknown | 010, 089 |

Both are https://github.com/csi-addons/kubernetes-csi-addons/issues/1000

---
Fixes #2449