### PR TITLE
Store meta information about s3 contents, to enable upgrades

### DIFF
--- a/internal/controller/s3_metadata.go
+++ b/internal/controller/s3_metadata.go
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+const (
+	// S3StoreMetadataKey is the S3 object key for the metadata file
+	S3StoreMetadataKey = ".metadata"
+
+	// S3StoreSchemaVersion is the current schema version
+	S3StoreSchemaVersion = "v1"
+)
+
+// S3StoreMetadata is a small manifest at <namespace>/<vrg>/.metadata in each S3 profile.
+// Schema version v1 carries only schemaVersion and clusterID (primary managed cluster).
+// Cluster data protection is not duplicated here; use the VRG ClusterDataProtected condition.
+// Consumers use this manifest to decide whether PV/PVC/VRG/VGR/VR kube manifests need a full
+// re-upload (e.g. after an empty bucket, manual deletion of .metadata, or schema bump).
+type S3StoreMetadata struct {
+	// SchemaVersion is the format version of this file (for migrations).
+	SchemaVersion string `json:"schemaVersion"`
+
+	// ClusterID is the managed cluster name where the workload is primary
+	// (from VRG destination-cluster annotation when set).
+	ClusterID string `json:"clusterID"`
+}
+
+// NeedsS3ClusterDataResync reports whether cluster-data manifests should be treated as missing
+// in S3: no metadata file at this prefix (new/empty bucket or first upload), or stored schema
+// is older than the operator expects. Endpoint/profile cosmetic changes do not trigger resync
+// when the same bucket still holds the same keys and backup data.
+func NeedsS3ClusterDataResync(metadata *S3StoreMetadata) (bool, string) {
+	if metadata == nil {
+		return true, "metadata not found (first upload or empty store after S3 recreation)"
+	}
+
+	if metadata.SchemaVersion != S3StoreSchemaVersion {
+		return true, fmt.Sprintf("schema version mismatch: store=%s, current=%s",
+			metadata.SchemaVersion, S3StoreSchemaVersion)
+	}
+
+	return false, ""
+}
+
+// NewS3StoreMetadata returns metadata with the current schema and primary cluster ID.
+func NewS3StoreMetadata(clusterID string) *S3StoreMetadata {
+	return &S3StoreMetadata{
+		SchemaVersion: S3StoreSchemaVersion,
+		ClusterID:     clusterID,
+	}
+}
+
+// ============================================================================
+// REPOSITORY - Handles S3 persistence
+// ============================================================================
+
+// S3MetadataRepository manages S3 metadata persistence
+type S3MetadataRepository struct {
+	objectStore ObjectStorer
+	pathPrefix  string
+}
+
+// NewS3MetadataRepository creates a new repository
+func NewS3MetadataRepository(objectStore ObjectStorer, vrgNamespace, vrgName string) *S3MetadataRepository {
+	return &S3MetadataRepository{
+		objectStore: objectStore,
+		pathPrefix:  s3PathNamePrefix(vrgNamespace, vrgName),
+	}
+}
+
+// Get retrieves metadata from S3
+func (r *S3MetadataRepository) Get() (*S3StoreMetadata, bool, error) {
+	metadataKey := r.pathPrefix + S3StoreMetadataKey
+
+	var metadata S3StoreMetadata
+
+	err := r.objectStore.DownloadObject(metadataKey, &metadata)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) || isAwsErrCodeNoSuchKey(err) {
+			return nil, false, nil
+		}
+
+		return nil, false, fmt.Errorf("failed to download metadata: %w", err)
+	}
+
+	return &metadata, true, nil
+}
+
+// Create creates new metadata in S3
+func (r *S3MetadataRepository) Create(metadata *S3StoreMetadata) error {
+	metadataKey := r.pathPrefix + S3StoreMetadataKey
+
+	exists, err := r.objectStore.ObjectExists(metadataKey)
+	if err != nil {
+		return fmt.Errorf("failed to check existing metadata: %w", err)
+	}
+
+	if exists {
+		return fmt.Errorf("metadata already exists")
+	}
+
+	return r.save(metadata)
+}
+
+// Update updates existing metadata in S3 (creates if not exists)
+func (r *S3MetadataRepository) Update(metadata *S3StoreMetadata) error {
+	return r.save(metadata)
+}
+
+// Save saves metadata to S3 (internal)
+func (r *S3MetadataRepository) save(metadata *S3StoreMetadata) error {
+	metadataKey := r.pathPrefix + S3StoreMetadataKey
+
+	if err := r.objectStore.UploadObject(metadataKey, metadata); err != nil {
+		return fmt.Errorf("failed to upload metadata: %w", err)
+	}
+
+	return nil
+}
+
+// Delete removes metadata from S3
+func (r *S3MetadataRepository) Delete() error {
+	metadataKey := r.pathPrefix + S3StoreMetadataKey
+
+	if err := r.objectStore.DeleteObject(metadataKey); err != nil {
+		return fmt.Errorf("failed to delete metadata: %w", err)
+	}
+
+	return nil
+}
+
+func isAwsErrCodeNoSuchKey(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if awsErr, ok := err.(awserr.Error); ok {
+		return awsErr.Code() == s3.ErrCodeNoSuchKey
+	}
+
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
+		return awsErr.Code() == s3.ErrCodeNoSuchKey
+	}
+
+	errMsg := err.Error()
+
+	return errors.Is(err, fs.ErrNotExist) ||
+		strings.Contains(errMsg, "NoSuchKey") ||
+		strings.Contains(errMsg, "no such key")
+}

