### PR TITLE
Add incremental sync support for CephFS consistency groups

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -374,6 +374,7 @@ rules:
   resources:
   - volumesnapshots
   verbs:
+  - create
   - delete
   - get
   - list

--- a/docs/design/Incremental-Sync.md
+++ b/docs/design/Incremental-Sync.md
@@ -1,0 +1,149 @@
+<!--
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Incremental Sync for Consistency Groups
+
+Extends [Cephfs-RDR-ConsistencyGroup.md](Cephfs-RDR-ConsistencyGroup.md).
+
+## Summary
+
+When `drplacementcontrol.ramendr.openshift.io/enable-diff: "true"` is set
+on a DRPC, Ramen preserves VolumeGroupSnapshots across sync cycles and uses
+the [ceph-volsync-plugin](https://github.com/RamenDR/ceph-volsync-plugin)
+External mover to transfer only changed blocks between consecutive snapshots.
+
+## Annotation Propagation
+
+```
+DRPC → VRG → RGS (ReplicationGroupSource)
+           → RGD (ReplicationGroupDestination)
+```
+
+Follows the same flow as `UseVolSyncAnnotation`: the user sets the
+annotation on the DRPC instance, which propagates it to the VRG via
+ManifestWork. The annotation is whitelisted in `constructVRGFromView`
+so it survives hub round-trips. DRPC annotation changes trigger
+reconcile automatically via the default `For(&DRPlacementControl{})`
+predicate.
+
+Checked via `util.IsDiffSyncEnabled()`. Value must be exactly `"true"`.
+
+## VolumeGroupSnapshot Lifecycle
+
+Standard handler: single VGS with fixed name, deleted each cycle.
+
+Diff handler: maintains two VGS via label `ramen.openshift.io/vgs-status`:
+
+| Phase | Action |
+|---|---|
+| Create | New VGS `{rgs-name}-{timestamp}`, `status=current` |
+| Cleanup | Prune old previous, delete restored PVCs, current→previous |
+
+At rest: exactly one VGS with `status=previous` serves as base for next cycle.
+
+```
+Cycle N:   [VGS-N: current] → sync → [VGS-N → previous]
+Cycle N+1: [VGS-N+1: current] → diff(VGS-N, VGS-N+1) → [VGS-N deleted, VGS-N+1 → previous]
+```
+
+## External Spec vs RsyncTLS
+
+Diff sync replaces the standard RsyncTLS ReplicationSource
+spec with an External spec:
+
+```go
+rs.Spec.External = &ReplicationSourceExternalSpec{
+    Provider: storageClass.Provisioner,
+    Parameters: map[string]string{
+        "copyMethod":         "Direct",
+        "volumeName":         sourcePVCName,
+        "baseSnapshotName":   previousSnapshotName,  // from previous VGS
+        "targetSnapshotName": currentSnapshotName,    // from current VGS
+        "address":            rdService,
+        "keySecret":          volsyncPSKSecretName,
+    },
+}
+```
+
+ReplicationDestination similarly uses External with `copyMethod=Snapshot`.
+
+The ceph-volsync-plugin mover compares `baseSnapshotName` and
+`targetSnapshotName` at block level using CephFS snapshot diff APIs,
+transferring only changed blocks. When `baseSnapshotName` is empty
+(first cycle), it falls back to full sync.
+
+## Handler Method Overrides
+
+`diffVolumeGroupSourceHandler` embeds `volumeGroupSourceHandler` and
+overrides four methods:
+
+| Method | Standard | Diff |
+|---|---|---|
+| CreateOrUpdateVGS | Fixed name, single | Timestamp suffix, labels |
+| CleanVGS | Delete VGS + PVCs | Preserve previous, rotate |
+| RestoreFromVGS | Lookup by name | Lookup by status label |
+| CreateOrUpdateRS | RsyncTLS spec | External spec + params |
+
+All other methods inherited: `RestoreVolumesFromSnapshot`,
+`CheckReplicationSourceForRestoredPVCsCompleted`, `WaitIfPVCTooNew`,
+`EnsureApplicationPVCsMounted`.
+
+## Failover Rollback (CopyMethodDirect)
+
+When `CopyMethodDirect` is used, the RD syncs directly into the app
+PVC. On failover the PVC may have partial data from an interrupted
+sync and must be rolled back to the last known good snapshot.
+
+Standard path: local RD + local RS with RsyncTLS copy the entire
+LatestImage snapshot into the app PVC (full copy).
+
+Diff sync path: replaces the full copy with a block-level diff
+rollback using the ceph-volsync-plugin External spec.
+
+### Flow
+
+```
+rollbackToLastSnapshot()
+  1. Pause main RD
+  2. Create current-state snapshot of app PVC
+  3. Wait for snapshot ready (return-and-retry)
+  4. Create local RD (External, CopyMethodDirect, destPVC=appPVC)
+  5. Wait for RD address (plugin populates Status.RsyncTLS.Address)
+  6. Create shallow PVC from LatestImage snapshot
+  7. Create local RS (External) with diff params
+  8. Wait for sync completion
+  9. Pause local RD
+ 10. Cleanup: delete current-state snapshot, shallow PVC, local RS/RD
+```
+
+### Local RS External Spec
+
+```go
+lrs.Spec.External = &ReplicationSourceExternalSpec{
+    Provider: storageClass.Provisioner,
+    Parameters: map[string]string{
+        "copyMethod":         "Direct",
+        "volumeName":         appPVCName,
+        "baseSnapshotName":   currentStateSnapshotName,
+        "targetSnapshotName": latestImageSnapshotName,
+        "address":            localRDServiceAddress,
+        "keySecret":          volsyncPSKSecretName,
+    },
+}
+```
+
+The plugin diffs `baseSnapshotName` (current corrupted state) against
+`targetSnapshotName` (last known good) and writes only the changed
+blocks to `volumeName`, rolling the PVC back efficiently.
+
+## DR Operations
+
+Transparent to failover/relocate. After failover, first sync on the
+new primary is full (no previous base); subsequent syncs are incremental.
+
+## Dependencies
+
+* VolumeGroupSnapshot CSI
+* ceph-volsync-plugin with External mover support

--- a/internal/controller/cephfscg/cghandler.go
+++ b/internal/controller/cephfscg/cghandler.go
@@ -165,6 +165,9 @@ func (c *cgHandler) createOrUpdateRGD(
 		util.AddAnnotation(rgd, volsync.OwnerNameAnnotation, c.instance.GetName())
 		util.AddAnnotation(rgd, volsync.OwnerNamespaceAnnotation, c.instance.GetNamespace())
 
+		// Propagate enable-diff annotation from VRG to RGD
+		util.AddAnnotation(rgd, util.EnableDiffAnnotation, c.instance.GetAnnotations()[util.EnableDiffAnnotation])
+
 		rgd.Spec.VolumeSnapshotClassSelector = c.volumeSnapshotClassSelector
 		rgd.Spec.RDSpecs = rdSpecsInGroup
 
@@ -453,6 +456,9 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupSource(
 		util.AddLabel(rgs, util.VRGOwnerNamespaceLabel, c.instance.GetNamespace())
 		util.AddAnnotation(rgs, volsync.OwnerNameAnnotation, c.instance.GetName())
 		util.AddAnnotation(rgs, volsync.OwnerNamespaceAnnotation, c.instance.GetNamespace())
+
+		// Propagate enable-diff annotation from VRG to RGS
+		util.AddAnnotation(rgs, util.EnableDiffAnnotation, c.instance.GetAnnotations()[util.EnableDiffAnnotation])
 
 		if runFinalSync {
 			rgs.Spec.Trigger = &ramendrv1alpha1.ReplicationSourceTriggerSpec{

--- a/internal/controller/cephfscg/diffvolumegroupsourcehandler.go
+++ b/internal/controller/cephfscg/diffvolumegroupsourcehandler.go
@@ -1,0 +1,569 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cephfscg
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+	"github.com/go-logr/logr"
+	vgsv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
+	"github.com/ramendr/ramen/internal/controller/util"
+	"github.com/ramendr/ramen/internal/controller/volsync"
+)
+
+const (
+	// VGS status labels for lifecycle management
+	// These labels are used to track VolumeGroupSnapshot state for differential sync
+	VGSStatusLabelKey = "ramen.openshift.io/vgs-status"
+	VGSStatusCurrent  = "current"  // Active VGS used for current sync cycle
+	VGSStatusPrevious = "previous" // Previous VGS used as base for differential sync
+)
+
+type diffVolumeGroupSourceHandler struct {
+	volumeGroupSourceHandler // embedded
+}
+
+func NewDiffVolumeGroupSourceHandler(
+	client client.Client,
+	rgs *ramendrv1alpha1.ReplicationGroupSource,
+	defaultCephFSCSIDriverName string,
+	vsHandler *volsync.VSHandler,
+	logger logr.Logger,
+) VolumeGroupSourceHandler {
+	vrgName := rgs.GetLabels()[util.VRGOwnerNameLabel]
+
+	vgsName := rgs.Name
+
+	return &diffVolumeGroupSourceHandler{
+		volumeGroupSourceHandler: volumeGroupSourceHandler{
+			Client:                       client,
+			VolumeGroupSnapshotName:      vgsName,
+			VolumeGroupSnapshotNamespace: rgs.Namespace,
+			VolumeGroupSnapshotClassName: rgs.Spec.VolumeGroupSnapshotClassName,
+			VolumeGroupLabel:             rgs.Spec.VolumeGroupSnapshotSource,
+			VolsyncKeySecretName:         volsync.GetVolSyncPSKSecretNameFromVRGName(vrgName),
+			DefaultCephFSCSIDriverName:   defaultCephFSCSIDriverName,
+			VSHandler:                    vsHandler,
+			Logger: logger.WithName("DiffVolumeGroupSourceHandler").
+				WithValues("VolumeGroupSnapshotName", vgsName).
+				WithValues("VolumeGroupSnapshotNamespace", rgs.Namespace),
+		},
+	}
+}
+
+// resolveRDService overrides the base handler to use the ceph-volsync-plugin service name
+// instead of the standard VolSync rsync-tls service
+func (h *diffVolumeGroupSourceHandler) resolveRDService(
+	originalPVCName, _ string,
+	vrg *ramendrv1alpha1.VolumeReplicationGroup,
+	rsNS string,
+	isSubmarinerEnabled bool,
+	logger logr.Logger,
+) (string, error) {
+	if isSubmarinerEnabled {
+		return util.GetRemoteServiceNameForDiffRDFromPVCName(originalPVCName, rsNS), nil
+	}
+
+	logger.Info("Non submariner diff sync", "rsspec", vrg.Spec.VolSync.RSSpec)
+
+	for _, rs := range vrg.Spec.VolSync.RSSpec {
+		if rs.ProtectedPVC.Name == originalPVCName {
+			return rs.RsyncTLS.Address, nil
+		}
+	}
+
+	return "", fmt.Errorf("no matching RSSpec for diff sync PVC %q", originalPVCName)
+}
+
+// findVGSWithStatus finds a VolumeGroupSnapshot with specific status label owned by this handler
+func (h *diffVolumeGroupSourceHandler) findVGSWithStatus(
+	ctx context.Context, status string,
+) (*vgsv1beta1.VolumeGroupSnapshot, error) {
+	vgsList, err := h.listVGSWithStatus(ctx, status)
+	if err != nil || len(vgsList) == 0 {
+		return nil, err
+	}
+
+	return &vgsList[0], nil
+}
+
+// listVGSWithStatus lists all VolumeGroupSnapshots with specific status label owned by this handler
+func (h *diffVolumeGroupSourceHandler) listVGSWithStatus(
+	ctx context.Context, status string,
+) ([]vgsv1beta1.VolumeGroupSnapshot, error) {
+	vgsList := &vgsv1beta1.VolumeGroupSnapshotList{}
+
+	listOptions := []client.ListOption{
+		client.InNamespace(h.VolumeGroupSnapshotNamespace),
+		client.MatchingLabels{
+			VGSStatusLabelKey:  status,
+			util.RGSOwnerLabel: h.VolumeGroupSnapshotName,
+		},
+	}
+
+	if err := h.Client.List(ctx, vgsList, listOptions...); err != nil {
+		return nil, err
+	}
+
+	return vgsList.Items, nil
+}
+
+// setVGSStatus updates the VolumeGroupSnapshot status label
+func (h *diffVolumeGroupSourceHandler) setVGSStatus(
+	ctx context.Context, vgs *vgsv1beta1.VolumeGroupSnapshot, status string,
+) error {
+	if vgs == nil {
+		return nil
+	}
+
+	util.AddLabel(vgs, VGSStatusLabelKey, status)
+
+	return h.Client.Update(ctx, vgs)
+}
+
+func (h *diffVolumeGroupSourceHandler) getPreviousSnapshotMap(
+	ctx context.Context,
+) (map[string]string, error) {
+	vgs, err := h.findVGSWithStatus(ctx, VGSStatusPrevious)
+	if err != nil {
+		return nil, err
+	}
+
+	previousSnapshotMap := make(map[string]string)
+	if vgs == nil {
+		return previousSnapshotMap, nil
+	}
+
+	volumeSnapshots, err := util.GetVolumeSnapshotsOwnedByVolumeGroupSnapshot(ctx, h.Client, vgs, h.Logger)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, vs := range volumeSnapshots {
+		if vs.Status == nil || vs.Status.BoundVolumeSnapshotContentName == nil {
+			continue
+		}
+
+		previousSnapshotMap[*vs.Spec.Source.PersistentVolumeClaimName] = vs.Name
+	}
+
+	return previousSnapshotMap, nil
+}
+
+// deleteRestoredPVCsForVGS deletes all restored PVCs for a given VolumeGroupSnapshot
+func (h *diffVolumeGroupSourceHandler) deleteRestoredPVCsForVGS(
+	ctx context.Context, vgs *vgsv1beta1.VolumeGroupSnapshot,
+) error {
+	logger := h.Logger.WithName("deleteRestoredPVCsForVGS").
+		WithValues("VGSName", vgs.Name)
+
+	if vgs.Status == nil {
+		return nil
+	}
+
+	volumeSnapshots, err := util.GetVolumeSnapshotsOwnedByVolumeGroupSnapshot(ctx, h.Client, vgs, logger)
+	if err != nil {
+		return err
+	}
+
+	for idx := range volumeSnapshots {
+		vs := &volumeSnapshots[idx]
+		if err := h.deleteRestoredPVC(ctx, vs); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// populateVolumeGroupSnapshot sets labels, annotations, and spec on a VGS for diff sync.
+func (h *diffVolumeGroupSourceHandler) populateVolumeGroupSnapshot(
+	owner metav1.Object, vgs *vgsv1beta1.VolumeGroupSnapshot,
+) error {
+	if !vgs.DeletionTimestamp.IsZero() {
+		return fmt.Errorf("the volume group snapshot is being deleted, need to wait")
+	}
+
+	if err := ctrl.SetControllerReference(owner, vgs, h.Client.Scheme()); err != nil {
+		return err
+	}
+
+	util.AddLabel(vgs, util.CreatedByRamenLabel, "true")
+	util.AddLabel(vgs, util.RGSOwnerLabel, owner.GetName())
+	// Add status=current label for lifecycle tracking
+	util.AddLabel(vgs, VGSStatusLabelKey, VGSStatusCurrent)
+	util.AddAnnotation(vgs, volsync.OwnerNameAnnotation, owner.GetName())
+	util.AddAnnotation(vgs, volsync.OwnerNamespaceAnnotation, owner.GetNamespace())
+
+	vgs.Spec.VolumeGroupSnapshotClassName = &h.VolumeGroupSnapshotClassName
+	vgs.Spec.Source.Selector = h.VolumeGroupLabel
+
+	return nil
+}
+
+// CreateOrUpdateVolumeGroupSnapshot creates or reuses a VolumeGroupSnapshot with status label tracking.
+// It follows the snapshot preservation pattern:
+// 1. Look for existing VGS with status=current
+// 2. If found and ready, reuse it
+// 3. If not found, create new VGS with timestamp suffix and status=current label
+func (h *diffVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshot(
+	ctx context.Context, owner metav1.Object,
+) (bool, error) {
+	logger := h.Logger.WithName("CreateOrUpdateVolumeGroupSnapshot")
+	logger.Info("Create or update volume group snapshot with status label tracking")
+
+	// Step 1: Look for existing VGS with status=current
+	currentVGS, err := h.findVGSWithStatus(ctx, VGSStatusCurrent)
+	if err != nil {
+		logger.Error(err, "Failed to find current VGS")
+
+		return false, err
+	}
+
+	if currentVGS != nil {
+		// Check if it's being deleted
+		if !currentVGS.DeletionTimestamp.IsZero() {
+			logger.Info("Current VGS is being deleted, need to wait", "name", currentVGS.Name)
+
+			return true, nil
+		}
+
+		// Check if ready
+		if IsVGSReady(currentVGS) {
+			logger.Info("Reusing existing ready current VGS", "name", currentVGS.Name)
+
+			return false, nil
+		}
+
+		// Wait for it to become ready
+		logger.Info("Current VGS exists but not ready yet, waiting", "name", currentVGS.Name)
+
+		return true, nil
+	}
+
+	return h.createNewVGS(ctx, owner, logger)
+}
+
+// createNewVGS creates a new VolumeGroupSnapshot with a timestamp suffix and status=current label.
+func (h *diffVolumeGroupSourceHandler) createNewVGS(
+	ctx context.Context, owner metav1.Object, logger logr.Logger,
+) (bool, error) {
+	suffix := strconv.FormatInt(time.Now().Unix(), 10)
+	vgsName := fmt.Sprintf("%s-%s", h.VolumeGroupSnapshotName, suffix)
+
+	logger.Info("Creating new VGS with status=current", "name", vgsName)
+
+	volumeGroupSnapshot := &vgsv1beta1.VolumeGroupSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: h.VolumeGroupSnapshotNamespace,
+			Name:      vgsName,
+		},
+	}
+
+	op, err := ctrlutil.CreateOrUpdate(ctx, h.Client, volumeGroupSnapshot, func() error {
+		return h.populateVolumeGroupSnapshot(owner, volumeGroupSnapshot)
+	})
+	if err != nil {
+		logger.Error(err, "Failed to CreateOrUpdate volume group snapshot")
+
+		return false, err
+	}
+
+	logger.Info("VolumeGroupSnapshot successfully created or updated", "operation", op,
+		"name", vgsName, "VGSUid", volumeGroupSnapshot.UID)
+
+	return op == ctrlutil.OperationResultCreated || op == ctrlutil.OperationResultUpdated, nil
+}
+
+// cleanOlderPreviousVGS keeps only the newest previous VGS, deleting older ones and their restored PVCs.
+func (h *diffVolumeGroupSourceHandler) cleanOlderPreviousVGS(
+	ctx context.Context, logger logr.Logger,
+) error {
+	previousVGSList, err := h.listVGSWithStatus(ctx, VGSStatusPrevious)
+	if err != nil {
+		logger.Error(err, "Failed to list previous VGS")
+
+		return err
+	}
+
+	if len(previousVGSList) <= 1 {
+		return nil
+	}
+
+	// Find the newest previous VGS by CreationTimestamp
+	latestIdx := 0
+	latestTime := previousVGSList[0].CreationTimestamp
+
+	for i := 1; i < len(previousVGSList); i++ {
+		if previousVGSList[i].CreationTimestamp.After(latestTime.Time) {
+			latestIdx = i
+			latestTime = previousVGSList[i].CreationTimestamp
+		}
+	}
+
+	for i := range previousVGSList {
+		if i == latestIdx {
+			continue
+		}
+
+		vgs := &previousVGSList[i]
+		logger.Info("Deleting older previous VGS", "name", vgs.Name)
+
+		if err := h.deleteRestoredPVCsForVGS(ctx, vgs); err != nil {
+			return err
+		}
+
+		if err := h.Client.Delete(ctx, vgs); err != nil && !k8serrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// CleanVolumeGroupSnapshot implements the snapshot preservation pattern during cleanup:
+// 1. Keep only the most recent previous VGS, delete older ones
+// 2. Delete restored PVCs for current VGS (they're temporary)
+// 3. Transition current VGS to previous status
+// After cleanup, up to 2 previous VGS may exist (the kept one + the just-transitioned one).
+func (h *diffVolumeGroupSourceHandler) CleanVolumeGroupSnapshot(
+	ctx context.Context,
+) error {
+	logger := h.Logger.WithName("CleanVolumeGroupSnapshot")
+	logger.Info("Starting VGS cleanup with snapshot preservation")
+
+	// Step 1: Handle previous VGS - keep only the newest, delete rest
+	if err := h.cleanOlderPreviousVGS(ctx, logger); err != nil {
+		return err
+	}
+
+	// Step 2: Find current VGS and transition it to previous
+	currentVGS, err := h.findVGSWithStatus(ctx, VGSStatusCurrent)
+	if err != nil {
+		logger.Error(err, "Failed to find current VGS")
+
+		return err
+	}
+
+	if currentVGS == nil {
+		logger.Info("No current VGS found to transition")
+
+		return nil
+	}
+
+	logger.Info("Processing current VGS", "name", currentVGS.Name)
+
+	// Delete restored PVCs for current VGS (they're temporary for sync)
+	if err := h.deleteRestoredPVCsForVGS(ctx, currentVGS); err != nil {
+		return err
+	}
+
+	// Transition status: current -> previous
+	if err := h.setVGSStatus(ctx, currentVGS, VGSStatusPrevious); err != nil {
+		return err
+	}
+
+	logger.Info("Successfully transitioned current VGS to previous", "name", currentVGS.Name)
+
+	return nil
+}
+
+// RestoreVolumesFromVolumeGroupSnapshot restores VolumeGroupSnapshot to PVCs
+// It finds the current VGS by status label instead of fixed name.
+//
+//nolint:dupl // intentional override — different VGS lookup, same post-processing
+func (h *diffVolumeGroupSourceHandler) RestoreVolumesFromVolumeGroupSnapshot(
+	ctx context.Context, owner metav1.Object,
+) ([]RestoredPVC, error) {
+	logger := h.Logger.WithName("RestoreFromVolumeGroupSnapshot")
+	logger.Info("Finding current VGS by status label")
+
+	// Find VGS with status=current instead of using fixed name
+	vgs, err := h.findVGSWithStatus(ctx, VGSStatusCurrent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find current volume group snapshot: %w", err)
+	}
+
+	if vgs == nil {
+		return nil, fmt.Errorf("no current VolumeGroupSnapshot found")
+	}
+
+	if !IsVGSReady(vgs) {
+		return nil, fmt.Errorf("can't restore volume group snapshot: volume group snapshot is not ready to be used")
+	}
+
+	logger.Info("Found current VGS", "name", vgs.Name)
+
+	volumeSnapshots, err := util.GetVolumeSnapshotsOwnedByVolumeGroupSnapshot(ctx, h.Client, vgs, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info("Restore: Found VolumeSnapshots", "len", len(volumeSnapshots), "in group", vgs.Name)
+
+	return h.restorePVCsFromSnapshots(ctx, vgs, volumeSnapshots, owner, logger)
+}
+
+// CreateOrUpdateReplicationSourceForRestoredPVCs create or update replication source for each restored pvc
+func (h *diffVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVCs(
+	ctx context.Context,
+	manual string,
+	restoredPVCs []RestoredPVC,
+	owner metav1.Object,
+	vrg *ramendrv1alpha1.VolumeReplicationGroup,
+	isSubmarinerEnabled bool,
+) ([]*corev1.ObjectReference, bool, error) {
+	logger := h.Logger.WithName("CreateReplicationSourceForRestoredPVCs").
+		WithValues("NumberOfRestoredPVCs", len(restoredPVCs))
+	logger.Info("Start to create replication source for restored PVCs")
+
+	createdOrUpdated := false
+
+	previousSnapshotMap, err := h.getPreviousSnapshotMap(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	replicationSources := []*corev1.ObjectReference{}
+
+	for _, tmpRestoredPVC := range restoredPVCs {
+		restoredPVC := tmpRestoredPVC
+
+		ref, op, err := h.createOrUpdateDiffRS(
+			ctx, manual, restoredPVC, previousSnapshotMap, owner, vrg, isSubmarinerEnabled, logger)
+		if err != nil {
+			return nil, createdOrUpdated, err
+		}
+
+		replicationSources = append(replicationSources, ref)
+
+		createdOrUpdated = createdOrUpdated ||
+			(op == ctrlutil.OperationResultCreated || op == ctrlutil.OperationResultUpdated)
+	}
+
+	logger.Info("Replication sources are successfully created for all restored PVCs")
+
+	return replicationSources, createdOrUpdated, nil
+}
+
+//nolint:funlen
+func (h *diffVolumeGroupSourceHandler) createOrUpdateDiffRS(
+	ctx context.Context,
+	manual string,
+	restoredPVC RestoredPVC,
+	previousSnapshotMap map[string]string,
+	owner metav1.Object,
+	vrg *ramendrv1alpha1.VolumeReplicationGroup,
+	isSubmarinerEnabled bool,
+	logger logr.Logger,
+) (*corev1.ObjectReference, ctrlutil.OperationResult, error) {
+	logger.Info("Create replication source for restored PVC", "RestoredPVC", restoredPVC.RestoredPVCName)
+
+	originalPVCName := strings.TrimSuffix(restoredPVC.SourcePVCName, util.SuffixForFinalsyncPVC)
+	replicationSourceNamespace := h.VolumeGroupSnapshotNamespace
+
+	replicationSource := &volsyncv1alpha1.ReplicationSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      originalPVCName,
+			Namespace: replicationSourceNamespace,
+		},
+	}
+
+	rdService, err := h.resolveRDService(originalPVCName, restoredPVC.RestoredPVCName,
+		vrg, replicationSourceNamespace, isSubmarinerEnabled, logger)
+	if err != nil {
+		return nil, "", err
+	}
+
+	provisioner, err := h.resolveProvisioner(ctx, restoredPVC.RestoredPVCName, replicationSourceNamespace, logger)
+	if err != nil {
+		return nil, "", err
+	}
+
+	op, err := ctrlutil.CreateOrUpdate(ctx, h.Client, replicationSource, func() error {
+		if err := ctrl.SetControllerReference(owner, replicationSource, h.Client.Scheme()); err != nil {
+			return err
+		}
+
+		util.AddLabel(replicationSource, util.CreatedByRamenLabel, "true")
+		util.AddLabel(replicationSource, util.RGSOwnerLabel, owner.GetName())
+		util.AddAnnotation(replicationSource, volsync.OwnerNameAnnotation, owner.GetName())
+		util.AddAnnotation(replicationSource, volsync.OwnerNamespaceAnnotation, owner.GetNamespace())
+
+		replicationSource.Spec.SourcePVC = restoredPVC.RestoredPVCName
+		replicationSource.Spec.Trigger = &volsyncv1alpha1.ReplicationSourceTriggerSpec{
+			Manual: manual,
+		}
+		replicationSource.Spec.RsyncTLS = nil
+		replicationSource.Spec.External = &volsyncv1alpha1.ReplicationSourceExternalSpec{
+			Provider: provisioner,
+			Parameters: map[string]string{
+				"keySecret":          h.VolsyncKeySecretName,
+				"address":            rdService,
+				"copyMethod":         string(volsyncv1alpha1.CopyMethodDirect),
+				"volumeName":         restoredPVC.SourcePVCName,
+				"baseSnapshotName":   previousSnapshotMap[restoredPVC.SourcePVCName],
+				"targetSnapshotName": restoredPVC.VolumeSnapshotName,
+			},
+		}
+
+		return nil
+	})
+	if err != nil {
+		logger.Error(err, "Failed to CreateOrUpdate replication source", "RestoredPVC", restoredPVC.RestoredPVCName)
+
+		return nil, op, err
+	}
+
+	logger.Info("replication source successfully reconciled", "operation", op, "RestoredPVC", restoredPVC.RestoredPVCName)
+
+	return &corev1.ObjectReference{
+		APIVersion: replicationSource.APIVersion,
+		Kind:       replicationSource.Kind,
+		Namespace:  replicationSource.Namespace,
+		Name:       replicationSource.Name,
+	}, op, nil
+}
+
+// resolveProvisioner gets the StorageClass provisioner for a PVC.
+func (h *diffVolumeGroupSourceHandler) resolveProvisioner(
+	ctx context.Context, pvcName, namespace string, logger logr.Logger,
+) (string, error) {
+	pvc, err := util.GetPVC(ctx, h.Client, types.NamespacedName{
+		Name:      pvcName,
+		Namespace: namespace,
+	})
+	if err != nil {
+		logger.Error(err, "Failed to get restored PVC for replication source", "RestoredPVC", pvcName)
+
+		return "", err
+	}
+
+	if pvc.Spec.StorageClassName != nil {
+		storageClass, err := GetStorageClass(ctx, h.Client, pvc.Spec.StorageClassName)
+		if err != nil {
+			logger.Error(err, "Failed to get storage class for restored PVC", "RestoredPVC", pvcName)
+
+			return "", err
+		}
+
+		return storageClass.Provisioner, nil
+	}
+
+	return h.DefaultCephFSCSIDriverName, nil
+}

--- a/internal/controller/cephfscg/diffvolumegroupsourcehandler_test.go
+++ b/internal/controller/cephfscg/diffvolumegroupsourcehandler_test.go
@@ -1,0 +1,457 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cephfscg_test
+
+import (
+	"context"
+	"fmt"
+
+	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	vgsv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ramendr/ramen/api/v1alpha1"
+	internalController "github.com/ramendr/ramen/internal/controller"
+	"github.com/ramendr/ramen/internal/controller/cephfscg"
+	"github.com/ramendr/ramen/internal/controller/util"
+)
+
+var (
+	diffVGSName  = "diff-vgs"
+	diffVGSCName = "diff-vgsc"
+	diffVGSLabel = map[string]string{"diff-test": "diff-test"}
+)
+
+var _ = Describe("DiffVolumeGroupSourceHandler", func() {
+	var diffHandler cephfscg.VolumeGroupSourceHandler
+
+	rgs := GenerateReplicationGroupSource(diffVGSName, diffVGSCName, diffVGSLabel)
+
+	BeforeEach(func() {
+		diffHandler = cephfscg.NewDiffVolumeGroupSourceHandler(
+			k8sClient, rgs, internalController.DefaultCephFSCSIDriverName, nil, testLogger,
+		)
+
+		CreatePVC("diff-apppvc")
+	})
+
+	Describe("CreateOrUpdateVolumeGroupSnapshot", func() {
+		It("Should create a VGS with status=current label and timestamp suffix", func() {
+			createdOrUpdated, err := diffHandler.CreateOrUpdateVolumeGroupSnapshot(context.TODO(), rgs)
+			Expect(err).To(BeNil())
+			Expect(createdOrUpdated).To(BeTrue())
+
+			// Verify a VGS was created with the expected labels
+			Eventually(func() bool {
+				vgsList := &vgsv1beta1.VolumeGroupSnapshotList{}
+
+				err := k8sClient.List(context.TODO(), vgsList,
+					client.InNamespace("default"),
+					client.MatchingLabels{
+						cephfscg.VGSStatusLabelKey: cephfscg.VGSStatusCurrent,
+						util.RGSOwnerLabel:         diffVGSName,
+					},
+				)
+				if err != nil {
+					return false
+				}
+
+				return len(vgsList.Items) == 1
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		Context("When a current VGS already exists and is not ready", func() {
+			BeforeEach(func() {
+				_, err := diffHandler.CreateOrUpdateVolumeGroupSnapshot(context.TODO(), rgs)
+				Expect(err).To(BeNil())
+			})
+
+			It("Should return true (wait) without creating another VGS", func() {
+				createdOrUpdated, err := diffHandler.CreateOrUpdateVolumeGroupSnapshot(context.TODO(), rgs)
+				Expect(err).To(BeNil())
+				Expect(createdOrUpdated).To(BeTrue())
+
+				// Should still be exactly 1 VGS
+				vgsList := &vgsv1beta1.VolumeGroupSnapshotList{}
+				Expect(k8sClient.List(context.TODO(), vgsList,
+					client.InNamespace("default"),
+					client.MatchingLabels{
+						cephfscg.VGSStatusLabelKey: cephfscg.VGSStatusCurrent,
+						util.RGSOwnerLabel:         diffVGSName,
+					},
+				)).To(Succeed())
+				Expect(vgsList.Items).To(HaveLen(1))
+			})
+		})
+
+		Context("When current VGS exists and is ready", func() {
+			BeforeEach(func() {
+				_, err := diffHandler.CreateOrUpdateVolumeGroupSnapshot(context.TODO(), rgs)
+				Expect(err).To(BeNil())
+				updateDiffVGSReady(diffVGSName)
+			})
+
+			It("Should return false (reuse existing)", func() {
+				createdOrUpdated, err := diffHandler.CreateOrUpdateVolumeGroupSnapshot(context.TODO(), rgs)
+				Expect(err).To(BeNil())
+				Expect(createdOrUpdated).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("CleanVolumeGroupSnapshot", func() {
+		It("Should succeed with no VGS", func() {
+			err := diffHandler.CleanVolumeGroupSnapshot(context.TODO())
+			Expect(err).To(BeNil())
+		})
+
+		Context("When a current VGS exists", func() {
+			BeforeEach(func() {
+				// Clean up any previous VGS from prior test contexts
+				cleanupAllDiffVGS(diffVGSName)
+
+				_, err := diffHandler.CreateOrUpdateVolumeGroupSnapshot(context.TODO(), rgs)
+				Expect(err).To(BeNil())
+				updateDiffVGSReady(diffVGSName)
+			})
+
+			It("Should transition current VGS to previous status", func() {
+				err := diffHandler.CleanVolumeGroupSnapshot(context.TODO())
+				Expect(err).To(BeNil())
+
+				// No current VGS should remain
+				Eventually(func() int {
+					vgsList := &vgsv1beta1.VolumeGroupSnapshotList{}
+					Expect(k8sClient.List(context.TODO(), vgsList,
+						client.InNamespace("default"),
+						client.MatchingLabels{
+							cephfscg.VGSStatusLabelKey: cephfscg.VGSStatusCurrent,
+							util.RGSOwnerLabel:         diffVGSName,
+						},
+					)).To(Succeed())
+
+					return len(vgsList.Items)
+				}, timeout, interval).Should(Equal(0))
+
+				// At least one previous VGS should exist (the transitioned one)
+				vgsList := &vgsv1beta1.VolumeGroupSnapshotList{}
+				Expect(k8sClient.List(context.TODO(), vgsList,
+					client.InNamespace("default"),
+					client.MatchingLabels{
+						cephfscg.VGSStatusLabelKey: cephfscg.VGSStatusPrevious,
+						util.RGSOwnerLabel:         diffVGSName,
+					},
+				)).To(Succeed())
+				Expect(len(vgsList.Items)).To(BeNumerically(">=", 1))
+			})
+		})
+
+		Context("When multiple previous VGS exist", func() {
+			BeforeEach(func() {
+				cleanupAllDiffVGS(diffVGSName)
+
+				// Create 2 previous VGS directly with distinct names
+				for _, name := range []string{diffVGSName + "-old", diffVGSName + "-newer"} {
+					createPreviousVGS(name, diffVGSName)
+				}
+
+				// Create a current VGS and mark ready
+				_, err := diffHandler.CreateOrUpdateVolumeGroupSnapshot(context.TODO(), rgs)
+				Expect(err).To(BeNil())
+				updateDiffVGSReady(diffVGSName)
+			})
+
+			It("Should keep only the newest previous VGS and delete older ones", func() {
+				err := diffHandler.CleanVolumeGroupSnapshot(context.TODO())
+				Expect(err).To(BeNil())
+
+				// After cleanup: cleanOlderPreviousVGS keeps 1 of the 2 previous,
+				// then current is transitioned to previous → 2 total previous VGS
+				Eventually(func() int {
+					vgsList := &vgsv1beta1.VolumeGroupSnapshotList{}
+					Expect(k8sClient.List(context.TODO(), vgsList,
+						client.InNamespace("default"),
+						client.MatchingLabels{
+							cephfscg.VGSStatusLabelKey: cephfscg.VGSStatusPrevious,
+							util.RGSOwnerLabel:         diffVGSName,
+						},
+					)).To(Succeed())
+
+					return len(vgsList.Items)
+				}, timeout, interval).Should(Equal(2))
+
+				// No current VGS should remain
+				vgsList := &vgsv1beta1.VolumeGroupSnapshotList{}
+				Expect(k8sClient.List(context.TODO(), vgsList,
+					client.InNamespace("default"),
+					client.MatchingLabels{
+						cephfscg.VGSStatusLabelKey: cephfscg.VGSStatusCurrent,
+						util.RGSOwnerLabel:         diffVGSName,
+					},
+				)).To(Succeed())
+				Expect(vgsList.Items).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("RestoreVolumesFromVolumeGroupSnapshot", func() {
+		BeforeEach(func() {
+			cleanupAllDiffVGS(diffVGSName)
+		})
+
+		It("Should fail when no current VGS exists", func() {
+			_, err := diffHandler.RestoreVolumesFromVolumeGroupSnapshot(context.Background(), rgs)
+			Expect(err).To(HaveOccurred())
+		})
+
+		Context("When current VGS exists but is not ready", func() {
+			BeforeEach(func() {
+				_, err := diffHandler.CreateOrUpdateVolumeGroupSnapshot(context.TODO(), rgs)
+				Expect(err).To(BeNil())
+			})
+
+			It("Should fail", func() {
+				_, err := diffHandler.RestoreVolumesFromVolumeGroupSnapshot(context.Background(), rgs)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("When current VGS is ready with volume snapshots", func() {
+			BeforeEach(func() {
+				CreateStorageClass()
+
+				_, err := diffHandler.CreateOrUpdateVolumeGroupSnapshot(context.TODO(), rgs)
+				Expect(err).To(BeNil())
+
+				vgsList := &vgsv1beta1.VolumeGroupSnapshotList{}
+
+				Eventually(func() int {
+					Expect(k8sClient.List(context.TODO(), vgsList,
+						client.InNamespace("default"),
+						client.MatchingLabels{
+							cephfscg.VGSStatusLabelKey: cephfscg.VGSStatusCurrent,
+							util.RGSOwnerLabel:         diffVGSName,
+						},
+					)).To(Succeed())
+
+					return len(vgsList.Items)
+				}, timeout, interval).Should(Equal(1))
+
+				createdVGSName := vgsList.Items[0].Name
+				updateDiffVGSReadyByName(createdVGSName)
+				createVSWithPVC("diff-vs", createdVGSName, "default", "diff-apppvc")
+			})
+
+			It("Should restore volumes successfully", func() {
+				restoredPVCs, err := diffHandler.RestoreVolumesFromVolumeGroupSnapshot(context.Background(), rgs)
+				Expect(err).To(BeNil())
+				Expect(restoredPVCs).To(HaveLen(1))
+			})
+		})
+	})
+
+	Describe("CreateOrUpdateReplicationSourceForRestoredPVCs with External spec", func() {
+		It("Should create replication source with External spec for diff sync", func() {
+			vrg := &v1alpha1.VolumeReplicationGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "diff-vrg",
+					Namespace: "default",
+					Annotations: map[string]string{
+						util.EnableDiffAnnotation: "true",
+					},
+				},
+				Spec: v1alpha1.VolumeReplicationGroupSpec{
+					VolSync: v1alpha1.VolSyncSpec{
+						RSSpec: []v1alpha1.VolSyncReplicationSourceSpec{
+							{
+								ProtectedPVC: v1alpha1.ProtectedPVC{
+									Name: "diff-source",
+								},
+								RsyncTLS: &v1alpha1.RsyncTLSConfig{
+									Address: "dummy-address.default.svc",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			// Create the restored PVC that resolveProvisioner will look up
+			restoredPVC := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vs-diff-source",
+					Namespace: "default",
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: &scName,
+					AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			}
+			Expect(client.IgnoreAlreadyExists(k8sClient.Create(context.Background(), restoredPVC))).To(BeNil())
+
+			rsList, srcCreatedOrUpdated, err := diffHandler.CreateOrUpdateReplicationSourceForRestoredPVCs(
+				context.Background(), "manual",
+				[]cephfscg.RestoredPVC{{
+					SourcePVCName:      "diff-source",
+					RestoredPVCName:    "vs-diff-source",
+					VolumeSnapshotName: "diff-snap",
+				}},
+				rgs, vrg, true)
+			Expect(err).To(BeNil())
+			Expect(srcCreatedOrUpdated).To(BeTrue())
+			Expect(rsList).To(HaveLen(1))
+		})
+	})
+})
+
+func updateDiffVGSReady(ownerName string) {
+	vgsList := &vgsv1beta1.VolumeGroupSnapshotList{}
+
+	Eventually(func() int {
+		Expect(k8sClient.List(context.TODO(), vgsList,
+			client.InNamespace("default"),
+			client.MatchingLabels{
+				cephfscg.VGSStatusLabelKey: cephfscg.VGSStatusCurrent,
+				util.RGSOwnerLabel:         ownerName,
+			},
+		)).To(Succeed())
+
+		return len(vgsList.Items)
+	}, timeout, interval).Should(BeNumerically(">=", 1))
+
+	updateDiffVGSReadyByName(vgsList.Items[0].Name)
+}
+
+func updateDiffVGSReadyByName(name string) {
+	retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		vgs := &vgsv1beta1.VolumeGroupSnapshot{}
+
+		err := k8sClient.Get(context.TODO(), types.NamespacedName{
+			Name:      name,
+			Namespace: "default",
+		}, vgs)
+		if err != nil {
+			return err
+		}
+
+		ready := true
+		vgs.Status = &vgsv1beta1.VolumeGroupSnapshotStatus{
+			ReadyToUse: &ready,
+		}
+
+		return k8sClient.Status().Update(context.TODO(), vgs)
+	})
+	Expect(retryErr).To(BeNil())
+}
+
+func cleanupAllDiffVGS(ownerName string) {
+	vgsList := &vgsv1beta1.VolumeGroupSnapshotList{}
+
+	Expect(k8sClient.List(context.TODO(), vgsList,
+		client.InNamespace("default"),
+		client.MatchingLabels{util.RGSOwnerLabel: ownerName},
+	)).To(Succeed())
+
+	for i := range vgsList.Items {
+		Expect(client.IgnoreNotFound(
+			k8sClient.Delete(context.TODO(), &vgsList.Items[i]),
+		)).To(Succeed())
+	}
+
+	// Wait for all to be gone
+	Eventually(func() int {
+		list := &vgsv1beta1.VolumeGroupSnapshotList{}
+
+		Expect(k8sClient.List(context.TODO(), list,
+			client.InNamespace("default"),
+			client.MatchingLabels{util.RGSOwnerLabel: ownerName},
+		)).To(Succeed())
+
+		return len(list.Items)
+	}, timeout, interval).Should(Equal(0))
+}
+
+func createPreviousVGS(name, ownerName string) {
+	ready := true
+	vgs := &vgsv1beta1.VolumeGroupSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				cephfscg.VGSStatusLabelKey: cephfscg.VGSStatusPrevious,
+				util.RGSOwnerLabel:         ownerName,
+				util.CreatedByRamenLabel:   "true",
+			},
+		},
+		Spec: vgsv1beta1.VolumeGroupSnapshotSpec{
+			VolumeGroupSnapshotClassName: &diffVGSCName,
+			Source: vgsv1beta1.VolumeGroupSnapshotSource{
+				Selector: &metav1.LabelSelector{MatchLabels: diffVGSLabel},
+			},
+		},
+	}
+
+	Expect(k8sClient.Create(context.TODO(), vgs)).To(Succeed())
+
+	retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		if err := k8sClient.Get(context.TODO(), types.NamespacedName{
+			Name: name, Namespace: "default",
+		}, vgs); err != nil {
+			return err
+		}
+
+		vgs.Status = &vgsv1beta1.VolumeGroupSnapshotStatus{ReadyToUse: &ready}
+
+		return k8sClient.Status().Update(context.TODO(), vgs)
+	})
+	Expect(retryErr).To(BeNil())
+}
+
+func createVSWithPVC(name, vgsName, namespace, pvcName string) {
+	vgs := &vgsv1beta1.VolumeGroupSnapshot{}
+	Expect(k8sClient.Get(context.TODO(), types.NamespacedName{
+		Name:      vgsName,
+		Namespace: namespace,
+	}, vgs)).To(Succeed())
+
+	vs := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: fmt.Sprintf(
+						"%s/%s",
+						vgsv1beta1.SchemeGroupVersion.Group,
+						vgsv1beta1.SchemeGroupVersion.Version,
+					),
+					Kind: "VolumeGroupSnapshot",
+					Name: vgs.Name,
+					UID:  vgs.UID,
+				},
+			},
+		},
+		Spec: snapv1.VolumeSnapshotSpec{
+			Source: snapv1.VolumeSnapshotSource{PersistentVolumeClaimName: &pvcName},
+		},
+	}
+
+	Eventually(func() error {
+		err := k8sClient.Create(context.TODO(), vs)
+
+		return client.IgnoreAlreadyExists(err)
+	}, timeout, interval).Should(BeNil())
+}

--- a/internal/controller/cephfscg/replicationgroupdestination.go
+++ b/internal/controller/cephfscg/replicationgroupdestination.go
@@ -95,7 +95,7 @@ func (m *rgdMachine) Synchronize(ctx context.Context) (mover.Result, error) {
 	for _, rdSpec := range m.ReplicationGroupDestination.Spec.RDSpecs {
 		m.Logger.Info("Create replication destination for PVC", "PVCName", rdSpec.ProtectedPVC.Name)
 
-		rd, err := m.ReconcileRD(rdSpec, m.ReplicationGroupDestination.Status.LastSyncStartTime.String())
+		rd, err := m.ReconcileRD(ctx, rdSpec, m.ReplicationGroupDestination.Status.LastSyncStartTime.String())
 		if err != nil {
 			return mover.InProgress(), fmt.Errorf("failed to create replication destination: %w", err)
 		}
@@ -117,34 +117,9 @@ func (m *rgdMachine) Synchronize(ctx context.Context) (mover.Result, error) {
 	m.ReplicationGroupDestination.Status.ReplicationDestinations = rds
 	latestImages := make(map[string]*corev1.TypedLocalObjectReference)
 
-	for _, rd := range createdRDs {
-		m.Logger.Info("Check if replication destination is completed", "ReplicationDestinationName", rd.Name)
-
-		if rd.Spec.Trigger.Manual != rd.Status.LastManualSync {
-			m.Logger.Info("replication destination is not completed", "ReplicationDestinationName", rd.Name)
-
-			return mover.InProgress(), nil
-		}
-
-		if rd.Status.LatestImage != nil && rd.Spec.RsyncTLS != nil && rd.Spec.RsyncTLS.DestinationPVC != nil {
-			m.Logger.Info("Append latest image in the list",
-				"ReplicationDestinationName", rd.Name, "LatestImage", rd.Status.LatestImage)
-
-			latestImages[*rd.Spec.RsyncTLS.DestinationPVC] = rd.Status.LatestImage
-		}
-
-		m.Logger.Info("Set DoNotDeleteLabel to the image",
-			"ReplicationDestinationName", rd.Name, "LatestImage", rd.Status.LatestImage)
-
-		rgdName := m.ReplicationGroupDestination.Name
-		vrgName := m.ReplicationGroupDestination.GetLabels()[util.VRGOwnerNameLabel]
-		vrgNamespace := m.ReplicationGroupDestination.GetLabels()[util.VRGOwnerNamespaceLabel]
-
-		if err := util.DeferDeleteImage(
-			ctx, m.Client, rd.Status.LatestImage.Name, rd.Namespace, rgdName, vrgName, vrgNamespace,
-		); err != nil {
-			return mover.InProgress(), err
-		}
+	result, err := m.processCompletedRDs(ctx, createdRDs, latestImages)
+	if err != nil || result.ReconcileResult().Requeue {
+		return result, err
 	}
 
 	readytoUse, err := util.CheckImagesReadyToUse(
@@ -169,6 +144,52 @@ func (m *rgdMachine) Synchronize(ctx context.Context) (mover.Result, error) {
 	return mover.Complete(), nil
 }
 
+func (m *rgdMachine) processCompletedRDs(
+	ctx context.Context,
+	createdRDs []*volsyncv1alpha1.ReplicationDestination,
+	latestImages map[string]*corev1.TypedLocalObjectReference,
+) (mover.Result, error) {
+	for i, rd := range createdRDs {
+		m.Logger.Info("Check if replication destination is completed", "ReplicationDestinationName", rd.Name)
+
+		if rd.Spec.Trigger.Manual != rd.Status.LastManualSync {
+			m.Logger.Info("replication destination is not completed", "ReplicationDestinationName", rd.Name)
+
+			return mover.InProgress(), nil
+		}
+
+		if rd.Status.LatestImage != nil {
+			pvcName := m.getDestinationPVCName(rd, i)
+			if pvcName == "" {
+				m.Logger.Info("WARNING: Skipping RD with empty destination PVC name, check spec",
+					"ReplicationDestinationName", rd.Name)
+
+				continue
+			}
+
+			m.Logger.Info("Append latest image in the list",
+				"ReplicationDestinationName", rd.Name, "LatestImage", rd.Status.LatestImage)
+
+			latestImages[pvcName] = rd.Status.LatestImage
+		}
+
+		m.Logger.Info("Set DoNotDeleteLabel to the image",
+			"ReplicationDestinationName", rd.Name, "LatestImage", rd.Status.LatestImage)
+
+		rgdName := m.ReplicationGroupDestination.Name
+		vrgName := m.ReplicationGroupDestination.GetLabels()[util.VRGOwnerNameLabel]
+		vrgNamespace := m.ReplicationGroupDestination.GetLabels()[util.VRGOwnerNamespaceLabel]
+
+		if err := util.DeferDeleteImage(
+			ctx, m.Client, rd.Status.LatestImage.Name, rd.Namespace, rgdName, vrgName, vrgNamespace,
+		); err != nil {
+			return mover.InProgress(), err
+		}
+	}
+
+	return mover.Complete(), nil
+}
+
 func (m *rgdMachine) Cleanup(ctx context.Context) (mover.Result, error) {
 	m.Logger.Info("Clean expired RD images")
 
@@ -185,6 +206,7 @@ func (m *rgdMachine) ObserveSyncDuration(dur time.Duration) {}
 
 //nolint:cyclop
 func (m *rgdMachine) ReconcileRD(
+	ctx context.Context,
 	rdSpec ramendrv1alpha1.VolSyncReplicationDestinationSpec, manual string,
 ) (*volsyncv1alpha1.ReplicationDestination, error,
 ) {
@@ -211,7 +233,7 @@ func (m *rgdMachine) ReconcileRD(
 
 	var rd *volsyncv1alpha1.ReplicationDestination
 
-	rd, err = m.CreateReplicationDestinations(rdSpec, pskSecretName, dstPVC, manual)
+	rd, err = m.CreateReplicationDestinations(ctx, rdSpec, pskSecretName, dstPVC, manual)
 	if err != nil {
 		return nil, err
 	}
@@ -256,8 +278,23 @@ func (m *rgdMachine) ensurePSKSecretReady(pskSecretName string, log logr.Logger)
 	return nil
 }
 
-//nolint:funlen
+// getDestinationPVCName returns the destination PVC name from the RD spec.
+// For RsyncTLS, it uses the DestinationPVC field. For External (diff sync), it uses the protected PVC name.
+func (m *rgdMachine) getDestinationPVCName(rd *volsyncv1alpha1.ReplicationDestination, rdSpecIdx int) string {
+	if rd.Spec.RsyncTLS != nil && rd.Spec.RsyncTLS.DestinationPVC != nil {
+		return *rd.Spec.RsyncTLS.DestinationPVC
+	}
+
+	if rd.Spec.External != nil && rdSpecIdx < len(m.ReplicationGroupDestination.Spec.RDSpecs) {
+		return m.ReplicationGroupDestination.Spec.RDSpecs[rdSpecIdx].ProtectedPVC.Name
+	}
+
+	return ""
+}
+
+//nolint:funlen,cyclop
 func (m *rgdMachine) CreateReplicationDestinations(
+	ctx context.Context,
 	rdSpec ramendrv1alpha1.VolSyncReplicationDestinationSpec,
 	pskSecretName string, dstPVC *string, manual string,
 ) (*volsyncv1alpha1.ReplicationDestination, error) {
@@ -281,8 +318,17 @@ func (m *rgdMachine) CreateReplicationDestinations(
 		},
 	}
 
+	diffEnabled := util.IsDiffSyncEnabled(m.ReplicationGroupDestination.GetAnnotations())
+
+	storageClass, err := GetStorageClass(ctx, m.Client, rdSpec.ProtectedPVC.StorageClassName)
+	if err != nil {
+		m.Logger.Error(err, "Failed to get StorageClass for provider lookup", "PVCName", rdSpec.ProtectedPVC.Name)
+
+		return nil, err
+	}
+
 	if _, err := ctrlutil.CreateOrUpdate(
-		context.Background(), m.Client, rd,
+		ctx, m.Client, rd,
 		func() error {
 			if err := ctrl.SetControllerReference(m.ReplicationGroupDestination, rd, m.Client.Scheme()); err != nil {
 				return err
@@ -297,18 +343,40 @@ func (m *rgdMachine) CreateReplicationDestinations(
 			util.AddAnnotation(rd, volsync.OwnerNamespaceAnnotation, m.ReplicationGroupDestination.Namespace)
 
 			rd.Spec.Trigger = &volsyncv1alpha1.ReplicationDestinationTriggerSpec{Manual: manual}
-			rd.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationDestinationRsyncTLSSpec{
-				ServiceType: m.VSHandler.GetRsyncServiceType(),
-				KeySecret:   &pskSecretName,
-				ReplicationDestinationVolumeOptions: volsyncv1alpha1.ReplicationDestinationVolumeOptions{
-					CopyMethod:              volsyncv1alpha1.CopyMethodSnapshot,
-					Capacity:                rdSpec.ProtectedPVC.Resources.Requests.Storage(),
-					StorageClassName:        rdSpec.ProtectedPVC.StorageClassName,
-					AccessModes:             pvcAccessModes,
-					VolumeSnapshotClassName: &volumeSnapshotClassName,
-					DestinationPVC:          dstPVC,
-				},
-				MoverConfig: getMoverConfig(rdSpec),
+
+			if diffEnabled {
+				params := map[string]string{
+					"copyMethod":              string(volsyncv1alpha1.CopyMethodSnapshot),
+					"capacity":                rdSpec.ProtectedPVC.Resources.Requests.Storage().String(),
+					"storageClassName":        *rdSpec.ProtectedPVC.StorageClassName,
+					"accessModes":             string(pvcAccessModes[0]),
+					"volumeSnapshotClassName": volumeSnapshotClassName,
+					"keySecret":               pskSecretName,
+				}
+				if dstPVC != nil {
+					params["destinationPVC"] = *dstPVC
+				}
+
+				rd.Spec.RsyncTLS = nil
+				rd.Spec.External = &volsyncv1alpha1.ReplicationDestinationExternalSpec{
+					Provider:   storageClass.Provisioner,
+					Parameters: params,
+				}
+			} else {
+				rd.Spec.External = nil
+				rd.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationDestinationRsyncTLSSpec{
+					ServiceType: m.VSHandler.GetRsyncServiceType(),
+					KeySecret:   &pskSecretName,
+					ReplicationDestinationVolumeOptions: volsyncv1alpha1.ReplicationDestinationVolumeOptions{
+						CopyMethod:              volsyncv1alpha1.CopyMethodSnapshot,
+						Capacity:                rdSpec.ProtectedPVC.Resources.Requests.Storage(),
+						StorageClassName:        rdSpec.ProtectedPVC.StorageClassName,
+						AccessModes:             pvcAccessModes,
+						VolumeSnapshotClassName: &volumeSnapshotClassName,
+						DestinationPVC:          dstPVC,
+					},
+					MoverConfig: getMoverConfig(rdSpec),
+				}
 			}
 
 			return nil

--- a/internal/controller/cephfscg/replicationgroupdestination_test.go
+++ b/internal/controller/cephfscg/replicationgroupdestination_test.go
@@ -130,6 +130,128 @@ var _ = Describe("Replicationgroupdestination", func() {
 				}, timeout, interval).Should(BeElementOf(true, nil))
 			})
 		})
+		Context("When diff sync is enabled", func() {
+			testStorageProvisioner := internalController.DefaultCephFSCSIDriverName
+
+			BeforeEach(func() {
+				CreateStorageClass()
+				CreateVolumeSnapshotClass()
+				CreateVS(vsName, "", "")
+				UpdateVS(vsName)
+			})
+			Context("External spec creation with StorageProvisioner set", func() {
+				It("Should create ReplicationDestination with External spec", func() {
+					rgd := newDiffSyncRGD(testStorageProvisioner)
+
+					replicationGroupDestinationMachine = cephfscg.NewRGDMachine(
+						mgrClient, rgd, volsync.NewVSHandler(context.Background(), mgrClient, testLogger, rgd,
+							&ramendrv1alpha1.VRGAsyncSpec{}, internalController.DefaultCephFSCSIDriverName,
+							"Direct", false,
+						), testLogger,
+					)
+
+					pskSecretName := volsync.GetVolSyncPSKSecretNameFromVRGName(vrgName)
+					err := k8sClient.Create(
+						context.Background(),
+						&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: pskSecretName, Namespace: "default"}},
+					)
+					Expect(client.IgnoreAlreadyExists(err)).To(BeNil())
+
+					Eventually(func() error {
+						_, err := replicationGroupDestinationMachine.Synchronize(context.Background())
+
+						return err
+					}, timeout, interval).Should(BeNil())
+
+					rd := &volsyncv1alpha1.ReplicationDestination{}
+
+					Eventually(func() error {
+						return k8sClient.Get(context.Background(),
+							types.NamespacedName{Name: protectedPVCName, Namespace: "default"}, rd)
+					}, timeout, interval).Should(BeNil())
+
+					Expect(rd.Spec.External).ToNot(BeNil())
+					Expect(rd.Spec.RsyncTLS).To(BeNil())
+					Expect(rd.Spec.External.Parameters).To(HaveKeyWithValue("copyMethod", "Snapshot"))
+					Expect(rd.Spec.External.Parameters).To(HaveKey("keySecret"))
+					Expect(rd.Spec.External.Parameters).To(HaveKey("destinationPVC"))
+					Expect(rd.Spec.External.Parameters).To(HaveKeyWithValue("storageClassName", scName))
+					Expect(rd.Spec.External.Parameters).To(HaveKeyWithValue("volumeSnapshotClassName", vscName))
+				})
+			})
+			Context("Provider fallback when StorageProvisioner is empty", func() {
+				It("Should resolve provider from StorageClass", func() {
+					rgd := newDiffSyncRGD("")
+
+					replicationGroupDestinationMachine = cephfscg.NewRGDMachine(
+						mgrClient, rgd, volsync.NewVSHandler(context.Background(), mgrClient, testLogger, rgd,
+							&ramendrv1alpha1.VRGAsyncSpec{}, internalController.DefaultCephFSCSIDriverName,
+							"Direct", false,
+						), testLogger,
+					)
+
+					pskSecretName := volsync.GetVolSyncPSKSecretNameFromVRGName(vrgName)
+					err := k8sClient.Create(
+						context.Background(),
+						&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: pskSecretName, Namespace: "default"}},
+					)
+					Expect(client.IgnoreAlreadyExists(err)).To(BeNil())
+
+					Eventually(func() error {
+						_, err := replicationGroupDestinationMachine.Synchronize(context.Background())
+
+						return err
+					}, timeout, interval).Should(BeNil())
+
+					rd := &volsyncv1alpha1.ReplicationDestination{}
+
+					Eventually(func() error {
+						return k8sClient.Get(context.Background(),
+							types.NamespacedName{Name: protectedPVCName, Namespace: "default"}, rd)
+					}, timeout, interval).Should(BeNil())
+
+					Expect(rd.Spec.External).ToNot(BeNil())
+					Expect(rd.Spec.RsyncTLS).To(BeNil())
+				})
+			})
+			Context("getDestinationPVCName with External spec", func() {
+				It("Should create RD with External spec and correct provider", func() {
+					rgd := newDiffSyncRGD(testStorageProvisioner)
+
+					replicationGroupDestinationMachine = cephfscg.NewRGDMachine(
+						mgrClient, rgd, volsync.NewVSHandler(context.Background(), mgrClient, testLogger, rgd,
+							&ramendrv1alpha1.VRGAsyncSpec{}, internalController.DefaultCephFSCSIDriverName,
+							"Direct", false,
+						), testLogger,
+					)
+
+					pskSecretName := volsync.GetVolSyncPSKSecretNameFromVRGName(vrgName)
+					err := k8sClient.Create(
+						context.Background(),
+						&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: pskSecretName, Namespace: "default"}},
+					)
+					Expect(client.IgnoreAlreadyExists(err)).To(BeNil())
+
+					Eventually(func() error {
+						_, err := replicationGroupDestinationMachine.Synchronize(context.Background())
+
+						return err
+					}, timeout, interval).Should(BeNil())
+
+					rd := &volsyncv1alpha1.ReplicationDestination{}
+
+					Eventually(func() error {
+						return k8sClient.Get(context.Background(),
+							types.NamespacedName{Name: protectedPVCName, Namespace: "default"}, rd)
+					}, timeout, interval).Should(BeNil())
+
+					Expect(rd.Spec.External).ToNot(BeNil())
+					Expect(rd.Spec.RsyncTLS).To(BeNil())
+					Expect(rd.Spec.External.Provider).To(Equal(testStorageProvisioner))
+					Expect(rd.Spec.External.Parameters).To(HaveKeyWithValue("destinationPVC", protectedPVCName))
+				})
+			})
+		})
 	})
 })
 
@@ -187,4 +309,47 @@ func UpdateRplicationDestination(pvcName string) error {
 	testLogger.Info("rd is successfully to update")
 
 	return nil
+}
+
+func newDiffSyncRGD(testStorageProvisioner string) *ramendrv1alpha1.ReplicationGroupDestination {
+	metaTime := metav1.NewTime(time.Now())
+	protectedPVC := ramendrv1alpha1.ProtectedPVC{
+		Name:               protectedPVCName,
+		Namespace:          "default",
+		ProtectedByVolSync: true,
+		StorageClassName:   &scName,
+		AccessModes:        []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany},
+		Resources: corev1.VolumeResourceRequirements{
+			Limits: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceStorage: *resource.NewQuantity(1, resource.BinarySI),
+			},
+			Requests: map[corev1.ResourceName]resource.Quantity{
+				corev1.ResourceStorage: *resource.NewQuantity(1, resource.BinarySI),
+			},
+		},
+	}
+
+	if testStorageProvisioner != "" {
+		protectedPVC.StorageIdentifiers = ramendrv1alpha1.StorageIdentifiers{StorageProvisioner: testStorageProvisioner}
+	}
+
+	return &ramendrv1alpha1.ReplicationGroupDestination{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rgdName,
+			Namespace: "default",
+			UID:       "123",
+			Labels:    map[string]string{util.VRGOwnerNameLabel: vrgName},
+			Annotations: map[string]string{
+				util.EnableDiffAnnotation: "true",
+			},
+		},
+		Spec: ramendrv1alpha1.ReplicationGroupDestinationSpec{
+			RDSpecs: []ramendrv1alpha1.VolSyncReplicationDestinationSpec{{
+				ProtectedPVC: protectedPVC,
+			}},
+		},
+		Status: ramendrv1alpha1.ReplicationGroupDestinationStatus{
+			LastSyncStartTime: &metaTime,
+		},
+	}
 }

--- a/internal/controller/cephfscg/utils.go
+++ b/internal/controller/cephfscg/utils.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	vgsv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -50,3 +51,12 @@ func GetStorageClass(
 }
 
 // ------------- [End] Edited from existing code in Ramen ----
+
+// IsVGSReady checks if a VolumeGroupSnapshot is ready to use
+func IsVGSReady(vgs *vgsv1beta1.VolumeGroupSnapshot) bool {
+	if vgs == nil {
+		return false
+	}
+
+	return vgs.Status != nil && vgs.Status.ReadyToUse != nil && *vgs.Status.ReadyToUse
+}

--- a/internal/controller/cephfscg/utils_test.go
+++ b/internal/controller/cephfscg/utils_test.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cephfscg_test
+
+import (
+	"testing"
+
+	vgsv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
+
+	"github.com/ramendr/ramen/internal/controller/cephfscg"
+)
+
+func TestIsVGSReady(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		vgs      *vgsv1beta1.VolumeGroupSnapshot
+		expected bool
+	}{
+		{
+			name:     "nil VGS",
+			vgs:      nil,
+			expected: false,
+		},
+		{
+			name:     "nil Status",
+			vgs:      &vgsv1beta1.VolumeGroupSnapshot{},
+			expected: false,
+		},
+		{
+			name: "nil ReadyToUse",
+			vgs: &vgsv1beta1.VolumeGroupSnapshot{
+				Status: &vgsv1beta1.VolumeGroupSnapshotStatus{},
+			},
+			expected: false,
+		},
+		{
+			name: "ReadyToUse false",
+			vgs: &vgsv1beta1.VolumeGroupSnapshot{
+				Status: &vgsv1beta1.VolumeGroupSnapshotStatus{
+					ReadyToUse: boolPtr(false),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "ReadyToUse true",
+			vgs: &vgsv1beta1.VolumeGroupSnapshot{
+				Status: &vgsv1beta1.VolumeGroupSnapshotStatus{
+					ReadyToUse: boolPtr(true),
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := cephfscg.IsVGSReady(tt.vgs); got != tt.expected {
+				t.Errorf("IsVGSReady() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/internal/controller/cephfscg/volumegroupsourcehandler.go
+++ b/internal/controller/cephfscg/volumegroupsourcehandler.go
@@ -272,12 +272,9 @@ func (h *volumeGroupSourceHandler) RestoreVolumesFromVolumeGroupSnapshot(
 		return nil, fmt.Errorf("failed to get volume group snapshot: %w", err)
 	}
 
-	if vgs.Status == nil || vgs.Status.ReadyToUse == nil ||
-		(vgs.Status.ReadyToUse != nil && !*vgs.Status.ReadyToUse) {
+	if !IsVGSReady(vgs) {
 		return nil, fmt.Errorf("can't restore volume group snapshot: volume group snapshot is not ready to be used")
 	}
-
-	restoredPVCs := []RestoredPVC{}
 
 	volumeSnapshots, err := util.GetVolumeSnapshotsOwnedByVolumeGroupSnapshot(ctx, h.Client, vgs, logger)
 	if err != nil {
@@ -285,6 +282,19 @@ func (h *volumeGroupSourceHandler) RestoreVolumesFromVolumeGroupSnapshot(
 	}
 
 	logger.Info("Restore: Found VolumeSnapshots", "len", len(volumeSnapshots), "in group", vgs.Name)
+
+	return h.restorePVCsFromSnapshots(ctx, vgs, volumeSnapshots, owner, logger)
+}
+
+// restorePVCsFromSnapshots iterates over VolumeSnapshots owned by a VGS, restoring each to a read-only PVC.
+func (h *volumeGroupSourceHandler) restorePVCsFromSnapshots(
+	ctx context.Context,
+	vgs *vgsv1beta1.VolumeGroupSnapshot,
+	volumeSnapshots []vsv1.VolumeSnapshot,
+	owner metav1.Object,
+	logger logr.Logger,
+) ([]RestoredPVC, error) {
+	restoredPVCs := []RestoredPVC{}
 
 	for _, vs := range volumeSnapshots {
 		logger.Info("Get PVCName from volume snapshot",
@@ -506,6 +516,7 @@ func (h *volumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVC
 			replicationSource.Spec.Trigger = &volsyncv1alpha1.ReplicationSourceTriggerSpec{
 				Manual: manual,
 			}
+			replicationSource.Spec.External = nil
 			replicationSource.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationSourceRsyncTLSSpec{
 				ReplicationSourceVolumeOptions: volsyncv1alpha1.ReplicationSourceVolumeOptions{
 					CopyMethod: volsyncv1alpha1.CopyMethodDirect,

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -2021,6 +2021,7 @@ func (d *DRPCInstance) updateVRGOptionalFields(vrg, vrgFromView *rmn.VolumeRepli
 		DoNotDeletePVCAnnotation:              d.instance.GetAnnotations()[DoNotDeletePVCAnnotation],
 		DRPCUIDAnnotation:                     string(d.instance.UID),
 		rmnutil.UseVolSyncAnnotation:          d.instance.GetAnnotations()[rmnutil.UseVolSyncAnnotation],
+		rmnutil.EnableDiffAnnotation:          d.instance.GetAnnotations()[rmnutil.EnableDiffAnnotation],
 		rmnutil.IsSubmarinerEnabledAnnotation: d.instance.GetAnnotations()[rmnutil.IsSubmarinerEnabledAnnotation],
 	}
 

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -2913,6 +2913,8 @@ func constructVRGFromView(viewVRG *rmn.VolumeReplicationGroup) *rmn.VolumeReplic
 			fallthrough
 		case rmnutil.UseVolSyncAnnotation:
 			fallthrough
+		case rmnutil.EnableDiffAnnotation:
+			fallthrough
 		case DRPCUIDAnnotation:
 			rmnutil.AddAnnotation(vrg, k, v)
 		default:

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -1887,6 +1887,53 @@ var _ = Describe("DRPlacementControl - Ensure do-not-delete PVC Annotation", fun
 	})
 })
 
+var _ = Describe("DRPlacementControl - EnableDiff Annotation Propagation", func() {
+	BeforeEach(func() {
+		populateDRClusters()
+	})
+
+	AfterEach(func() {
+		err := forceCleanupClusterAfterAErrorTest()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Should propagate EnableDiffAnnotation from DRPC to VRG in ManifestWork", func(ctx SpecContext) {
+		_, _ = InitialDeploymentAsync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster,
+			UsePlacementRule)
+
+		waitForCompletion(string(rmn.Deployed))
+
+		// Set EnableDiffAnnotation on DRPC
+		retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			drpc := getLatestDRPC(DefaultDRPCNamespace)
+
+			annotations := drpc.GetAnnotations()
+			if annotations == nil {
+				annotations = make(map[string]string)
+			}
+
+			annotations[rmnutil.EnableDiffAnnotation] = "true"
+			drpc.SetAnnotations(annotations)
+
+			return k8sClient.Update(context.TODO(), drpc)
+		})
+		Expect(retryErr).NotTo(HaveOccurred())
+
+		// Wait for the VRG ManifestWork to contain the annotation
+		Eventually(func() string {
+			vrg, err := getVRGFromManifestWork(East1ManagedCluster)
+			if err != nil {
+				return ""
+			}
+
+			return vrg.GetAnnotations()[rmnutil.EnableDiffAnnotation]
+		}, timeout, interval).Should(Equal("true"))
+
+		deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+		deleteDRPC()
+	})
+})
+
 var _ = Describe("DRPlacementControl Reconciler Errors", func() {
 	BeforeEach(func() {
 		populateDRClusters()

--- a/internal/controller/replicationgroupsource_controller.go
+++ b/internal/controller/replicationgroupsource_controller.go
@@ -119,7 +119,13 @@ func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ct
 		&ramendrv1alpha1.VRGAsyncSpec{}, defaultCephFSCSIDriverName,
 		volSyncDestinationCopyMethodOrDefault(ramenConfig), adminNamespaceVRG,
 	)
-	vgsHandler := cephfscg.NewVolumeGroupSourceHandler(r.Client, rgs, defaultCephFSCSIDriverName, vsHandler, logger)
+
+	var vgsHandler cephfscg.VolumeGroupSourceHandler
+	if util.IsDiffSyncEnabled(rgs.GetAnnotations()) {
+		vgsHandler = cephfscg.NewDiffVolumeGroupSourceHandler(r.Client, rgs, defaultCephFSCSIDriverName, vsHandler, logger)
+	} else {
+		vgsHandler = cephfscg.NewVolumeGroupSourceHandler(r.Client, rgs, defaultCephFSCSIDriverName, vsHandler, logger)
+	}
 
 	if cephfscg.IsPrepareForFinalSyncTriggered(rgs) {
 		logger.Info("Detected request for final sync preparation, waiting for confirmation to continue")

--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -35,6 +35,9 @@ const (
 	// When this annotation is set to true, VolSync will protect RBD PVCs.
 	UseVolSyncAnnotation = "drplacementcontrol.ramendr.openshift.io/use-volsync-for-pvc-protection"
 
+	// When this annotation is set to true, differential (incremental) syncs will be enabled for CephFS CG.
+	EnableDiffAnnotation = "drplacementcontrol.ramendr.openshift.io/enable-diff"
+
 	MaxK8sLabelLength = validation.DNS1123LabelMaxLength
 	MaxK8sNameLength  = validation.DNS1123LabelMaxLength
 
@@ -412,6 +415,11 @@ func IsPVCMarkedForVolSync(annotations map[string]string) bool {
 	return annotations[UseVolSyncAnnotation] == "true"
 }
 
+// IsDiffSyncEnabled checks if the enable-diff annotation is set to true on the resource
+func IsDiffSyncEnabled(annotations map[string]string) bool {
+	return annotations[EnableDiffAnnotation] == "true"
+}
+
 func TrimToK8sResourceNameLength(name string) string {
 	const maxLength = 63
 	if len(name) > maxLength {
@@ -498,4 +506,17 @@ func GetLocalServiceNameForRD(rdName string) string {
 // a ServiceExport is created for the service on the cluster that has the ReplicationDestination
 func GetRemoteServiceNameForRDFromPVCName(pvcName, rdNamespace string) string {
 	return fmt.Sprintf("%s.%s.svc.clusterset.local", getLocalServiceNameForRDFromPVCName(pvcName), rdNamespace)
+}
+
+// GetLocalServiceNameForDiffRD returns the service name created by the ceph-volsync-plugin
+// for External ReplicationDestinations using diff sync
+func GetLocalServiceNameForDiffRD(rdName string) string {
+	return GetServiceName("ceph-volsync-dst-", rdName)
+}
+
+// GetRemoteServiceNameForDiffRDFromPVCName returns the remote service name for diff sync RDs
+func GetRemoteServiceNameForDiffRDFromPVCName(pvcName, rdNamespace string) string {
+	diffLocalName := GetLocalServiceNameForDiffRD(GetReplicationDestinationName(pvcName))
+
+	return fmt.Sprintf("%s.%s.svc.clusterset.local", diffLocalName, rdNamespace)
 }

--- a/internal/controller/util/misc_test.go
+++ b/internal/controller/util/misc_test.go
@@ -17,6 +17,15 @@ var _ = Describe("misc", func() {
 	Expect(util.IsPVCMarkedForVolSync(map[string]string{util.UseVolSyncAnnotation: "true"})).
 		Should(Equal(true))
 
+	// Tests for IsDiffSyncEnabled
+	Expect(util.IsDiffSyncEnabled(nil)).Should(Equal(false))
+	Expect(util.IsDiffSyncEnabled(map[string]string{})).Should(Equal(false))
+	Expect(util.IsDiffSyncEnabled(map[string]string{"other-key": "true"})).Should(Equal(false))
+	Expect(util.IsDiffSyncEnabled(map[string]string{util.EnableDiffAnnotation: ""})).Should(Equal(false))
+	Expect(util.IsDiffSyncEnabled(map[string]string{util.EnableDiffAnnotation: "false"})).Should(Equal(false))
+	Expect(util.IsDiffSyncEnabled(map[string]string{util.EnableDiffAnnotation: "True"})).Should(Equal(false))
+	Expect(util.IsDiffSyncEnabled(map[string]string{util.EnableDiffAnnotation: "true"})).Should(Equal(true))
+
 	pvcNamespace1 := "busybox-box-appT"
 	pvcNamespace2 := "busybox-box-appppppppXppppT"
 	pvcNamespace3 := "busybox-box-appppppppXppppddffghT"

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -191,8 +191,7 @@ func (v *VSHandler) ReconcileRD(
 		return nil, nil, err
 	}
 
-	err = v.ReconcileServiceExportForRD(rd)
-	if err != nil {
+	if err = v.ReconcileServiceExportForRD(rd); err != nil {
 		return nil, nil, err
 	}
 
@@ -224,8 +223,7 @@ func (v *VSHandler) generateRDInfo(
 	isSubmarinerEnabled := v.IsSubmarinerEnabled()
 
 	if isSubmarinerEnabled {
-		err := v.ReconcileServiceExportForRD(rd)
-		if err != nil {
+		if err := v.ReconcileServiceExportForRD(rd); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -370,7 +368,12 @@ func (v *VSHandler) createOrUpdateRD(
 ) {
 	l := v.log.WithValues("rdSpec", rdSpec)
 
-	volumeSnapshotClassName, err := v.GetVolumeSnapshotClassFromPVCStorageClass(rdSpec.ProtectedPVC.StorageClassName)
+	storageclass, err := v.getStorageClass(rdSpec.ProtectedPVC.StorageClassName)
+	if err != nil {
+		return nil, err
+	}
+
+	volumeSnapshotClassName, err := v.getVolumeSnapshotClassFromPVCStorageClass(storageclass)
 	if err != nil {
 		return nil, err
 	}
@@ -404,19 +407,40 @@ func (v *VSHandler) createOrUpdateRD(
 			}
 		}
 
-		rd.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationDestinationRsyncTLSSpec{
-			ServiceType: v.GetRsyncServiceType(),
-			KeySecret:   &pskSecretName,
+		if util.IsDiffSyncEnabled(v.owner.GetAnnotations()) {
+			params := map[string]string{
+				"storageClassName":        *rdSpec.ProtectedPVC.StorageClassName,
+				"volumeSnapshotClassName": volumeSnapshotClassName,
+				"copyMethod":              string(volsyncv1alpha1.CopyMethodSnapshot),
+				"keySecret":               pskSecretName,
+				"capacity":                rdSpec.ProtectedPVC.Resources.Requests.Storage().String(),
+				"accessModes":             string(pvcAccessModes[0]),
+			}
+			if dstPVC != nil {
+				params["destinationPVC"] = *dstPVC
+			}
 
-			ReplicationDestinationVolumeOptions: volsyncv1alpha1.ReplicationDestinationVolumeOptions{
-				CopyMethod:              volsyncv1alpha1.CopyMethodSnapshot,
-				Capacity:                rdSpec.ProtectedPVC.Resources.Requests.Storage(),
-				StorageClassName:        rdSpec.ProtectedPVC.StorageClassName,
-				AccessModes:             pvcAccessModes,
-				VolumeSnapshotClassName: &volumeSnapshotClassName,
-				DestinationPVC:          dstPVC,
-			},
-			MoverConfig: moverConfig,
+			rd.Spec.External = &volsyncv1alpha1.ReplicationDestinationExternalSpec{
+				Provider:   storageclass.Provisioner,
+				Parameters: params,
+			}
+			rd.Spec.RsyncTLS = nil
+		} else {
+			rd.Spec.External = nil
+			rd.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationDestinationRsyncTLSSpec{
+				ServiceType: v.GetRsyncServiceType(),
+				KeySecret:   &pskSecretName,
+
+				ReplicationDestinationVolumeOptions: volsyncv1alpha1.ReplicationDestinationVolumeOptions{
+					CopyMethod:              volsyncv1alpha1.CopyMethodSnapshot,
+					Capacity:                rdSpec.ProtectedPVC.Resources.Requests.Storage(),
+					StorageClassName:        rdSpec.ProtectedPVC.StorageClassName,
+					AccessModes:             pvcAccessModes,
+					VolumeSnapshotClassName: &volumeSnapshotClassName,
+					DestinationPVC:          dstPVC,
+				},
+				MoverConfig: moverConfig,
+			}
 		}
 
 		return nil
@@ -658,19 +682,34 @@ func (v *VSHandler) createOrUpdateRS(rsSpec ramendrv1alpha1.VolSyncReplicationSo
 			}
 		}
 
-		rs.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationSourceRsyncTLSSpec{
-			KeySecret: &pskSecretName,
-			Address:   &remoteAddress,
+		if util.IsDiffSyncEnabled(v.owner.GetAnnotations()) {
+			rs.Spec.External = &volsyncv1alpha1.ReplicationSourceExternalSpec{
+				Provider: storageClass.Provisioner,
+				Parameters: map[string]string{
+					"copyMethod":              string(volsyncv1alpha1.CopyMethodSnapshot),
+					"storageClassName":        *rsSpec.ProtectedPVC.StorageClassName,
+					"volumeSnapshotClassName": volumeSnapshotClassName,
+					"keySecret":               pskSecretName,
+					"address":                 remoteAddress,
+				},
+			}
+			rs.Spec.RsyncTLS = nil
+		} else {
+			rs.Spec.External = nil
+			rs.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationSourceRsyncTLSSpec{
+				KeySecret: &pskSecretName,
+				Address:   &remoteAddress,
 
-			ReplicationSourceVolumeOptions: volsyncv1alpha1.ReplicationSourceVolumeOptions{
-				// Always using CopyMethod of snapshot for now - could use 'Clone' CopyMethod for specific
-				// storage classes that support it in the future
-				CopyMethod:              volsyncv1alpha1.CopyMethodSnapshot,
-				VolumeSnapshotClassName: &volumeSnapshotClassName,
-				StorageClassName:        rsSpec.ProtectedPVC.StorageClassName,
-				AccessModes:             rsSpec.ProtectedPVC.AccessModes,
-			},
-			MoverConfig: *moverConfig,
+				ReplicationSourceVolumeOptions: volsyncv1alpha1.ReplicationSourceVolumeOptions{
+					// Always using CopyMethod of snapshot for now - could use 'Clone' CopyMethod for specific
+					// storage classes that support it in the future
+					CopyMethod:              volsyncv1alpha1.CopyMethodSnapshot,
+					VolumeSnapshotClassName: &volumeSnapshotClassName,
+					StorageClassName:        rsSpec.ProtectedPVC.StorageClassName,
+					AccessModes:             rsSpec.ProtectedPVC.AccessModes,
+				},
+				MoverConfig: *moverConfig,
+			}
 		}
 
 		return nil
@@ -688,7 +727,14 @@ func (v *VSHandler) resolveRemoteAddress(rsSpec ramendrv1alpha1.VolSyncReplicati
 	if util.IsSubmarinerEnabled(v.owner.GetAnnotations()) {
 		// Remote service address created for the ReplicationDestination on the secondary
 		// The secondary namespace will be the same as primary namespace so use the vrg.Namespace
-		remoteAddress := util.GetRemoteServiceNameForRDFromPVCName(rsSpec.ProtectedPVC.Name, rsSpec.ProtectedPVC.Namespace)
+		var remoteAddress string
+		if util.IsDiffSyncEnabled(v.owner.GetAnnotations()) {
+			remoteAddress = util.GetRemoteServiceNameForDiffRDFromPVCName(
+				rsSpec.ProtectedPVC.Name, rsSpec.ProtectedPVC.Namespace)
+		} else {
+			remoteAddress = util.GetRemoteServiceNameForRDFromPVCName(rsSpec.ProtectedPVC.Name, rsSpec.ProtectedPVC.Namespace)
+		}
+
 		v.log.Info("Using Submariner remote address", "remoteAddress", remoteAddress)
 
 		return remoteAddress, nil
@@ -1742,15 +1788,21 @@ func (v *VSHandler) CleanupRDNotInSpecList(rdSpecList []ramendrv1alpha1.VolSyncR
 }
 
 // Make sure a ServiceExport exists to export the service for this RD to remote clusters
+// When diff sync is enabled, uses the ceph-volsync-plugin service name instead of rsync-tls.
 // See: https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/
 // 2.4/html/services/services-overview#enable-service-discovery-submariner
 func (v *VSHandler) ReconcileServiceExportForRD(rd *volsyncv1alpha1.ReplicationDestination) error {
+	// Get name of the local service (this needs to be exported)
+	serviceName := util.GetLocalServiceNameForRD(rd.GetName())
+	if util.IsDiffSyncEnabled(v.owner.GetAnnotations()) {
+		serviceName = util.GetLocalServiceNameForDiffRD(rd.GetName())
+	}
+
 	// Using unstructured to avoid needing to require serviceexport in client scheme
 	svcExport := &unstructured.Unstructured{}
 	svcExport.Object = map[string]interface{}{
 		"metadata": map[string]interface{}{
-			// Get name of the local service (this needs to be exported)
-			"name":      util.GetLocalServiceNameForRD(rd.GetName()),
+			"name":      serviceName,
 			"namespace": rd.GetNamespace(),
 		},
 	}
@@ -1769,7 +1821,7 @@ func (v *VSHandler) ReconcileServiceExportForRD(rd *volsyncv1alpha1.ReplicationD
 		// This way on relocate scenarios or failover/failback, when the RD is cleaned up the associated
 		// ServiceExport will get cleaned up with it.
 		if err := ctrlutil.SetOwnerReference(rd, svcExport, v.client.Scheme()); err != nil {
-			v.log.Error(err, "unable to set controller reference", "resource", svcExport)
+			v.log.Error(err, "unable to set owner reference", "resource", svcExport)
 
 			return fmt.Errorf("%w", err)
 		}
@@ -1777,7 +1829,7 @@ func (v *VSHandler) ReconcileServiceExportForRD(rd *volsyncv1alpha1.ReplicationD
 		return nil
 	})
 
-	v.log.V(1).Info("ServiceExport createOrUpdate Complete", "op", op)
+	v.log.V(1).Info("ServiceExport createOrUpdate Complete", "op", op, "serviceName", serviceName)
 
 	if err != nil {
 		v.log.Error(err, "error creating or updating ServiceExport", "replication destination name", rd.GetName(),
@@ -1785,8 +1837,6 @@ func (v *VSHandler) ReconcileServiceExportForRD(rd *volsyncv1alpha1.ReplicationD
 
 		return fmt.Errorf("error creating or updating ServiceExport (%w)", err)
 	}
-
-	v.log.V(1).Info("ServiceExport Reconcile Complete")
 
 	return nil
 }
@@ -2038,8 +2088,17 @@ func (v *VSHandler) rollbackToLastSnapshot(rdSpec ramendrv1alpha1.VolSyncReplica
 	pskSecretName := GetVolSyncPSKSecretNameFromVRGName(v.owner.GetName())
 
 	moverConfig := v.GetMoverConfigForPVC(rdSpec.ProtectedPVC.Name, rdSpec.ProtectedPVC.Namespace)
-	// Create localRD and localRS. The latest snapshot of the main RD will be used for the rollback
-	lrd, lrs, err := v.reconcileLocalReplication(rd, rdSpec, &snapshotRef, pskSecretName, moverConfig, v.log)
+
+	// Create localRD and localRS. The latest snapshot of the main RD will be used for the rollback.
+	// When diff sync is enabled, use External spec for efficient block-level rollback.
+	var lrs *volsyncv1alpha1.ReplicationSource
+
+	if util.IsDiffSyncEnabled(v.owner.GetAnnotations()) {
+		lrd, lrs, err = v.reconcileDiffLocalReplication(rd, rdSpec, &snapshotRef, pskSecretName, v.log)
+	} else {
+		lrd, lrs, err = v.reconcileLocalReplication(rd, rdSpec, &snapshotRef, pskSecretName, moverConfig, v.log)
+	}
+
 	if err != nil {
 		return err
 	}
@@ -2622,6 +2681,7 @@ func (v *VSHandler) reconcileLocalRD(rdSpec ramendrv1alpha1.VolSyncReplicationDe
 			}
 		}
 
+		lrd.Spec.External = nil
 		lrd.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationDestinationRsyncTLSSpec{
 			ServiceType: &DefaultRsyncServiceType,
 			KeySecret:   &pskSecretName,
@@ -2699,6 +2759,7 @@ func (v *VSHandler) reconcileLocalRS(rd *volsyncv1alpha1.ReplicationDestination,
 			}
 		}
 
+		lrs.Spec.External = nil
 		lrs.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationSourceRsyncTLSSpec{
 			KeySecret: &pskSecretName,
 			Address:   &address,
@@ -2732,6 +2793,16 @@ func (v *VSHandler) CleanupLocalResources(lrs *volsyncv1alpha1.ReplicationSource
 	err = util.DeletePVC(v.ctx, v.client, lrs.Spec.SourcePVC, lrs.GetNamespace(), v.log)
 	if err != nil {
 		return err
+	}
+
+	// If diff sync was used, clean up the current-state snapshot created for rollback
+	if util.IsDiffSyncEnabled(v.owner.GetAnnotations()) {
+		pvcName := strings.TrimPrefix(lrs.GetName(), "local-")
+		currentStateSnapName := fmt.Sprintf("current-state-%s", pvcName)
+
+		if snapErr := v.deleteSnapshot(v.ctx, v.client, currentStateSnapName, lrs.GetNamespace(), v.log); snapErr != nil {
+			v.log.Error(snapErr, "Failed to delete current-state snapshot", "snapshotName", currentStateSnapName)
+		}
 	}
 
 	// delete localRS
@@ -2820,6 +2891,48 @@ func (v *VSHandler) setupLocalRS(rd *volsyncv1alpha1.ReplicationDestination,
 	return v.createPVCFromSnapshot(rd, rdSpec, snapshotRef, restoreSize)
 }
 
+// resolveCapacity determines the PVC capacity by resolving between RD spec, rdSpec, and snapshot restore size.
+func (v *VSHandler) resolveCapacity(
+	rd *volsyncv1alpha1.ReplicationDestination,
+	rdSpec *ramendrv1alpha1.VolSyncReplicationDestinationSpec,
+	snapRestoreSize *resource.Quantity,
+) *resource.Quantity {
+	var pvcRequestedCapacity *resource.Quantity
+	if rd.Spec.RsyncTLS != nil {
+		pvcRequestedCapacity = rd.Spec.RsyncTLS.Capacity
+	} else {
+		pvcRequestedCapacity = rdSpec.ProtectedPVC.Resources.Requests.Storage()
+	}
+
+	if snapRestoreSize != nil {
+		if pvcRequestedCapacity == nil || snapRestoreSize.Cmp(*pvcRequestedCapacity) > 0 {
+			pvcRequestedCapacity = snapRestoreSize
+		}
+	}
+
+	return pvcRequestedCapacity
+}
+
+// setImmutablePVCFields sets the immutable fields on a PVC being created from a snapshot.
+func (v *VSHandler) setImmutablePVCFields(
+	pvc *corev1.PersistentVolumeClaim,
+	rd *volsyncv1alpha1.ReplicationDestination,
+	rdSpec *ramendrv1alpha1.VolSyncReplicationDestinationSpec,
+	snapshotRef *corev1.TypedLocalObjectReference,
+	accessModes []corev1.PersistentVolumeAccessMode,
+) {
+	pvc.Spec.AccessModes = accessModes
+
+	if rd.Spec.RsyncTLS != nil {
+		pvc.Spec.StorageClassName = rd.Spec.RsyncTLS.StorageClassName
+	} else {
+		pvc.Spec.StorageClassName = rdSpec.ProtectedPVC.StorageClassName
+	}
+
+	pvc.Spec.DataSource = snapshotRef
+	pvc.Spec.VolumeMode = v.volumeModeForProtectedPVC(&rdSpec.ProtectedPVC)
+}
+
 //nolint:funlen
 func (v *VSHandler) createPVCFromSnapshot(rd *volsyncv1alpha1.ReplicationDestination,
 	rdSpec *ramendrv1alpha1.VolSyncReplicationDestinationSpec,
@@ -2842,12 +2955,7 @@ func (v *VSHandler) createPVCFromSnapshot(rd *volsyncv1alpha1.ReplicationDestina
 
 	util.AddLabel(pvc, util.CreatedByRamenLabel, "true")
 
-	pvcRequestedCapacity := rd.Spec.RsyncTLS.Capacity
-	if snapRestoreSize != nil {
-		if pvcRequestedCapacity == nil || snapRestoreSize.Cmp(*pvcRequestedCapacity) > 0 {
-			pvcRequestedCapacity = snapRestoreSize
-		}
-	}
+	pvcRequestedCapacity := v.resolveCapacity(rd, rdSpec, snapRestoreSize)
 
 	op, err := ctrlutil.CreateOrUpdate(v.ctx, v.client, pvc, func() error {
 		if pvc.Status.Phase == corev1.ClaimBound {
@@ -2864,11 +2972,7 @@ func (v *VSHandler) createPVCFromSnapshot(rd *volsyncv1alpha1.ReplicationDestina
 		}
 
 		if pvc.CreationTimestamp.IsZero() { // set immutable fields
-			pvc.Spec.AccessModes = accessModes
-			pvc.Spec.StorageClassName = rd.Spec.RsyncTLS.StorageClassName
-
-			pvc.Spec.DataSource = snapshotRef
-			pvc.Spec.VolumeMode = v.volumeModeForProtectedPVC(&rdSpec.ProtectedPVC)
+			v.setImmutablePVCFields(pvc, rd, rdSpec, snapshotRef, accessModes)
 		}
 
 		pvc.Spec.Resources.Requests = corev1.ResourceList{

--- a/internal/controller/volsync/vshandler_diff.go
+++ b/internal/controller/volsync/vshandler_diff.go
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package volsync
+
+import (
+	"fmt"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+	"github.com/go-logr/logr"
+	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
+	"github.com/ramendr/ramen/internal/controller/util"
+)
+
+// CreateCurrentStateSnapshot creates a VolumeSnapshot of the app PVC's current state.
+// Used before diff sync rollback to capture the (possibly corrupted) state for diff calculation.
+func (v *VSHandler) CreateCurrentStateSnapshot(
+	rdSpec ramendrv1alpha1.VolSyncReplicationDestinationSpec,
+) (string, error) {
+	pvcName := rdSpec.ProtectedPVC.Name
+	namespace := rdSpec.ProtectedPVC.Namespace
+	snapshotName := fmt.Sprintf("current-state-%s", pvcName)
+
+	storageClass, err := v.getStorageClass(rdSpec.ProtectedPVC.StorageClassName)
+	if err != nil {
+		return "", err
+	}
+
+	volumeSnapshotClassName, err := v.getVolumeSnapshotClassFromPVCStorageClass(storageClass)
+	if err != nil {
+		return "", err
+	}
+
+	snap := &snapv1.VolumeSnapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      snapshotName,
+			Namespace: namespace,
+		},
+	}
+
+	_, err = ctrlutil.CreateOrUpdate(v.ctx, v.client, snap, func() error {
+		util.AddLabel(snap, util.CreatedByRamenLabel, "true")
+		util.AddLabel(snap, util.VRGOwnerNameLabel, v.owner.GetName())
+		util.AddLabel(snap, util.VRGOwnerNamespaceLabel, v.owner.GetNamespace())
+
+		snap.Spec.Source.PersistentVolumeClaimName = &pvcName
+		snap.Spec.VolumeSnapshotClassName = &volumeSnapshotClassName
+
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create current state snapshot for %s: %w", pvcName, err)
+	}
+
+	v.log.Info("Current state snapshot created", "snapshotName", snapshotName, "pvcName", pvcName)
+
+	return snapshotName, nil
+}
+
+// IsSnapshotReady checks if a VolumeSnapshot has ReadyToUse=true.
+func (v *VSHandler) IsSnapshotReady(name, namespace string) (bool, error) {
+	snap := &snapv1.VolumeSnapshot{}
+
+	err := v.client.Get(v.ctx, types.NamespacedName{Name: name, Namespace: namespace}, snap)
+	if err != nil {
+		return false, err
+	}
+
+	if snap.Status == nil || snap.Status.ReadyToUse == nil || !*snap.Status.ReadyToUse {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// reconcileDiffLocalReplication orchestrates diff-based local rollback using External spec.
+// Instead of full rsync copy, uses the ceph-volsync-plugin to transfer only changed blocks.
+//
+//nolint:funlen
+func (v *VSHandler) reconcileDiffLocalReplication(
+	rd *volsyncv1alpha1.ReplicationDestination,
+	rdSpec ramendrv1alpha1.VolSyncReplicationDestinationSpec,
+	snapshotRef *corev1.TypedLocalObjectReference,
+	pskSecretName string,
+	l logr.Logger,
+) (*volsyncv1alpha1.ReplicationDestination, *volsyncv1alpha1.ReplicationSource, error) {
+	// Step 1: Create current state snapshot of the app PVC
+	currentSnapName, err := v.CreateCurrentStateSnapshot(rdSpec)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Step 2: Wait for snapshot ready (return-and-retry)
+	ready, err := v.IsSnapshotReady(currentSnapName, rdSpec.ProtectedPVC.Namespace)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error checking current state snapshot readiness: %w", err)
+	}
+
+	if !ready {
+		return nil, nil, fmt.Errorf("waiting for current state snapshot %s to be ready", currentSnapName)
+	}
+
+	// Step 3: Create diff local RD with External spec
+	lrd, err := v.ReconcileDiffLocalRD(rdSpec, pskSecretName)
+	if lrd == nil || err != nil {
+		return nil, nil, fmt.Errorf("failed to reconcile diff localRD (%w)", err)
+	}
+
+	// Step 4: Create shallow PVC from LatestImage + diff local RS with External spec
+	lrs, err := v.ReconcileDiffLocalRS(rd, &rdSpec, snapshotRef, currentSnapName,
+		pskSecretName, *lrd.Status.RsyncTLS.Address)
+	if err != nil {
+		return lrd, nil, fmt.Errorf("failed to reconcile diff localRS (%w)", err)
+	}
+
+	l.V(1).Info(fmt.Sprintf("Diff local replication reconcile complete lrd=%s, lrs=%s", lrd.Name, lrs.Name))
+
+	return lrd, lrs, nil
+}
+
+// ReconcileDiffLocalRD creates a local ReplicationDestination with External spec for diff rollback.
+//
+//nolint:funlen
+func (v *VSHandler) ReconcileDiffLocalRD(
+	rdSpec ramendrv1alpha1.VolSyncReplicationDestinationSpec,
+	pskSecretName string,
+) (*volsyncv1alpha1.ReplicationDestination, error) {
+	v.log.Info("Reconciling diff localRD", "rdSpec name", rdSpec.ProtectedPVC.Name)
+
+	lrd := &volsyncv1alpha1.ReplicationDestination{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.GetLocalReplicationName(rdSpec.ProtectedPVC.Name),
+			Namespace: rdSpec.ProtectedPVC.Namespace,
+		},
+	}
+
+	err := v.EnsurePVCforDirectCopy(v.ctx, rdSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	storageClass, err := v.getStorageClass(rdSpec.ProtectedPVC.StorageClassName)
+	if err != nil {
+		return nil, err
+	}
+
+	volumeSnapshotClassName, err := v.getVolumeSnapshotClassFromPVCStorageClass(storageClass)
+	if err != nil {
+		return nil, err
+	}
+
+	pvcAccessModes := []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+	if len(rdSpec.ProtectedPVC.AccessModes) > 0 {
+		pvcAccessModes = rdSpec.ProtectedPVC.AccessModes
+	}
+
+	op, err := ctrlutil.CreateOrUpdate(v.ctx, v.client, lrd, func() error {
+		util.AddLabel(lrd, util.CreatedByRamenLabel, "true")
+		util.AddLabel(lrd, util.VRGOwnerNameLabel, v.owner.GetName())
+		util.AddLabel(lrd, util.VRGOwnerNamespaceLabel, v.owner.GetNamespace())
+		util.AddLabel(lrd, VolSyncDoNotDeleteLabel, VolSyncDoNotDeleteLabelVal)
+
+		lrd.Spec.RsyncTLS = nil
+		lrd.Spec.External = &volsyncv1alpha1.ReplicationDestinationExternalSpec{
+			Provider: storageClass.Provisioner,
+			Parameters: map[string]string{
+				"copyMethod":              string(volsyncv1alpha1.CopyMethodDirect),
+				"destinationPVC":          rdSpec.ProtectedPVC.Name,
+				"keySecret":               pskSecretName,
+				"capacity":                rdSpec.ProtectedPVC.Resources.Requests.Storage().String(),
+				"storageClassName":        *rdSpec.ProtectedPVC.StorageClassName,
+				"accessModes":             string(pvcAccessModes[0]),
+				"volumeSnapshotClassName": volumeSnapshotClassName,
+			},
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Wait for address — plugin populates Status.RsyncTLS.Address even for External spec
+	if lrd.Status == nil || lrd.Status.RsyncTLS == nil || lrd.Status.RsyncTLS.Address == nil {
+		v.log.V(1).Info("Diff local ReplicationDestination waiting for Address...")
+
+		return nil, fmt.Errorf("waiting for address")
+	}
+
+	v.log.V(1).Info("Diff local ReplicationDestination Reconcile Complete", "op", op)
+
+	return lrd, nil
+}
+
+// ReconcileDiffLocalRS creates a local ReplicationSource with External spec for diff rollback.
+//
+//nolint:funlen
+func (v *VSHandler) ReconcileDiffLocalRS(
+	rd *volsyncv1alpha1.ReplicationDestination,
+	rdSpec *ramendrv1alpha1.VolSyncReplicationDestinationSpec,
+	snapshotRef *corev1.TypedLocalObjectReference,
+	currentStateSnapshotName string,
+	pskSecretName, address string,
+) (*volsyncv1alpha1.ReplicationSource, error) {
+	v.log.Info("Reconciling diff localRS", "RD", rd.GetName())
+
+	// Reuse setupLocalRS to validate LatestImage + create shallow PVC from snapshot
+	pvc, err := v.setupLocalRS(rd, rdSpec, snapshotRef)
+	if err != nil {
+		return nil, err
+	}
+
+	storageClass, err := v.getStorageClass(rdSpec.ProtectedPVC.StorageClassName)
+	if err != nil {
+		return nil, err
+	}
+
+	lrs := &volsyncv1alpha1.ReplicationSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.GetLocalReplicationName(rdSpec.ProtectedPVC.Name),
+			Namespace: rdSpec.ProtectedPVC.Namespace,
+		},
+	}
+
+	op, err := ctrlutil.CreateOrUpdate(v.ctx, v.client, lrs, func() error {
+		util.AddLabel(lrs, util.CreatedByRamenLabel, "true")
+		util.AddLabel(lrs, util.VRGOwnerNameLabel, v.owner.GetName())
+		util.AddLabel(lrs, util.VRGOwnerNamespaceLabel, v.owner.GetNamespace())
+
+		lrs.Spec.SourcePVC = pvc.GetName()
+		lrs.Spec.Trigger = &volsyncv1alpha1.ReplicationSourceTriggerSpec{
+			Manual: pvc.GetName(),
+		}
+
+		lrs.Spec.RsyncTLS = nil
+		lrs.Spec.External = &volsyncv1alpha1.ReplicationSourceExternalSpec{
+			Provider: storageClass.Provisioner,
+			Parameters: map[string]string{
+				"copyMethod":         string(volsyncv1alpha1.CopyMethodDirect),
+				"volumeName":         rdSpec.ProtectedPVC.Name,
+				"baseSnapshotName":   currentStateSnapshotName,
+				"targetSnapshotName": snapshotRef.Name,
+				"address":            address,
+				"keySecret":          pskSecretName,
+			},
+		}
+
+		return nil
+	})
+
+	v.log.V(1).Info("Diff local ReplicationSource createOrUpdate Complete", "op", op, "error", err)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return lrs, nil
+}

--- a/internal/controller/volsync/vshandler_diff_test.go
+++ b/internal/controller/volsync/vshandler_diff_test.go
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package volsync_test
+
+import (
+	"fmt"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
+	"github.com/ramendr/ramen/internal/controller/util"
+	"github.com/ramendr/ramen/internal/controller/volsync"
+)
+
+var _ = Describe("VolSync Handler - Diff sync rollback", func() {
+	var (
+		testNamespace *corev1.Namespace
+		owner         client.Object
+		vsHandler     *volsync.VSHandler
+	)
+
+	asyncSpec := &ramendrv1alpha1.VRGAsyncSpec{
+		SchedulingInterval:          "5m",
+		VolumeSnapshotClassSelector: metav1.LabelSelector{},
+	}
+
+	capacity := resource.MustParse("2Gi")
+
+	BeforeEach(func() {
+		testNamespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "vh-diff-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
+		Expect(testNamespace.GetName()).NotTo(BeEmpty())
+
+		// Create owner with diff sync annotation
+		ownerCm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "dummycm-diff-owner-",
+				Namespace:    testNamespace.GetName(),
+				Annotations: map[string]string{
+					util.EnableDiffAnnotation: "true",
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ownerCm)).To(Succeed())
+		Expect(ownerCm.GetName()).NotTo(BeEmpty())
+		owner = ownerCm
+
+		vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, owner, asyncSpec,
+			testCephFSStorageDriverName, "Direct", false)
+	})
+
+	AfterEach(func() {
+		Expect(k8sClient.Delete(ctx, testNamespace)).To(Succeed())
+	})
+
+	Describe("createCurrentStateSnapshot", func() {
+		It("Should create a VolumeSnapshot of the app PVC's current state", func() {
+			pvcName := "test-app-pvc"
+
+			// Create a dummy PVC first
+			createDummyPVC(pvcName, testNamespace.GetName(), capacity, nil)
+
+			rdSpec := ramendrv1alpha1.VolSyncReplicationDestinationSpec{
+				ProtectedPVC: ramendrv1alpha1.ProtectedPVC{
+					Name:             pvcName,
+					Namespace:        testNamespace.GetName(),
+					StorageClassName: &testCephFSStorageClassName,
+				},
+			}
+
+			snapName, err := vsHandler.CreateCurrentStateSnapshot(rdSpec)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(snapName).To(Equal(fmt.Sprintf("current-state-%s", pvcName)))
+
+			// Verify the snapshot was created
+			snap := &snapv1.VolumeSnapshot{}
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name: snapName, Namespace: testNamespace.GetName(),
+				}, snap)
+			}, maxWait, interval).Should(Succeed())
+
+			Expect(snap.Spec.Source.PersistentVolumeClaimName).NotTo(BeNil())
+			Expect(*snap.Spec.Source.PersistentVolumeClaimName).To(Equal(pvcName))
+			Expect(snap.Spec.VolumeSnapshotClassName).NotTo(BeNil())
+			Expect(*snap.Spec.VolumeSnapshotClassName).To(Equal(testCephFSVolumeSnapshotClassName))
+			Expect(snap.Labels[util.CreatedByRamenLabel]).To(Equal("true"))
+		})
+	})
+
+	Describe("isSnapshotReady", func() {
+		It("Should return false when snapshot is not ready", func() {
+			snap := createSnapshot("test-snap-not-ready", testNamespace.GetName())
+			// Snapshot created without status — should not be ready
+			ready, err := vsHandler.IsSnapshotReady(snap.Name, snap.Namespace)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ready).To(BeFalse())
+		})
+
+		It("Should return true when snapshot has ReadyToUse=true", func() {
+			snap := createSnapshot("test-snap-ready", testNamespace.GetName())
+
+			// Update status to ready
+			snap.Status = &snapv1.VolumeSnapshotStatus{
+				ReadyToUse: ptr.To(true),
+			}
+			Expect(k8sClient.Status().Update(ctx, snap)).To(Succeed())
+
+			Eventually(func() bool {
+				ready, err := vsHandler.IsSnapshotReady(snap.Name, snap.Namespace)
+				if err != nil {
+					return false
+				}
+
+				return ready
+			}, maxWait, interval).Should(BeTrue())
+		})
+	})
+
+	Describe("reconcileDiffLocalRD", func() {
+		It("Should create a local RD with External spec", func() {
+			pvcName := "test-diff-rd-pvc"
+
+			// Create the app PVC
+			createDummyPVC(pvcName, testNamespace.GetName(), capacity, nil)
+
+			// Create PSK secret
+			pskSecretName := volsync.GetVolSyncPSKSecretNameFromVRGName(owner.GetName())
+			Expect(k8sClient.Create(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: pskSecretName, Namespace: testNamespace.GetName()},
+			})).To(Succeed())
+
+			rdSpec := ramendrv1alpha1.VolSyncReplicationDestinationSpec{
+				ProtectedPVC: ramendrv1alpha1.ProtectedPVC{
+					Name:               pvcName,
+					Namespace:          testNamespace.GetName(),
+					ProtectedByVolSync: true,
+					StorageClassName:   &testCephFSStorageClassName,
+					AccessModes:        []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: capacity,
+						},
+					},
+				},
+			}
+
+			lrd, err := vsHandler.ReconcileDiffLocalRD(rdSpec, pskSecretName)
+			// RD is created but address may not be populated yet — expect waiting error
+			if err != nil {
+				Expect(err.Error()).To(ContainSubstring("waiting for address"))
+			}
+
+			// Verify the RD was created with External spec
+			rd := &volsyncv1alpha1.ReplicationDestination{}
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      util.GetLocalReplicationName(pvcName),
+					Namespace: testNamespace.GetName(),
+				}, rd)
+			}, maxWait, interval).Should(Succeed())
+
+			Expect(rd.Spec.External).NotTo(BeNil())
+			Expect(rd.Spec.RsyncTLS).To(BeNil())
+			Expect(rd.Spec.External.Provider).To(Equal(testCephFSStorageDriverName))
+			Expect(rd.Spec.External.Parameters).To(HaveKeyWithValue("copyMethod", "Direct"))
+			Expect(rd.Spec.External.Parameters).To(HaveKeyWithValue("destinationPVC", pvcName))
+			Expect(rd.Spec.External.Parameters).To(HaveKeyWithValue("keySecret", pskSecretName))
+			Expect(rd.Spec.External.Parameters).To(HaveKeyWithValue("storageClassName", testCephFSStorageClassName))
+			Expect(rd.Spec.External.Parameters).To(
+				HaveKeyWithValue("volumeSnapshotClassName", testCephFSVolumeSnapshotClassName))
+
+			// Verify labels
+			Expect(rd.Labels[volsync.VolSyncDoNotDeleteLabel]).To(Equal(volsync.VolSyncDoNotDeleteLabelVal))
+			Expect(rd.Labels[util.CreatedByRamenLabel]).To(Equal("true"))
+
+			_ = lrd // may be nil if address not populated
+		})
+	})
+
+	Describe("reconcileDiffLocalRS", func() {
+		It("Should create a local RS with External spec and diff params", func() {
+			pvcName := "test-diff-rs-pvc"
+
+			// Create the app PVC
+			createDummyPVC(pvcName, testNamespace.GetName(), capacity, nil)
+
+			// Create PSK secret
+			pskSecretName := volsync.GetVolSyncPSKSecretNameFromVRGName(owner.GetName())
+			Expect(k8sClient.Create(ctx, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: pskSecretName, Namespace: testNamespace.GetName()},
+			})).To(Succeed())
+
+			// Create a fake LatestImage snapshot
+			latestSnap := createSnapshot("latest-image-snap", testNamespace.GetName())
+
+			// Create a dummy RD that the local RS references
+			rd := &volsyncv1alpha1.ReplicationDestination{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      util.GetReplicationDestinationName(pvcName),
+					Namespace: testNamespace.GetName(),
+				},
+			}
+			Expect(k8sClient.Create(ctx, rd)).To(Succeed())
+
+			// Update RD status with LatestImage
+			rd.Status = &volsyncv1alpha1.ReplicationDestinationStatus{
+				RsyncTLS: &volsyncv1alpha1.ReplicationDestinationRsyncTLSStatus{
+					Address: ptr.To("10.0.0.1"),
+				},
+				LatestImage: &corev1.TypedLocalObjectReference{
+					Kind:     "VolumeSnapshot",
+					Name:     latestSnap.Name,
+					APIGroup: ptr.To(snapv1.GroupName),
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, rd)).To(Succeed())
+
+			// Update snapshot status to ready
+			latestSnap.Status = &snapv1.VolumeSnapshotStatus{
+				ReadyToUse:  ptr.To(true),
+				RestoreSize: &capacity,
+			}
+			Expect(k8sClient.Status().Update(ctx, latestSnap)).To(Succeed())
+
+			rdSpec := &ramendrv1alpha1.VolSyncReplicationDestinationSpec{
+				ProtectedPVC: ramendrv1alpha1.ProtectedPVC{
+					Name:               pvcName,
+					Namespace:          testNamespace.GetName(),
+					ProtectedByVolSync: true,
+					StorageClassName:   &testCephFSStorageClassName,
+					AccessModes:        []corev1.PersistentVolumeAccessMode{corev1.ReadOnlyMany},
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: capacity,
+						},
+					},
+				},
+			}
+
+			snapshotRef := &corev1.TypedLocalObjectReference{
+				Kind:     "VolumeSnapshot",
+				Name:     latestSnap.Name,
+				APIGroup: ptr.To(snapv1.GroupName),
+			}
+
+			currentStateSnapName := "current-state-" + pvcName
+			address := "10.0.0.1"
+
+			lrs, err := vsHandler.ReconcileDiffLocalRS(rd, rdSpec, snapshotRef,
+				currentStateSnapName, pskSecretName, address)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(lrs).NotTo(BeNil())
+
+			// Verify RS has External spec
+			rs := &volsyncv1alpha1.ReplicationSource{}
+
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      util.GetLocalReplicationName(pvcName),
+					Namespace: testNamespace.GetName(),
+				}, rs)
+			}, maxWait, interval).Should(Succeed())
+
+			Expect(rs.Spec.External).NotTo(BeNil())
+			Expect(rs.Spec.RsyncTLS).To(BeNil())
+			Expect(rs.Spec.External.Provider).To(Equal(testCephFSStorageDriverName))
+			Expect(rs.Spec.External.Parameters).To(HaveKeyWithValue("copyMethod", "Direct"))
+			Expect(rs.Spec.External.Parameters).To(HaveKeyWithValue("volumeName", pvcName))
+			Expect(rs.Spec.External.Parameters).To(HaveKeyWithValue("baseSnapshotName", currentStateSnapName))
+			Expect(rs.Spec.External.Parameters).To(HaveKeyWithValue("targetSnapshotName", latestSnap.Name))
+			Expect(rs.Spec.External.Parameters).To(HaveKeyWithValue("address", address))
+			Expect(rs.Spec.External.Parameters).To(HaveKeyWithValue("keySecret", pskSecretName))
+		})
+	})
+})

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -394,7 +394,7 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 // +kubebuilder:rbac:groups=volsync.backube,resources=replicationdestinations/finalizers,verbs=update
 // +kubebuilder:rbac:groups=volsync.backube,resources=replicationsources,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=volsync.backube,resources=replicationsources/finalizers,verbs=update
-// +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;list;watch;update;delete
+// +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=multicluster.x-k8s.io,resources=serviceexports,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;create;patch;update

--- a/internal/controller/vrg_volrep_test.go
+++ b/internal/controller/vrg_volrep_test.go
@@ -36,10 +36,11 @@ import (
 )
 
 const (
-	vrgtimeout   = time.Second
-	vrginterval  = time.Millisecond * 10
-	letters      = "abcdefghijklmnopqrstuxwxyz"
-	namespaceLen = 5
+	vrgtimeout          = time.Second
+	vrginterval         = time.Millisecond * 10
+	vrgReconcileTimeout = 5 * time.Second
+	letters             = "abcdefghijklmnopqrstuxwxyz"
+	namespaceLen        = 5
 )
 
 var (
@@ -510,6 +511,9 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 						Expect(k8sClient.Update(context.TODO(), &pvc)).To(Succeed())
 					})
 				})
+				It("updates the status", func() {
+					Eventually(vrgResourceVersionGet, vrgReconcileTimeout, interval).ShouldNot(Equal(vrgResourceVersion))
+				})
 				It("keeps the selected protected", func() {
 					pvcsVerify(pvcNamesSelected, pvcProtectedVerify)
 				})
@@ -525,7 +529,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 					configMapUpdate()
 				})
 				It("updates the status", func() {
-					Eventually(vrgResourceVersionGet).ShouldNot(Equal(vrgResourceVersion))
+					Eventually(vrgResourceVersionGet, vrgReconcileTimeout, interval).ShouldNot(Equal(vrgResourceVersion))
 				})
 				It("keeps the selected protected", func() {
 					pvcsVerify(pvcNamesSelected, pvcProtectedVerify)
@@ -553,7 +557,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 					})
 				})
 				It("updates the status", func() {
-					Eventually(vrgResourceVersionGet).ShouldNot(Equal(vrgResourceVersion))
+					Eventually(vrgResourceVersionGet, vrgReconcileTimeout, interval).ShouldNot(Equal(vrgResourceVersion))
 				})
 				It("keeps the selected protected", func() {
 					pvcsVerify(pvcNamesSelected, pvcProtectedVerify)
@@ -607,7 +611,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 					})
 				})
 				It("updates the status", func() {
-					Eventually(vrgResourceVersionGet).ShouldNot(Equal(vrgResourceVersion))
+					Eventually(vrgResourceVersionGet, vrgReconcileTimeout, interval).ShouldNot(Equal(vrgResourceVersion))
 				})
 				It("keeps the deselected unprotected", func() {
 					pvcsVerify(pvcNamesDeselected, pvcUnprotectedVerify)


### PR DESCRIPTION
Add differential (incremental) sync for CephFS CG Regional DR,
controlled by the `drplacementcontrol.ramendr.openshift.io/enable-diff`
annotation.

When enabled, Ramen preserves VolumeGroupSnapshots across sync cycles
using status labels (current/previous) and creates VolSync
ReplicationSources with External spec instead of RsyncTLS.
The External spec passes baseSnapshotName and targetSnapshotName
parameters to the ceph-volsync-plugin mover, which transfers only
changed blocks between consecutive snapshots.

Key changes:
- Add `drplacement.ramendr.openshift.io/enable-diff` annotation to DRPC
  and propagation (DRPC → VRG → RGS/RGD) via IsDiffSyncEnabled() util
- Add diffVolumeGroupSourceHandler embedding volumeGroupSourceHandler,
  overriding CreateOrUpdateVGS (timestamped VGS with status labels),
  CleanVGS (preserve previous, rotate current→previous), RestoreFromVGS
  (lookup by status label), CreateOrUpdateRS (External spec with diff params)
- Add External ReplicationSource/Destination spec builders in vshandler_diff
  with ceph-volsync-plugin mover parameters
- Add failover rollback support using CopyMethodDirect with local RS/RD
  for diff recovery via External spec
- Add VGS status label helpers and CSI provisioner detection utils
- Add unit tests for diff handler lifecycle, VGS rotation, rollback,
  and External spec construction
- Add design doc: docs/design/Incremental-Sync.md

Refer:
- https://github.com/RamenDR/ceph-volsync-plugin

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Rakshith R <rar@redhat.com>
