### PR TITLE
test/addons/rbd-mirror: Enable maintenance mode for failover

### DIFF
--- a/test/addons/rbd-mirror/start-data/vrc.yaml
+++ b/test/addons/rbd-mirror/start-data/vrc.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     ramendr.openshift.io/storageid: $scname-$cluster-1
     ramendr.openshift.io/replicationid: rook-ceph-replication-1
+    ramendr.openshift.io/maintenancemodes: Failover
 spec:
   provisioner: rook-ceph.rbd.csi.ceph.com
   parameters:


### PR DESCRIPTION
Add the maintenancemodes label to the VolumeReplicationClass so Ramen activates maintenance mode before failover. Without this label the DRPC controller skips the maintenance mode prerequisites and proceeds with failover without notifying the storage backend.

The label must be on the VolumeReplicationClass (not the StorageClass) because the failover prerequisite check only reads ReplicationID.Modes.

## Issues

All rbd e2e runs time out:

```
    --- FAIL: TestDR/appset-deploy-rbd (1005.36s)
        --- PASS: TestDR/appset-deploy-rbd/Deploy (15.12s)
        --- PASS: TestDR/appset-deploy-rbd/Enable (90.24s)
        --- FAIL: TestDR/appset-deploy-rbd/Failover (900.00s)
    --- FAIL: TestDR/subscr-deploy-rbd (1010.75s)
        --- PASS: TestDR/subscr-deploy-rbd/Deploy (15.19s)
        --- PASS: TestDR/subscr-deploy-rbd/Enable (95.56s)
        --- FAIL: TestDR/subscr-deploy-rbd/Failover (900.00s)
    --- FAIL: TestDR/disapp-deploy-rbd (1012.21s)
        --- PASS: TestDR/disapp-deploy-rbd/Deploy (16.97s)
        --- PASS: TestDR/disapp-deploy-rbd/Enable (95.24s)
        --- FAIL: TestDR/disapp-deploy-rbd/Failover (900.00s)
    --- FAIL: TestDR/disapp-recipe-check-exec-deploy-rbd (1012.26s)
        --- PASS: TestDR/disapp-recipe-check-exec-deploy-rbd/Deploy (17.02s)
        --- PASS: TestDR/disapp-recipe-check-exec-deploy-rbd/Enable (95.24s)
        --- FAIL: TestDR/disapp-recipe-check-exec-deploy-rbd/Failover (900.00s)
```

## Why maintenance mode does not work in drenv

Adding the `ramendr.openshift.io/maintenancemodes: Failover` label to the
VolumeReplicationClass correctly triggers the maintenance mode flow:

1. The VRG controller reads the label and populates
   `ProtectedPVC.StorageIdentifiers.ReplicationID.Modes` with `Failover`.

2. When failover is requested, the DRPC controller finds that maintenance
   mode prerequisites are required and enters
   `ProgressionWaitForStorageMaintenanceActivation`.

3. The DRCluster controller creates a `MaintenanceMode` CR on the failover
   cluster (dr2) via ManifestWork.

4. The DRPC waits for `FailoverActivated=True` in
   `DRCluster.Status.MaintenanceModes`, which never comes.

All 4 RBD workloads timed out after 15 minutes. CephFS workloads were
not affected (they don't use VolumeReplicationClass).

### Evidence from the test run

DRPC stuck waiting for maintenance mode activation:

```yaml
# hub: drplacementcontrols/appset-deploy-rbd
status:
  phase: FailingOver
  progression: WaitForStorageMaintenanceActivation
  conditions:
  - type: Available
    status: "False"
    reason: FailingOver
    message: Waiting for spec.failoverCluster to meet failover prerequisites
```

MaintenanceMode CR created on dr2 but has no status (no controller
reconciled it):

```yaml
# dr2: maintenancemodes/rook-ceph-replication-1
spec:
  modes:
  - Failover
  storageProvisioner: rook-ceph.rbd.csi.ceph.com
  targetID: rook-ceph-replication-1
# status: <missing>
```

DRCluster dr2 has no `maintenanceModes` in its status:

```yaml
# hub: drclusters/dr2
status:
  phase: Available
  # maintenanceModes: <missing>
```

### Root cause

The `MaintenanceMode` CRD is defined by ramen, but ramen only creates
the CR — it does not reconcile it. The CR is expected to be reconciled
by the storage driver, which should set `Status.State=Completed` and
the `FailoverActivated=True` condition.

In downstream (ODF), this is handled by
[ocs-client-operator](https://github.com/red-hat-storage/ocs-client-operator)
in
[`maintenancemode_controller.go`](https://github.com/red-hat-storage/ocs-client-operator/blob/main/internal/controller/maintenancemode_controller.go).
This controller watches `MaintenanceMode` CRs, calls the OCS provider
to put the storage backend in maintenance mode, and updates the CR
status when complete.

There is no upstream equivalent. Neither csi-addons nor upstream rook
reconcile the `ramendr.openshift.io/MaintenanceMode` CR.

---
Fixes: #2432