--- a/internal/controller/s3utils.go
+++ b/internal/controller/s3utils.go
@@ -11,7 +11,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -93,6 +95,8 @@ type ObjectStoreGetter interface {
 type ObjectStorer interface {
 	UploadObject(key string, object interface{}) error
 	DownloadObject(key string, objectPointer interface{}) error
+	// ObjectExists reports whether an object is present at key without downloading its body.
+	ObjectExists(key string) (bool, error)
 	ListKeys(keyPrefix string) (keys []string, err error)
 	DeleteObject(key string) error
 	DeleteObjects(key ...string) error
@@ -633,6 +637,56 @@ func (s *s3ObjectStore) DownloadObject(key string,
 	}
 
 	return nil
+}
+
+// ObjectExists uses HeadObject to test key presence without transferring the object body.
+func (s *s3ObjectStore) ObjectExists(key string) (bool, error) {
+	bucket := s.s3Bucket
+
+	ctx, cancel := context.WithDeadline(context.TODO(), time.Now().Add(s3Timeout))
+	defer cancel()
+
+	_, err := s.client.HeadObjectWithContext(ctx, &s3.HeadObjectInput{
+		Bucket: &bucket,
+		Key:    &key,
+	})
+	if err != nil {
+		if isS3ObjectHeadNotFound(err) {
+			return false, nil
+		}
+
+		errMsgPrefix := fmt.Errorf("failed to head object %s:%s", bucket, key)
+
+		return false, processAwsError(errMsgPrefix, err)
+	}
+
+	return true, nil
+}
+
+func isS3ObjectHeadNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if awsErr, ok := err.(awserr.Error); ok {
+		if awsErr.Code() == s3.ErrCodeNoSuchKey {
+			return true
+		}
+	}
+
+	var awsErr awserr.Error
+	if errors.As(err, &awsErr) {
+		if awsErr.Code() == s3.ErrCodeNoSuchKey {
+			return true
+		}
+	}
+
+	errMsg := err.Error()
+
+	return errors.Is(err, fs.ErrNotExist) ||
+		strings.Contains(errMsg, "NoSuchKey") ||
+		strings.Contains(errMsg, "NotFound") ||
+		strings.Contains(errMsg, "no such key")
 }
 
 func (s *s3ObjectStore) DeleteObject(key string) error {

--- a/internal/controller/s3utils_test.go
+++ b/internal/controller/s3utils_test.go
@@ -121,6 +121,15 @@ func (f *fakeObjectStorer) DownloadObject(key string, objectPointer interface{})
 	return nil
 }
 
