### PR TITLE
Skip finalsync tmpPVCs in EnsureApplicationPVCsMounted()

### DIFF
--- a/internal/controller/cephfscg/volumegroupsourcehandler.go
+++ b/internal/controller/cephfscg/volumegroupsourcehandler.go
@@ -701,6 +701,13 @@ func (h *volumeGroupSourceHandler) EnsureApplicationPVCsMounted(
 
 	for i := range pvcList.Items {
 		pvc := &pvcList.Items[i]
+
+		if strings.HasSuffix(pvc.Name, util.SuffixForFinalsyncPVC) {
+			h.Logger.Info("Skipping finalsync tmpPVC for mount check", "pvc", pvc.Name)
+
+			continue
+		}
+
 		rsSpec := ramendrv1alpha1.VolSyncReplicationSourceSpec{
 			ProtectedPVC: ramendrv1alpha1.ProtectedPVC{
 				Name:               pvc.Name,


### PR DESCRIPTION
During CephFS CG relocate, `-for-finalsync` tmpPVCs inherit the consistency-group label. `EnsureApplicationPVCsMounted()` lists PVCs by CG label and creates mount jobs
for these tmpPVCs. The mount jobs complete but are never deleted (no matching
ReplicationSource exists), and the completed pods block tmpPVC deletion via the
`kubernetes.io/pvc-protection` finalizer.

Fix is to Skip PVCs ending with `-for-finalsync` in `EnsureApplicationPVCsMounted()`

Fixes: #2487 