+func (f *fakeObjectStorer) ObjectExists(key string) (bool, error) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	_, ok := f.objects[key]
+
+	return ok, nil
+}
+
 func (f *fakeObjectStorer) ListKeys(keyPrefix string) ([]string, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -437,6 +437,7 @@ func (r *VolumeReplicationGroupReconciler) Reconcile(ctx context.Context, req ct
 		namespacedName:    req.NamespacedName.String(),
 		objectStorers:     make(map[string]cachedObjectStorer),
 		storageClassCache: make(map[string]*storagev1.StorageClass),
+		metadataRepos:     make(map[string]*S3MetadataRepository),
 	}
 
 	// Fetch the VolumeReplicationGroup instance
@@ -513,6 +514,7 @@ type VRGInstance struct {
 	volSyncHandler       *volsync.VSHandler
 	objectStorers        map[string]cachedObjectStorer
 	s3StoreAccessors     []s3StoreAccessor
+	metadataRepos        map[string]*S3MetadataRepository
 	result               ctrl.Result
 }
 
@@ -593,6 +595,8 @@ func (v *VRGInstance) processVRG() ctrl.Result {
 
 	v.log = v.log.WithValues("State", v.instance.Spec.ReplicationState)
 	v.s3StoreAccessorsGet()
+
+	v.initializeMetadataRepositories()
 
 	if util.ResourceIsDeleted(v.instance) {
 		v.log = v.log.WithValues("Finalize", true)
@@ -2787,4 +2791,29 @@ func (v *VRGInstance) aggregateVRGAutoCleanupCondition() *metav1.Condition {
 
 func (v *VRGInstance) isDiscoveredApp() bool {
 	return v.instance.Spec.ProtectedNamespaces != nil && len(*v.instance.Spec.ProtectedNamespaces) > 0
+}
+
+func (v *VRGInstance) initializeMetadataRepositories() {
+	if len(v.s3StoreAccessors) == 0 {
+		v.log.Info("No S3 stores configured, skipping metadata repository initialization")
+
+		return
+	}
+
+	for _, s3StoreAccessor := range v.s3StoreAccessors {
+		repo := NewS3MetadataRepository(
+			s3StoreAccessor.ObjectStorer,
+			v.instance.Namespace,
+			v.instance.Name,
+		)
+
+		v.metadataRepos[s3StoreAccessor.S3ProfileName] = repo
+
+		v.log.V(1).Info("Created metadata repository",
+			"s3Profile", s3StoreAccessor.S3ProfileName,
+			"namespace", v.instance.Namespace,
+			"vrgName", v.instance.Name)
+	}
+
+	v.log.Info("Initialized metadata repositories", "count", len(v.metadataRepos))
 }

--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -92,6 +92,8 @@ func (v *VRGInstance) kubeObjectsProtect(
 	vrg := v.instance
 	status := &vrg.Status.KubeObjectProtection
 
+	v.initializeS3Metadata()
+
 	captureToRecoverFrom := status.CaptureToRecoverFrom
 	if captureToRecoverFrom == nil {
 		v.log.Info("Kube objects capture-to-recover-from nil")
@@ -509,6 +511,9 @@ func (v *VRGInstance) kubeObjectsCaptureIdentifierUpdateComplete(
 		delaySetMinimum(result)
 		v.log.Info("Kube objects capture schedule to run immediately")
 	}
+
+	// Reflect successful cluster-data upload in S3 metadata only after VRG upload and capture cleanup succeed.
+	v.updateS3MetadataAfterCapture(captureToRecoverFromIdentifier.Number)
 }
 
 func (v *VRGInstance) kubeObjectsCaptureStatusFalse(reason, message string) {
@@ -1355,4 +1360,97 @@ func getRequestsStartTime(requests []kubeobjects.Request) metav1.Time {
 	}
 
 	return metav1.Time{}
+}
+
+func (v *VRGInstance) initializeS3Metadata() {
+	if len(v.metadataRepos) == 0 {
+		v.log.Info("No metadata repositories configured")
+
+		return
+	}
+
+	primaryCluster := v.getClusterName()
+
+	for s3ProfileName, repo := range v.metadataRepos {
+		existingMetadata, exists, err := repo.Get()
+		if err != nil {
+			// Transient S3/network errors: do not create or rewrite metadata; retry next reconcile.
+			v.log.Error(err, "Failed to check metadata", "s3Profile", s3ProfileName)
+
+			continue
+		}
+
+		if !exists {
+			metadata := NewS3StoreMetadata(primaryCluster)
+
+			if err := repo.Create(metadata); err != nil {
+				v.log.Error(err, "Failed to create initial metadata", "s3Profile", s3ProfileName)
+
+				continue
+			}
+
+			v.log.Info("Created initial S3 metadata", "s3Profile", s3ProfileName)
+
+			continue
+		}
+
+		needsResync, reason := NeedsS3ClusterDataResync(existingMetadata)
+		if needsResync {
+			v.log.Info("S3 store needs cluster-data re-upload; refreshing metadata",
+				"reason", reason,
+				"s3Profile", s3ProfileName,
+				"oldSchema", existingMetadata.SchemaVersion,
+				"newSchema", S3StoreSchemaVersion)
+
+			metadata := NewS3StoreMetadata(primaryCluster)
+
+			if err := repo.Update(metadata); err != nil {
+				v.log.Error(err, "Failed to update metadata after resync decision", "s3Profile", s3ProfileName)
+			}
+
+			continue
+		}
+
+		v.log.V(1).Info("S3 metadata present and schema current for this profile",
+			"s3Profile", s3ProfileName)
+	}
+}
+
+func (v *VRGInstance) updateS3MetadataAfterCapture(captureNumber int64) {
+	if len(v.metadataRepos) == 0 {
+		v.log.Info("No metadata repositories to update")
+
+		return
+	}
+
+	primaryCluster := v.getClusterName()
+
+	for s3ProfileName, repo := range v.metadataRepos {
+		metadata := NewS3StoreMetadata(primaryCluster)
+
+		if err := repo.Update(metadata); err != nil {
+			v.log.Error(err, "Failed to update metadata after capture",
+				"s3Profile", s3ProfileName,
+				"captureNumber", captureNumber)
+
+			continue
+		}
+
+		v.log.Info("Updated S3 metadata after successful capture",
+			"s3Profile", s3ProfileName,
+			"captureNumber", captureNumber,
+			"clusterID", metadata.ClusterID)
+	}
+}
+
+func (v *VRGInstance) getClusterName() string {
+	if v.instance.Annotations == nil {
+		return ""
+	}
+
+	if clusterName := v.instance.Annotations[DestinationClusterAnnotationKey]; clusterName != "" {
+		return clusterName
+	}
+
+	return ""
 }


### PR DESCRIPTION
This fix focuses on handling changes in the S3 store layout across Ramen versions, which requires detection and potentially a versioned metadata store to support upgrade handling. As part of this effort, a .metadata manifest is added per VRG prefix to record the schema version and primary cluster ID.
This is an initial step toward enabling upgrade workflows and detecting store format evolution.

Sample metafile:
```
{
  "schemaVersion": "v1",
  "clusterID": "dr2"
}
```