### PR TITLE
tests: refactor DRPC tests to make them more readable 

### DIFF
--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -395,8 +395,11 @@ func GetFakeVRGFromMCVUsingMW(managedCluster, resourceNamespace string,
 	}
 
 	vrg := &rmn.VolumeReplicationGroup{}
+
 	err = yaml.Unmarshal(mw.Spec.Workload.Manifests[0].Raw, vrg)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal VRG: %w", err)
+	}
 
 	vrg.Generation = 1
 	vrg.Status.ObservedGeneration = 1

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -176,6 +176,30 @@ var (
 	}
 )
 
+func waitForCondition(d, poll time.Duration, desc string, cond func() bool) error {
+	deadline := time.Now().Add(d)
+	for {
+		if cond() {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out: %s", desc)
+		}
+		time.Sleep(poll)
+	}
+}
+
+func ensureConsistent(d, poll time.Duration, desc string, cond func() bool) error {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if !cond() {
+			return fmt.Errorf("consistency violated: %s", desc)
+		}
+		time.Sleep(poll)
+	}
+	return nil
+}
+
 func getSyncDRPolicy() *rmn.DRPolicy {
 	return &rmn.DRPolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -669,7 +669,7 @@ func ensureNamespaceMWsDeletedFromAllClusters(namespace string) {
 	}
 }
 
-func setDRPCSpecExpectationTo(namespace, preferredCluster, failoverCluster string, action rmn.DRAction) {
+func setDRPCSpecExpectationTo(namespace, preferredCluster, failoverCluster string, action rmn.DRAction) error {
 	drpcLookupKey := types.NamespacedName{
 		Name:      DRPCCommonName,
 		Namespace: namespace,
@@ -688,9 +688,11 @@ func setDRPCSpecExpectationTo(namespace, preferredCluster, failoverCluster strin
 		return k8sClient.Update(context.TODO(), latestDRPC)
 	})
 
-	Expect(retryErr).NotTo(HaveOccurred())
+	if retryErr != nil {
+		return retryErr
+	}
 
-	Eventually(func() bool {
+	return waitForCondition(timeout, interval, "failed to update DRPC DR action on time", func() bool {
 		var err error
 		latestDRPC, err = getLatestDRPC(namespace)
 		if err != nil {
@@ -698,7 +700,7 @@ func setDRPCSpecExpectationTo(namespace, preferredCluster, failoverCluster strin
 		}
 
 		return latestDRPC.Spec.Action == action
-	}, timeout, interval).Should(BeTrue(), "failed to update DRPC DR action on time")
+	})
 }
 
 func getLatestDRPC(namespace string) (*rmn.DRPlacementControl, error) {
@@ -715,7 +717,7 @@ func getLatestDRPC(namespace string) (*rmn.DRPlacementControl, error) {
 	return latestDRPC, nil
 }
 
-func clearDRPCStatus() {
+func clearDRPCStatus() error {
 	drpcLookupKey := types.NamespacedName{
 		Name:      DRPCCommonName,
 		Namespace: DefaultDRPCNamespace,
@@ -731,11 +733,15 @@ func clearDRPCStatus() {
 
 		return k8sClient.Status().Update(context.TODO(), latestDRPC)
 	})
-	Expect(retryErr).NotTo(HaveOccurred())
+
+	if retryErr != nil {
+		return retryErr
+	}
+
+	return nil
 }
 
-//nolint:unparam
-func clearFakeUserPlacementRuleStatus(name, namespace string) {
+func clearFakeUserPlacementRuleStatus(name, namespace string) error {
 	usrPlRuleLookupKey := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -753,7 +759,11 @@ func clearFakeUserPlacementRuleStatus(name, namespace string) {
 		return k8sClient.Status().Update(context.TODO(), usrPlRule)
 	})
 
-	Expect(retryErr).NotTo(HaveOccurred())
+	if retryErr != nil {
+		return retryErr
+	}
+
+	return nil
 }
 
 func createNamespace(ns *corev1.Namespace) error {
@@ -989,19 +999,22 @@ func createVRGMW(name, namespace, homeCluster string) error {
 	return err
 }
 
-func updateManifestWorkStatus(clusterNamespace, vrgNamespace, mwType, workType string) {
+func updateManifestWorkStatus(clusterNamespace, vrgNamespace, mwType, workType string) error {
 	manifestLookupKey := types.NamespacedName{
 		Name:      rmnutil.ManifestWorkName(DRPCCommonName, getVRGNamespace(vrgNamespace), mwType),
 		Namespace: clusterNamespace,
 	}
 	mw := &ocmworkv1.ManifestWork{}
 
-	Eventually(func() bool {
-		err := k8sClient.Get(context.TODO(), manifestLookupKey, mw)
+	if err := waitForCondition(timeout, interval,
+		fmt.Sprintf("failed to wait for manifest creation for type %s cluster %s", mwType, clusterNamespace),
+		func() bool {
+			err := k8sClient.Get(context.TODO(), manifestLookupKey, mw)
 
-		return err == nil
-	}, timeout, interval).Should(BeTrue(),
-		fmt.Sprintf("failed to wait for manifest creation for type %s cluster %s", mwType, clusterNamespace))
+			return err == nil
+		}); err != nil {
+		return err
+	}
 
 	timeOld := time.Now().Local()
 	timeMostRecent := timeOld.Add(time.Second)
@@ -1036,13 +1049,16 @@ func updateManifestWorkStatus(clusterNamespace, vrgNamespace, mwType, workType s
 		return k8sClient.Status().Update(context.TODO(), mw)
 	})
 
-	Expect(retryErr).NotTo(HaveOccurred())
+	if retryErr != nil {
+		return retryErr
+	}
 
-	Eventually(func() bool {
-		err := k8sClient.Get(context.TODO(), manifestLookupKey, mw)
+	return waitForCondition(timeout, interval,
+		"failed to wait for PV manifest condition type to change to 'Applied'", func() bool {
+			err := k8sClient.Get(context.TODO(), manifestLookupKey, mw)
 
-		return err == nil && len(mw.Status.Conditions) != 0
-	}, timeout, interval).Should(BeTrue(), "failed to wait for PV manifest condition type to change to 'Applied'")
+			return err == nil && len(mw.Status.Conditions) != 0
+		})
 }
 
 func ensureDRPolicyIsNotDeleted(drpc *rmn.DRPlacementControl) {
@@ -1595,7 +1611,7 @@ func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR 
 }
 
 func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferredCluster, failoverCluster string) {
-	setDRPCSpecExpectationTo(userPlacementRule.GetNamespace(), preferredCluster, failoverCluster, "")
+	Expect(setDRPCSpecExpectationTo(userPlacementRule.GetNamespace(), preferredCluster, failoverCluster, "")).To(Succeed())
 	waitForCompletion(string(rmn.Deployed))
 
 	drpc, err := getLatestDRPC(userPlacementRule.GetNamespace())
@@ -1617,9 +1633,9 @@ func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferre
 func relocateToPreferredCluster(placementObj client.Object, fromCluster string) {
 	toCluster1 := "east1-cluster"
 
-	setDRPCSpecExpectationTo(placementObj.GetNamespace(), toCluster1, fromCluster, rmn.ActionRelocate)
+	Expect(setDRPCSpecExpectationTo(placementObj.GetNamespace(), toCluster1, fromCluster, rmn.ActionRelocate)).To(Succeed())
 
-	updateManifestWorkStatus(toCluster1, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)
+	Expect(updateManifestWorkStatus(toCluster1, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
 
 	waitForDRPCProtected(placementObj.GetNamespace())
 
@@ -1631,9 +1647,9 @@ func relocateToPreferredCluster(placementObj client.Object, fromCluster string) 
 }
 
 func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster string) {
-	setDRPCSpecExpectationTo(placementObj.GetNamespace(), fromCluster, toCluster, rmn.ActionFailover)
+	Expect(setDRPCSpecExpectationTo(placementObj.GetNamespace(), fromCluster, toCluster, rmn.ActionFailover)).To(Succeed())
 
-	updateManifestWorkStatus(toCluster, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)
+	Expect(updateManifestWorkStatus(toCluster, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
 
 	waitForDRPCProtected(placementObj.GetNamespace())
 
@@ -1759,7 +1775,7 @@ func resetdrCluster(cluster string) {
 //nolint:unparam
 func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster string) {
 	verifyVRGManifestWorkCreatedAsPrimary(userPlacement.GetNamespace(), preferredCluster)
-	updateManifestWorkStatus(preferredCluster, userPlacement.GetNamespace(), "vrg", ocmworkv1.WorkApplied)
+	Expect(updateManifestWorkStatus(preferredCluster, userPlacement.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
 	verifyUserPlacementRuleDecision(userPlacement.GetName(), userPlacement.GetNamespace(), preferredCluster)
 	verifyDRPCStatusPreferredClusterExpectation(userPlacement.GetNamespace(), rmn.Deployed)
 	Expect(getManifestWorkCount(preferredCluster)).Should(BeElementOf(3, 4)) // MWs for VRG, 2 namespaces, and DRCluster
@@ -2161,7 +2177,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should not failover to Secondary (West1ManagedCluster) till PV manifest is applied", func() {
 				By("\n\n*** Failover - 1\n\n")
 				setRestorePVsIncomplete()
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)).To(Succeed())
 				verifyUserPlacementRuleDecisionUnchanged(userPlacementRule.Name, userPlacementRule.Namespace, East1ManagedCluster)
 				// MWs for VRG, NS, DRCluster, and MMode
 				Expect(getManifestWorkCount(West1ManagedCluster)).Should(BeElementOf(3, 4))
@@ -2176,8 +2192,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("DRAction is Failover during hub recovery", func() {
 			It("Should reconstructs the DRPC state and points to Secondary (West1ManagedCluster)", func() {
 				By("\n\n*** Failover after \n\n")
-				clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)
-				clearDRPCStatus()
+				Expect(clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
+				Expect(clearDRPCStatus()).To(Succeed())
 				verifyFailoverToSecondary(userPlacementRule, West1ManagedCluster, false)
 			})
 		})
@@ -2285,7 +2301,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("DRAction changes to Failover using Placement with Subscription", func() {
 			It("Should not failover to Secondary (West1ManagedCluster) till PV manifest is applied", func() {
 				setRestorePVsIncomplete()
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)).To(Succeed())
 				verifyUserPlacementRuleDecisionUnchanged(placement.Name, placement.Namespace, East1ManagedCluster)
 				// MWs for VRG, NS, VRG DRCluster, and MMode
 				Expect(getManifestWorkCount(West1ManagedCluster)).Should(BeElementOf(3, 4))
@@ -2370,7 +2386,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("DRAction changes to Failover using Placement", func() {
 			It("Should not failover to Secondary (West1ManagedCluster) till PV manifest is applied", func() {
 				setRestorePVsIncomplete()
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)).To(Succeed())
 				verifyUserPlacementRuleDecisionUnchanged(placement.Name, placement.Namespace, East1ManagedCluster)
 				// MWs for VRG, NS, VRG DRCluster, and MMode
 				Expect(getManifestWorkCount(West1ManagedCluster)).Should(BeElementOf(3, 4))
@@ -2458,7 +2474,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("\n\n*** Failover - 1\n\n")
 				setRestorePVsIncomplete()
 				fenceCluster(East1ManagedCluster, false)
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, East2ManagedCluster, rmn.ActionFailover)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, East2ManagedCluster, rmn.ActionFailover)).To(Succeed())
 				verifyUserPlacementRuleDecisionUnchanged(userPlacementRule.Name, userPlacementRule.Namespace, East1ManagedCluster)
 				// MWs for VRG, VRG DRCluster and the MW for NetworkFence CR to fence off
 				Expect(getManifestWorkCount(East2ManagedCluster)).Should(BeElementOf(3, 4))
@@ -2536,7 +2552,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("\n\n*** Failover - 1\n\n")
 				setRestorePVsIncomplete()
 				fenceCluster(East1ManagedCluster, true)
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, East2ManagedCluster, rmn.ActionFailover)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, East2ManagedCluster, rmn.ActionFailover)).To(Succeed())
 				verifyUserPlacementRuleDecisionUnchanged(userPlacementRule.Name, userPlacementRule.Namespace, East1ManagedCluster)
 				// MWs for VRG, VRG DRCluster and the MW for NetworkFence CR to fence off
 				Expect(getManifestWorkCount(East2ManagedCluster)).Should(BeElementOf(3, 4))
@@ -2610,7 +2626,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				userPlacementRule1 = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule1).NotTo(BeNil())
 				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)
-				uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(""))
+				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(""))).To(Succeed())
 			})
 		})
 		//nolint:lll
@@ -2626,9 +2642,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("HubRecovery: DRAction is Initial deploy -> Secondary Down", func() {
 			It("Should reconstructs the DRPC state to completion. Primary is East1ManagedCluster", func() {
 				setClusterDown(West1ManagedCluster)
-				clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)
-				clearDRPCStatus()
-
+				Expect(clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
+				Expect(clearDRPCStatus()).To(Succeed())
 				expectedAction := rmn.DRAction("")
 				expectedPhase := rmn.Deployed
 				expectedPorgression := rmn.ProgressionCompleted
@@ -2652,8 +2667,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("HubRecovery: DRAction is Initial deploy -> Primary Down", func() {
 			It("Should pause and wait for user to trigger a failover. Primary East1ManagedCluster", func() {
 				setClusterDown(East1ManagedCluster)
-				clearDRPCStatus()
-
+				Expect(clearDRPCStatus()).To(Succeed())
 				expectedAction := rmn.DRAction("")
 				expectedPhase := rmn.WaitForUser
 				expectedPorgression := rmn.ProgressionActionPaused
@@ -2670,7 +2684,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				resetClusterDown()
 				runFailoverAction(userPlacementRule1, from, to, false, false)
 				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.FailedOver)
-				uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, West1ManagedCluster, rmn.VRGActionFailover)
+				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, West1ManagedCluster, rmn.VRGActionFailover)).To(Succeed())
 				resetClusterDown()
 			})
 		})
@@ -2688,11 +2702,11 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("HubRecovery: DRAction is Failover -> Primary Down", func() {
 			It("Should Pause, but allows failover. Primary West1ManagedCluster", func() {
 				setClusterDown(West1ManagedCluster)
-				clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)
-				clearDRPCStatus()
+				Expect(clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
+				Expect(clearDRPCStatus()).To(Succeed())
 				// TODO: Why did we shift the failover to deploy action here? It fails as VRG exists as Secondary now
 				// on the cluster to deploy to
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)).To(Succeed())
 				expectedAction := rmn.ActionFailover
 				expectedPhase := rmn.WaitForUser
 				expectedPorgression := rmn.ProgressionActionPaused
@@ -2701,7 +2715,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 				// User intervention is required (simulate user intervention)
 				resetClusterDown()
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)).To(Succeed())
 				expectedAction = rmn.ActionFailover
 				expectedPhase = rmn.FailedOver
 				expectedPorgression = rmn.ProgressionCompleted
@@ -2716,7 +2730,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				// ----------------------------- RELOCATION TO PRIMARY --------------------------------------
 				from := West1ManagedCluster
 				runRelocateAction(userPlacementRule1, from, false, false)
-				uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(rmn.ActionRelocate))
+				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(rmn.ActionRelocate))).To(Succeed())
 				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Relocated)
 			})
 		})
@@ -2733,9 +2747,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("HubRecovery: DRAction is Relocate -> Secondary Down", func() {
 			It("Should Continue given the primary East1ManagedCluster is up", func() {
 				setClusterDown(West1ManagedCluster)
-				clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)
-				clearDRPCStatus()
-
+				Expect(clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
+				Expect(clearDRPCStatus()).To(Succeed())
 				expectedAction := rmn.ActionRelocate
 				expectedPhase := rmn.DRState("")
 				expectedPorgression := rmn.ProgressionStatus("")
@@ -2743,7 +2756,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 				// User intervention is required (simulate user intervention)
 				resetClusterDown()
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionRelocate)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionRelocate)).To(Succeed())
 				expectedAction = rmn.ActionRelocate
 				expectedPhase = rmn.Relocated
 				expectedPorgression = rmn.ProgressionCompleted
@@ -2764,10 +2777,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("HubRecovery: DRAction is supposed to be Relocate -> Primary Down -> Action Cleared", func() {
 			It("Should Pause given the primary East1ManagedCluster is down, but allow failover", func() {
 				setClusterDown(East1ManagedCluster)
-				clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)
-				clearDRPCStatus()
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, "")
-
+				Expect(clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
+				Expect(clearDRPCStatus()).To(Succeed())
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, "")).To(Succeed())
 				expectedAction := rmn.DRAction("")
 				expectedPhase := rmn.WaitForUser
 				expectedPorgression := rmn.ProgressionActionPaused
@@ -2776,7 +2788,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 				// User intervention is required (simulate user intervention)
 				resetClusterDown()
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionRelocate)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionRelocate)).To(Succeed())
 				expectedAction = rmn.ActionRelocate
 				expectedPhase = rmn.Relocated
 				expectedPorgression = rmn.ProgressionCompleted
@@ -2838,7 +2850,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				userPlacementRule1 = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule1).NotTo(BeNil())
 				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)
-				uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(""))
+				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(""))).To(Succeed())
 				resetToggleUIDChecks()
 			})
 		})
@@ -3127,15 +3139,17 @@ func checkConditionAllowFailover(namespace string) {
 }
 
 //nolint:unparam
-func uploadVRGtoS3Store(name, namespace, dstCluster string, action rmn.VRGAction) {
+func uploadVRGtoS3Store(name, namespace, dstCluster string, action rmn.VRGAction) error {
 	vrg := buildVRG(name, namespace, dstCluster, action)
 	s3ProfileNames := []string{s3Profiles[0].S3ProfileName, s3Profiles[1].S3ProfileName}
 
 	objectStorer, _, err := drpcReconciler.ObjStoreGetter.ObjectStore(
 		ctx, apiReader, s3ProfileNames[0], "Hub Recovery", testLogger)
+	if err != nil {
+		return err
+	}
 
-	Expect(err).ToNot(HaveOccurred())
-	Expect(controllers.VrgObjectProtect(objectStorer, vrg)).To(Succeed())
+	return controllers.VrgObjectProtect(objectStorer, vrg)
 }
 
 // drpcRenconcile calls the drpc reconciler with the given drpc name and

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -524,7 +524,7 @@ func fakeVRGWithMModesProtectedPVC(vrgNamespace string) *rmn.VolumeReplicationGr
 	return vrg
 }
 
-func createPlacementRule(name, namespace string) *plrv1.PlacementRule {
+func createPlacementRule(name, namespace string) (*plrv1.PlacementRule, error) {
 	namereq := metav1.LabelSelectorRequirement{}
 	namereq.Key = "key1"
 	namereq.Operator = metav1.LabelSelectorOpIn
@@ -548,12 +548,14 @@ func createPlacementRule(name, namespace string) *plrv1.PlacementRule {
 	}
 
 	err := k8sClient.Create(context.TODO(), placementRule)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, err
+	}
 
-	return placementRule
+	return placementRule, nil
 }
 
-func createPlacement(name, namespace string) *clrapiv1beta1.Placement {
+func createPlacement(name, namespace string) (*clrapiv1beta1.Placement, error) {
 	var numberOfClustersToDeployTo int32 = 1
 
 	placement := &clrapiv1beta1.Placement{
@@ -571,12 +573,14 @@ func createPlacement(name, namespace string) *clrapiv1beta1.Placement {
 	}
 
 	err := k8sClient.Create(context.TODO(), placement)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, err
+	}
 
-	return placement
+	return placement, nil
 }
 
-func createDRPC(placementName, name, namespace, drPolicyName, preferredCluster string) *rmn.DRPlacementControl {
+func createDRPC(placementName, name, namespace, drPolicyName, preferredCluster string) (*rmn.DRPlacementControl, error) {
 	drpc := &rmn.DRPlacementControl{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -599,9 +603,11 @@ func createDRPC(placementName, name, namespace, drPolicyName, preferredCluster s
 			PreferredCluster:     preferredCluster,
 		},
 	}
-	Expect(k8sClient.Create(context.TODO(), drpc)).Should(Succeed())
+	if err := k8sClient.Create(context.TODO(), drpc); err != nil {
+		return nil, err
+	}
 
-	return drpc
+	return drpc, nil
 }
 
 //nolint:unparam
@@ -729,23 +735,32 @@ func clearFakeUserPlacementRuleStatus(name, namespace string) {
 	Expect(retryErr).NotTo(HaveOccurred())
 }
 
-func createNamespace(ns *corev1.Namespace) {
+func createNamespace(ns *corev1.Namespace) error {
 	nsName := types.NamespacedName{Name: ns.Name}
 
 	err := k8sClient.Get(context.TODO(), nsName, &corev1.Namespace{})
 	if err != nil {
-		Expect(k8sClient.Create(context.TODO(), ns)).NotTo(HaveOccurred(),
-			"failed to create %v managed cluster namespace", ns.Name)
+		if err := k8sClient.Create(context.TODO(), ns); err != nil {
+			return fmt.Errorf("failed to create %v managed cluster namespace: %w", ns.Name, err)
+		}
 	}
+
+	return nil
 }
 
-func createNamespacesAsync(appNamespace *corev1.Namespace) {
-	createNamespace(east1ManagedClusterNamespace)
-	createNamespace(west1ManagedClusterNamespace)
-	createNamespace(appNamespace)
+func createNamespacesAsync(appNamespace *corev1.Namespace) error {
+	if err := createNamespace(east1ManagedClusterNamespace); err != nil {
+		return err
+	}
+
+	if err := createNamespace(west1ManagedClusterNamespace); err != nil {
+		return err
+	}
+
+	return createNamespace(appNamespace)
 }
 
-func createManagedClusters(managedClusters []*spokeClusterV1.ManagedCluster) {
+func createManagedClusters(managedClusters []*spokeClusterV1.ManagedCluster) error {
 	for _, cl := range managedClusters {
 		mcLookupKey := types.NamespacedName{Name: cl.Name}
 		mcObj := &spokeClusterV1.ManagedCluster{}
@@ -755,7 +770,9 @@ func createManagedClusters(managedClusters []*spokeClusterV1.ManagedCluster) {
 			clinstance := cl.DeepCopy()
 
 			err := k8sClient.Create(context.TODO(), clinstance)
-			Expect(err).NotTo(HaveOccurred())
+			if err != nil {
+				return err
+			}
 
 			updateManagedClusterStatus(k8sClient, clinstance)
 
@@ -764,6 +781,8 @@ func createManagedClusters(managedClusters []*spokeClusterV1.ManagedCluster) {
 
 		updateManagedClusterStatus(k8sClient, mcObj)
 	}
+
+	return nil
 }
 
 func populateDRClusters() {
@@ -799,37 +818,47 @@ func populateDRClusters() {
 	)
 }
 
-func createDRClusters(inClusters []*spokeClusterV1.ManagedCluster) {
+func createDRClusters(inClusters []*spokeClusterV1.ManagedCluster) error {
 	for _, managedCluster := range inClusters {
 		for idx := range drClusters {
 			if managedCluster.Name == drClusters[idx].Name {
 				err := k8sClient.Create(context.TODO(), &drClusters[idx])
-				Expect(err).NotTo(HaveOccurred())
+				if err != nil {
+					return err
+				}
+
 				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drClusters[idx].Name)
 				updateDRClusterConfigMWStatus(k8sClient, apiReader, drClusters[idx].Name)
 			}
 		}
 	}
+
+	return nil
 }
 
-func createPlacementDecision() {
+func createPlacementDecision() error {
 	deletePlacementDecision()
 
 	plDecision := placementDecision.DeepCopy()
-	err := k8sClient.Create(context.TODO(), plDecision)
-	Expect(err).NotTo(HaveOccurred())
+
+	return k8sClient.Create(context.TODO(), plDecision)
 }
 
-func createDRClustersAsync() {
-	createDRClusters(asyncClusters)
+func createDRClustersAsync() error {
+	return createDRClusters(asyncClusters)
 }
 
-func createDRPolicy(inDRPolicy *rmn.DRPolicy) {
+func createDRPolicy(inDRPolicy *rmn.DRPolicy) error {
 	err := k8sClient.Create(context.TODO(), inDRPolicy)
-	Expect(err).NotTo(HaveOccurred())
-	Eventually(func() bool {
+	if err != nil {
+		return err
+	}
+
+	return waitForCondition(timeout, interval, "waiting for DRPolicy to be validated", func() bool {
 		drpolicy := &rmn.DRPolicy{}
-		Expect(apiReader.Get(context.TODO(), types.NamespacedName{Name: inDRPolicy.Name}, drpolicy)).To(Succeed())
+		if err := apiReader.Get(context.TODO(), types.NamespacedName{Name: inDRPolicy.Name}, drpolicy); err != nil {
+			return false
+		}
 
 		for _, condition := range drpolicy.Status.Conditions {
 			if condition.Type != rmn.DRPolicyValidated {
@@ -848,17 +877,17 @@ func createDRPolicy(inDRPolicy *rmn.DRPolicy) {
 		}
 
 		return false
-	}, timeout, interval).Should(BeTrue())
+	})
 }
 
-func createDRPolicyAsync() {
+func createDRPolicyAsync() error {
 	policy := asyncDRPolicy.DeepCopy()
-	createDRPolicy(policy)
+
+	return createDRPolicy(policy)
 }
 
-func createAppSet() {
-	err := k8sClient.Create(context.TODO(), &appSet)
-	Expect(err).NotTo(HaveOccurred())
+func createAppSet() error {
+	return k8sClient.Create(context.TODO(), &appSet)
 }
 
 func deleteAppSet() {
@@ -907,7 +936,7 @@ func deleteDRPolicyAsync() {
 
 // createVRGMW creates a basic (always Primary) ManifestWork for a VRG, used to fake existing VRG MW
 // to test upgrade cases for DRPC based UID adoption
-func createVRGMW(name, namespace, homeCluster string) {
+func createVRGMW(name, namespace, homeCluster string) error {
 	vrg := getDefaultVRG(namespace)
 	vrg.Generation = 1
 
@@ -921,7 +950,8 @@ func createVRGMW(name, namespace, homeCluster string) {
 	}
 
 	_, err := mwu.CreateOrUpdateVRGManifestWork(name, namespace, homeCluster, *vrg, nil)
-	Expect(err).To(Succeed())
+
+	return err
 }
 
 func updateManifestWorkStatus(clusterNamespace, vrgNamespace, mwType, workType string) {
@@ -1041,12 +1071,12 @@ const (
 func InitialDeploymentAsync(namespace, placementName, homeCluster string, plType PlacementType) (
 	client.Object, *rmn.DRPlacementControl,
 ) {
-	createNamespacesAsync(getNamespaceObj(namespace))
+	Expect(createNamespacesAsync(getNamespaceObj(namespace))).To(Succeed())
 
-	createManagedClusters(asyncClusters)
-	createDRClustersAsync()
-	createDRPolicyAsync()
-	createPlacementDecision()
+	Expect(createManagedClusters(asyncClusters)).To(Succeed())
+	Expect(createDRClustersAsync()).To(Succeed())
+	Expect(createDRPolicyAsync()).To(Succeed())
+	Expect(createPlacementDecision()).To(Succeed())
 
 	return CreatePlacementAndDRPC(namespace, placementName, homeCluster, plType)
 }
@@ -1056,29 +1086,40 @@ func CreatePlacementAndDRPC(namespace, placementName, homeCluster string, plType
 ) {
 	var placementObj client.Object
 
+	var err error
+
 	switch plType {
 	case UsePlacementRule:
-		placementObj = createPlacementRule(placementName, namespace)
+		placementObj, err = createPlacementRule(placementName, namespace)
+		Expect(err).NotTo(HaveOccurred())
 	case UsePlacementWithSubscription:
-		placementObj = createPlacement(placementName, namespace)
+		placementObj, err = createPlacement(placementName, namespace)
+		Expect(err).NotTo(HaveOccurred())
 	case UsePlacementWithAppSet:
-		createAppSet()
+		Expect(createAppSet()).To(Succeed())
 
-		placementObj = createPlacement(placementName, namespace)
+		placementObj, err = createPlacement(placementName, namespace)
+		Expect(err).NotTo(HaveOccurred())
 	default:
 		Fail("Wrong placement type")
 	}
 
-	return placementObj, createDRPC(placementName, DRPCCommonName, namespace, AsyncDRPolicyName, homeCluster)
+	drpc, err := createDRPC(placementName, DRPCCommonName, namespace, AsyncDRPolicyName, homeCluster)
+	Expect(err).NotTo(HaveOccurred())
+
+	return placementObj, drpc
 }
 
 func FollowOnDeploymentAsync(namespace, placementName, homeCluster string) (*plrv1.PlacementRule,
 	*rmn.DRPlacementControl,
 ) {
-	createNamespace(appNamespace2)
+	Expect(createNamespace(appNamespace2)).To(Succeed())
 
-	placementRule := createPlacementRule(placementName, namespace)
-	drpc := createDRPC(placementName, DRPCCommonName, namespace, AsyncDRPolicyName, homeCluster)
+	placementRule, err := createPlacementRule(placementName, namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	drpc, err := createDRPC(placementName, DRPCCommonName, namespace, AsyncDRPolicyName, homeCluster)
+	Expect(err).NotTo(HaveOccurred())
 
 	return placementRule, drpc
 }
@@ -1568,34 +1609,44 @@ func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster
 	waitForCompletion(string(rmn.FailedOver))
 }
 
-func createNamespacesSync() {
-	createNamespace(east1ManagedClusterNamespace)
-	createNamespace(east2ManagedClusterNamespace)
-	createNamespace(appNamespace)
+func createNamespacesSync() error {
+	if err := createNamespace(east1ManagedClusterNamespace); err != nil {
+		return err
+	}
+
+	if err := createNamespace(east2ManagedClusterNamespace); err != nil {
+		return err
+	}
+
+	return createNamespace(appNamespace)
 }
 
 func InitialDeploymentSync(namespace, placementName, homeCluster string) (*plrv1.PlacementRule,
 	*rmn.DRPlacementControl,
 ) {
-	createNamespacesSync()
+	Expect(createNamespacesSync()).To(Succeed())
 
-	createManagedClusters(syncClusters)
-	createDRClustersSync()
-	createDRPolicySync()
+	Expect(createManagedClusters(syncClusters)).To(Succeed())
+	Expect(createDRClustersSync()).To(Succeed())
+	Expect(createDRPolicySync()).To(Succeed())
 
-	placementRule := createPlacementRule(placementName, namespace)
-	drpc := createDRPC(UserPlacementRuleName, DRPCCommonName, DefaultDRPCNamespace, SyncDRPolicyName, homeCluster)
+	placementRule, err := createPlacementRule(placementName, namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	drpc, err := createDRPC(UserPlacementRuleName, DRPCCommonName, DefaultDRPCNamespace, SyncDRPolicyName, homeCluster)
+	Expect(err).NotTo(HaveOccurred())
 
 	return placementRule, drpc
 }
 
-func createDRClustersSync() {
-	createDRClusters(syncClusters)
+func createDRClustersSync() error {
+	return createDRClusters(syncClusters)
 }
 
-func createDRPolicySync() {
+func createDRPolicySync() error {
 	policy := syncDRPolicy.DeepCopy()
-	createDRPolicy(policy)
+
+	return createDRPolicy(policy)
 }
 
 func deleteDRClustersSync() {
@@ -2510,10 +2561,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		When("Application deployed for the first time", func() {
 			It("Should deploy drpc", func() {
-				createNamespacesAsync(getNamespaceObj(DefaultDRPCNamespace))
-				createManagedClusters(asyncClusters)
-				createDRClustersAsync()
-				createDRPolicyAsync()
+				Expect(createNamespacesAsync(getNamespaceObj(DefaultDRPCNamespace))).To(Succeed())
+				Expect(createManagedClusters(asyncClusters)).To(Succeed())
+				Expect(createDRClustersAsync()).To(Succeed())
+				Expect(createDRPolicyAsync()).To(Succeed())
 
 				var placementObj client.Object
 
@@ -2733,15 +2784,15 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 		When("Application deployed for the first time", func() {
 			It("Should deploy drpc", func() {
-				createNamespacesAsync(getNamespaceObj(DefaultDRPCNamespace))
-				createManagedClusters(asyncClusters)
-				createDRClustersAsync()
-				createDRPolicyAsync()
+				Expect(createNamespacesAsync(getNamespaceObj(DefaultDRPCNamespace))).To(Succeed())
+				Expect(createManagedClusters(asyncClusters)).To(Succeed())
+				Expect(createDRClustersAsync()).To(Succeed())
+				Expect(createDRPolicyAsync()).To(Succeed())
 				setToggleUIDChecks()
 
 				// Create an existing VRG MW on East, to simulate upgrade cases (West1 will report an
 				// orphan VRG for orphan cases)
-				createVRGMW(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster)
+				Expect(createVRGMW(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster)).To(Succeed())
 
 				var placementObj client.Object
 

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -611,22 +611,43 @@ func createDRPC(placementName, name, namespace, drPolicyName, preferredCluster s
 }
 
 //nolint:unparam
-func deleteUserPlacementRule(name, namespace string) {
+func deleteUserPlacementRule(name, namespace string) error {
 	userPlacementRule, err := getLatestUserPlacementRule(name, namespace)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient.Delete(context.TODO(), userPlacementRule)).Should(Succeed())
+	if err != nil {
+		return err
+	}
+
+	if err := k8sClient.Delete(context.TODO(), userPlacementRule); err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func deleteUserPlacement() {
+func deleteUserPlacement() error {
 	userPlacement, err := getLatestUserPlacement(UserPlacementName, DefaultDRPCNamespace)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient.Delete(context.TODO(), userPlacement)).Should(Succeed())
+	if err != nil {
+		return err
+	}
+
+	if err := k8sClient.Delete(context.TODO(), userPlacement); err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func deleteDRPC() {
+func deleteDRPC() error {
 	drpc, err := getLatestDRPC(DefaultDRPCNamespace)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient.Delete(context.TODO(), drpc)).Should(Succeed())
+	if err != nil {
+		return err
+	}
+
+	if err := k8sClient.Delete(context.TODO(), drpc); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func ensureNamespaceMWsDeletedFromAllClusters(namespace string) {
@@ -837,7 +858,9 @@ func createDRClusters(inClusters []*spokeClusterV1.ManagedCluster) error {
 }
 
 func createPlacementDecision() error {
-	deletePlacementDecision()
+	if err := deletePlacementDecision(); err != nil {
+		return err
+	}
 
 	plDecision := placementDecision.DeepCopy()
 
@@ -890,48 +913,60 @@ func createAppSet() error {
 	return k8sClient.Create(context.TODO(), &appSet)
 }
 
-func deleteAppSet() {
-	Expect(k8sClient.Delete(context.TODO(), &appSet)).To(Succeed())
+func deleteAppSet() error {
+	if err := k8sClient.Delete(context.TODO(), &appSet); err != nil {
+		return err
+	}
 
-	Eventually(func() bool {
+	return waitForCondition(timeout, interval, "waiting for AppSet to be deleted", func() bool {
 		resource := &argocdv1alpha1hack.ApplicationSet{}
 
 		return k8serrors.IsNotFound(apiReader.Get(context.TODO(), types.NamespacedName{
 			Namespace: appSet.Namespace,
 			Name:      appSet.Name,
 		}, resource))
-	}, timeout, interval).Should(BeTrue())
+	})
 }
 
-func deleteDRCluster(inDRCluster *rmn.DRCluster) {
-	Expect(k8sClient.Delete(context.TODO(), inDRCluster)).To(Succeed())
+func deleteDRCluster(inDRCluster *rmn.DRCluster) error {
+	if err := k8sClient.Delete(context.TODO(), inDRCluster); err != nil {
+		return err
+	}
 
-	Eventually(func() bool {
+	return waitForCondition(timeout, interval, "waiting for DRCluster to be deleted", func() bool {
 		drcluster := &rmn.DRCluster{}
 
 		return k8serrors.IsNotFound(apiReader.Get(context.TODO(), types.NamespacedName{
 			Namespace: inDRCluster.Namespace,
 			Name:      inDRCluster.Name,
 		}, drcluster))
-	}, timeout, interval).Should(BeTrue())
+	})
 }
 
-func deleteDRClusters(inClusters []*spokeClusterV1.ManagedCluster) {
+func deleteDRClusters(inClusters []*spokeClusterV1.ManagedCluster) error {
 	for _, managedCluster := range inClusters {
 		for idx := range drClusters {
 			if managedCluster.Name == drClusters[idx].Name {
-				deleteDRCluster(&drClusters[idx])
+				if err := deleteDRCluster(&drClusters[idx]); err != nil {
+					return err
+				}
 			}
 		}
 	}
+
+	return nil
 }
 
-func deleteDRClustersAsync() {
-	deleteDRClusters(asyncClusters)
+func deleteDRClustersAsync() error {
+	return deleteDRClusters(asyncClusters)
 }
 
-func deleteDRPolicyAsync() {
-	Expect(k8sClient.Delete(context.TODO(), asyncDRPolicy)).To(Succeed())
+func deleteDRPolicyAsync() error {
+	if err := k8sClient.Delete(context.TODO(), asyncDRPolicy); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // createVRGMW creates a basic (always Primary) ManifestWork for a VRG, used to fake existing VRG MW
@@ -1649,26 +1684,31 @@ func createDRPolicySync() error {
 	return createDRPolicy(policy)
 }
 
-func deleteDRClustersSync() {
-	deleteDRClusters(syncClusters)
+func deleteDRClustersSync() error {
+	return deleteDRClusters(syncClusters)
 }
 
-func deleteDRPolicySync() {
-	Expect(k8sClient.Delete(context.TODO(), getSyncDRPolicy())).To(Succeed())
+func deleteDRPolicySync() error {
+	if err := k8sClient.Delete(context.TODO(), getSyncDRPolicy()); err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func deletePlacementDecision() {
-	err := k8sClient.Delete(context.TODO(), placementDecision)
-	Expect(client.IgnoreNotFound(err)).To(Succeed())
+func deletePlacementDecision() error {
+	if err := client.IgnoreNotFound(k8sClient.Delete(context.TODO(), placementDecision)); err != nil {
+		return err
+	}
 
-	Eventually(func() bool {
+	return waitForCondition(timeout, interval, "waiting for PlacementDecision to be deleted", func() bool {
 		resource := &clrapiv1beta1.PlacementDecision{}
 
 		return k8serrors.IsNotFound(apiReader.Get(context.TODO(), types.NamespacedName{
 			Namespace: placementDecision.Namespace,
 			Name:      placementDecision.Name,
 		}, resource))
-	}, timeout, interval).Should(BeTrue())
+	})
 }
 
 func fenceCluster(cluster string, manual bool) {
@@ -1983,12 +2023,12 @@ var _ = Describe("DRPlacementControl - Ensure do-not-delete PVC Annotation", fun
 			Expect(err).To(BeNil())
 
 			if plType == UsePlacementRule {
-				deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+				Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 			} else {
-				deleteUserPlacement()
+				Expect(deleteUserPlacement()).To(Succeed())
 			}
 
-			deleteDRPC()
+			Expect(deleteDRPC()).To(Succeed())
 		})
 	}
 
@@ -2067,7 +2107,7 @@ var _ = Describe("DRPlacementControl Reconciler Errors", func() {
 			err := retry.RetryOnConflict(retry.DefaultBackoff, deleteAllDRClusters)
 			Expect(err).ToNot(HaveOccurred())
 
-			deleteDRPC()
+			Expect(deleteDRPC()).To(Succeed())
 
 			errCount := 0
 
@@ -2171,7 +2211,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
 				// ----------------------------- DELETE DRPolicy  --------------------------------------
 				By("\n\n*** DELETE drpolicy ***\n\n")
-				deleteDRPolicyAsync()
+				Expect(deleteDRPolicyAsync()).To(Succeed())
 				ensureDRPolicyIsNotDeleted(drpc)
 			})
 		})
@@ -2186,7 +2226,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should cleanup DRPC", func() {
 				// ----------------------------- DELETE DRPC from PRIMARY --------------------------------------
 				By("\n\n*** DELETE User PlacementRule ***\n\n")
-				deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+				Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 
@@ -2200,7 +2240,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				drpolicyName = drpc.Spec.DRPolicyRef.Name
 
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG MW
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
@@ -2212,7 +2252,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			})
 		})
 		Specify("delete drclusters", func() {
-			deleteDRClustersAsync()
+			Expect(deleteDRClustersAsync()).To(Succeed())
 		})
 	})
 	// TEST WITH Placement AND Subscription
@@ -2266,14 +2306,13 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		When("Deleting DRPolicy with DRPC references when using Placement", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
-				deleteDRPolicyAsync()
+				Expect(deleteDRPolicyAsync()).To(Succeed())
 				ensureDRPolicyIsNotDeleted(drpc)
 			})
 		})
 		When("Deleting user Placement", func() {
 			It("Should cleanup DRPC", func() {
-				deleteUserPlacement()
-
+				Expect(deleteUserPlacement()).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
 				_, condition := getDRPCCondition(&latestDRPC.Status, rmn.ConditionPeerReady)
@@ -2283,7 +2322,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting DRPC when using Placement", func() {
 			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG + NS MW
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
@@ -2295,7 +2334,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			})
 		})
 		Specify("delete drclusters when using Placement", func() {
-			deleteDRClustersAsync()
+			Expect(deleteDRClustersAsync()).To(Succeed())
 		})
 	})
 	// TEST WITH Placement AND ApplicationSet
@@ -2364,14 +2403,13 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		When("Deleting DRPolicy with DRPC references when using Placement", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
-				deleteDRPolicyAsync()
+				Expect(deleteDRPolicyAsync()).To(Succeed())
 				ensureDRPolicyIsNotDeleted(drpc)
 			})
 		})
 		When("Deleting user Placement", func() {
 			It("Should cleanup DRPC", func() {
-				deleteUserPlacement()
-
+				Expect(deleteUserPlacement()).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
 				_, condition := getDRPCCondition(&latestDRPC.Status, rmn.ConditionPeerReady)
@@ -2381,13 +2419,12 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting DRPC when using Placement", func() {
 			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG + NS MW
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
 				ensureNamespaceMWsDeletedFromAllClusters(ApplicationNamespace)
-				deleteAppSet()
-
+				Expect(deleteAppSet()).To(Succeed())
 				UseApplicationSet = false
 			})
 			It("should delete the DRPC causing its referenced drpolicy to be deleted"+
@@ -2396,7 +2433,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			})
 		})
 		Specify("delete drclusters when using Placement", func() {
-			deleteDRClustersAsync()
+			Expect(deleteDRClustersAsync()).To(Succeed())
 		})
 	})
 	Context("DRPlacementControl Reconciler Sync DR", func() {
@@ -2463,17 +2500,17 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting user PlacementRule", func() {
 			It("Should cleanup DRPC", func() {
 				By("\n\n*** DELETE User PlacementRule ***\n\n")
-				deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+				Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 		When("Deleting DRPC", func() {
 			It("Should delete VRG from Primary (East1ManagedCluster)", func() {
 				By("\n\n*** DELETE DRPC ***\n\n")
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1)) // DRCluster
-				deleteDRPolicySync()
-				deleteDRClustersSync()
+				Expect(deleteDRPolicySync()).To(Succeed())
+				Expect(deleteDRClustersSync()).To(Succeed())
 			})
 		})
 
@@ -2535,7 +2572,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting user PlacementRule", func() {
 			It("Should cleanup DRPC", func() {
 				By("\n\n*** DELETE User PlacementRule ***\n\n")
-				deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+				Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 
@@ -2543,11 +2580,11 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should delete VRG from Primary (East1ManagedCluster)", func() {
 				By("\n\n*** DELETE DRPC ***\n\n")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + NS + VRG MW
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1)) // DRCluster
-				deleteDRPolicySync()
-				deleteDRClustersSync()
+				Expect(deleteDRPolicySync()).To(Succeed())
+				Expect(deleteDRClustersSync()).To(Succeed())
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
 			})
 		})
@@ -2752,26 +2789,26 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
 				// ----------------------------- DELETE DRPolicy  --------------------------------------
 				By("\n\n*** DELETE drpolicy ***\n\n")
-				deleteDRPolicyAsync()
+				Expect(deleteDRPolicyAsync()).To(Succeed())
 			})
 		})
 		When("Deleting user PlacementRule", func() {
 			It("Should cleanup DRPC", func() {
 				// ----------------------------- DELETE DRPC from PRIMARY --------------------------------------
 				By("\n\n*** DELETE User PlacementRule ***\n\n")
-				deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+				Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 
 		When("Deleting DRPC", func() {
 			It("Should delete all VRGs", func() {
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
 			})
 		})
 		Specify("delete drclusters", func() {
-			deleteDRClustersAsync()
+			Expect(deleteDRClustersAsync()).To(Succeed())
 		})
 	})
 
@@ -2809,27 +2846,27 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting DRPolicy with DRPC references", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
 				By("\n\n*** DELETE drpolicy ***\n\n")
-				deleteDRPolicyAsync()
+				Expect(deleteDRPolicyAsync()).To(Succeed())
 			})
 		})
 
 		When("Deleting user PlacementRule", func() {
 			It("Should cleanup DRPC", func() {
 				By("\n\n*** DELETE User PlacementRule ***\n\n")
-				deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+				Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 
 		When("Deleting DRPC", func() {
 			It("Should delete all VRGs", func() {
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
 			})
 		})
 
 		Specify("delete drclusters", func() {
-			deleteDRClustersAsync()
+			Expect(deleteDRClustersAsync()).To(Succeed())
 		})
 	})
 
@@ -2963,20 +3000,20 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		When("Deleting DRPolicy with DRPC references", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
-				deleteDRPolicyAsync()
+				Expect(deleteDRPolicyAsync()).To(Succeed())
 				ensureDRPolicyIsNotDeleted(drpc)
 			})
 		})
 		When("Deleting user PlacementRule", func() {
 			It("Should cleanup DRPC", func() {
-				deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+				Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 
 		When("Deleting DRPC", func() {
 			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG MW
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
@@ -2989,8 +3026,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		Specify("delete drclusters", func() {
 			RunningVolSyncTests = false
-
-			deleteDRClustersAsync()
+			Expect(deleteDRClustersAsync()).To(Succeed())
 		})
 	})
 })

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/format"
 	. "github.com/onsi/gomega/gstruct"
 	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -650,7 +649,7 @@ func deleteDRPC() error {
 	return nil
 }
 
-func ensureNamespaceMWsDeletedFromAllClusters(namespace string) {
+func ensureNamespaceMWsDeletedFromAllClusters(namespace string) error {
 	foundMW := &ocmworkv1.ManifestWork{}
 	mwName := fmt.Sprintf(rmnutil.ManifestWorkNameFormat, DRPCCommonName, namespace, rmnutil.MWTypeNS)
 
@@ -658,15 +657,17 @@ func ensureNamespaceMWsDeletedFromAllClusters(namespace string) {
 		types.NamespacedName{Name: mwName, Namespace: East1ManagedCluster},
 		foundMW)
 	if err == nil {
-		Expect(foundMW).To(BeNil())
+		return fmt.Errorf("namespace MW still exists on %s", East1ManagedCluster)
 	}
 
 	err = k8sClient.Get(context.TODO(),
 		types.NamespacedName{Name: mwName, Namespace: West1ManagedCluster},
 		foundMW)
 	if err == nil {
-		Expect(foundMW).To(BeNil())
+		return fmt.Errorf("namespace MW still exists on %s", West1ManagedCluster)
 	}
+
+	return nil
 }
 
 func setDRPCSpecExpectationTo(namespace, preferredCluster, failoverCluster string, action rmn.DRAction) error {
@@ -1061,43 +1062,40 @@ func updateManifestWorkStatus(clusterNamespace, vrgNamespace, mwType, workType s
 		})
 }
 
-func ensureDRPolicyIsNotDeleted(drpc *rmn.DRPlacementControl) {
-	Consistently(func() bool {
+func ensureDRPolicyIsNotDeleted(drpc *rmn.DRPlacementControl) error {
+	msg := "DRPolicy deleted prematurely, with active DRPC references"
+
+	return ensureConsistent(timeout, interval, msg, func() bool {
 		drpolicy := &rmn.DRPolicy{}
 		name := drpc.Spec.DRPolicyRef.Name
 		err := apiReader.Get(context.TODO(), types.NamespacedName{Name: name}, drpolicy)
 		// TODO: Technically we need to Expect deletion TS is non-zero as well here!
 		return err == nil
-	}, timeout, interval).Should(BeTrue(), "DRPolicy deleted prematurely, with active DRPC references")
+	})
 }
 
-func ensureDRPolicyIsDeleted(drpolicyName string) {
-	drpolicy := &rmn.DRPolicy{}
-	Eventually(func() error {
-		return apiReader.Get(context.TODO(), types.NamespacedName{Name: drpolicyName}, drpolicy)
-	}, timeout, interval).Should(
-		MatchError(
-			k8serrors.NewNotFound(
-				schema.GroupResource{
-					Group:    rmn.GroupVersion.Group,
-					Resource: "drpolicies",
-				},
-				drpolicyName,
-			),
-		),
-		"DRPolicy %s not found\n%s",
-		drpolicyName,
-		format.Object(*drpolicy, 0),
-	)
+func ensureDRPolicyIsDeleted(drpolicyName string) error {
+	msg := fmt.Sprintf("DRPolicy %s not deleted", drpolicyName)
+
+	return waitForCondition(timeout, interval, msg, func() bool {
+		drpolicy := &rmn.DRPolicy{}
+		err := apiReader.Get(context.TODO(), types.NamespacedName{Name: drpolicyName}, drpolicy)
+
+		return k8serrors.IsNotFound(err)
+	})
 }
 
-func checkIfDRPCFinalizerNotAdded(drpc *rmn.DRPlacementControl) {
-	Consistently(func() bool {
+func checkIfDRPCFinalizerNotAdded(drpc *rmn.DRPlacementControl) error {
+	msg := "DRPlacementControl reconciled with a finalizer when DRPolicy is in a deleted state"
+
+	return ensureConsistent(timeout, interval, msg, func() bool {
 		drpcl := &rmn.DRPlacementControl{}
 		err := apiReader.Get(context.TODO(),
 			types.NamespacedName{Name: drpc.Name, Namespace: drpc.Namespace},
 			drpcl)
-		Expect(err).NotTo(HaveOccurred())
+		if err != nil {
+			return false
+		}
 
 		f := drpcl.GetFinalizers()
 		for _, e := range f {
@@ -1107,8 +1105,7 @@ func checkIfDRPCFinalizerNotAdded(drpc *rmn.DRPlacementControl) {
 		}
 
 		return true
-	}, timeout, interval).Should(BeTrue(), "DRPlacementControl reconciled with a finalizer",
-		"when DRPolicy is in a deleted state")
+	})
 }
 
 type PlacementType int
@@ -1175,35 +1172,37 @@ func FollowOnDeploymentAsync(namespace, placementName, homeCluster string) (*plr
 	return placementRule, drpc
 }
 
-func verifyVRGManifestWorkCreatedAsPrimary(namespace, managedCluster string) {
+func verifyVRGManifestWorkCreatedAsPrimary(namespace, managedCluster string) error {
 	vrgManifestLookupKey := types.NamespacedName{
 		Name:      rmnutil.DrClusterManifestWorkName,
 		Namespace: managedCluster,
 	}
 	createdVRGRolesManifest := &ocmworkv1.ManifestWork{}
 
-	Eventually(func() bool {
+	if err := waitForCondition(timeout, interval, "waiting for VRG roles manifest", func() bool {
 		err := k8sClient.Get(context.TODO(), vrgManifestLookupKey, createdVRGRolesManifest)
 
 		return err == nil
-	}, timeout, interval).Should(BeTrue())
+	}); err != nil {
+		return err
+	}
 
-	Expect(len(createdVRGRolesManifest.Spec.Workload.Manifests)).To(Equal(10))
+	if len(createdVRGRolesManifest.Spec.Workload.Manifests) != 10 {
+		return fmt.Errorf("expected 10 manifests, got %d", len(createdVRGRolesManifest.Spec.Workload.Manifests))
+	}
 
 	vrgClusterRoleManifest := createdVRGRolesManifest.Spec.Workload.Manifests[0]
-	Expect(vrgClusterRoleManifest).ToNot(BeNil())
 
 	vrgClusterRole := &rbacv1.ClusterRole{}
-	err := yaml.Unmarshal(vrgClusterRoleManifest.RawExtension.Raw, &vrgClusterRole)
-	Expect(err).NotTo(HaveOccurred())
-
-	vrgClusterRoleBindingManifest := createdVRGRolesManifest.Spec.Workload.Manifests[1]
-	Expect(vrgClusterRoleBindingManifest).ToNot(BeNil())
+	if err := yaml.Unmarshal(vrgClusterRoleManifest.RawExtension.Raw, &vrgClusterRole); err != nil {
+		return fmt.Errorf("failed to unmarshal VRG ClusterRole: %w", err)
+	}
 
 	vrgClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 
-	err = yaml.Unmarshal(vrgClusterRoleManifest.RawExtension.Raw, &vrgClusterRoleBinding)
-	Expect(err).NotTo(HaveOccurred())
+	if err := yaml.Unmarshal(vrgClusterRoleManifest.RawExtension.Raw, &vrgClusterRoleBinding); err != nil {
+		return fmt.Errorf("failed to unmarshal VRG ClusterRoleBinding: %w", err)
+	}
 
 	manifestLookupKey := types.NamespacedName{
 		Name:      rmnutil.ManifestWorkName(DRPCCommonName, getVRGNamespace(namespace), "vrg"),
@@ -1212,30 +1211,51 @@ func verifyVRGManifestWorkCreatedAsPrimary(namespace, managedCluster string) {
 
 	mw := &ocmworkv1.ManifestWork{}
 
-	Eventually(func() bool {
-		err := k8sClient.Get(context.TODO(), manifestLookupKey, mw)
+	if err := waitForCondition(timeout, interval,
+		fmt.Sprintf("waiting for manifest work %+v", manifestLookupKey), func() bool {
+			err := k8sClient.Get(context.TODO(), manifestLookupKey, mw)
 
-		return err == nil
-	}, timeout, interval).Should(BeTrue(), fmt.Sprintf("manifestlookup %+v", manifestLookupKey))
+			return err == nil
+		}); err != nil {
+		return err
+	}
 
-	Expect(len(mw.Spec.Workload.Manifests)).To(Equal(1))
+	if len(mw.Spec.Workload.Manifests) != 1 {
+		return fmt.Errorf("expected 1 manifest, got %d", len(mw.Spec.Workload.Manifests))
+	}
 
 	vrgClientManifest := mw.Spec.Workload.Manifests[0]
 
-	Expect(vrgClientManifest).ToNot(BeNil())
-
 	vrg := &rmn.VolumeReplicationGroup{}
 
-	err = yaml.Unmarshal(vrgClientManifest.RawExtension.Raw, &vrg)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(vrg.Name).Should(Equal(DRPCCommonName))
-	Expect(vrg.Spec.PVCSelector.MatchLabels["appclass"]).Should(Equal("gold"))
-	Expect(vrg.Spec.ReplicationState).Should(Equal(rmn.Primary))
+	if err := yaml.Unmarshal(vrgClientManifest.RawExtension.Raw, &vrg); err != nil {
+		return fmt.Errorf("failed to unmarshal VRG: %w", err)
+	}
+
+	if vrg.Name != DRPCCommonName {
+		return fmt.Errorf("expected VRG name %s, got %s", DRPCCommonName, vrg.Name)
+	}
+
+	if vrg.Spec.PVCSelector.MatchLabels["appclass"] != "gold" {
+		return fmt.Errorf("expected PVCSelector appclass=gold, got %s", vrg.Spec.PVCSelector.MatchLabels["appclass"])
+	}
+
+	if vrg.Spec.ReplicationState != rmn.Primary {
+		return fmt.Errorf("expected ReplicationState Primary, got %s", vrg.Spec.ReplicationState)
+	}
 
 	// ensure DRPC copied KubeObjectProtection contents to VRG
 	drpc, err := getLatestDRPC(namespace)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(vrg.Spec.KubeObjectProtection).Should(Equal(drpc.Spec.KubeObjectProtection))
+	if err != nil {
+		return err
+	}
+
+	if vrg.Spec.KubeObjectProtection == nil && drpc.Spec.KubeObjectProtection != nil ||
+		vrg.Spec.KubeObjectProtection != nil && drpc.Spec.KubeObjectProtection == nil {
+		return fmt.Errorf("KubeObjectProtection mismatch between VRG and DRPC")
+	}
+
+	return nil
 }
 
 func getManifestWorkCount(homeClusterNamespace string) (int, error) {
@@ -1254,18 +1274,26 @@ func getManifestWorkCount(homeClusterNamespace string) (int, error) {
 	return len(manifestWorkList.Items) - 1, nil
 }
 
-func verifyNSManifestWork(resourceName, namespaceString, managedCluster string) {
+func verifyNSManifestWork(resourceName, namespaceString, managedCluster string) error {
 	mw := &ocmworkv1.ManifestWork{}
 	mwName := fmt.Sprintf(rmnutil.ManifestWorkNameFormat, resourceName, namespaceString, rmnutil.MWTypeNS)
 	err := k8sClient.Get(context.TODO(),
 		types.NamespacedName{Name: mwName, Namespace: managedCluster},
 		mw)
+	if err != nil {
+		return fmt.Errorf("failed to get NS ManifestWork %s: %w", mwName, err)
+	}
 
-	Expect(err).NotTo(HaveOccurred())
+	if mw.Spec.DeleteOption == nil {
+		return fmt.Errorf("NS ManifestWork %s DeleteOption is nil", mwName)
+	}
 
-	Expect(mw).ToNot(BeNil())
-	Expect(mw.Spec.DeleteOption).ToNot(BeNil())
-	Expect(mw.Labels[rmnutil.OCMBackupLabelKey]).To(Equal(""))
+	if mw.Labels[rmnutil.OCMBackupLabelKey] != "" {
+		return fmt.Errorf("NS ManifestWork %s OCMBackupLabelKey is %q, expected empty",
+			mwName, mw.Labels[rmnutil.OCMBackupLabelKey])
+	}
+
+	return nil
 }
 
 //nolint:unparam
@@ -1280,7 +1308,7 @@ func getManagedClusterViewCount(homeClusterNamespace string) (int, error) {
 	return len(mcvList.Items), nil
 }
 
-func verifyUserPlacementRuleDecision(name, namespace, homeCluster string) {
+func verifyUserPlacementRuleDecision(name, namespace, homeCluster string) error {
 	usrPlacementLookupKey := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -1290,7 +1318,7 @@ func verifyUserPlacementRuleDecision(name, namespace, homeCluster string) {
 
 	var placementObj client.Object
 
-	Eventually(func() bool {
+	if err := waitForCondition(timeout, interval, "waiting for placement decision", func() bool {
 		err := k8sClient.Get(context.TODO(), usrPlacementLookupKey, usrPlRule)
 		if k8serrors.IsNotFound(err) {
 			usrPlmnt := &clrapiv1beta1.Placement{}
@@ -1311,10 +1339,21 @@ func verifyUserPlacementRuleDecision(name, namespace, homeCluster string) {
 
 		return err == nil && len(usrPlRule.Status.Decisions) > 0 &&
 			usrPlRule.Status.Decisions[0].ClusterName == homeCluster
-	}, timeout, interval).Should(BeTrue())
+	}); err != nil {
+		return err
+	}
 
-	Expect(placementObj.GetAnnotations()[controllers.DRPCNameAnnotation]).Should(Equal(DRPCCommonName))
-	Expect(placementObj.GetAnnotations()[controllers.DRPCNamespaceAnnotation]).Should(Equal(namespace))
+	if placementObj.GetAnnotations()[controllers.DRPCNameAnnotation] != DRPCCommonName {
+		return fmt.Errorf("expected DRPCNameAnnotation %s, got %s",
+			DRPCCommonName, placementObj.GetAnnotations()[controllers.DRPCNameAnnotation])
+	}
+
+	if placementObj.GetAnnotations()[controllers.DRPCNamespaceAnnotation] != namespace {
+		return fmt.Errorf("expected DRPCNamespaceAnnotation %s, got %s",
+			namespace, placementObj.GetAnnotations()[controllers.DRPCNamespaceAnnotation])
+	}
+
+	return nil
 }
 
 func waitForDRPCProtected(namespace string) error {
@@ -1344,8 +1383,7 @@ func getPlacementDecision(plName, plNamespace string) *clrapiv1beta1.PlacementDe
 	return plDecision
 }
 
-//nolint:unparam
-func verifyUserPlacementRuleDecisionUnchanged(name, namespace, homeCluster string) {
+func verifyUserPlacementRuleDecisionUnchanged(name, namespace, homeCluster string) error {
 	usrPlacementLookupKey := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -1355,7 +1393,7 @@ func verifyUserPlacementRuleDecisionUnchanged(name, namespace, homeCluster strin
 
 	var placementObj client.Object
 
-	Consistently(func() bool {
+	if err := ensureConsistent(timeout, interval, "placement decision changed unexpectedly", func() bool {
 		err := k8sClient.Get(context.TODO(), usrPlacementLookupKey, usrPlRule)
 		if k8serrors.IsNotFound(err) {
 			usrPlmnt := &clrapiv1beta1.Placement{}
@@ -1375,13 +1413,24 @@ func verifyUserPlacementRuleDecisionUnchanged(name, namespace, homeCluster strin
 		placementObj = usrPlRule
 
 		return err == nil && usrPlRule.Status.Decisions[0].ClusterName == homeCluster
-	}, timeout, interval).Should(BeTrue())
+	}); err != nil {
+		return err
+	}
 
-	Expect(placementObj.GetAnnotations()[controllers.DRPCNameAnnotation]).Should(Equal(DRPCCommonName))
-	Expect(placementObj.GetAnnotations()[controllers.DRPCNamespaceAnnotation]).Should(Equal(namespace))
+	if placementObj.GetAnnotations()[controllers.DRPCNameAnnotation] != DRPCCommonName {
+		return fmt.Errorf("expected DRPCNameAnnotation %s, got %s",
+			DRPCCommonName, placementObj.GetAnnotations()[controllers.DRPCNameAnnotation])
+	}
+
+	if placementObj.GetAnnotations()[controllers.DRPCNamespaceAnnotation] != namespace {
+		return fmt.Errorf("expected DRPCNamespaceAnnotation %s, got %s",
+			namespace, placementObj.GetAnnotations()[controllers.DRPCNamespaceAnnotation])
+	}
+
+	return nil
 }
 
-func verifyDRPCStatusPreferredClusterExpectation(namespace string, drState rmn.DRState) {
+func verifyDRPCStatusPreferredClusterExpectation(namespace string, drState rmn.DRState) error {
 	drpcLookupKey := types.NamespacedName{
 		Name:      DRPCCommonName,
 		Namespace: namespace,
@@ -1389,24 +1438,35 @@ func verifyDRPCStatusPreferredClusterExpectation(namespace string, drState rmn.D
 
 	updatedDRPC := &rmn.DRPlacementControl{}
 
-	Eventually(func() bool {
-		err := k8sClient.Get(context.TODO(), drpcLookupKey, updatedDRPC)
+	if err := waitForCondition(timeout, interval,
+		fmt.Sprintf("failed waiting for an updated DRPC. State %v", drState), func() bool {
+			err := k8sClient.Get(context.TODO(), drpcLookupKey, updatedDRPC)
 
-		if d := updatedDRPC.Status.PreferredDecision; err == nil && d != (rmn.PlacementDecision{}) {
-			idx, condition := getDRPCCondition(&updatedDRPC.Status, rmn.ConditionAvailable)
+			if d := updatedDRPC.Status.PreferredDecision; err == nil && d != (rmn.PlacementDecision{}) {
+				idx, condition := getDRPCCondition(&updatedDRPC.Status, rmn.ConditionAvailable)
 
-			return d.ClusterName == East1ManagedCluster &&
-				idx != -1 &&
-				condition.Reason == string(drState) &&
-				len(updatedDRPC.Status.ResourceConditions.ResourceMeta.ProtectedPVCs) == ProtectedPVCCount
-		}
+				return d.ClusterName == East1ManagedCluster &&
+					idx != -1 &&
+					condition.Reason == string(drState) &&
+					len(updatedDRPC.Status.ResourceConditions.ResourceMeta.ProtectedPVCs) == ProtectedPVCCount
+			}
 
-		return false
-	}, timeout, interval).Should(BeTrue(), fmt.Sprintf("failed waiting for an updated DRPC. State %v", drState))
+			return false
+		}); err != nil {
+		return err
+	}
 
-	Expect(updatedDRPC.Status.PreferredDecision.ClusterName).Should(Equal(East1ManagedCluster))
+	if updatedDRPC.Status.PreferredDecision.ClusterName != East1ManagedCluster {
+		return fmt.Errorf("expected PreferredDecision cluster %s, got %s",
+			East1ManagedCluster, updatedDRPC.Status.PreferredDecision.ClusterName)
+	}
+
 	_, condition := getDRPCCondition(&updatedDRPC.Status, rmn.ConditionAvailable)
-	Expect(condition.Reason).Should(Equal(string(drState)))
+	if condition.Reason != string(drState) {
+		return fmt.Errorf("expected condition reason %s, got %s", string(drState), condition.Reason)
+	}
+
+	return nil
 }
 
 func getLatestUserPlacementRule(name, namespace string) (*plrv1.PlacementRule, error) {
@@ -1640,9 +1700,9 @@ func relocateToPreferredCluster(placementObj client.Object, fromCluster string) 
 
 	Expect(waitForDRPCProtected(placementObj.GetNamespace())).To(Succeed())
 
-	verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster1)
-	verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.Relocated)
-	verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster1)
+	Expect(verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster1)).To(Succeed())
+	Expect(verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.Relocated)).To(Succeed())
+	Expect(verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster1)).To(Succeed())
 
 	Expect(waitForCompletion(string(rmn.Relocated))).To(Succeed())
 }
@@ -1654,9 +1714,9 @@ func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster
 
 	Expect(waitForDRPCProtected(placementObj.GetNamespace())).To(Succeed())
 
-	verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster)
-	verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.FailedOver)
-	verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster)
+	Expect(verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster)).To(Succeed())
+	Expect(verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.FailedOver)).To(Succeed())
+	Expect(verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster)).To(Succeed())
 
 	Expect(waitForCompletion(string(rmn.FailedOver))).To(Succeed())
 }
@@ -1773,35 +1833,74 @@ func resetdrCluster(cluster string) {
 	updateDRClusterParameters(latestDRCluster)
 }
 
-//nolint:unparam
-func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster string) {
-	verifyVRGManifestWorkCreatedAsPrimary(userPlacement.GetNamespace(), preferredCluster)
-	Expect(updateManifestWorkStatus(preferredCluster, userPlacement.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
-	verifyUserPlacementRuleDecision(userPlacement.GetName(), userPlacement.GetNamespace(), preferredCluster)
-	verifyDRPCStatusPreferredClusterExpectation(userPlacement.GetNamespace(), rmn.Deployed)
-	Expect(getManifestWorkCount(preferredCluster)).Should(BeElementOf(3, 4)) // MWs for VRG, 2 namespaces, and DRCluster
-	Expect(waitForCompletion(string(rmn.Deployed))).To(Succeed())
+func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster string) error {
+	if err := verifyVRGManifestWorkCreatedAsPrimary(userPlacement.GetNamespace(), preferredCluster); err != nil {
+		return err
+	}
+
+	if err := updateManifestWorkStatus(preferredCluster, userPlacement.GetNamespace(), "vrg", ocmworkv1.WorkApplied); err != nil {
+		return err
+	}
+
+	if err := verifyUserPlacementRuleDecision(userPlacement.GetName(), userPlacement.GetNamespace(), preferredCluster); err != nil {
+		return err
+	}
+
+	if err := verifyDRPCStatusPreferredClusterExpectation(userPlacement.GetNamespace(), rmn.Deployed); err != nil {
+		return err
+	}
+
+	mwCount, err := getManifestWorkCount(preferredCluster)
+	if err != nil {
+		return err
+	}
+
+	if mwCount != 3 && mwCount != 4 {
+		return fmt.Errorf("expected ManifestWorkCount 3 or 4, got %d", mwCount)
+	}
+
+	if err := waitForCompletion(string(rmn.Deployed)); err != nil {
+		return err
+	}
 
 	latestDRPC, err := getLatestDRPC(userPlacement.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return err
+	}
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'Deployed'
-	Expect(latestDRPC.Status.Phase).To(Equal(rmn.Deployed))
-	Expect(len(latestDRPC.Status.Conditions)).To(Equal(3))
-	_, condition := getDRPCCondition(&latestDRPC.Status, rmn.ConditionAvailable)
-	Expect(condition.Reason).To(Equal(string(rmn.Deployed)))
-	Expect(latestDRPC.GetAnnotations()[controllers.LastAppDeploymentCluster]).To(Equal(preferredCluster))
-	Expect(latestDRPC.GetAnnotations()[controllers.DRPCAppNamespace]).
-		To(Equal(getVRGNamespace(userPlacement.GetNamespace())))
+	if latestDRPC.Status.Phase != rmn.Deployed {
+		return fmt.Errorf("expected phase Deployed, got %s", latestDRPC.Status.Phase)
+	}
 
-	verifyNSManifestWork(latestDRPC.Name, getVRGNamespace(latestDRPC.Namespace),
+	if len(latestDRPC.Status.Conditions) != 3 {
+		return fmt.Errorf("expected 3 conditions, got %d", len(latestDRPC.Status.Conditions))
+	}
+
+	_, condition := getDRPCCondition(&latestDRPC.Status, rmn.ConditionAvailable)
+	if condition.Reason != string(rmn.Deployed) {
+		return fmt.Errorf("expected condition reason Deployed, got %s", condition.Reason)
+	}
+
+	if latestDRPC.GetAnnotations()[controllers.LastAppDeploymentCluster] != preferredCluster {
+		return fmt.Errorf("expected LastAppDeploymentCluster %s, got %s",
+			preferredCluster, latestDRPC.GetAnnotations()[controllers.LastAppDeploymentCluster])
+	}
+
+	if latestDRPC.GetAnnotations()[controllers.DRPCAppNamespace] != getVRGNamespace(userPlacement.GetNamespace()) {
+		return fmt.Errorf("expected DRPCAppNamespace %s, got %s",
+			getVRGNamespace(userPlacement.GetNamespace()),
+			latestDRPC.GetAnnotations()[controllers.DRPCAppNamespace])
+	}
+
+	return verifyNSManifestWork(latestDRPC.Name, getVRGNamespace(latestDRPC.Namespace),
 		East1ManagedCluster)
 }
 
 func verifyFailoverToSecondary(placementObj client.Object, toCluster string,
 	isSyncDR bool,
-) {
+) error {
 	recoverToFailoverCluster(placementObj, East1ManagedCluster, toCluster)
 
 	// TODO: DRCluster as part of Unfence operation, first unfences
@@ -1810,45 +1909,106 @@ func verifyFailoverToSecondary(placementObj client.Object, toCluster string,
 	//       resource is cleaned up or not, number of MW may change.
 	if !isSyncDR {
 		// MW for VRG+NS+DRCluster
-		Eventually(getManifestWorkCount, timeout, interval).WithArguments(toCluster).Should(BeElementOf(3, 4))
+		if err := waitForCondition(timeout, interval, "waiting for MW count on toCluster", func() bool {
+			count, err := getManifestWorkCount(toCluster)
+
+			return err == nil && (count == 3 || count == 4)
+		}); err != nil {
+			return err
+		}
 	} else {
-		Expect(getManifestWorkCount(toCluster)).Should(BeElementOf(3, 4)) // MW for VRG+NS+DRCluster+NF
+		mwCount, err := getManifestWorkCount(toCluster)
+		if err != nil {
+			return err
+		}
+
+		if mwCount != 3 && mwCount != 4 {
+			return fmt.Errorf("expected MW count 3 or 4 on %s, got %d", toCluster, mwCount)
+		}
 	}
 
-	Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(3)) // DRClustern + NS + VRG-MW
+	east1MWCount, err := getManifestWorkCount(East1ManagedCluster)
+	if err != nil {
+		return err
+	}
+
+	if east1MWCount != 3 {
+		return fmt.Errorf("expected MW count 3 on %s, got %d", East1ManagedCluster, east1MWCount)
+	}
 
 	drpc, err := getLatestDRPC(placementObj.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return err
+	}
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'FailedOver'
-	Expect(drpc.Status.Phase).To(Equal(rmn.FailedOver))
-	Expect(len(drpc.Status.Conditions)).To(Equal(3))
+	if drpc.Status.Phase != rmn.FailedOver {
+		return fmt.Errorf("expected phase FailedOver, got %s", drpc.Status.Phase)
+	}
+
+	if len(drpc.Status.Conditions) != 3 {
+		return fmt.Errorf("expected 3 conditions, got %d", len(drpc.Status.Conditions))
+	}
+
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
-	Expect(condition.Reason).To(Equal(string(rmn.FailedOver)))
+	if condition.Reason != string(rmn.FailedOver) {
+		return fmt.Errorf("expected condition reason FailedOver, got %s", condition.Reason)
+	}
 
 	decision, err := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
-	Expect(decision.ClusterName).To(Equal(toCluster))
-	Expect(drpc.GetAnnotations()[controllers.LastAppDeploymentCluster]).To(Equal(toCluster))
+	if err != nil {
+		return err
+	}
+
+	if decision.ClusterName != toCluster {
+		return fmt.Errorf("expected decision cluster %s, got %s", toCluster, decision.ClusterName)
+	}
+
+	if drpc.GetAnnotations()[controllers.LastAppDeploymentCluster] != toCluster {
+		return fmt.Errorf("expected LastAppDeploymentCluster %s, got %s",
+			toCluster, drpc.GetAnnotations()[controllers.LastAppDeploymentCluster])
+	}
+
+	return nil
 }
 
-func verifyActionResultForPlacement(placement *clrapiv1beta1.Placement, homeCluster string, plType PlacementType) {
+func verifyActionResultForPlacement(placement *clrapiv1beta1.Placement, homeCluster string, plType PlacementType) error {
 	placementDecision := getPlacementDecision(placement.GetName(), placement.GetNamespace())
-	Expect(placementDecision).ShouldNot(BeNil())
-	Expect(placementDecision.GetLabels()[rmnutil.ExcludeFromVeleroBackup]).Should(Equal("true"))
-	Expect(placementDecision.Status.Decisions[0].ClusterName).Should(Equal(homeCluster))
+	if placementDecision == nil {
+		return fmt.Errorf("placementDecision is nil")
+	}
+
+	if placementDecision.GetLabels()[rmnutil.ExcludeFromVeleroBackup] != "true" {
+		return fmt.Errorf("expected ExcludeFromVeleroBackup label to be true, got %s",
+			placementDecision.GetLabels()[rmnutil.ExcludeFromVeleroBackup])
+	}
+
+	if placementDecision.Status.Decisions[0].ClusterName != homeCluster {
+		return fmt.Errorf("expected decision cluster %s, got %s",
+			homeCluster, placementDecision.Status.Decisions[0].ClusterName)
+	}
+
 	vrg, err := GetFakeVRGFromMCVUsingMW(homeCluster, placement.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return err
+	}
 
 	switch plType {
 	case UsePlacementWithSubscription:
-		Expect(vrg.Namespace).Should(Equal(placement.GetNamespace()))
+		if vrg.Namespace != placement.GetNamespace() {
+			return fmt.Errorf("expected VRG namespace %s, got %s", placement.GetNamespace(), vrg.Namespace)
+		}
 	case UsePlacementWithAppSet:
-		Expect(vrg.Namespace).Should(Equal(appSet.Spec.Template.Spec.Destination.Namespace))
+		if vrg.Namespace != appSet.Spec.Template.Spec.Destination.Namespace {
+			return fmt.Errorf("expected VRG namespace %s, got %s",
+				appSet.Spec.Template.Spec.Destination.Namespace, vrg.Namespace)
+		}
 	default:
-		Fail("Wrong placement type")
+		return fmt.Errorf("wrong placement type %d", plType)
 	}
+
+	return nil
 }
 
 func buildVRG(objectName, namespaceName, dstCluster string, action rmn.VRGAction) rmn.VolumeReplicationGroup {
@@ -1874,58 +2034,72 @@ func buildVRG(objectName, namespaceName, dstCluster string, action rmn.VRGAction
 	}
 }
 
-func ensureLatestVRGDownloadedFromS3Stores() {
+func ensureLatestVRGDownloadedFromS3Stores() error {
 	orgVRG := buildVRG("vrgName1", "vrgNamespace1", East1ManagedCluster, rmn.VRGAction(""))
 	s3ProfileNames := []string{s3Profiles[0].S3ProfileName, s3Profiles[1].S3ProfileName}
 
 	objectStorer1, _, err := drpcReconciler.ObjStoreGetter.ObjectStore(
 		ctx, apiReader, s3ProfileNames[0], "drpolicy validation", testLogger)
+	if err != nil {
+		return fmt.Errorf("failed to get object store 1: %w", err)
+	}
 
-	Expect(err).ToNot(HaveOccurred())
-	Expect(controllers.VrgObjectProtect(objectStorer1, orgVRG)).To(Succeed())
+	if err := controllers.VrgObjectProtect(objectStorer1, orgVRG); err != nil {
+		return fmt.Errorf("failed to protect VRG in store 1: %w", err)
+	}
 
 	objectStorer2, _, err := drpcReconciler.ObjStoreGetter.ObjectStore(
 		ctx, apiReader, s3ProfileNames[1], "drpolicy validation", testLogger)
-	Expect(err).ToNot(HaveOccurred())
+	if err != nil {
+		return fmt.Errorf("failed to get object store 2: %w", err)
+	}
 
-	Expect(controllers.VrgObjectProtect(objectStorer2, orgVRG)).To(Succeed())
+	if err := controllers.VrgObjectProtect(objectStorer2, orgVRG); err != nil {
+		return fmt.Errorf("failed to protect VRG in store 2: %w", err)
+	}
 
 	vrg := controllers.GetLastKnownVRGPrimaryFromS3(context.TODO(),
 		apiReader, s3ProfileNames,
 		"vrgName1", "vrgNamespace1", drpcReconciler.ObjStoreGetter, testLogger)
 
-	Expect(err).ToNot(HaveOccurred())
-	Expect(vrg.Name).To(Equal("vrgName1"))
+	if vrg.Name != "vrgName1" {
+		return fmt.Errorf("expected VRG name vrgName1, got %s", vrg.Name)
+	}
 
 	t1 := metav1.Now()
 	orgVRG.Status.LastUpdateTime = t1
-	Expect(controllers.VrgObjectProtect(objectStorer2, orgVRG)).To(Succeed())
+
+	if err := controllers.VrgObjectProtect(objectStorer2, orgVRG); err != nil {
+		return fmt.Errorf("failed to protect updated VRG in store 2: %w", err)
+	}
 
 	vrg2 := controllers.GetLastKnownVRGPrimaryFromS3(context.TODO(),
 		apiReader, s3ProfileNames,
 		"vrgName1", "vrgNamespace1", drpcReconciler.ObjStoreGetter, testLogger)
 
-	Expect(err).ToNot(HaveOccurred())
-	Expect(vrg2.Status.LastUpdateTime).To(Equal(t1))
+	if vrg2.Status.LastUpdateTime != t1 {
+		return fmt.Errorf("expected LastUpdateTime %v, got %v", t1, vrg2.Status.LastUpdateTime)
+	}
 
 	vrg3 := controllers.GetLastKnownVRGPrimaryFromS3(context.TODO(),
 		apiReader, s3ProfileNames,
 		"vrgName1", "vrgNamespace1", drpcReconciler.ObjStoreGetter, testLogger)
 
-	Expect(err).ToNot(HaveOccurred())
-	Expect(vrg3.Status.LastUpdateTime).To(Equal(t1))
+	if vrg3.Status.LastUpdateTime != t1 {
+		return fmt.Errorf("expected LastUpdateTime %v, got %v", t1, vrg3.Status.LastUpdateTime)
+	}
 
-	Expect(controllers.VrgObjectUnprotect(objectStorer2, orgVRG)).To(Succeed())
+	return controllers.VrgObjectUnprotect(objectStorer2, orgVRG)
 }
 
-func verifyDRPCOwnedByPlacement(placementObj client.Object, drpc *rmn.DRPlacementControl) {
+func verifyDRPCOwnedByPlacement(placementObj client.Object, drpc *rmn.DRPlacementControl) error {
 	for _, ownerReference := range drpc.GetOwnerReferences() {
 		if ownerReference.Name == placementObj.GetName() {
-			return
+			return nil
 		}
 	}
 
-	Fail(fmt.Sprintf("DRPC %s not owned by Placement %s", drpc.GetName(), placementObj.GetName()))
+	return fmt.Errorf("DRPC %s not owned by Placement %s", drpc.GetName(), placementObj.GetName())
 }
 
 var _ = Describe("DRPlacementControl - Ensure do-not-delete PVC Annotation", func() {
@@ -2167,10 +2341,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
 				userPlacementRule = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule).NotTo(BeNil())
-				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
+				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
-				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
+				Expect(verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)).To(Succeed())
 			})
 		})
 		When("DRAction changes to Failover", func() {
@@ -2186,7 +2360,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should failover to Secondary (West1ManagedCluster)", func() {
 				// ----------------------------- FAILOVER TO SECONDARY (West1ManagedCluster) --------------------------------------
 				By("\n\n*** Failover - 1\n\n")
-				verifyFailoverToSecondary(userPlacementRule, West1ManagedCluster, false)
+				Expect(verifyFailoverToSecondary(userPlacementRule, West1ManagedCluster, false)).To(Succeed())
 			})
 		})
 		When("DRAction is Failover during hub recovery", func() {
@@ -2194,7 +2368,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("\n\n*** Failover after \n\n")
 				Expect(clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 				Expect(clearDRPCStatus()).To(Succeed())
-				verifyFailoverToSecondary(userPlacementRule, West1ManagedCluster, false)
+				Expect(verifyFailoverToSecondary(userPlacementRule, West1ManagedCluster, false)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate", func() {
@@ -2228,13 +2402,13 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				// ----------------------------- DELETE DRPolicy  --------------------------------------
 				By("\n\n*** DELETE drpolicy ***\n\n")
 				Expect(deleteDRPolicyAsync()).To(Succeed())
-				ensureDRPolicyIsNotDeleted(drpc)
+				Expect(ensureDRPolicyIsNotDeleted(drpc)).To(Succeed())
 			})
 		})
 		When("A DRPC is created referring to a deleted DRPolicy", func() {
 			It("Should fail DRPC reconciliaiton and not add a finalizer", func() {
 				_, drpc2 := FollowOnDeploymentAsync(DRPC2NamespaceName, UserPlacementRuleName, East1ManagedCluster)
-				checkIfDRPCFinalizerNotAdded(drpc2)
+				Expect(checkIfDRPCFinalizerNotAdded(drpc2)).To(Succeed())
 				Expect(k8sClient.Delete(context.TODO(), drpc2)).Should(Succeed())
 			})
 		})
@@ -2260,11 +2434,11 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
-				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
+				Expect(ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)).To(Succeed())
 			})
 			It("should delete the DRPC causing its referenced drpolicy to be deleted"+
 				" by drpolicy controller since no DRPCs reference it anymore", func() {
-				ensureDRPolicyIsDeleted(drpolicyName)
+				Expect(ensureDRPolicyIsDeleted(drpolicyName)).To(Succeed())
 			})
 		})
 		Specify("delete drclusters", func() {
@@ -2291,8 +2465,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 					DefaultDRPCNamespace, UserPlacementName, East1ManagedCluster, UsePlacementWithSubscription)
 				placement = placementObj.(*clrapiv1beta1.Placement)
 				Expect(placement).NotTo(BeNil())
-				verifyInitialDRPCDeployment(placement, East1ManagedCluster)
-				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)
+				Expect(verifyInitialDRPCDeployment(placement, East1ManagedCluster)).To(Succeed())
+				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
 				verifyDRPCOwnedByPlacement(placement, latestDRPC)
@@ -2311,19 +2485,19 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			})
 			It("Should failover to Secondary (West1ManagedCluster) when using Subscription", func() {
 				runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)
-				verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithSubscription)
+				Expect(verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithSubscription)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate using Placement with Subscriptioin", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				runRelocateAction(placement, West1ManagedCluster, false, false)
-				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)
+				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)).To(Succeed())
 			})
 		})
 		When("Deleting DRPolicy with DRPC references when using Placement", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
 				Expect(deleteDRPolicyAsync()).To(Succeed())
-				ensureDRPolicyIsNotDeleted(drpc)
+				Expect(ensureDRPolicyIsNotDeleted(drpc)).To(Succeed())
 			})
 		})
 		When("Deleting user Placement", func() {
@@ -2342,11 +2516,11 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
-				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
+				Expect(ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)).To(Succeed())
 			})
 			It("should delete the DRPC causing its referenced drpolicy to be deleted"+
 				" by drpolicy controller since no DRPCs reference it anymore", func() {
-				ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)
+				Expect(ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)).To(Succeed())
 			})
 		})
 		Specify("delete drclusters when using Placement", func() {
@@ -2376,8 +2550,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 					DefaultDRPCNamespace, UserPlacementName, East1ManagedCluster, UsePlacementWithAppSet)
 				placement = placementObj.(*clrapiv1beta1.Placement)
 				Expect(placement).NotTo(BeNil())
-				verifyInitialDRPCDeployment(placement, East1ManagedCluster)
-				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)
+				Expect(verifyInitialDRPCDeployment(placement, East1ManagedCluster)).To(Succeed())
+				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
 				verifyDRPCOwnedByPlacement(placement, latestDRPC)
@@ -2396,31 +2570,31 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			})
 			It("Should failover to Secondary (West1ManagedCluster)", func() {
 				runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)
-				verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithAppSet)
+				Expect(verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate using Placement", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				runRelocateAction(placement, West1ManagedCluster, false, false)
-				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)
+				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
 		When("DRAction is changed to Failover after relocation using Placement", func() {
 			It("Should failover again to Secondary (West1ManagedCluster)", func() {
 				runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)
-				verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithAppSet)
+				Expect(verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate again using Placement", func() {
 			It("Should relocate again to Primary (East1ManagedCluster)", func() {
 				runRelocateAction(placement, West1ManagedCluster, false, false)
-				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)
+				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
 		When("Deleting DRPolicy with DRPC references when using Placement", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
 				Expect(deleteDRPolicyAsync()).To(Succeed())
-				ensureDRPolicyIsNotDeleted(drpc)
+				Expect(ensureDRPolicyIsNotDeleted(drpc)).To(Succeed())
 			})
 		})
 		When("Deleting user Placement", func() {
@@ -2439,13 +2613,13 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
-				ensureNamespaceMWsDeletedFromAllClusters(ApplicationNamespace)
+				Expect(ensureNamespaceMWsDeletedFromAllClusters(ApplicationNamespace)).To(Succeed())
 				Expect(deleteAppSet()).To(Succeed())
 				UseApplicationSet = false
 			})
 			It("should delete the DRPC causing its referenced drpolicy to be deleted"+
 				" by drpolicy controller since no DRPCs reference it anymore", func() {
-				ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)
+				Expect(ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)).To(Succeed())
 			})
 		})
 		Specify("delete drclusters when using Placement", func() {
@@ -2463,10 +2637,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("Initial Deployment")
 
 				userPlacementRule, _ = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
-				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
+				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
-				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
+				Expect(verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)).To(Succeed())
 			})
 		})
 		When("DRAction changes to Failover", func() {
@@ -2483,7 +2657,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			})
 			It("Should failover to Secondary (East2ManagedCluster)", func() {
 				By("\n\n*** Failover - 1\n\n")
-				verifyFailoverToSecondary(userPlacementRule, East2ManagedCluster, true)
+				Expect(verifyFailoverToSecondary(userPlacementRule, East2ManagedCluster, true)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate", func() {
@@ -2541,10 +2715,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("Initial Deployment")
 
 				userPlacementRule, _ = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
-				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
+				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
-				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
+				Expect(verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)).To(Succeed())
 			})
 		})
 		When("DRAction changes to Failover", func() {
@@ -2561,7 +2735,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			})
 			It("Should failover to Secondary (East2ManagedCluster)", func() {
 				By("\n\n*** Failover - 1\n\n")
-				verifyFailoverToSecondary(userPlacementRule, East2ManagedCluster, true)
+				Expect(verifyFailoverToSecondary(userPlacementRule, East2ManagedCluster, true)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate", func() {
@@ -2601,7 +2775,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1)) // DRCluster
 				Expect(deleteDRPolicySync()).To(Succeed())
 				Expect(deleteDRClustersSync()).To(Succeed())
-				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
+				Expect(ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 	})
@@ -2816,7 +2990,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should delete all VRGs", func() {
 				Expect(deleteDRPC()).To(Succeed())
 				Expect(waitForCompletion("deleted")).To(Succeed())
-				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
+				Expect(ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 		Specify("delete drclusters", func() {
@@ -2873,7 +3047,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should delete all VRGs", func() {
 				Expect(deleteDRPC()).To(Succeed())
 				Expect(waitForCompletion("deleted")).To(Succeed())
-				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
+				Expect(ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 
@@ -2898,8 +3072,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 					DefaultDRPCNamespace, UserPlacementName, East1ManagedCluster, UsePlacementWithSubscription)
 				placement = placementObj.(*clrapiv1beta1.Placement)
 				Expect(placement).NotTo(BeNil())
-				verifyInitialDRPCDeployment(placement, East1ManagedCluster)
-				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)
+				Expect(verifyInitialDRPCDeployment(placement, East1ManagedCluster)).To(Succeed())
+				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)).To(Succeed())
 				verifyDRPCOwnedByPlacement(placement, getLatestDRPC(DefaultDRPCNamespace))
 			})
 		})
@@ -2919,9 +3093,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			Expect(waitForCompletion("deleted")).To(Succeed())
 			Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 			Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
-			ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
+			Expect(ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)).To(Succeed())
 			deleteDRPolicyAsync()
-			ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)
+			Expect(ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)).To(Succeed())
 			deleteDRClustersAsync()
 			Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(0))
 		})
@@ -2946,10 +3120,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
 				userPlacementRule = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule).NotTo(BeNil())
-				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
+				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
-				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
+				Expect(verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)).To(Succeed())
 			})
 		})
 		When("DRAction is changed to Failover", func() {
@@ -3013,7 +3187,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting DRPolicy with DRPC references", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
 				Expect(deleteDRPolicyAsync()).To(Succeed())
-				ensureDRPolicyIsNotDeleted(drpc)
+				Expect(ensureDRPolicyIsNotDeleted(drpc)).To(Succeed())
 			})
 		})
 		When("Deleting user PlacementRule", func() {
@@ -3029,11 +3203,11 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
-				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
+				Expect(ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)).To(Succeed())
 			})
 			It("should delete the DRPC causing its referenced drpolicy to be deleted"+
 				" by drpolicy controller since no DRPCs reference it anymore", func() {
-				ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)
+				Expect(ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)).To(Succeed())
 			})
 		})
 		Specify("delete drclusters", func() {
@@ -3075,67 +3249,102 @@ func getVRGFromManifestWork(clusterNamespace string) (*rmn.VolumeReplicationGrou
 	return rmnutil.ExtractVRGFromManifestWork(mw)
 }
 
-func verifyRDSpecAfterActionSwitch(primaryCluster, secondaryCluster string, numOfRDSpecs int) {
+func verifyRDSpecAfterActionSwitch(primaryCluster, secondaryCluster string, numOfRDSpecs int) error {
 	// For Primary Cluster
 	vrg, err := getVRGFromManifestWork(primaryCluster)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(len(vrg.Spec.VolSync.RDSpec)).Should(Equal(0))
+	if err != nil {
+		return fmt.Errorf("failed to get VRG from MW for primary %s: %w", primaryCluster, err)
+	}
+
+	if len(vrg.Spec.VolSync.RDSpec) != 0 {
+		return fmt.Errorf("expected 0 RDSpec for primary, got %d", len(vrg.Spec.VolSync.RDSpec))
+	}
+
 	// For Secondary Cluster
 	vrg, err = getVRGFromManifestWork(secondaryCluster)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(len(vrg.Spec.VolSync.RDSpec)).Should(Equal(numOfRDSpecs))
+	if err != nil {
+		return fmt.Errorf("failed to get VRG from MW for secondary %s: %w", secondaryCluster, err)
+	}
+
+	if len(vrg.Spec.VolSync.RDSpec) != numOfRDSpecs {
+		return fmt.Errorf("expected %d RDSpec for secondary, got %d", numOfRDSpecs, len(vrg.Spec.VolSync.RDSpec))
+	}
+
+	return nil
 }
 
 func verifyDRPCStateAndProgression(expectedAction rmn.DRAction, expectedPhase rmn.DRState,
 	expectedPorgression rmn.ProgressionStatus,
-) {
+) error {
 	var phase rmn.DRState
 
 	var progression rmn.ProgressionStatus
 
-	Eventually(func() bool {
-		drpc, err := getLatestDRPC(DefaultDRPCNamespace)
-		if err != nil {
-			return false
-		}
-		phase = drpc.Status.Phase
-		progression = drpc.Status.Progression
-
-		return phase == expectedPhase && progression == expectedPorgression
-	}, timeout, interval).Should(BeTrue(),
+	if err := waitForCondition(timeout, interval,
 		fmt.Sprintf("Phase has not been updated yet! Phase:%s Expected:%s - progression:%s expected:%s",
-			phase, expectedPhase, progression, expectedPorgression))
+			phase, expectedPhase, progression, expectedPorgression), func() bool {
+			drpc, err := getLatestDRPC(DefaultDRPCNamespace)
+			if err != nil {
+				return false
+			}
+			phase = drpc.Status.Phase
+			progression = drpc.Status.Progression
+
+			return phase == expectedPhase && progression == expectedPorgression
+		}); err != nil {
+		return err
+	}
 
 	drpc, err := getLatestDRPC(DefaultDRPCNamespace)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(drpc.Spec.Action).Should(Equal(expectedAction))
-	Expect(drpc.Status.Phase).Should(Equal(expectedPhase))
-	Expect(drpc.Status.Progression).Should(Equal(expectedPorgression))
+	if err != nil {
+		return err
+	}
+
+	if drpc.Spec.Action != expectedAction {
+		return fmt.Errorf("expected action %s, got %s", expectedAction, drpc.Spec.Action)
+	}
+
+	if drpc.Status.Phase != expectedPhase {
+		return fmt.Errorf("expected phase %s, got %s", expectedPhase, drpc.Status.Phase)
+	}
+
+	if drpc.Status.Progression != expectedPorgression {
+		return fmt.Errorf("expected progression %s, got %s", expectedPorgression, drpc.Status.Progression)
+	}
+
+	return nil
 }
 
-func checkConditionAllowFailover(namespace string) {
+func checkConditionAllowFailover(namespace string) error {
 	var drpc *rmn.DRPlacementControl
 
 	var availableCondition metav1.Condition
 
-	Eventually(func() bool {
-		var err error
-		drpc, err = getLatestDRPC(namespace)
-		if err != nil {
-			return false
-		}
-		for _, availableCondition = range drpc.Status.Conditions {
-			if availableCondition.Type != rmn.ConditionPeerReady {
-				if availableCondition.Status == metav1.ConditionTrue {
-					return true
+	if err := waitForCondition(timeout, interval,
+		fmt.Sprintf("waiting for allow failover condition '%+v'", availableCondition), func() bool {
+			var err error
+			drpc, err = getLatestDRPC(namespace)
+			if err != nil {
+				return false
+			}
+			for _, availableCondition = range drpc.Status.Conditions {
+				if availableCondition.Type != rmn.ConditionPeerReady {
+					if availableCondition.Status == metav1.ConditionTrue {
+						return true
+					}
 				}
 			}
-		}
 
-		return false
-	}, timeout, interval).Should(BeTrue(), fmt.Sprintf("Condition '%+v'", availableCondition))
+			return false
+		}); err != nil {
+		return err
+	}
 
-	Expect(drpc.Status.Phase).To(Equal(rmn.WaitForUser))
+	if drpc.Status.Phase != rmn.WaitForUser {
+		return fmt.Errorf("expected phase WaitForUser, got %s", drpc.Status.Phase)
+	}
+
+	return nil
 }
 
 //nolint:unparam

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -606,17 +606,20 @@ func createDRPC(placementName, name, namespace, drPolicyName, preferredCluster s
 
 //nolint:unparam
 func deleteUserPlacementRule(name, namespace string) {
-	userPlacementRule := getLatestUserPlacementRule(name, namespace)
+	userPlacementRule, err := getLatestUserPlacementRule(name, namespace)
+	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient.Delete(context.TODO(), userPlacementRule)).Should(Succeed())
 }
 
 func deleteUserPlacement() {
-	userPlacement := getLatestUserPlacement(UserPlacementName, DefaultDRPCNamespace)
+	userPlacement, err := getLatestUserPlacement(UserPlacementName, DefaultDRPCNamespace)
+	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient.Delete(context.TODO(), userPlacement)).Should(Succeed())
 }
 
 func deleteDRPC() {
-	drpc := getLatestDRPC(DefaultDRPCNamespace)
+	drpc, err := getLatestDRPC(DefaultDRPCNamespace)
+	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient.Delete(context.TODO(), drpc)).Should(Succeed())
 }
 
@@ -661,22 +664,28 @@ func setDRPCSpecExpectationTo(namespace, preferredCluster, failoverCluster strin
 	Expect(retryErr).NotTo(HaveOccurred())
 
 	Eventually(func() bool {
-		latestDRPC = getLatestDRPC(namespace)
+		var err error
+		latestDRPC, err = getLatestDRPC(namespace)
+		if err != nil {
+			return false
+		}
 
 		return latestDRPC.Spec.Action == action
 	}, timeout, interval).Should(BeTrue(), "failed to update DRPC DR action on time")
 }
 
-func getLatestDRPC(namespace string) *rmn.DRPlacementControl {
+func getLatestDRPC(namespace string) (*rmn.DRPlacementControl, error) {
 	drpcLookupKey := types.NamespacedName{
 		Name:      DRPCCommonName,
 		Namespace: namespace,
 	}
 	latestDRPC := &rmn.DRPlacementControl{}
 	err := apiReader.Get(context.TODO(), drpcLookupKey, latestDRPC)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, err
+	}
 
-	return latestDRPC
+	return latestDRPC, nil
 }
 
 func clearDRPCStatus() {
@@ -1132,22 +1141,25 @@ func verifyVRGManifestWorkCreatedAsPrimary(namespace, managedCluster string) {
 	Expect(vrg.Spec.ReplicationState).Should(Equal(rmn.Primary))
 
 	// ensure DRPC copied KubeObjectProtection contents to VRG
-	drpc := getLatestDRPC(namespace)
+	drpc, err := getLatestDRPC(namespace)
+	Expect(err).NotTo(HaveOccurred())
 	Expect(vrg.Spec.KubeObjectProtection).Should(Equal(drpc.Spec.KubeObjectProtection))
 }
 
-func getManifestWorkCount(homeClusterNamespace string) int {
+func getManifestWorkCount(homeClusterNamespace string) (int, error) {
 	manifestWorkList := &ocmworkv1.ManifestWorkList{}
 	listOptions := &client.ListOptions{Namespace: homeClusterNamespace}
 
-	Expect(apiReader.List(context.TODO(), manifestWorkList, listOptions)).NotTo(HaveOccurred())
+	if err := apiReader.List(context.TODO(), manifestWorkList, listOptions); err != nil {
+		return 0, err
+	}
 
 	if len(manifestWorkList.Items) == 0 {
-		return 0
+		return 0, nil
 	}
 
 	// Reduce by one to accommodate for DRClusterConfig ManifestWork
-	return len(manifestWorkList.Items) - 1
+	return len(manifestWorkList.Items) - 1, nil
 }
 
 func verifyNSManifestWork(resourceName, namespaceString, managedCluster string) {
@@ -1165,13 +1177,15 @@ func verifyNSManifestWork(resourceName, namespaceString, managedCluster string) 
 }
 
 //nolint:unparam
-func getManagedClusterViewCount(homeClusterNamespace string) int {
+func getManagedClusterViewCount(homeClusterNamespace string) (int, error) {
 	mcvList := &viewv1beta1.ManagedClusterViewList{}
 	listOptions := &client.ListOptions{Namespace: homeClusterNamespace}
 
-	Expect(k8sClient.List(context.TODO(), mcvList, listOptions)).NotTo(HaveOccurred())
+	if err := k8sClient.List(context.TODO(), mcvList, listOptions); err != nil {
+		return 0, err
+	}
 
-	return len(mcvList.Items)
+	return len(mcvList.Items), nil
 }
 
 func verifyUserPlacementRuleDecision(name, namespace, homeCluster string) {
@@ -1213,7 +1227,10 @@ func verifyUserPlacementRuleDecision(name, namespace, homeCluster string) {
 
 func waitForDRPCProtected(namespace string) {
 	Eventually(func() bool {
-		drpc := getLatestDRPC(namespace)
+		drpc, err := getLatestDRPC(namespace)
+		if err != nil {
+			return false
+		}
 		_, cond := getDRPCCondition(&drpc.Status, rmn.ConditionProtected)
 
 		return cond != nil && cond.Status == metav1.ConditionTrue
@@ -1300,7 +1317,7 @@ func verifyDRPCStatusPreferredClusterExpectation(namespace string, drState rmn.D
 	Expect(condition.Reason).Should(Equal(string(drState)))
 }
 
-func getLatestUserPlacementRule(name, namespace string) *plrv1.PlacementRule {
+func getLatestUserPlacementRule(name, namespace string) (*plrv1.PlacementRule, error) {
 	usrPlRuleLookupKey := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -1308,15 +1325,18 @@ func getLatestUserPlacementRule(name, namespace string) *plrv1.PlacementRule {
 
 	usrPlRule := &plrv1.PlacementRule{}
 
-	Eventually(func() error {
-		return k8sClient.Get(context.TODO(), usrPlRuleLookupKey, usrPlRule)
-	}, timeout, interval).Should(Succeed(),
-		fmt.Sprintf("PlacementRule %s/%s not found", namespace, name))
+	if err := waitForCondition(timeout, interval,
+		fmt.Sprintf("PlacementRule %s/%s not found", namespace, name),
+		func() bool {
+			return k8sClient.Get(context.TODO(), usrPlRuleLookupKey, usrPlRule) == nil
+		}); err != nil {
+		return nil, err
+	}
 
-	return usrPlRule
+	return usrPlRule, nil
 }
 
-func getLatestUserPlacement(name, namespace string) *clrapiv1beta1.Placement {
+func getLatestUserPlacement(name, namespace string) (*clrapiv1beta1.Placement, error) {
 	key := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -1325,12 +1345,14 @@ func getLatestUserPlacement(name, namespace string) *clrapiv1beta1.Placement {
 	plmnt := &clrapiv1beta1.Placement{}
 
 	err := k8sClient.Get(context.TODO(), key, plmnt)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, err
+	}
 
-	return plmnt
+	return plmnt, nil
 }
 
-func getLatestUserPlacementDecision(name, namespace string) *clrapiv1beta1.ClusterDecision {
+func getLatestUserPlacementDecision(name, namespace string) (*clrapiv1beta1.ClusterDecision, error) {
 	key := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -1343,24 +1365,26 @@ func getLatestUserPlacementDecision(name, namespace string) *clrapiv1beta1.Clust
 		return &clrapiv1beta1.ClusterDecision{
 			ClusterName: usrPlRule.Status.Decisions[0].ClusterName,
 			Reason:      "PlacementRule Testing",
-		}
+		}, nil
 	}
 
 	if k8serrors.IsNotFound(err) {
 		usrPlmnt := &clrapiv1beta1.Placement{}
 		err = k8sClient.Get(context.TODO(), key, usrPlmnt)
-		Expect(err).NotTo(HaveOccurred())
+		if err != nil {
+			return nil, err
+		}
 
 		plDecision := getPlacementDecision(usrPlmnt.GetName(), usrPlmnt.GetNamespace())
 		if plDecision != nil {
 			return &clrapiv1beta1.ClusterDecision{
 				ClusterName: plDecision.Status.Decisions[0].ClusterName,
 				Reason:      "Placement Testing",
-			}
+			}, nil
 		}
 	}
 
-	return nil
+	return nil, nil
 }
 
 func waitForCompletion(expectedState string) {
@@ -1373,7 +1397,10 @@ func waitForCompletion(expectedState string) {
 //nolint:unparam
 func waitForDRPCPhaseAndProgression(namespace string, drState rmn.DRState) {
 	Eventually(func() bool {
-		drpc := getLatestDRPC(namespace)
+		drpc, err := getLatestDRPC(namespace)
+		if err != nil {
+			return false
+		}
 
 		return drpc.Status.Phase == drState && drpc.Status.Progression == rmn.ProgressionCompleted
 	}, timeout, interval).Should(BeTrue(), fmt.Sprintf("Timed out waiting for Phase to match. Expected %s for drpcNS %s",
@@ -1419,7 +1446,8 @@ func runFailoverAction(placementObj client.Object, fromCluster, toCluster string
 
 	Expect(getManifestWorkCount(fromCluster)).Should(Equal(3)) // DRCluster + NS MW + VRG MW
 
-	drpc := getLatestDRPC(placementObj.GetNamespace())
+	drpc, err := getLatestDRPC(placementObj.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'FailedOver'
@@ -1429,7 +1457,8 @@ func runFailoverAction(placementObj client.Object, fromCluster, toCluster string
 	Expect(condition.Reason).To(Equal(string(rmn.FailedOver)))
 	Expect(drpc.Status.ActionStartTime).ShouldNot(BeNil())
 
-	decision := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
+	decision, err := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	Expect(decision.ClusterName).To(Equal(toCluster))
 }
 
@@ -1472,7 +1501,8 @@ func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR 
 		Expect(getManifestWorkCount(fromCluster)).Should(BeElementOf(2, 3))
 	}
 
-	drpc := getLatestDRPC(placementObj.GetNamespace())
+	drpc, err := getLatestDRPC(placementObj.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'Relocated'
@@ -1481,7 +1511,8 @@ func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR 
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
 	Expect(condition.Reason).To(Equal(string(rmn.Relocated)))
 
-	decision := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
+	decision, err := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	Expect(decision.ClusterName).To(Equal(toCluster1))
 	Expect(condition.Reason).To(Equal(string(rmn.Relocated)))
 	Expect(drpc.GetAnnotations()[controllers.LastAppDeploymentCluster]).To(Equal(toCluster1))
@@ -1491,7 +1522,8 @@ func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferre
 	setDRPCSpecExpectationTo(userPlacementRule.GetNamespace(), preferredCluster, failoverCluster, "")
 	waitForCompletion(string(rmn.Deployed))
 
-	drpc := getLatestDRPC(userPlacementRule.GetNamespace())
+	drpc, err := getLatestDRPC(userPlacementRule.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state didn't change and it is 'Relocated' even though we tried to run
@@ -1501,7 +1533,8 @@ func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferre
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
 	Expect(condition.Reason).To(Equal(string(rmn.Deployed)))
 
-	decision := getLatestUserPlacementDecision(userPlacementRule.Name, userPlacementRule.Namespace)
+	decision, err := getLatestUserPlacementDecision(userPlacementRule.Name, userPlacementRule.Namespace)
+	Expect(err).NotTo(HaveOccurred())
 	Expect(decision.ClusterName).To(Equal(preferredCluster))
 }
 
@@ -1641,7 +1674,8 @@ func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster s
 	Expect(getManifestWorkCount(preferredCluster)).Should(BeElementOf(3, 4)) // MWs for VRG, 2 namespaces, and DRCluster
 	waitForCompletion(string(rmn.Deployed))
 
-	latestDRPC := getLatestDRPC(userPlacement.GetNamespace())
+	latestDRPC, err := getLatestDRPC(userPlacement.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'Deployed'
@@ -1675,7 +1709,8 @@ func verifyFailoverToSecondary(placementObj client.Object, toCluster string,
 
 	Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(3)) // DRClustern + NS + VRG-MW
 
-	drpc := getLatestDRPC(placementObj.GetNamespace())
+	drpc, err := getLatestDRPC(placementObj.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'FailedOver'
@@ -1684,7 +1719,8 @@ func verifyFailoverToSecondary(placementObj client.Object, toCluster string,
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
 	Expect(condition.Reason).To(Equal(string(rmn.FailedOver)))
 
-	decision := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
+	decision, err := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	Expect(decision.ClusterName).To(Equal(toCluster))
 	Expect(drpc.GetAnnotations()[controllers.LastAppDeploymentCluster]).To(Equal(toCluster))
 }
@@ -2025,7 +2061,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				userPlacementRule = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule).NotTo(BeNil())
 				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
-				verifyDRPCOwnedByPlacement(userPlacementRule, getLatestDRPC(DefaultDRPCNamespace))
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
 			})
 		})
 		When("DRAction changes to Failover", func() {
@@ -2148,7 +2186,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(placement).NotTo(BeNil())
 				verifyInitialDRPCDeployment(placement, East1ManagedCluster)
 				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)
-				verifyDRPCOwnedByPlacement(placement, getLatestDRPC(DefaultDRPCNamespace))
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				verifyDRPCOwnedByPlacement(placement, latestDRPC)
 			})
 		})
 		When("DRAction changes to Failover using Placement with Subscription", func() {
@@ -2183,8 +2223,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should cleanup DRPC", func() {
 				deleteUserPlacement()
 
-				drpc := getLatestDRPC(DefaultDRPCNamespace)
-				_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionPeerReady)
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				_, condition := getDRPCCondition(&latestDRPC.Status, rmn.ConditionPeerReady)
 				Expect(condition).NotTo(BeNil())
 			})
 		})
@@ -2231,7 +2272,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(placement).NotTo(BeNil())
 				verifyInitialDRPCDeployment(placement, East1ManagedCluster)
 				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)
-				verifyDRPCOwnedByPlacement(placement, getLatestDRPC(DefaultDRPCNamespace))
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				verifyDRPCOwnedByPlacement(placement, latestDRPC)
 			})
 		})
 		When("DRAction changes to Failover using Placement", func() {
@@ -2278,8 +2321,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should cleanup DRPC", func() {
 				deleteUserPlacement()
 
-				drpc := getLatestDRPC(DefaultDRPCNamespace)
-				_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionPeerReady)
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				_, condition := getDRPCCondition(&latestDRPC.Status, rmn.ConditionPeerReady)
 				Expect(condition).NotTo(BeNil())
 			})
 		})
@@ -2316,7 +2360,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 				userPlacementRule, _ = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
 				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
-				verifyDRPCOwnedByPlacement(userPlacementRule, getLatestDRPC(DefaultDRPCNamespace))
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
 			})
 		})
 		When("DRAction changes to Failover", func() {
@@ -2392,7 +2438,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 				userPlacementRule, _ = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
 				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
-				verifyDRPCOwnedByPlacement(userPlacementRule, getLatestDRPC(DefaultDRPCNamespace))
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
 			})
 		})
 		When("DRAction changes to Failover", func() {
@@ -2799,7 +2847,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				userPlacementRule = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule).NotTo(BeNil())
 				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
-				verifyDRPCOwnedByPlacement(userPlacementRule, getLatestDRPC(DefaultDRPCNamespace))
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
 			})
 		})
 		When("DRAction is changed to Failover", func() {
@@ -2914,10 +2964,14 @@ func getVRGFromManifestWork(clusterNamespace string) (*rmn.VolumeReplicationGrou
 	mwName := rmnutil.ManifestWorkName(DRPCCommonName, DefaultDRPCNamespace, rmnutil.MWTypeVRG)
 	mw := &ocmworkv1.ManifestWork{}
 
-	Eventually(func() error {
-		return k8sClient.Get(context.TODO(), types.NamespacedName{Name: mwName, Namespace: clusterNamespace}, mw)
-	}, timeout, interval).Should(Succeed(),
-		"timed out waiting for VRG ManifestWork %s in namespace %s", mwName, clusterNamespace)
+	if err := waitForCondition(timeout, interval,
+		fmt.Sprintf("timed out waiting for VRG ManifestWork %s in namespace %s", mwName, clusterNamespace),
+		func() bool {
+			return k8sClient.Get(context.TODO(),
+				types.NamespacedName{Name: mwName, Namespace: clusterNamespace}, mw) == nil
+		}); err != nil {
+		return nil, err
+	}
 
 	return rmnutil.ExtractVRGFromManifestWork(mw)
 }
@@ -2941,7 +2995,10 @@ func verifyDRPCStateAndProgression(expectedAction rmn.DRAction, expectedPhase rm
 	var progression rmn.ProgressionStatus
 
 	Eventually(func() bool {
-		drpc := getLatestDRPC(DefaultDRPCNamespace)
+		drpc, err := getLatestDRPC(DefaultDRPCNamespace)
+		if err != nil {
+			return false
+		}
 		phase = drpc.Status.Phase
 		progression = drpc.Status.Progression
 
@@ -2950,7 +3007,8 @@ func verifyDRPCStateAndProgression(expectedAction rmn.DRAction, expectedPhase rm
 		fmt.Sprintf("Phase has not been updated yet! Phase:%s Expected:%s - progression:%s expected:%s",
 			phase, expectedPhase, progression, expectedPorgression))
 
-	drpc := getLatestDRPC(DefaultDRPCNamespace)
+	drpc, err := getLatestDRPC(DefaultDRPCNamespace)
+	Expect(err).NotTo(HaveOccurred())
 	Expect(drpc.Spec.Action).Should(Equal(expectedAction))
 	Expect(drpc.Status.Phase).Should(Equal(expectedPhase))
 	Expect(drpc.Status.Progression).Should(Equal(expectedPorgression))
@@ -2962,7 +3020,11 @@ func checkConditionAllowFailover(namespace string) {
 	var availableCondition metav1.Condition
 
 	Eventually(func() bool {
-		drpc = getLatestDRPC(namespace)
+		var err error
+		drpc, err = getLatestDRPC(namespace)
+		if err != nil {
+			return false
+		}
 		for _, availableCondition = range drpc.Status.Conditions {
 			if availableCondition.Type != rmn.ConditionPeerReady {
 				if availableCondition.Status == metav1.ConditionTrue {

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -1317,8 +1317,8 @@ func verifyUserPlacementRuleDecision(name, namespace, homeCluster string) {
 	Expect(placementObj.GetAnnotations()[controllers.DRPCNamespaceAnnotation]).Should(Equal(namespace))
 }
 
-func waitForDRPCProtected(namespace string) {
-	Eventually(func() bool {
+func waitForDRPCProtected(namespace string) error {
+	return waitForCondition(timeout, interval, "DRPC to be protected", func() bool {
 		drpc, err := getLatestDRPC(namespace)
 		if err != nil {
 			return false
@@ -1326,7 +1326,7 @@ func waitForDRPCProtected(namespace string) {
 		_, cond := getDRPCCondition(&drpc.Status, rmn.ConditionProtected)
 
 		return cond != nil && cond.Status == metav1.ConditionTrue
-	}, timeout, interval).Should(BeTrue())
+	})
 }
 
 func getPlacementDecision(plName, plNamespace string) *clrapiv1beta1.PlacementDecision {
@@ -1479,24 +1479,25 @@ func getLatestUserPlacementDecision(name, namespace string) (*clrapiv1beta1.Clus
 	return nil, nil
 }
 
-func waitForCompletion(expectedState string) {
-	Eventually(func() bool {
+func waitForCompletion(expectedState string) error {
+	msg := fmt.Sprintf("failed waiting for state to match. expecting: %s, found %s", expectedState, drstate)
+
+	return waitForCondition(timeout*2, interval, msg, func() bool {
 		return drstate == expectedState
-	}, timeout*2, interval).Should(BeTrue(),
-		fmt.Sprintf("failed waiting for state to match. expecting: %s, found %s", expectedState, drstate))
+	})
 }
 
-//nolint:unparam
-func waitForDRPCPhaseAndProgression(namespace string, drState rmn.DRState) {
-	Eventually(func() bool {
+func waitForDRPCPhaseAndProgression(namespace string, drState rmn.DRState) error {
+	msg := fmt.Sprintf("Timed out waiting for Phase to match. Expected %s for drpcNS %s", drState, namespace)
+
+	return waitForCondition(timeout, interval, msg, func() bool {
 		drpc, err := getLatestDRPC(namespace)
 		if err != nil {
 			return false
 		}
 
 		return drpc.Status.Phase == drState && drpc.Status.Progression == rmn.ProgressionCompleted
-	}, timeout, interval).Should(BeTrue(), fmt.Sprintf("Timed out waiting for Phase to match. Expected %s for drpcNS %s",
-		drState, namespace))
+	})
 }
 
 func getDRPCCondition(status *rmn.DRPlacementControlStatus, conditionType string) (int, *metav1.Condition) {
@@ -1612,7 +1613,7 @@ func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR 
 
 func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferredCluster, failoverCluster string) {
 	Expect(setDRPCSpecExpectationTo(userPlacementRule.GetNamespace(), preferredCluster, failoverCluster, "")).To(Succeed())
-	waitForCompletion(string(rmn.Deployed))
+	Expect(waitForCompletion(string(rmn.Deployed))).To(Succeed())
 
 	drpc, err := getLatestDRPC(userPlacementRule.GetNamespace())
 	Expect(err).NotTo(HaveOccurred())
@@ -1637,13 +1638,13 @@ func relocateToPreferredCluster(placementObj client.Object, fromCluster string) 
 
 	Expect(updateManifestWorkStatus(toCluster1, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
 
-	waitForDRPCProtected(placementObj.GetNamespace())
+	Expect(waitForDRPCProtected(placementObj.GetNamespace())).To(Succeed())
 
 	verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster1)
 	verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.Relocated)
 	verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster1)
 
-	waitForCompletion(string(rmn.Relocated))
+	Expect(waitForCompletion(string(rmn.Relocated))).To(Succeed())
 }
 
 func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster string) {
@@ -1651,13 +1652,13 @@ func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster
 
 	Expect(updateManifestWorkStatus(toCluster, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
 
-	waitForDRPCProtected(placementObj.GetNamespace())
+	Expect(waitForDRPCProtected(placementObj.GetNamespace())).To(Succeed())
 
 	verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster)
 	verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.FailedOver)
 	verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster)
 
-	waitForCompletion(string(rmn.FailedOver))
+	Expect(waitForCompletion(string(rmn.FailedOver))).To(Succeed())
 }
 
 func createNamespacesSync() error {
@@ -1779,7 +1780,7 @@ func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster s
 	verifyUserPlacementRuleDecision(userPlacement.GetName(), userPlacement.GetNamespace(), preferredCluster)
 	verifyDRPCStatusPreferredClusterExpectation(userPlacement.GetNamespace(), rmn.Deployed)
 	Expect(getManifestWorkCount(preferredCluster)).Should(BeElementOf(3, 4)) // MWs for VRG, 2 namespaces, and DRCluster
-	waitForCompletion(string(rmn.Deployed))
+	Expect(waitForCompletion(string(rmn.Deployed))).To(Succeed())
 
 	latestDRPC, err := getLatestDRPC(userPlacement.GetNamespace())
 	Expect(err).NotTo(HaveOccurred())
@@ -2117,8 +2118,7 @@ var _ = Describe("DRPlacementControl Reconciler Errors", func() {
 		It("Should return an error", func(ctx SpecContext) {
 			_, _ = InitialDeploymentAsync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster,
 				UsePlacementRule)
-
-			waitForCompletion(string(rmn.Deployed))
+			Expect(waitForCompletion(string(rmn.Deployed))).To(Succeed())
 
 			err := retry.RetryOnConflict(retry.DefaultBackoff, deleteAllDRClusters)
 			Expect(err).ToNot(HaveOccurred())
@@ -2257,7 +2257,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG MW
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
@@ -2339,7 +2339,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG + NS MW
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
@@ -2436,7 +2436,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG + NS MW
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
 				ensureNamespaceMWsDeletedFromAllClusters(ApplicationNamespace)
@@ -2523,7 +2523,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should delete VRG from Primary (East1ManagedCluster)", func() {
 				By("\n\n*** DELETE DRPC ***\n\n")
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1)) // DRCluster
 				Expect(deleteDRPolicySync()).To(Succeed())
 				Expect(deleteDRClustersSync()).To(Succeed())
@@ -2597,7 +2597,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("\n\n*** DELETE DRPC ***\n\n")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + NS + VRG MW
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1)) // DRCluster
 				Expect(deleteDRPolicySync()).To(Succeed())
 				Expect(deleteDRClustersSync()).To(Succeed())
@@ -2625,7 +2625,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
 				userPlacementRule1 = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule1).NotTo(BeNil())
-				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)
+				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)).To(Succeed())
 				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(""))).To(Succeed())
 			})
 		})
@@ -2683,7 +2683,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 				resetClusterDown()
 				runFailoverAction(userPlacementRule1, from, to, false, false)
-				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.FailedOver)
+				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.FailedOver)).To(Succeed())
 				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, West1ManagedCluster, rmn.VRGActionFailover)).To(Succeed())
 				resetClusterDown()
 			})
@@ -2720,7 +2720,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				expectedPhase = rmn.FailedOver
 				expectedPorgression = rmn.ProgressionCompleted
 				verifyDRPCStateAndProgression(expectedAction, expectedPhase, expectedPorgression)
-				waitForCompletion(string(rmn.FailedOver))
+				Expect(waitForCompletion(string(rmn.FailedOver))).To(Succeed())
 			})
 		})
 
@@ -2731,7 +2731,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				from := West1ManagedCluster
 				runRelocateAction(userPlacementRule1, from, false, false)
 				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(rmn.ActionRelocate))).To(Succeed())
-				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Relocated)
+				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Relocated)).To(Succeed())
 			})
 		})
 		//nolint:lll
@@ -2761,7 +2761,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				expectedPhase = rmn.Relocated
 				expectedPorgression = rmn.ProgressionCompleted
 				verifyDRPCStateAndProgression(expectedAction, expectedPhase, expectedPorgression)
-				waitForCompletion(string(rmn.Relocated))
+				Expect(waitForCompletion(string(rmn.Relocated))).To(Succeed())
 			})
 		})
 		//nolint:lll
@@ -2793,7 +2793,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				expectedPhase = rmn.Relocated
 				expectedPorgression = rmn.ProgressionCompleted
 				verifyDRPCStateAndProgression(expectedAction, expectedPhase, expectedPorgression)
-				waitForCompletion(string(rmn.Relocated))
+				Expect(waitForCompletion(string(rmn.Relocated))).To(Succeed())
 			})
 		})
 
@@ -2815,7 +2815,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting DRPC", func() {
 			It("Should delete all VRGs", func() {
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
 			})
 		})
@@ -2849,7 +2849,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
 				userPlacementRule1 = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule1).NotTo(BeNil())
-				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)
+				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)).To(Succeed())
 				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(""))).To(Succeed())
 				resetToggleUIDChecks()
 			})
@@ -2872,7 +2872,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting DRPC", func() {
 			It("Should delete all VRGs", func() {
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
 			})
 		})
@@ -2916,7 +2916,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		Specify("Cleanup after tests", func() {
 			deleteUserPlacement()
 			deleteDRPC()
-			waitForCompletion("deleted")
+			Expect(waitForCompletion("deleted")).To(Succeed())
 			Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 			Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
 			ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
@@ -3026,7 +3026,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG MW
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -1117,59 +1117,87 @@ const (
 )
 
 func InitialDeploymentAsync(namespace, placementName, homeCluster string, plType PlacementType) (
-	client.Object, *rmn.DRPlacementControl,
+	client.Object, *rmn.DRPlacementControl, error,
 ) {
-	Expect(createNamespacesAsync(getNamespaceObj(namespace))).To(Succeed())
+	if err := createNamespacesAsync(getNamespaceObj(namespace)); err != nil {
+		return nil, nil, err
+	}
 
-	Expect(createManagedClusters(asyncClusters)).To(Succeed())
-	Expect(createDRClustersAsync()).To(Succeed())
-	Expect(createDRPolicyAsync()).To(Succeed())
-	Expect(createPlacementDecision()).To(Succeed())
+	if err := createManagedClusters(asyncClusters); err != nil {
+		return nil, nil, err
+	}
+
+	if err := createDRClustersAsync(); err != nil {
+		return nil, nil, err
+	}
+
+	if err := createDRPolicyAsync(); err != nil {
+		return nil, nil, err
+	}
+
+	if err := createPlacementDecision(); err != nil {
+		return nil, nil, err
+	}
 
 	return CreatePlacementAndDRPC(namespace, placementName, homeCluster, plType)
 }
 
 func CreatePlacementAndDRPC(namespace, placementName, homeCluster string, plType PlacementType) (
-	client.Object, *rmn.DRPlacementControl,
+	client.Object, *rmn.DRPlacementControl, error,
 ) {
 	var placementObj client.Object
-
 	var err error
 
 	switch plType {
 	case UsePlacementRule:
 		placementObj, err = createPlacementRule(placementName, namespace)
-		Expect(err).NotTo(HaveOccurred())
+		if err != nil {
+			return nil, nil, err
+		}
 	case UsePlacementWithSubscription:
 		placementObj, err = createPlacement(placementName, namespace)
-		Expect(err).NotTo(HaveOccurred())
+		if err != nil {
+			return nil, nil, err
+		}
 	case UsePlacementWithAppSet:
-		Expect(createAppSet()).To(Succeed())
+		if err := createAppSet(); err != nil {
+			return nil, nil, err
+		}
 
 		placementObj, err = createPlacement(placementName, namespace)
-		Expect(err).NotTo(HaveOccurred())
+		if err != nil {
+			return nil, nil, err
+		}
 	default:
-		Fail("Wrong placement type")
+		return nil, nil, fmt.Errorf("wrong placement type")
 	}
 
 	drpc, err := createDRPC(placementName, DRPCCommonName, namespace, AsyncDRPolicyName, homeCluster)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, nil, err
+	}
 
-	return placementObj, drpc
+	return placementObj, drpc, nil
 }
 
 func FollowOnDeploymentAsync(namespace, placementName, homeCluster string) (*plrv1.PlacementRule,
-	*rmn.DRPlacementControl,
+	*rmn.DRPlacementControl, error,
 ) {
-	Expect(createNamespace(appNamespace2)).To(Succeed())
+	if err := createNamespace(appNamespace2); err != nil {
+		return nil, nil, err
+	}
 
 	placementRule, err := createPlacementRule(placementName, namespace)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, nil, err
+	}
 
 	drpc, err := createDRPC(placementName, DRPCCommonName, namespace, AsyncDRPolicyName, homeCluster)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, nil, err
+	}
 
-	return placementRule, drpc
+	return placementRule, drpc, nil
 }
 
 func verifyVRGManifestWorkCreatedAsPrimary(namespace, managedCluster string) error {
@@ -1577,45 +1605,87 @@ func getDRPCCondition(status *rmn.DRPlacementControlStatus, conditionType string
 //nolint:unparam
 func runFailoverAction(placementObj client.Object, fromCluster, toCluster string, isSyncDR bool,
 	manualFence bool,
-) {
+) error {
 	if isSyncDR {
 		fenceCluster(fromCluster, manualFence)
 	}
 
-	recoverToFailoverCluster(placementObj, fromCluster, toCluster)
+	if err := recoverToFailoverCluster(placementObj, fromCluster, toCluster); err != nil {
+		return err
+	}
+
 	// TODO: DRCluster as part of Unfence operation, first unfences
 	//       the NetworkFence CR and then deletes it. Hence, by the
 	//       time this test is made, depending upon whether NetworkFence
 	//       resource is cleaned up or not, number of MW may change.
+	toMWCount, err := getManifestWorkCount(toCluster)
+	if err != nil {
+		return err
+	}
+
 	if !isSyncDR {
-		Expect(getManifestWorkCount(toCluster)).Should(BeElementOf(3, 4)) // MW for VRG+DRCluster+NS
+		if toMWCount != 3 && toMWCount != 4 { // MW for VRG+DRCluster+NS
+			return fmt.Errorf("expected MW count 3 or 4 on %s, got %d", toCluster, toMWCount)
+		}
 	} else {
 		if manualFence {
-			Expect(getManifestWorkCount(toCluster)).Should(Equal(3)) // MW for VRG+DRCluster + NS
+			if toMWCount != 3 { // MW for VRG+DRCluster + NS
+				return fmt.Errorf("expected MW count 3 on %s, got %d", toCluster, toMWCount)
+			}
 		} else {
-			Expect(getManifestWorkCount(toCluster)).Should(Equal(4)) // MW for VRG+DRCluster + NS + NF
+			if toMWCount != 4 { // MW for VRG+DRCluster + NS + NF
+				return fmt.Errorf("expected MW count 4 on %s, got %d", toCluster, toMWCount)
+			}
 		}
 	}
 
-	Expect(getManifestWorkCount(fromCluster)).Should(Equal(3)) // DRCluster + NS MW + VRG MW
+	fromMWCount, err := getManifestWorkCount(fromCluster)
+	if err != nil {
+		return err
+	}
+
+	if fromMWCount != 3 { // DRCluster + NS MW + VRG MW
+		return fmt.Errorf("expected MW count 3 on %s, got %d", fromCluster, fromMWCount)
+	}
 
 	drpc, err := getLatestDRPC(placementObj.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return err
+	}
+
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'FailedOver'
-	Expect(drpc.Status.Phase).To(Equal(rmn.FailedOver))
-	Expect(len(drpc.Status.Conditions)).To(Equal(3))
+	if drpc.Status.Phase != rmn.FailedOver {
+		return fmt.Errorf("expected phase FailedOver, got %v", drpc.Status.Phase)
+	}
+
+	if len(drpc.Status.Conditions) != 3 {
+		return fmt.Errorf("expected 3 conditions, got %d", len(drpc.Status.Conditions))
+	}
+
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
-	Expect(condition.Reason).To(Equal(string(rmn.FailedOver)))
-	Expect(drpc.Status.ActionStartTime).ShouldNot(BeNil())
+	if condition.Reason != string(rmn.FailedOver) {
+		return fmt.Errorf("expected condition reason FailedOver, got %s", condition.Reason)
+	}
+
+	if drpc.Status.ActionStartTime == nil {
+		return fmt.Errorf("expected ActionStartTime to be non-nil")
+	}
 
 	decision, err := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
-	Expect(decision.ClusterName).To(Equal(toCluster))
+	if err != nil {
+		return err
+	}
+
+	if decision.ClusterName != toCluster {
+		return fmt.Errorf("expected decision cluster %s, got %s", toCluster, decision.ClusterName)
+	}
+
+	return nil
 }
 
-func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR bool, manualUnfence bool) {
+func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR bool, manualUnfence bool) error {
 	toCluster1 := "east1-cluster"
 
 	if isSyncDR {
@@ -1637,88 +1707,170 @@ func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR 
 		resetdrCluster(toCluster1)
 	}
 
-	relocateToPreferredCluster(placementObj, fromCluster)
+	if err := relocateToPreferredCluster(placementObj, fromCluster); err != nil {
+		return err
+	}
+
 	// TODO: DRCluster as part of Unfence operation, first unfences
 	//       the NetworkFence CR and then deletes it. Hence, by the
 	//       time this test is made, depending upon whether NetworkFence
 	//       resource is cleaned up or not, number of MW may change.
+	fromMWCount, err := getManifestWorkCount(fromCluster)
+	if err != nil {
+		return err
+	}
 
-	// Expect(getManifestWorkCount(toCluster1)).Should(Equal(2)) // MWs for VRG+ROLES
 	if !isSyncDR {
-		Expect(getManifestWorkCount(fromCluster)).Should(BeElementOf(3, 4)) // DRClusters + NS MW + VRG MW
+		if fromMWCount != 3 && fromMWCount != 4 { // DRClusters + NS MW + VRG MW
+			return fmt.Errorf("expected MW count 3 or 4 on %s, got %d", fromCluster, fromMWCount)
+		}
 	} else {
 		// By the time this check is made, the NetworkFence CR in the
 		// cluster from where the application is migrated might not have
 		// been deleted. Hence, the number of MW expectation will be
 		// either of 2 or 3.
-		Expect(getManifestWorkCount(fromCluster)).Should(BeElementOf(2, 3))
+		if fromMWCount != 2 && fromMWCount != 3 {
+			return fmt.Errorf("expected MW count 2 or 3 on %s, got %d", fromCluster, fromMWCount)
+		}
 	}
 
 	drpc, err := getLatestDRPC(placementObj.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return err
+	}
+
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'Relocated'
-	Expect(drpc.Status.Phase).To(Equal(rmn.Relocated))
-	Expect(len(drpc.Status.Conditions)).To(Equal(3))
+	if drpc.Status.Phase != rmn.Relocated {
+		return fmt.Errorf("expected phase Relocated, got %v", drpc.Status.Phase)
+	}
+
+	if len(drpc.Status.Conditions) != 3 {
+		return fmt.Errorf("expected 3 conditions, got %d", len(drpc.Status.Conditions))
+	}
+
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
-	Expect(condition.Reason).To(Equal(string(rmn.Relocated)))
+	if condition.Reason != string(rmn.Relocated) {
+		return fmt.Errorf("expected condition reason Relocated, got %s", condition.Reason)
+	}
 
 	decision, err := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
-	Expect(decision.ClusterName).To(Equal(toCluster1))
-	Expect(condition.Reason).To(Equal(string(rmn.Relocated)))
-	Expect(drpc.GetAnnotations()[controllers.LastAppDeploymentCluster]).To(Equal(toCluster1))
+	if err != nil {
+		return err
+	}
+
+	if decision.ClusterName != toCluster1 {
+		return fmt.Errorf("expected decision cluster %s, got %s", toCluster1, decision.ClusterName)
+	}
+
+	if drpc.GetAnnotations()[controllers.LastAppDeploymentCluster] != toCluster1 {
+		return fmt.Errorf("expected LastAppDeploymentCluster %s, got %s",
+			toCluster1, drpc.GetAnnotations()[controllers.LastAppDeploymentCluster])
+	}
+
+	return nil
 }
 
-func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferredCluster, failoverCluster string) {
-	Expect(setDRPCSpecExpectationTo(userPlacementRule.GetNamespace(), preferredCluster, failoverCluster, "")).To(Succeed())
-	Expect(waitForCompletion(string(rmn.Deployed))).To(Succeed())
+func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferredCluster, failoverCluster string) error {
+	if err := setDRPCSpecExpectationTo(userPlacementRule.GetNamespace(), preferredCluster, failoverCluster, ""); err != nil {
+		return err
+	}
+
+	if err := waitForCompletion(string(rmn.Deployed)); err != nil {
+		return err
+	}
 
 	drpc, err := getLatestDRPC(userPlacementRule.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return err
+	}
+
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state didn't change and it is 'Relocated' even though we tried to run
 	// initial deployment
-	Expect(drpc.Status.Phase).To(Equal(rmn.Deployed))
-	Expect(len(drpc.Status.Conditions)).To(Equal(3))
+	if drpc.Status.Phase != rmn.Deployed {
+		return fmt.Errorf("expected phase Deployed, got %v", drpc.Status.Phase)
+	}
+
+	if len(drpc.Status.Conditions) != 3 {
+		return fmt.Errorf("expected 3 conditions, got %d", len(drpc.Status.Conditions))
+	}
+
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
-	Expect(condition.Reason).To(Equal(string(rmn.Deployed)))
+	if condition.Reason != string(rmn.Deployed) {
+		return fmt.Errorf("expected condition reason Deployed, got %s", condition.Reason)
+	}
 
 	decision, err := getLatestUserPlacementDecision(userPlacementRule.Name, userPlacementRule.Namespace)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(decision.ClusterName).To(Equal(preferredCluster))
+	if err != nil {
+		return err
+	}
+
+	if decision.ClusterName != preferredCluster {
+		return fmt.Errorf("expected decision cluster %s, got %s", preferredCluster, decision.ClusterName)
+	}
+
+	return nil
 }
 
-func relocateToPreferredCluster(placementObj client.Object, fromCluster string) {
+func relocateToPreferredCluster(placementObj client.Object, fromCluster string) error {
 	toCluster1 := "east1-cluster"
 
-	Expect(setDRPCSpecExpectationTo(placementObj.GetNamespace(), toCluster1, fromCluster, rmn.ActionRelocate)).To(Succeed())
+	if err := setDRPCSpecExpectationTo(placementObj.GetNamespace(), toCluster1, fromCluster, rmn.ActionRelocate); err != nil {
+		return err
+	}
 
-	Expect(updateManifestWorkStatus(toCluster1, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
+	if err := updateManifestWorkStatus(toCluster1, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied); err != nil {
+		return err
+	}
 
-	Expect(waitForDRPCProtected(placementObj.GetNamespace())).To(Succeed())
+	if err := waitForDRPCProtected(placementObj.GetNamespace()); err != nil {
+		return err
+	}
 
-	Expect(verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster1)).To(Succeed())
-	Expect(verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.Relocated)).To(Succeed())
-	Expect(verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster1)).To(Succeed())
+	if err := verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster1); err != nil {
+		return err
+	}
 
-	Expect(waitForCompletion(string(rmn.Relocated))).To(Succeed())
+	if err := verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.Relocated); err != nil {
+		return err
+	}
+
+	if err := verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster1); err != nil {
+		return err
+	}
+
+	return waitForCompletion(string(rmn.Relocated))
 }
 
-func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster string) {
-	Expect(setDRPCSpecExpectationTo(placementObj.GetNamespace(), fromCluster, toCluster, rmn.ActionFailover)).To(Succeed())
+func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster string) error {
+	if err := setDRPCSpecExpectationTo(placementObj.GetNamespace(), fromCluster, toCluster, rmn.ActionFailover); err != nil {
+		return err
+	}
 
-	Expect(updateManifestWorkStatus(toCluster, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
+	if err := updateManifestWorkStatus(toCluster, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied); err != nil {
+		return err
+	}
 
-	Expect(waitForDRPCProtected(placementObj.GetNamespace())).To(Succeed())
+	if err := waitForDRPCProtected(placementObj.GetNamespace()); err != nil {
+		return err
+	}
 
-	Expect(verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster)).To(Succeed())
-	Expect(verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.FailedOver)).To(Succeed())
-	Expect(verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster)).To(Succeed())
+	if err := verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster); err != nil {
+		return err
+	}
 
-	Expect(waitForCompletion(string(rmn.FailedOver))).To(Succeed())
+	if err := verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.FailedOver); err != nil {
+		return err
+	}
+
+	if err := verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster); err != nil {
+		return err
+	}
+
+	return waitForCompletion(string(rmn.FailedOver))
 }
 
 func createNamespacesSync() error {
@@ -1734,21 +1886,35 @@ func createNamespacesSync() error {
 }
 
 func InitialDeploymentSync(namespace, placementName, homeCluster string) (*plrv1.PlacementRule,
-	*rmn.DRPlacementControl,
+	*rmn.DRPlacementControl, error,
 ) {
-	Expect(createNamespacesSync()).To(Succeed())
+	if err := createNamespacesSync(); err != nil {
+		return nil, nil, err
+	}
 
-	Expect(createManagedClusters(syncClusters)).To(Succeed())
-	Expect(createDRClustersSync()).To(Succeed())
-	Expect(createDRPolicySync()).To(Succeed())
+	if err := createManagedClusters(syncClusters); err != nil {
+		return nil, nil, err
+	}
+
+	if err := createDRClustersSync(); err != nil {
+		return nil, nil, err
+	}
+
+	if err := createDRPolicySync(); err != nil {
+		return nil, nil, err
+	}
 
 	placementRule, err := createPlacementRule(placementName, namespace)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, nil, err
+	}
 
 	drpc, err := createDRPC(UserPlacementRuleName, DRPCCommonName, DefaultDRPCNamespace, SyncDRPolicyName, homeCluster)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, nil, err
+	}
 
-	return placementRule, drpc
+	return placementRule, drpc, nil
 }
 
 func createDRClustersSync() error {
@@ -1901,7 +2067,9 @@ func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster s
 func verifyFailoverToSecondary(placementObj client.Object, toCluster string,
 	isSyncDR bool,
 ) error {
-	recoverToFailoverCluster(placementObj, East1ManagedCluster, toCluster)
+	if err := recoverToFailoverCluster(placementObj, East1ManagedCluster, toCluster); err != nil {
+		return err
+	}
 
 	// TODO: DRCluster as part of Unfence operation, first unfences
 	//       the NetworkFence CR and then deletes it. Hence, by the
@@ -2135,12 +2303,13 @@ var _ = Describe("DRPlacementControl - Ensure do-not-delete PVC Annotation", fun
 		}
 
 		It(fmt.Sprintf("Should handle annotation propagation for %s", resourceType), func(ctx SpecContext) {
-			placementObj, drpc := InitialDeploymentAsync(
+			placementObj, drpc, err := InitialDeploymentAsync(
 				DefaultDRPCNamespace,
 				placementName,
 				East1ManagedCluster,
 				plType, // UsePlacementRule or UsePlacement
 			)
+			Expect(err).NotTo(HaveOccurred())
 
 			vrg := getDefaultVRG(DefaultDRPCNamespace)
 
@@ -2167,7 +2336,7 @@ var _ = Describe("DRPlacementControl - Ensure do-not-delete PVC Annotation", fun
 			}
 
 			// Positive base case: Ramen is the scheduler - do nothing, no error
-			err := controllers.EnsureDoNotDeletePVCAnnotation(mwu, drpc, placementObj, vrg, East1ManagedCluster, mwu.Log)
+			err = controllers.EnsureDoNotDeletePVCAnnotation(mwu, drpc, placementObj, vrg, East1ManagedCluster, mwu.Log)
 			Expect(err).To(BeNil())
 
 			// Default scheduler
@@ -2243,14 +2412,18 @@ var _ = Describe("DRPlacementControl - EnableDiff Annotation Propagation", func(
 	})
 
 	It("Should propagate EnableDiffAnnotation from DRPC to VRG in ManifestWork", func(ctx SpecContext) {
-		_, _ = InitialDeploymentAsync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster,
+		_, _, err := InitialDeploymentAsync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster,
 			UsePlacementRule)
+		Expect(err).NotTo(HaveOccurred())
 
-		waitForCompletion(string(rmn.Deployed))
+		Expect(waitForCompletion(string(rmn.Deployed))).To(Succeed())
 
 		// Set EnableDiffAnnotation on DRPC
 		retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			drpc := getLatestDRPC(DefaultDRPCNamespace)
+			drpc, err := getLatestDRPC(DefaultDRPCNamespace)
+			if err != nil {
+				return err
+			}
 
 			annotations := drpc.GetAnnotations()
 			if annotations == nil {
@@ -2274,8 +2447,8 @@ var _ = Describe("DRPlacementControl - EnableDiff Annotation Propagation", func(
 			return vrg.GetAnnotations()[rmnutil.EnableDiffAnnotation]
 		}, timeout, interval).Should(Equal("true"))
 
-		deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
-		deleteDRPC()
+		Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
+		Expect(deleteDRPC()).To(Succeed())
 	})
 })
 
@@ -2290,11 +2463,12 @@ var _ = Describe("DRPlacementControl Reconciler Errors", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should return an error", func(ctx SpecContext) {
-			_, _ = InitialDeploymentAsync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster,
+			_, _, err := InitialDeploymentAsync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster,
 				UsePlacementRule)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(waitForCompletion(string(rmn.Deployed))).To(Succeed())
 
-			err := retry.RetryOnConflict(retry.DefaultBackoff, deleteAllDRClusters)
+			err = retry.RetryOnConflict(retry.DefaultBackoff, deleteAllDRClusters)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(deleteDRPC()).To(Succeed())
@@ -2336,9 +2510,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("Initial Deployment")
 
 				var placementObj client.Object
-
-				placementObj, drpc = InitialDeploymentAsync(
+				var err error
+				placementObj, drpc, err = InitialDeploymentAsync(
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
+				Expect(err).NotTo(HaveOccurred())
 				userPlacementRule = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule).NotTo(BeNil())
 				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
@@ -2375,21 +2550,21 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				// ----------------------------- RELOCATION TO PRIMARY --------------------------------------
 				By("\n\n*** Relocate - 1\n\n")
-				runRelocateAction(userPlacementRule, West1ManagedCluster, false, false)
+				Expect(runRelocateAction(userPlacementRule, West1ManagedCluster, false, false)).To(Succeed())
 			})
 		})
 		When("DRAction is changed to Failover after relocation", func() {
 			It("Should failover again to Secondary (West1ManagedCluster)", func() {
 				// ----------------------------- FAILOVER TO SECONDARY --------------------------------------
 				By("\n\n*** Failover - 3\n\n")
-				runFailoverAction(userPlacementRule, East1ManagedCluster, West1ManagedCluster, false, false)
+				Expect(runFailoverAction(userPlacementRule, East1ManagedCluster, West1ManagedCluster, false, false)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				// ----------------------------- RELOCATION TO PRIMARY --------------------------------------
 				By("\n\n*** relocate 2\n\n")
-				runRelocateAction(userPlacementRule, West1ManagedCluster, false, false)
+				Expect(runRelocateAction(userPlacementRule, West1ManagedCluster, false, false)).To(Succeed())
 			})
 		})
 		When("Get VRG from s3 store", func() {
@@ -2407,7 +2582,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		When("A DRPC is created referring to a deleted DRPolicy", func() {
 			It("Should fail DRPC reconciliaiton and not add a finalizer", func() {
-				_, drpc2 := FollowOnDeploymentAsync(DRPC2NamespaceName, UserPlacementRuleName, East1ManagedCluster)
+				_, drpc2, err := FollowOnDeploymentAsync(DRPC2NamespaceName, UserPlacementRuleName, East1ManagedCluster)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(checkIfDRPCFinalizerNotAdded(drpc2)).To(Succeed())
 				Expect(k8sClient.Delete(context.TODO(), drpc2)).Should(Succeed())
 			})
@@ -2460,9 +2636,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("Initial Deployment")
 
 				var placementObj client.Object
-
-				placementObj, drpc = InitialDeploymentAsync(
+				var err error
+				placementObj, drpc, err = InitialDeploymentAsync(
 					DefaultDRPCNamespace, UserPlacementName, East1ManagedCluster, UsePlacementWithSubscription)
+				Expect(err).NotTo(HaveOccurred())
 				placement = placementObj.(*clrapiv1beta1.Placement)
 				Expect(placement).NotTo(BeNil())
 				Expect(verifyInitialDRPCDeployment(placement, East1ManagedCluster)).To(Succeed())
@@ -2484,13 +2661,13 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				setRestorePVsComplete()
 			})
 			It("Should failover to Secondary (West1ManagedCluster) when using Subscription", func() {
-				runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)
+				Expect(runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)).To(Succeed())
 				Expect(verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithSubscription)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate using Placement with Subscriptioin", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
-				runRelocateAction(placement, West1ManagedCluster, false, false)
+				Expect(runRelocateAction(placement, West1ManagedCluster, false, false)).To(Succeed())
 				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)).To(Succeed())
 			})
 		})
@@ -2545,9 +2722,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				getBaseVRG(DefaultDRPCNamespace).ObjectMeta.Namespace = ApplicationNamespace
 
 				var placementObj client.Object
-
-				placementObj, drpc = InitialDeploymentAsync(
+				var err error
+				placementObj, drpc, err = InitialDeploymentAsync(
 					DefaultDRPCNamespace, UserPlacementName, East1ManagedCluster, UsePlacementWithAppSet)
+				Expect(err).NotTo(HaveOccurred())
 				placement = placementObj.(*clrapiv1beta1.Placement)
 				Expect(placement).NotTo(BeNil())
 				Expect(verifyInitialDRPCDeployment(placement, East1ManagedCluster)).To(Succeed())
@@ -2569,25 +2747,25 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				setRestorePVsComplete()
 			})
 			It("Should failover to Secondary (West1ManagedCluster)", func() {
-				runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)
+				Expect(runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)).To(Succeed())
 				Expect(verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate using Placement", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
-				runRelocateAction(placement, West1ManagedCluster, false, false)
+				Expect(runRelocateAction(placement, West1ManagedCluster, false, false)).To(Succeed())
 				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
 		When("DRAction is changed to Failover after relocation using Placement", func() {
 			It("Should failover again to Secondary (West1ManagedCluster)", func() {
-				runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)
+				Expect(runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)).To(Succeed())
 				Expect(verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate again using Placement", func() {
 			It("Should relocate again to Primary (East1ManagedCluster)", func() {
-				runRelocateAction(placement, West1ManagedCluster, false, false)
+				Expect(runRelocateAction(placement, West1ManagedCluster, false, false)).To(Succeed())
 				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
@@ -2635,8 +2813,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("An Application is deployed for the first time", func() {
 			It("Should deploy to East1ManagedCluster", func() {
 				By("Initial Deployment")
-
-				userPlacementRule, _ = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
+				var err error
+				userPlacementRule, _, err = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
@@ -2664,27 +2843,27 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				// ----------------------------- RELOCATION TO PRIMARY FOR SYNC DR -------------------
 				By("\n\n*** relocate 2\n\n")
-				runRelocateAction(userPlacementRule, East2ManagedCluster, true, false)
+				Expect(runRelocateAction(userPlacementRule, East2ManagedCluster, true, false)).To(Succeed())
 			})
 		})
 		When("DRAction is cleared after relocation", func() {
 			It("Should not do anything", func() {
 				// ----------------------------- Clear DRAction --------------------------------------
-				clearDRActionAfterRelocate(userPlacementRule, East1ManagedCluster, East2ManagedCluster)
+				Expect(clearDRActionAfterRelocate(userPlacementRule, East1ManagedCluster, East2ManagedCluster)).To(Succeed())
 			})
 		})
 		When("DRAction is changed to Failover after relocation", func() {
 			It("Should failover again to Secondary (East2ManagedCluster)", func() {
 				// ----------------------------- FAILOVER TO SECONDARY FOR SYNC DR--------------------
 				By("\n\n*** Failover - 3\n\n")
-				runFailoverAction(userPlacementRule, East1ManagedCluster, East2ManagedCluster, true, false)
+				Expect(runFailoverAction(userPlacementRule, East1ManagedCluster, East2ManagedCluster, true, false)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				// ----------------------------- RELOCATION TO PRIMARY FOR SYNC DR------------------------
 				By("\n\n*** relocate 2\n\n")
-				runRelocateAction(userPlacementRule, East2ManagedCluster, true, false)
+				Expect(runRelocateAction(userPlacementRule, East2ManagedCluster, true, false)).To(Succeed())
 			})
 		})
 		When("Deleting user PlacementRule", func() {
@@ -2713,8 +2892,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("An Application is deployed for the first time", func() {
 			It("Should deploy to East1ManagedCluster", func() {
 				By("Initial Deployment")
-
-				userPlacementRule, _ = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
+				var err error
+				userPlacementRule, _, err = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
@@ -2742,21 +2922,21 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				// ----------------------------- RELOCATION TO PRIMARY FOR SYNC DR -------------------
 				By("\n\n*** relocate 2\n\n")
-				runRelocateAction(userPlacementRule, East2ManagedCluster, true, true)
+				Expect(runRelocateAction(userPlacementRule, East2ManagedCluster, true, true)).To(Succeed())
 			})
 		})
 		When("DRAction is changed to Failover after relocation", func() {
 			It("Should failover again to Secondary (East2ManagedCluster)", func() {
 				// ----------------------------- FAILOVER TO SECONDARY FOR SYNC DR--------------------
 				By("\n\n*** Failover - 3\n\n")
-				runFailoverAction(userPlacementRule, East1ManagedCluster, East2ManagedCluster, true, true)
+				Expect(runFailoverAction(userPlacementRule, East1ManagedCluster, East2ManagedCluster, true, true)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				// ----------------------------- RELOCATION TO PRIMARY FOR SYNC DR------------------------
 				By("\n\n*** relocate 2\n\n")
-				runRelocateAction(userPlacementRule, East2ManagedCluster, true, false)
+				Expect(runRelocateAction(userPlacementRule, East2ManagedCluster, true, false)).To(Succeed())
 			})
 		})
 		When("Deleting user PlacementRule", func() {
@@ -2794,9 +2974,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(createDRPolicyAsync()).To(Succeed())
 
 				var placementObj client.Object
-
-				placementObj, _ = CreatePlacementAndDRPC(
+				var err error
+				placementObj, _, err = CreatePlacementAndDRPC(
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
+				Expect(err).NotTo(HaveOccurred())
 				userPlacementRule1 = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule1).NotTo(BeNil())
 				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)).To(Succeed())
@@ -2856,7 +3037,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				to := West1ManagedCluster
 
 				resetClusterDown()
-				runFailoverAction(userPlacementRule1, from, to, false, false)
+				Expect(runFailoverAction(userPlacementRule1, from, to, false, false)).To(Succeed())
 				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.FailedOver)).To(Succeed())
 				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, West1ManagedCluster, rmn.VRGActionFailover)).To(Succeed())
 				resetClusterDown()
@@ -2903,7 +3084,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				// ----------------------------- RELOCATION TO PRIMARY --------------------------------------
 				from := West1ManagedCluster
-				runRelocateAction(userPlacementRule1, from, false, false)
+				Expect(runRelocateAction(userPlacementRule1, from, false, false)).To(Succeed())
 				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(rmn.ActionRelocate))).To(Succeed())
 				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Relocated)).To(Succeed())
 			})
@@ -3018,9 +3199,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(createVRGMW(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster)).To(Succeed())
 
 				var placementObj client.Object
-
-				placementObj, _ = CreatePlacementAndDRPC(
+				var err error
+				placementObj, _, err = CreatePlacementAndDRPC(
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
+				Expect(err).NotTo(HaveOccurred())
 				userPlacementRule1 = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule1).NotTo(BeNil())
 				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)).To(Succeed())
@@ -3068,13 +3250,17 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should deploy to East1ManagedCluster", func() {
 				By("Initial Deployment")
 				var placementObj client.Object
-				placementObj, drpc = InitialDeploymentAsync(
+				var err error
+				placementObj, drpc, err = InitialDeploymentAsync(
 					DefaultDRPCNamespace, UserPlacementName, East1ManagedCluster, UsePlacementWithSubscription)
+				Expect(err).NotTo(HaveOccurred())
 				placement = placementObj.(*clrapiv1beta1.Placement)
 				Expect(placement).NotTo(BeNil())
 				Expect(verifyInitialDRPCDeployment(placement, East1ManagedCluster)).To(Succeed())
 				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)).To(Succeed())
-				verifyDRPCOwnedByPlacement(placement, getLatestDRPC(DefaultDRPCNamespace))
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				verifyDRPCOwnedByPlacement(placement, latestDRPC)
 			})
 		})
 		When("DRAction changes to Failover", func() {
@@ -3115,9 +3301,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("The Application is deployed for VolSync", func() {
 			It("Should deploy to East1ManagedCluster", func() {
 				var placementObj client.Object
-
-				placementObj, drpc = InitialDeploymentAsync(
+				var err error
+				placementObj, drpc, err = InitialDeploymentAsync(
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
+				Expect(err).NotTo(HaveOccurred())
 				userPlacementRule = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule).NotTo(BeNil())
 				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
@@ -3128,14 +3315,14 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		When("DRAction is changed to Failover", func() {
 			It("Should failover to Secondary (West1ManagedCluster)", func() {
-				recoverToFailoverCluster(userPlacementRule, East1ManagedCluster, West1ManagedCluster)
+				Expect(recoverToFailoverCluster(userPlacementRule, East1ManagedCluster, West1ManagedCluster)).To(Succeed())
 				Expect(getVRGManifestWorkCount()).Should(Equal(2))
 				verifyRDSpecAfterActionSwitch(West1ManagedCluster, East1ManagedCluster, 2)
 			})
 		})
 		When("DRAction is set to Relocate", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
-				relocateToPreferredCluster(userPlacementRule, West1ManagedCluster)
+				Expect(relocateToPreferredCluster(userPlacementRule, West1ManagedCluster)).To(Succeed())
 				Expect(getVRGManifestWorkCount()).Should(Equal(2))
 				verifyRDSpecAfterActionSwitch(East1ManagedCluster, West1ManagedCluster, 2)
 			})
@@ -3143,8 +3330,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("DRAction is changed back to Failover using only 1 protectedPVC", func() {
 			It("Should failover to secondary (West1ManagedCluster)", func() {
 				ProtectedPVCCount = 1
-
-				recoverToFailoverCluster(userPlacementRule, East1ManagedCluster, West1ManagedCluster)
+				Expect(recoverToFailoverCluster(userPlacementRule, East1ManagedCluster, West1ManagedCluster)).To(Succeed())
 				Expect(getVRGManifestWorkCount()).Should(Equal(2))
 				verifyRDSpecAfterActionSwitch(West1ManagedCluster, East1ManagedCluster, 1)
 
@@ -3154,8 +3340,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("DRAction is set back to Relocate using only 1 protectedPVC", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				ProtectedPVCCount = 1
-
-				relocateToPreferredCluster(userPlacementRule, West1ManagedCluster)
+				Expect(relocateToPreferredCluster(userPlacementRule, West1ManagedCluster)).To(Succeed())
 				Expect(getVRGManifestWorkCount()).Should(Equal(2))
 				verifyRDSpecAfterActionSwitch(East1ManagedCluster, West1ManagedCluster, 1)
 
@@ -3165,8 +3350,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("DRAction is changed back to Failover using only 10 protectedPVC", func() {
 			It("Should failover to secondary (West1ManagedCluster)", func() {
 				ProtectedPVCCount = 10
-
-				recoverToFailoverCluster(userPlacementRule, East1ManagedCluster, West1ManagedCluster)
+				Expect(recoverToFailoverCluster(userPlacementRule, East1ManagedCluster, West1ManagedCluster)).To(Succeed())
 				Expect(getVRGManifestWorkCount()).Should(Equal(2))
 				verifyRDSpecAfterActionSwitch(West1ManagedCluster, East1ManagedCluster, 10)
 
@@ -3176,8 +3360,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("DRAction is set back to Relocate using only 10 protectedPVC", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				ProtectedPVCCount = 10
-
-				relocateToPreferredCluster(userPlacementRule, West1ManagedCluster)
+				Expect(relocateToPreferredCluster(userPlacementRule, West1ManagedCluster)).To(Succeed())
 				Expect(getVRGManifestWorkCount()).Should(Equal(2))
 				verifyRDSpecAfterActionSwitch(East1ManagedCluster, West1ManagedCluster, 10)
 

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/format"
 	. "github.com/onsi/gomega/gstruct"
 	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -651,7 +650,7 @@ func deleteDRPC() error {
 	return nil
 }
 
-func ensureNamespaceMWsDeletedFromAllClusters(namespace string) {
+func ensureNamespaceMWsDeletedFromAllClusters(namespace string) error {
 	foundMW := &ocmworkv1.ManifestWork{}
 	mwName := fmt.Sprintf(rmnutil.ManifestWorkNameFormat, DRPCCommonName, namespace, rmnutil.MWTypeNS)
 
@@ -659,15 +658,17 @@ func ensureNamespaceMWsDeletedFromAllClusters(namespace string) {
 		types.NamespacedName{Name: mwName, Namespace: East1ManagedCluster},
 		foundMW)
 	if err == nil {
-		Expect(foundMW).To(BeNil())
+		return fmt.Errorf("namespace MW still exists on %s", East1ManagedCluster)
 	}
 
 	err = k8sClient.Get(context.TODO(),
 		types.NamespacedName{Name: mwName, Namespace: West1ManagedCluster},
 		foundMW)
 	if err == nil {
-		Expect(foundMW).To(BeNil())
+		return fmt.Errorf("namespace MW still exists on %s", West1ManagedCluster)
 	}
+
+	return nil
 }
 
 func setDRPCSpecExpectationTo(namespace, preferredCluster, failoverCluster string, action rmn.DRAction) error {
@@ -1062,43 +1063,40 @@ func updateManifestWorkStatus(clusterNamespace, vrgNamespace, mwType, workType s
 		})
 }
 
-func ensureDRPolicyIsNotDeleted(drpc *rmn.DRPlacementControl) {
-	Consistently(func() bool {
+func ensureDRPolicyIsNotDeleted(drpc *rmn.DRPlacementControl) error {
+	msg := "DRPolicy deleted prematurely, with active DRPC references"
+
+	return ensureConsistent(timeout, interval, msg, func() bool {
 		drpolicy := &rmn.DRPolicy{}
 		name := drpc.Spec.DRPolicyRef.Name
 		err := apiReader.Get(context.TODO(), types.NamespacedName{Name: name}, drpolicy)
 		// TODO: Technically we need to Expect deletion TS is non-zero as well here!
 		return err == nil
-	}, timeout, interval).Should(BeTrue(), "DRPolicy deleted prematurely, with active DRPC references")
+	})
 }
 
-func ensureDRPolicyIsDeleted(drpolicyName string) {
-	drpolicy := &rmn.DRPolicy{}
-	Eventually(func() error {
-		return apiReader.Get(context.TODO(), types.NamespacedName{Name: drpolicyName}, drpolicy)
-	}, timeout, interval).Should(
-		MatchError(
-			k8serrors.NewNotFound(
-				schema.GroupResource{
-					Group:    rmn.GroupVersion.Group,
-					Resource: "drpolicies",
-				},
-				drpolicyName,
-			),
-		),
-		"DRPolicy %s not found\n%s",
-		drpolicyName,
-		format.Object(*drpolicy, 0),
-	)
+func ensureDRPolicyIsDeleted(drpolicyName string) error {
+	msg := fmt.Sprintf("DRPolicy %s not deleted", drpolicyName)
+
+	return waitForCondition(timeout, interval, msg, func() bool {
+		drpolicy := &rmn.DRPolicy{}
+		err := apiReader.Get(context.TODO(), types.NamespacedName{Name: drpolicyName}, drpolicy)
+
+		return k8serrors.IsNotFound(err)
+	})
 }
 
-func checkIfDRPCFinalizerNotAdded(drpc *rmn.DRPlacementControl) {
-	Consistently(func() bool {
+func checkIfDRPCFinalizerNotAdded(drpc *rmn.DRPlacementControl) error {
+	msg := "DRPlacementControl reconciled with a finalizer when DRPolicy is in a deleted state"
+
+	return ensureConsistent(timeout, interval, msg, func() bool {
 		drpcl := &rmn.DRPlacementControl{}
 		err := apiReader.Get(context.TODO(),
 			types.NamespacedName{Name: drpc.Name, Namespace: drpc.Namespace},
 			drpcl)
-		Expect(err).NotTo(HaveOccurred())
+		if err != nil {
+			return false
+		}
 
 		f := drpcl.GetFinalizers()
 		for _, e := range f {
@@ -1108,8 +1106,7 @@ func checkIfDRPCFinalizerNotAdded(drpc *rmn.DRPlacementControl) {
 		}
 
 		return true
-	}, timeout, interval).Should(BeTrue(), "DRPlacementControl reconciled with a finalizer",
-		"when DRPolicy is in a deleted state")
+	})
 }
 
 type PlacementType int
@@ -1176,35 +1173,37 @@ func FollowOnDeploymentAsync(namespace, placementName, homeCluster string) (*plr
 	return placementRule, drpc
 }
 
-func verifyVRGManifestWorkCreatedAsPrimary(namespace, managedCluster string) {
+func verifyVRGManifestWorkCreatedAsPrimary(namespace, managedCluster string) error {
 	vrgManifestLookupKey := types.NamespacedName{
 		Name:      rmnutil.DrClusterManifestWorkName,
 		Namespace: managedCluster,
 	}
 	createdVRGRolesManifest := &ocmworkv1.ManifestWork{}
 
-	Eventually(func() bool {
+	if err := waitForCondition(timeout, interval, "waiting for VRG roles manifest", func() bool {
 		err := k8sClient.Get(context.TODO(), vrgManifestLookupKey, createdVRGRolesManifest)
 
 		return err == nil
-	}, timeout, interval).Should(BeTrue())
+	}); err != nil {
+		return err
+	}
 
-	Expect(len(createdVRGRolesManifest.Spec.Workload.Manifests)).To(Equal(10))
+	if len(createdVRGRolesManifest.Spec.Workload.Manifests) != 10 {
+		return fmt.Errorf("expected 10 manifests, got %d", len(createdVRGRolesManifest.Spec.Workload.Manifests))
+	}
 
 	vrgClusterRoleManifest := createdVRGRolesManifest.Spec.Workload.Manifests[0]
-	Expect(vrgClusterRoleManifest).ToNot(BeNil())
 
 	vrgClusterRole := &rbacv1.ClusterRole{}
-	err := yaml.Unmarshal(vrgClusterRoleManifest.RawExtension.Raw, &vrgClusterRole)
-	Expect(err).NotTo(HaveOccurred())
-
-	vrgClusterRoleBindingManifest := createdVRGRolesManifest.Spec.Workload.Manifests[1]
-	Expect(vrgClusterRoleBindingManifest).ToNot(BeNil())
+	if err := yaml.Unmarshal(vrgClusterRoleManifest.RawExtension.Raw, &vrgClusterRole); err != nil {
+		return fmt.Errorf("failed to unmarshal VRG ClusterRole: %w", err)
+	}
 
 	vrgClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 
-	err = yaml.Unmarshal(vrgClusterRoleManifest.RawExtension.Raw, &vrgClusterRoleBinding)
-	Expect(err).NotTo(HaveOccurred())
+	if err := yaml.Unmarshal(vrgClusterRoleManifest.RawExtension.Raw, &vrgClusterRoleBinding); err != nil {
+		return fmt.Errorf("failed to unmarshal VRG ClusterRoleBinding: %w", err)
+	}
 
 	manifestLookupKey := types.NamespacedName{
 		Name:      rmnutil.ManifestWorkName(DRPCCommonName, getVRGNamespace(namespace), "vrg"),
@@ -1213,30 +1212,51 @@ func verifyVRGManifestWorkCreatedAsPrimary(namespace, managedCluster string) {
 
 	mw := &ocmworkv1.ManifestWork{}
 
-	Eventually(func() bool {
-		err := k8sClient.Get(context.TODO(), manifestLookupKey, mw)
+	if err := waitForCondition(timeout, interval,
+		fmt.Sprintf("waiting for manifest work %+v", manifestLookupKey), func() bool {
+			err := k8sClient.Get(context.TODO(), manifestLookupKey, mw)
 
-		return err == nil
-	}, timeout, interval).Should(BeTrue(), fmt.Sprintf("manifestlookup %+v", manifestLookupKey))
+			return err == nil
+		}); err != nil {
+		return err
+	}
 
-	Expect(len(mw.Spec.Workload.Manifests)).To(Equal(1))
+	if len(mw.Spec.Workload.Manifests) != 1 {
+		return fmt.Errorf("expected 1 manifest, got %d", len(mw.Spec.Workload.Manifests))
+	}
 
 	vrgClientManifest := mw.Spec.Workload.Manifests[0]
 
-	Expect(vrgClientManifest).ToNot(BeNil())
-
 	vrg := &rmn.VolumeReplicationGroup{}
 
-	err = yaml.Unmarshal(vrgClientManifest.RawExtension.Raw, &vrg)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(vrg.Name).Should(Equal(DRPCCommonName))
-	Expect(vrg.Spec.PVCSelector.MatchLabels["appclass"]).Should(Equal("gold"))
-	Expect(vrg.Spec.ReplicationState).Should(Equal(rmn.Primary))
+	if err := yaml.Unmarshal(vrgClientManifest.RawExtension.Raw, &vrg); err != nil {
+		return fmt.Errorf("failed to unmarshal VRG: %w", err)
+	}
+
+	if vrg.Name != DRPCCommonName {
+		return fmt.Errorf("expected VRG name %s, got %s", DRPCCommonName, vrg.Name)
+	}
+
+	if vrg.Spec.PVCSelector.MatchLabels["appclass"] != "gold" {
+		return fmt.Errorf("expected PVCSelector appclass=gold, got %s", vrg.Spec.PVCSelector.MatchLabels["appclass"])
+	}
+
+	if vrg.Spec.ReplicationState != rmn.Primary {
+		return fmt.Errorf("expected ReplicationState Primary, got %s", vrg.Spec.ReplicationState)
+	}
 
 	// ensure DRPC copied KubeObjectProtection contents to VRG
 	drpc, err := getLatestDRPC(namespace)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(vrg.Spec.KubeObjectProtection).Should(Equal(drpc.Spec.KubeObjectProtection))
+	if err != nil {
+		return err
+	}
+
+	if vrg.Spec.KubeObjectProtection == nil && drpc.Spec.KubeObjectProtection != nil ||
+		vrg.Spec.KubeObjectProtection != nil && drpc.Spec.KubeObjectProtection == nil {
+		return fmt.Errorf("KubeObjectProtection mismatch between VRG and DRPC")
+	}
+
+	return nil
 }
 
 func getManifestWorkCount(homeClusterNamespace string) (int, error) {
@@ -1255,18 +1275,26 @@ func getManifestWorkCount(homeClusterNamespace string) (int, error) {
 	return len(manifestWorkList.Items) - 1, nil
 }
 
-func verifyNSManifestWork(resourceName, namespaceString, managedCluster string) {
+func verifyNSManifestWork(resourceName, namespaceString, managedCluster string) error {
 	mw := &ocmworkv1.ManifestWork{}
 	mwName := fmt.Sprintf(rmnutil.ManifestWorkNameFormat, resourceName, namespaceString, rmnutil.MWTypeNS)
 	err := k8sClient.Get(context.TODO(),
 		types.NamespacedName{Name: mwName, Namespace: managedCluster},
 		mw)
+	if err != nil {
+		return fmt.Errorf("failed to get NS ManifestWork %s: %w", mwName, err)
+	}
 
-	Expect(err).NotTo(HaveOccurred())
+	if mw.Spec.DeleteOption == nil {
+		return fmt.Errorf("NS ManifestWork %s DeleteOption is nil", mwName)
+	}
 
-	Expect(mw).ToNot(BeNil())
-	Expect(mw.Spec.DeleteOption).ToNot(BeNil())
-	Expect(mw.Labels[rmnutil.OCMBackupLabelKey]).To(Equal(""))
+	if mw.Labels[rmnutil.OCMBackupLabelKey] != "" {
+		return fmt.Errorf("NS ManifestWork %s OCMBackupLabelKey is %q, expected empty",
+			mwName, mw.Labels[rmnutil.OCMBackupLabelKey])
+	}
+
+	return nil
 }
 
 //nolint:unparam
@@ -1281,7 +1309,7 @@ func getManagedClusterViewCount(homeClusterNamespace string) (int, error) {
 	return len(mcvList.Items), nil
 }
 
-func verifyUserPlacementRuleDecision(name, namespace, homeCluster string) {
+func verifyUserPlacementRuleDecision(name, namespace, homeCluster string) error {
 	usrPlacementLookupKey := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -1291,7 +1319,7 @@ func verifyUserPlacementRuleDecision(name, namespace, homeCluster string) {
 
 	var placementObj client.Object
 
-	Eventually(func() bool {
+	if err := waitForCondition(timeout, interval, "waiting for placement decision", func() bool {
 		err := k8sClient.Get(context.TODO(), usrPlacementLookupKey, usrPlRule)
 		if k8serrors.IsNotFound(err) {
 			usrPlmnt := &clrapiv1beta1.Placement{}
@@ -1312,10 +1340,21 @@ func verifyUserPlacementRuleDecision(name, namespace, homeCluster string) {
 
 		return err == nil && len(usrPlRule.Status.Decisions) > 0 &&
 			usrPlRule.Status.Decisions[0].ClusterName == homeCluster
-	}, timeout, interval).Should(BeTrue())
+	}); err != nil {
+		return err
+	}
 
-	Expect(placementObj.GetAnnotations()[controllers.DRPCNameAnnotation]).Should(Equal(DRPCCommonName))
-	Expect(placementObj.GetAnnotations()[controllers.DRPCNamespaceAnnotation]).Should(Equal(namespace))
+	if placementObj.GetAnnotations()[controllers.DRPCNameAnnotation] != DRPCCommonName {
+		return fmt.Errorf("expected DRPCNameAnnotation %s, got %s",
+			DRPCCommonName, placementObj.GetAnnotations()[controllers.DRPCNameAnnotation])
+	}
+
+	if placementObj.GetAnnotations()[controllers.DRPCNamespaceAnnotation] != namespace {
+		return fmt.Errorf("expected DRPCNamespaceAnnotation %s, got %s",
+			namespace, placementObj.GetAnnotations()[controllers.DRPCNamespaceAnnotation])
+	}
+
+	return nil
 }
 
 func waitForDRPCProtected(namespace string) error {
@@ -1345,8 +1384,7 @@ func getPlacementDecision(plName, plNamespace string) *clrapiv1beta1.PlacementDe
 	return plDecision
 }
 
-//nolint:unparam
-func verifyUserPlacementRuleDecisionUnchanged(name, namespace, homeCluster string) {
+func verifyUserPlacementRuleDecisionUnchanged(name, namespace, homeCluster string) error {
 	usrPlacementLookupKey := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -1356,7 +1394,7 @@ func verifyUserPlacementRuleDecisionUnchanged(name, namespace, homeCluster strin
 
 	var placementObj client.Object
 
-	Consistently(func() bool {
+	if err := ensureConsistent(timeout, interval, "placement decision changed unexpectedly", func() bool {
 		err := k8sClient.Get(context.TODO(), usrPlacementLookupKey, usrPlRule)
 		if k8serrors.IsNotFound(err) {
 			usrPlmnt := &clrapiv1beta1.Placement{}
@@ -1376,13 +1414,24 @@ func verifyUserPlacementRuleDecisionUnchanged(name, namespace, homeCluster strin
 		placementObj = usrPlRule
 
 		return err == nil && usrPlRule.Status.Decisions[0].ClusterName == homeCluster
-	}, timeout, interval).Should(BeTrue())
+	}); err != nil {
+		return err
+	}
 
-	Expect(placementObj.GetAnnotations()[controllers.DRPCNameAnnotation]).Should(Equal(DRPCCommonName))
-	Expect(placementObj.GetAnnotations()[controllers.DRPCNamespaceAnnotation]).Should(Equal(namespace))
+	if placementObj.GetAnnotations()[controllers.DRPCNameAnnotation] != DRPCCommonName {
+		return fmt.Errorf("expected DRPCNameAnnotation %s, got %s",
+			DRPCCommonName, placementObj.GetAnnotations()[controllers.DRPCNameAnnotation])
+	}
+
+	if placementObj.GetAnnotations()[controllers.DRPCNamespaceAnnotation] != namespace {
+		return fmt.Errorf("expected DRPCNamespaceAnnotation %s, got %s",
+			namespace, placementObj.GetAnnotations()[controllers.DRPCNamespaceAnnotation])
+	}
+
+	return nil
 }
 
-func verifyDRPCStatusPreferredClusterExpectation(namespace string, drState rmn.DRState) {
+func verifyDRPCStatusPreferredClusterExpectation(namespace string, drState rmn.DRState) error {
 	drpcLookupKey := types.NamespacedName{
 		Name:      DRPCCommonName,
 		Namespace: namespace,
@@ -1390,24 +1439,35 @@ func verifyDRPCStatusPreferredClusterExpectation(namespace string, drState rmn.D
 
 	updatedDRPC := &rmn.DRPlacementControl{}
 
-	Eventually(func() bool {
-		err := k8sClient.Get(context.TODO(), drpcLookupKey, updatedDRPC)
+	if err := waitForCondition(timeout, interval,
+		fmt.Sprintf("failed waiting for an updated DRPC. State %v", drState), func() bool {
+			err := k8sClient.Get(context.TODO(), drpcLookupKey, updatedDRPC)
 
-		if d := updatedDRPC.Status.PreferredDecision; err == nil && d != (rmn.PlacementDecision{}) {
-			idx, condition := getDRPCCondition(&updatedDRPC.Status, rmn.ConditionAvailable)
+			if d := updatedDRPC.Status.PreferredDecision; err == nil && d != (rmn.PlacementDecision{}) {
+				idx, condition := getDRPCCondition(&updatedDRPC.Status, rmn.ConditionAvailable)
 
-			return d.ClusterName == East1ManagedCluster &&
-				idx != -1 &&
-				condition.Reason == string(drState) &&
-				len(updatedDRPC.Status.ResourceConditions.ResourceMeta.ProtectedPVCs) == ProtectedPVCCount
-		}
+				return d.ClusterName == East1ManagedCluster &&
+					idx != -1 &&
+					condition.Reason == string(drState) &&
+					len(updatedDRPC.Status.ResourceConditions.ResourceMeta.ProtectedPVCs) == ProtectedPVCCount
+			}
 
-		return false
-	}, timeout, interval).Should(BeTrue(), fmt.Sprintf("failed waiting for an updated DRPC. State %v", drState))
+			return false
+		}); err != nil {
+		return err
+	}
 
-	Expect(updatedDRPC.Status.PreferredDecision.ClusterName).Should(Equal(East1ManagedCluster))
+	if updatedDRPC.Status.PreferredDecision.ClusterName != East1ManagedCluster {
+		return fmt.Errorf("expected PreferredDecision cluster %s, got %s",
+			East1ManagedCluster, updatedDRPC.Status.PreferredDecision.ClusterName)
+	}
+
 	_, condition := getDRPCCondition(&updatedDRPC.Status, rmn.ConditionAvailable)
-	Expect(condition.Reason).Should(Equal(string(drState)))
+	if condition.Reason != string(drState) {
+		return fmt.Errorf("expected condition reason %s, got %s", string(drState), condition.Reason)
+	}
+
+	return nil
 }
 
 func getLatestUserPlacementRule(name, namespace string) (*plrv1.PlacementRule, error) {
@@ -1688,9 +1748,9 @@ func relocateToPreferredCluster(placementObj client.Object, fromCluster string) 
 
 	Expect(waitForDRPCProtected(placementObj.GetNamespace())).To(Succeed())
 
-	verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster1)
-	verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.Relocated)
-	verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster1)
+	Expect(verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster1)).To(Succeed())
+	Expect(verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.Relocated)).To(Succeed())
+	Expect(verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster1)).To(Succeed())
 
 	Expect(waitForCompletion(string(rmn.Relocated))).To(Succeed())
 }
@@ -1702,9 +1762,9 @@ func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster
 
 	Expect(waitForDRPCProtected(placementObj.GetNamespace())).To(Succeed())
 
-	verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster)
-	verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.FailedOver)
-	verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster)
+	Expect(verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster)).To(Succeed())
+	Expect(verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.FailedOver)).To(Succeed())
+	Expect(verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster)).To(Succeed())
 
 	Expect(waitForCompletion(string(rmn.FailedOver))).To(Succeed())
 }
@@ -1821,35 +1881,74 @@ func resetdrCluster(cluster string) {
 	updateDRClusterParameters(latestDRCluster)
 }
 
-//nolint:unparam
-func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster string) {
-	verifyVRGManifestWorkCreatedAsPrimary(userPlacement.GetNamespace(), preferredCluster)
-	Expect(updateManifestWorkStatus(preferredCluster, userPlacement.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
-	verifyUserPlacementRuleDecision(userPlacement.GetName(), userPlacement.GetNamespace(), preferredCluster)
-	verifyDRPCStatusPreferredClusterExpectation(userPlacement.GetNamespace(), rmn.Deployed)
-	Expect(getManifestWorkCount(preferredCluster)).Should(BeElementOf(3, 4)) // MWs for VRG, 2 namespaces, and DRCluster
-	Expect(waitForCompletion(string(rmn.Deployed))).To(Succeed())
+func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster string) error {
+	if err := verifyVRGManifestWorkCreatedAsPrimary(userPlacement.GetNamespace(), preferredCluster); err != nil {
+		return err
+	}
+
+	if err := updateManifestWorkStatus(preferredCluster, userPlacement.GetNamespace(), "vrg", ocmworkv1.WorkApplied); err != nil {
+		return err
+	}
+
+	if err := verifyUserPlacementRuleDecision(userPlacement.GetName(), userPlacement.GetNamespace(), preferredCluster); err != nil {
+		return err
+	}
+
+	if err := verifyDRPCStatusPreferredClusterExpectation(userPlacement.GetNamespace(), rmn.Deployed); err != nil {
+		return err
+	}
+
+	mwCount, err := getManifestWorkCount(preferredCluster)
+	if err != nil {
+		return err
+	}
+
+	if mwCount != 3 && mwCount != 4 {
+		return fmt.Errorf("expected ManifestWorkCount 3 or 4, got %d", mwCount)
+	}
+
+	if err := waitForCompletion(string(rmn.Deployed)); err != nil {
+		return err
+	}
 
 	latestDRPC, err := getLatestDRPC(userPlacement.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return err
+	}
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'Deployed'
-	Expect(latestDRPC.Status.Phase).To(Equal(rmn.Deployed))
-	Expect(len(latestDRPC.Status.Conditions)).To(Equal(3))
-	_, condition := getDRPCCondition(&latestDRPC.Status, rmn.ConditionAvailable)
-	Expect(condition.Reason).To(Equal(string(rmn.Deployed)))
-	Expect(latestDRPC.GetAnnotations()[controllers.LastAppDeploymentCluster]).To(Equal(preferredCluster))
-	Expect(latestDRPC.GetAnnotations()[controllers.DRPCAppNamespace]).
-		To(Equal(getVRGNamespace(userPlacement.GetNamespace())))
+	if latestDRPC.Status.Phase != rmn.Deployed {
+		return fmt.Errorf("expected phase Deployed, got %s", latestDRPC.Status.Phase)
+	}
 
-	verifyNSManifestWork(latestDRPC.Name, getVRGNamespace(latestDRPC.Namespace),
+	if len(latestDRPC.Status.Conditions) != 3 {
+		return fmt.Errorf("expected 3 conditions, got %d", len(latestDRPC.Status.Conditions))
+	}
+
+	_, condition := getDRPCCondition(&latestDRPC.Status, rmn.ConditionAvailable)
+	if condition.Reason != string(rmn.Deployed) {
+		return fmt.Errorf("expected condition reason Deployed, got %s", condition.Reason)
+	}
+
+	if latestDRPC.GetAnnotations()[controllers.LastAppDeploymentCluster] != preferredCluster {
+		return fmt.Errorf("expected LastAppDeploymentCluster %s, got %s",
+			preferredCluster, latestDRPC.GetAnnotations()[controllers.LastAppDeploymentCluster])
+	}
+
+	if latestDRPC.GetAnnotations()[controllers.DRPCAppNamespace] != getVRGNamespace(userPlacement.GetNamespace()) {
+		return fmt.Errorf("expected DRPCAppNamespace %s, got %s",
+			getVRGNamespace(userPlacement.GetNamespace()),
+			latestDRPC.GetAnnotations()[controllers.DRPCAppNamespace])
+	}
+
+	return verifyNSManifestWork(latestDRPC.Name, getVRGNamespace(latestDRPC.Namespace),
 		East1ManagedCluster)
 }
 
 func verifyFailoverToSecondary(placementObj client.Object, toCluster string,
 	isSyncDR bool,
-) {
+) error {
 	recoverToFailoverCluster(placementObj, East1ManagedCluster, toCluster)
 
 	// TODO: DRCluster as part of Unfence operation, first unfences
@@ -1858,45 +1957,106 @@ func verifyFailoverToSecondary(placementObj client.Object, toCluster string,
 	//       resource is cleaned up or not, number of MW may change.
 	if !isSyncDR {
 		// MW for VRG+NS+DRCluster
-		Eventually(getManifestWorkCount, timeout, interval).WithArguments(toCluster).Should(BeElementOf(3, 4))
+		if err := waitForCondition(timeout, interval, "waiting for MW count on toCluster", func() bool {
+			count, err := getManifestWorkCount(toCluster)
+
+			return err == nil && (count == 3 || count == 4)
+		}); err != nil {
+			return err
+		}
 	} else {
-		Expect(getManifestWorkCount(toCluster)).Should(BeElementOf(3, 4)) // MW for VRG+NS+DRCluster+NF
+		mwCount, err := getManifestWorkCount(toCluster)
+		if err != nil {
+			return err
+		}
+
+		if mwCount != 3 && mwCount != 4 {
+			return fmt.Errorf("expected MW count 3 or 4 on %s, got %d", toCluster, mwCount)
+		}
 	}
 
-	Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(3)) // DRClustern + NS + VRG-MW
+	east1MWCount, err := getManifestWorkCount(East1ManagedCluster)
+	if err != nil {
+		return err
+	}
+
+	if east1MWCount != 3 {
+		return fmt.Errorf("expected MW count 3 on %s, got %d", East1ManagedCluster, east1MWCount)
+	}
 
 	drpc, err := getLatestDRPC(placementObj.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return err
+	}
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'FailedOver'
-	Expect(drpc.Status.Phase).To(Equal(rmn.FailedOver))
-	Expect(len(drpc.Status.Conditions)).To(Equal(3))
+	if drpc.Status.Phase != rmn.FailedOver {
+		return fmt.Errorf("expected phase FailedOver, got %s", drpc.Status.Phase)
+	}
+
+	if len(drpc.Status.Conditions) != 3 {
+		return fmt.Errorf("expected 3 conditions, got %d", len(drpc.Status.Conditions))
+	}
+
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
-	Expect(condition.Reason).To(Equal(string(rmn.FailedOver)))
+	if condition.Reason != string(rmn.FailedOver) {
+		return fmt.Errorf("expected condition reason FailedOver, got %s", condition.Reason)
+	}
 
 	decision, err := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
-	Expect(decision.ClusterName).To(Equal(toCluster))
-	Expect(drpc.GetAnnotations()[controllers.LastAppDeploymentCluster]).To(Equal(toCluster))
+	if err != nil {
+		return err
+	}
+
+	if decision.ClusterName != toCluster {
+		return fmt.Errorf("expected decision cluster %s, got %s", toCluster, decision.ClusterName)
+	}
+
+	if drpc.GetAnnotations()[controllers.LastAppDeploymentCluster] != toCluster {
+		return fmt.Errorf("expected LastAppDeploymentCluster %s, got %s",
+			toCluster, drpc.GetAnnotations()[controllers.LastAppDeploymentCluster])
+	}
+
+	return nil
 }
 
-func verifyActionResultForPlacement(placement *clrapiv1beta1.Placement, homeCluster string, plType PlacementType) {
+func verifyActionResultForPlacement(placement *clrapiv1beta1.Placement, homeCluster string, plType PlacementType) error {
 	placementDecision := getPlacementDecision(placement.GetName(), placement.GetNamespace())
-	Expect(placementDecision).ShouldNot(BeNil())
-	Expect(placementDecision.GetLabels()[rmnutil.ExcludeFromVeleroBackup]).Should(Equal("true"))
-	Expect(placementDecision.Status.Decisions[0].ClusterName).Should(Equal(homeCluster))
+	if placementDecision == nil {
+		return fmt.Errorf("placementDecision is nil")
+	}
+
+	if placementDecision.GetLabels()[rmnutil.ExcludeFromVeleroBackup] != "true" {
+		return fmt.Errorf("expected ExcludeFromVeleroBackup label to be true, got %s",
+			placementDecision.GetLabels()[rmnutil.ExcludeFromVeleroBackup])
+	}
+
+	if placementDecision.Status.Decisions[0].ClusterName != homeCluster {
+		return fmt.Errorf("expected decision cluster %s, got %s",
+			homeCluster, placementDecision.Status.Decisions[0].ClusterName)
+	}
+
 	vrg, err := GetFakeVRGFromMCVUsingMW(homeCluster, placement.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return err
+	}
 
 	switch plType {
 	case UsePlacementWithSubscription:
-		Expect(vrg.Namespace).Should(Equal(placement.GetNamespace()))
+		if vrg.Namespace != placement.GetNamespace() {
+			return fmt.Errorf("expected VRG namespace %s, got %s", placement.GetNamespace(), vrg.Namespace)
+		}
 	case UsePlacementWithAppSet:
-		Expect(vrg.Namespace).Should(Equal(appSet.Spec.Template.Spec.Destination.Namespace))
+		if vrg.Namespace != appSet.Spec.Template.Spec.Destination.Namespace {
+			return fmt.Errorf("expected VRG namespace %s, got %s",
+				appSet.Spec.Template.Spec.Destination.Namespace, vrg.Namespace)
+		}
 	default:
-		Fail("Wrong placement type")
+		return fmt.Errorf("wrong placement type %d", plType)
 	}
+
+	return nil
 }
 
 func buildVRG(objectName, namespaceName, dstCluster string, action rmn.VRGAction) rmn.VolumeReplicationGroup {
@@ -1922,58 +2082,72 @@ func buildVRG(objectName, namespaceName, dstCluster string, action rmn.VRGAction
 	}
 }
 
-func ensureLatestVRGDownloadedFromS3Stores() {
+func ensureLatestVRGDownloadedFromS3Stores() error {
 	orgVRG := buildVRG("vrgName1", "vrgNamespace1", East1ManagedCluster, rmn.VRGAction(""))
 	s3ProfileNames := []string{s3Profiles[0].S3ProfileName, s3Profiles[1].S3ProfileName}
 
 	objectStorer1, _, err := drpcReconciler.ObjStoreGetter.ObjectStore(
 		ctx, apiReader, s3ProfileNames[0], "drpolicy validation", testLogger)
+	if err != nil {
+		return fmt.Errorf("failed to get object store 1: %w", err)
+	}
 
-	Expect(err).ToNot(HaveOccurred())
-	Expect(controllers.VrgObjectProtect(objectStorer1, orgVRG)).To(Succeed())
+	if err := controllers.VrgObjectProtect(objectStorer1, orgVRG); err != nil {
+		return fmt.Errorf("failed to protect VRG in store 1: %w", err)
+	}
 
 	objectStorer2, _, err := drpcReconciler.ObjStoreGetter.ObjectStore(
 		ctx, apiReader, s3ProfileNames[1], "drpolicy validation", testLogger)
-	Expect(err).ToNot(HaveOccurred())
+	if err != nil {
+		return fmt.Errorf("failed to get object store 2: %w", err)
+	}
 
-	Expect(controllers.VrgObjectProtect(objectStorer2, orgVRG)).To(Succeed())
+	if err := controllers.VrgObjectProtect(objectStorer2, orgVRG); err != nil {
+		return fmt.Errorf("failed to protect VRG in store 2: %w", err)
+	}
 
 	vrg := controllers.GetLastKnownVRGPrimaryFromS3(context.TODO(),
 		apiReader, s3ProfileNames,
 		"vrgName1", "vrgNamespace1", drpcReconciler.ObjStoreGetter, testLogger)
 
-	Expect(err).ToNot(HaveOccurred())
-	Expect(vrg.Name).To(Equal("vrgName1"))
+	if vrg.Name != "vrgName1" {
+		return fmt.Errorf("expected VRG name vrgName1, got %s", vrg.Name)
+	}
 
 	t1 := metav1.Now()
 	orgVRG.Status.LastUpdateTime = t1
-	Expect(controllers.VrgObjectProtect(objectStorer2, orgVRG)).To(Succeed())
+
+	if err := controllers.VrgObjectProtect(objectStorer2, orgVRG); err != nil {
+		return fmt.Errorf("failed to protect updated VRG in store 2: %w", err)
+	}
 
 	vrg2 := controllers.GetLastKnownVRGPrimaryFromS3(context.TODO(),
 		apiReader, s3ProfileNames,
 		"vrgName1", "vrgNamespace1", drpcReconciler.ObjStoreGetter, testLogger)
 
-	Expect(err).ToNot(HaveOccurred())
-	Expect(vrg2.Status.LastUpdateTime).To(Equal(t1))
+	if vrg2.Status.LastUpdateTime != t1 {
+		return fmt.Errorf("expected LastUpdateTime %v, got %v", t1, vrg2.Status.LastUpdateTime)
+	}
 
 	vrg3 := controllers.GetLastKnownVRGPrimaryFromS3(context.TODO(),
 		apiReader, s3ProfileNames,
 		"vrgName1", "vrgNamespace1", drpcReconciler.ObjStoreGetter, testLogger)
 
-	Expect(err).ToNot(HaveOccurred())
-	Expect(vrg3.Status.LastUpdateTime).To(Equal(t1))
+	if vrg3.Status.LastUpdateTime != t1 {
+		return fmt.Errorf("expected LastUpdateTime %v, got %v", t1, vrg3.Status.LastUpdateTime)
+	}
 
-	Expect(controllers.VrgObjectUnprotect(objectStorer2, orgVRG)).To(Succeed())
+	return controllers.VrgObjectUnprotect(objectStorer2, orgVRG)
 }
 
-func verifyDRPCOwnedByPlacement(placementObj client.Object, drpc *rmn.DRPlacementControl) {
+func verifyDRPCOwnedByPlacement(placementObj client.Object, drpc *rmn.DRPlacementControl) error {
 	for _, ownerReference := range drpc.GetOwnerReferences() {
 		if ownerReference.Name == placementObj.GetName() {
-			return
+			return nil
 		}
 	}
 
-	Fail(fmt.Sprintf("DRPC %s not owned by Placement %s", drpc.GetName(), placementObj.GetName()))
+	return fmt.Errorf("DRPC %s not owned by Placement %s", drpc.GetName(), placementObj.GetName())
 }
 
 var _ = Describe("DRPlacementControl - Ensure do-not-delete PVC Annotation", func() {
@@ -2263,10 +2437,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
 				userPlacementRule = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule).NotTo(BeNil())
-				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
+				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
-				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
+				Expect(verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)).To(Succeed())
 			})
 		})
 		When("DRAction changes to Failover", func() {
@@ -2282,7 +2456,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should failover to Secondary (West1ManagedCluster)", func() {
 				// ----------------------------- FAILOVER TO SECONDARY (West1ManagedCluster) --------------------------------------
 				By("\n\n*** Failover - 1\n\n")
-				verifyFailoverToSecondary(userPlacementRule, West1ManagedCluster, false)
+				Expect(verifyFailoverToSecondary(userPlacementRule, West1ManagedCluster, false)).To(Succeed())
 			})
 		})
 		When("DRAction is Failover during hub recovery", func() {
@@ -2290,7 +2464,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("\n\n*** Failover after \n\n")
 				Expect(clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 				Expect(clearDRPCStatus()).To(Succeed())
-				verifyFailoverToSecondary(userPlacementRule, West1ManagedCluster, false)
+				Expect(verifyFailoverToSecondary(userPlacementRule, West1ManagedCluster, false)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate", func() {
@@ -2324,13 +2498,13 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				// ----------------------------- DELETE DRPolicy  --------------------------------------
 				By("\n\n*** DELETE drpolicy ***\n\n")
 				Expect(deleteDRPolicyAsync()).To(Succeed())
-				ensureDRPolicyIsNotDeleted(drpc)
+				Expect(ensureDRPolicyIsNotDeleted(drpc)).To(Succeed())
 			})
 		})
 		When("A DRPC is created referring to a deleted DRPolicy", func() {
 			It("Should fail DRPC reconciliaiton and not add a finalizer", func() {
 				_, drpc2 := FollowOnDeploymentAsync(DRPC2NamespaceName, UserPlacementRuleName, East1ManagedCluster)
-				checkIfDRPCFinalizerNotAdded(drpc2)
+				Expect(checkIfDRPCFinalizerNotAdded(drpc2)).To(Succeed())
 				Expect(k8sClient.Delete(context.TODO(), drpc2)).Should(Succeed())
 			})
 		})
@@ -2356,11 +2530,11 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
-				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
+				Expect(ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)).To(Succeed())
 			})
 			It("should delete the DRPC causing its referenced drpolicy to be deleted"+
 				" by drpolicy controller since no DRPCs reference it anymore", func() {
-				ensureDRPolicyIsDeleted(drpolicyName)
+				Expect(ensureDRPolicyIsDeleted(drpolicyName)).To(Succeed())
 			})
 		})
 		Specify("delete drclusters", func() {
@@ -2387,8 +2561,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 					DefaultDRPCNamespace, UserPlacementName, East1ManagedCluster, UsePlacementWithSubscription)
 				placement = placementObj.(*clrapiv1beta1.Placement)
 				Expect(placement).NotTo(BeNil())
-				verifyInitialDRPCDeployment(placement, East1ManagedCluster)
-				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)
+				Expect(verifyInitialDRPCDeployment(placement, East1ManagedCluster)).To(Succeed())
+				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
 				verifyDRPCOwnedByPlacement(placement, latestDRPC)
@@ -2407,19 +2581,19 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			})
 			It("Should failover to Secondary (West1ManagedCluster) when using Subscription", func() {
 				runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)
-				verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithSubscription)
+				Expect(verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithSubscription)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate using Placement with Subscriptioin", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				runRelocateAction(placement, West1ManagedCluster, false, false)
-				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)
+				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)).To(Succeed())
 			})
 		})
 		When("Deleting DRPolicy with DRPC references when using Placement", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
 				Expect(deleteDRPolicyAsync()).To(Succeed())
-				ensureDRPolicyIsNotDeleted(drpc)
+				Expect(ensureDRPolicyIsNotDeleted(drpc)).To(Succeed())
 			})
 		})
 		When("Deleting user Placement", func() {
@@ -2438,11 +2612,11 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
-				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
+				Expect(ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)).To(Succeed())
 			})
 			It("should delete the DRPC causing its referenced drpolicy to be deleted"+
 				" by drpolicy controller since no DRPCs reference it anymore", func() {
-				ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)
+				Expect(ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)).To(Succeed())
 			})
 		})
 		Specify("delete drclusters when using Placement", func() {
@@ -2472,8 +2646,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 					DefaultDRPCNamespace, UserPlacementName, East1ManagedCluster, UsePlacementWithAppSet)
 				placement = placementObj.(*clrapiv1beta1.Placement)
 				Expect(placement).NotTo(BeNil())
-				verifyInitialDRPCDeployment(placement, East1ManagedCluster)
-				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)
+				Expect(verifyInitialDRPCDeployment(placement, East1ManagedCluster)).To(Succeed())
+				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
 				verifyDRPCOwnedByPlacement(placement, latestDRPC)
@@ -2492,31 +2666,31 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			})
 			It("Should failover to Secondary (West1ManagedCluster)", func() {
 				runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)
-				verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithAppSet)
+				Expect(verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate using Placement", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				runRelocateAction(placement, West1ManagedCluster, false, false)
-				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)
+				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
 		When("DRAction is changed to Failover after relocation using Placement", func() {
 			It("Should failover again to Secondary (West1ManagedCluster)", func() {
 				runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)
-				verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithAppSet)
+				Expect(verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate again using Placement", func() {
 			It("Should relocate again to Primary (East1ManagedCluster)", func() {
 				runRelocateAction(placement, West1ManagedCluster, false, false)
-				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)
+				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
 		When("Deleting DRPolicy with DRPC references when using Placement", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
 				Expect(deleteDRPolicyAsync()).To(Succeed())
-				ensureDRPolicyIsNotDeleted(drpc)
+				Expect(ensureDRPolicyIsNotDeleted(drpc)).To(Succeed())
 			})
 		})
 		When("Deleting user Placement", func() {
@@ -2535,13 +2709,13 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
-				ensureNamespaceMWsDeletedFromAllClusters(ApplicationNamespace)
+				Expect(ensureNamespaceMWsDeletedFromAllClusters(ApplicationNamespace)).To(Succeed())
 				Expect(deleteAppSet()).To(Succeed())
 				UseApplicationSet = false
 			})
 			It("should delete the DRPC causing its referenced drpolicy to be deleted"+
 				" by drpolicy controller since no DRPCs reference it anymore", func() {
-				ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)
+				Expect(ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)).To(Succeed())
 			})
 		})
 		Specify("delete drclusters when using Placement", func() {
@@ -2559,10 +2733,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("Initial Deployment")
 
 				userPlacementRule, _ = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
-				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
+				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
-				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
+				Expect(verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)).To(Succeed())
 			})
 		})
 		When("DRAction changes to Failover", func() {
@@ -2579,7 +2753,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			})
 			It("Should failover to Secondary (East2ManagedCluster)", func() {
 				By("\n\n*** Failover - 1\n\n")
-				verifyFailoverToSecondary(userPlacementRule, East2ManagedCluster, true)
+				Expect(verifyFailoverToSecondary(userPlacementRule, East2ManagedCluster, true)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate", func() {
@@ -2637,10 +2811,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("Initial Deployment")
 
 				userPlacementRule, _ = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
-				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
+				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
-				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
+				Expect(verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)).To(Succeed())
 			})
 		})
 		When("DRAction changes to Failover", func() {
@@ -2657,7 +2831,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			})
 			It("Should failover to Secondary (East2ManagedCluster)", func() {
 				By("\n\n*** Failover - 1\n\n")
-				verifyFailoverToSecondary(userPlacementRule, East2ManagedCluster, true)
+				Expect(verifyFailoverToSecondary(userPlacementRule, East2ManagedCluster, true)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate", func() {
@@ -2697,7 +2871,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1)) // DRCluster
 				Expect(deleteDRPolicySync()).To(Succeed())
 				Expect(deleteDRClustersSync()).To(Succeed())
-				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
+				Expect(ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 	})
@@ -2912,7 +3086,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should delete all VRGs", func() {
 				Expect(deleteDRPC()).To(Succeed())
 				Expect(waitForCompletion("deleted")).To(Succeed())
-				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
+				Expect(ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 		Specify("delete drclusters", func() {
@@ -2969,7 +3143,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should delete all VRGs", func() {
 				Expect(deleteDRPC()).To(Succeed())
 				Expect(waitForCompletion("deleted")).To(Succeed())
-				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
+				Expect(ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 
@@ -2994,8 +3168,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 					DefaultDRPCNamespace, UserPlacementName, East1ManagedCluster, UsePlacementWithSubscription)
 				placement = placementObj.(*clrapiv1beta1.Placement)
 				Expect(placement).NotTo(BeNil())
-				verifyInitialDRPCDeployment(placement, East1ManagedCluster)
-				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)
+				Expect(verifyInitialDRPCDeployment(placement, East1ManagedCluster)).To(Succeed())
+				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)).To(Succeed())
 				verifyDRPCOwnedByPlacement(placement, getLatestDRPC(DefaultDRPCNamespace))
 			})
 		})
@@ -3015,9 +3189,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			Expect(waitForCompletion("deleted")).To(Succeed())
 			Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 			Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
-			ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
+			Expect(ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)).To(Succeed())
 			deleteDRPolicyAsync()
-			ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)
+			Expect(ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)).To(Succeed())
 			deleteDRClustersAsync()
 			Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(0))
 		})
@@ -3042,10 +3216,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
 				userPlacementRule = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule).NotTo(BeNil())
-				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
+				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
-				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
+				Expect(verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)).To(Succeed())
 			})
 		})
 		When("DRAction is changed to Failover", func() {
@@ -3109,7 +3283,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting DRPolicy with DRPC references", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
 				Expect(deleteDRPolicyAsync()).To(Succeed())
-				ensureDRPolicyIsNotDeleted(drpc)
+				Expect(ensureDRPolicyIsNotDeleted(drpc)).To(Succeed())
 			})
 		})
 		When("Deleting user PlacementRule", func() {
@@ -3125,11 +3299,11 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
-				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
+				Expect(ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)).To(Succeed())
 			})
 			It("should delete the DRPC causing its referenced drpolicy to be deleted"+
 				" by drpolicy controller since no DRPCs reference it anymore", func() {
-				ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)
+				Expect(ensureDRPolicyIsDeleted(drpc.Spec.DRPolicyRef.Name)).To(Succeed())
 			})
 		})
 		Specify("delete drclusters", func() {
@@ -3171,67 +3345,102 @@ func getVRGFromManifestWork(clusterNamespace string) (*rmn.VolumeReplicationGrou
 	return rmnutil.ExtractVRGFromManifestWork(mw)
 }
 
-func verifyRDSpecAfterActionSwitch(primaryCluster, secondaryCluster string, numOfRDSpecs int) {
+func verifyRDSpecAfterActionSwitch(primaryCluster, secondaryCluster string, numOfRDSpecs int) error {
 	// For Primary Cluster
 	vrg, err := getVRGFromManifestWork(primaryCluster)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(len(vrg.Spec.VolSync.RDSpec)).Should(Equal(0))
+	if err != nil {
+		return fmt.Errorf("failed to get VRG from MW for primary %s: %w", primaryCluster, err)
+	}
+
+	if len(vrg.Spec.VolSync.RDSpec) != 0 {
+		return fmt.Errorf("expected 0 RDSpec for primary, got %d", len(vrg.Spec.VolSync.RDSpec))
+	}
+
 	// For Secondary Cluster
 	vrg, err = getVRGFromManifestWork(secondaryCluster)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(len(vrg.Spec.VolSync.RDSpec)).Should(Equal(numOfRDSpecs))
+	if err != nil {
+		return fmt.Errorf("failed to get VRG from MW for secondary %s: %w", secondaryCluster, err)
+	}
+
+	if len(vrg.Spec.VolSync.RDSpec) != numOfRDSpecs {
+		return fmt.Errorf("expected %d RDSpec for secondary, got %d", numOfRDSpecs, len(vrg.Spec.VolSync.RDSpec))
+	}
+
+	return nil
 }
 
 func verifyDRPCStateAndProgression(expectedAction rmn.DRAction, expectedPhase rmn.DRState,
 	expectedPorgression rmn.ProgressionStatus,
-) {
+) error {
 	var phase rmn.DRState
 
 	var progression rmn.ProgressionStatus
 
-	Eventually(func() bool {
-		drpc, err := getLatestDRPC(DefaultDRPCNamespace)
-		if err != nil {
-			return false
-		}
-		phase = drpc.Status.Phase
-		progression = drpc.Status.Progression
-
-		return phase == expectedPhase && progression == expectedPorgression
-	}, timeout, interval).Should(BeTrue(),
+	if err := waitForCondition(timeout, interval,
 		fmt.Sprintf("Phase has not been updated yet! Phase:%s Expected:%s - progression:%s expected:%s",
-			phase, expectedPhase, progression, expectedPorgression))
+			phase, expectedPhase, progression, expectedPorgression), func() bool {
+			drpc, err := getLatestDRPC(DefaultDRPCNamespace)
+			if err != nil {
+				return false
+			}
+			phase = drpc.Status.Phase
+			progression = drpc.Status.Progression
+
+			return phase == expectedPhase && progression == expectedPorgression
+		}); err != nil {
+		return err
+	}
 
 	drpc, err := getLatestDRPC(DefaultDRPCNamespace)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(drpc.Spec.Action).Should(Equal(expectedAction))
-	Expect(drpc.Status.Phase).Should(Equal(expectedPhase))
-	Expect(drpc.Status.Progression).Should(Equal(expectedPorgression))
+	if err != nil {
+		return err
+	}
+
+	if drpc.Spec.Action != expectedAction {
+		return fmt.Errorf("expected action %s, got %s", expectedAction, drpc.Spec.Action)
+	}
+
+	if drpc.Status.Phase != expectedPhase {
+		return fmt.Errorf("expected phase %s, got %s", expectedPhase, drpc.Status.Phase)
+	}
+
+	if drpc.Status.Progression != expectedPorgression {
+		return fmt.Errorf("expected progression %s, got %s", expectedPorgression, drpc.Status.Progression)
+	}
+
+	return nil
 }
 
-func checkConditionAllowFailover(namespace string) {
+func checkConditionAllowFailover(namespace string) error {
 	var drpc *rmn.DRPlacementControl
 
 	var availableCondition metav1.Condition
 
-	Eventually(func() bool {
-		var err error
-		drpc, err = getLatestDRPC(namespace)
-		if err != nil {
-			return false
-		}
-		for _, availableCondition = range drpc.Status.Conditions {
-			if availableCondition.Type != rmn.ConditionPeerReady {
-				if availableCondition.Status == metav1.ConditionTrue {
-					return true
+	if err := waitForCondition(timeout, interval,
+		fmt.Sprintf("waiting for allow failover condition '%+v'", availableCondition), func() bool {
+			var err error
+			drpc, err = getLatestDRPC(namespace)
+			if err != nil {
+				return false
+			}
+			for _, availableCondition = range drpc.Status.Conditions {
+				if availableCondition.Type != rmn.ConditionPeerReady {
+					if availableCondition.Status == metav1.ConditionTrue {
+						return true
+					}
 				}
 			}
-		}
 
-		return false
-	}, timeout, interval).Should(BeTrue(), fmt.Sprintf("Condition '%+v'", availableCondition))
+			return false
+		}); err != nil {
+		return err
+	}
 
-	Expect(drpc.Status.Phase).To(Equal(rmn.WaitForUser))
+	if drpc.Status.Phase != rmn.WaitForUser {
+		return fmt.Errorf("expected phase WaitForUser, got %s", drpc.Status.Phase)
+	}
+
+	return nil
 }
 
 //nolint:unparam

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -670,7 +670,7 @@ func ensureNamespaceMWsDeletedFromAllClusters(namespace string) {
 	}
 }
 
-func setDRPCSpecExpectationTo(namespace, preferredCluster, failoverCluster string, action rmn.DRAction) {
+func setDRPCSpecExpectationTo(namespace, preferredCluster, failoverCluster string, action rmn.DRAction) error {
 	drpcLookupKey := types.NamespacedName{
 		Name:      DRPCCommonName,
 		Namespace: namespace,
@@ -689,9 +689,11 @@ func setDRPCSpecExpectationTo(namespace, preferredCluster, failoverCluster strin
 		return k8sClient.Update(context.TODO(), latestDRPC)
 	})
 
-	Expect(retryErr).NotTo(HaveOccurred())
+	if retryErr != nil {
+		return retryErr
+	}
 
-	Eventually(func() bool {
+	return waitForCondition(timeout, interval, "failed to update DRPC DR action on time", func() bool {
 		var err error
 		latestDRPC, err = getLatestDRPC(namespace)
 		if err != nil {
@@ -699,7 +701,7 @@ func setDRPCSpecExpectationTo(namespace, preferredCluster, failoverCluster strin
 		}
 
 		return latestDRPC.Spec.Action == action
-	}, timeout, interval).Should(BeTrue(), "failed to update DRPC DR action on time")
+	})
 }
 
 func getLatestDRPC(namespace string) (*rmn.DRPlacementControl, error) {
@@ -716,7 +718,7 @@ func getLatestDRPC(namespace string) (*rmn.DRPlacementControl, error) {
 	return latestDRPC, nil
 }
 
-func clearDRPCStatus() {
+func clearDRPCStatus() error {
 	drpcLookupKey := types.NamespacedName{
 		Name:      DRPCCommonName,
 		Namespace: DefaultDRPCNamespace,
@@ -732,11 +734,15 @@ func clearDRPCStatus() {
 
 		return k8sClient.Status().Update(context.TODO(), latestDRPC)
 	})
-	Expect(retryErr).NotTo(HaveOccurred())
+
+	if retryErr != nil {
+		return retryErr
+	}
+
+	return nil
 }
 
-//nolint:unparam
-func clearFakeUserPlacementRuleStatus(name, namespace string) {
+func clearFakeUserPlacementRuleStatus(name, namespace string) error {
 	usrPlRuleLookupKey := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -754,7 +760,11 @@ func clearFakeUserPlacementRuleStatus(name, namespace string) {
 		return k8sClient.Status().Update(context.TODO(), usrPlRule)
 	})
 
-	Expect(retryErr).NotTo(HaveOccurred())
+	if retryErr != nil {
+		return retryErr
+	}
+
+	return nil
 }
 
 func createNamespace(ns *corev1.Namespace) error {
@@ -990,19 +1000,22 @@ func createVRGMW(name, namespace, homeCluster string) error {
 	return err
 }
 
-func updateManifestWorkStatus(clusterNamespace, vrgNamespace, mwType, workType string) {
+func updateManifestWorkStatus(clusterNamespace, vrgNamespace, mwType, workType string) error {
 	manifestLookupKey := types.NamespacedName{
 		Name:      rmnutil.ManifestWorkName(DRPCCommonName, getVRGNamespace(vrgNamespace), mwType),
 		Namespace: clusterNamespace,
 	}
 	mw := &ocmworkv1.ManifestWork{}
 
-	Eventually(func() bool {
-		err := k8sClient.Get(context.TODO(), manifestLookupKey, mw)
+	if err := waitForCondition(timeout, interval,
+		fmt.Sprintf("failed to wait for manifest creation for type %s cluster %s", mwType, clusterNamespace),
+		func() bool {
+			err := k8sClient.Get(context.TODO(), manifestLookupKey, mw)
 
-		return err == nil
-	}, timeout, interval).Should(BeTrue(),
-		fmt.Sprintf("failed to wait for manifest creation for type %s cluster %s", mwType, clusterNamespace))
+			return err == nil
+		}); err != nil {
+		return err
+	}
 
 	timeOld := time.Now().Local()
 	timeMostRecent := timeOld.Add(time.Second)
@@ -1037,13 +1050,16 @@ func updateManifestWorkStatus(clusterNamespace, vrgNamespace, mwType, workType s
 		return k8sClient.Status().Update(context.TODO(), mw)
 	})
 
-	Expect(retryErr).NotTo(HaveOccurred())
+	if retryErr != nil {
+		return retryErr
+	}
 
-	Eventually(func() bool {
-		err := k8sClient.Get(context.TODO(), manifestLookupKey, mw)
+	return waitForCondition(timeout, interval,
+		"failed to wait for PV manifest condition type to change to 'Applied'", func() bool {
+			err := k8sClient.Get(context.TODO(), manifestLookupKey, mw)
 
-		return err == nil && len(mw.Status.Conditions) != 0
-	}, timeout, interval).Should(BeTrue(), "failed to wait for PV manifest condition type to change to 'Applied'")
+			return err == nil && len(mw.Status.Conditions) != 0
+		})
 }
 
 func ensureDRPolicyIsNotDeleted(drpc *rmn.DRPlacementControl) {
@@ -1643,7 +1659,7 @@ func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR 
 }
 
 func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferredCluster, failoverCluster string) {
-	setDRPCSpecExpectationTo(userPlacementRule.GetNamespace(), preferredCluster, failoverCluster, "")
+	Expect(setDRPCSpecExpectationTo(userPlacementRule.GetNamespace(), preferredCluster, failoverCluster, "")).To(Succeed())
 	waitForCompletion(string(rmn.Deployed))
 
 	drpc, err := getLatestDRPC(userPlacementRule.GetNamespace())
@@ -1665,9 +1681,9 @@ func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferre
 func relocateToPreferredCluster(placementObj client.Object, fromCluster string) {
 	toCluster1 := "east1-cluster"
 
-	setDRPCSpecExpectationTo(placementObj.GetNamespace(), toCluster1, fromCluster, rmn.ActionRelocate)
+	Expect(setDRPCSpecExpectationTo(placementObj.GetNamespace(), toCluster1, fromCluster, rmn.ActionRelocate)).To(Succeed())
 
-	updateManifestWorkStatus(toCluster1, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)
+	Expect(updateManifestWorkStatus(toCluster1, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
 
 	waitForDRPCProtected(placementObj.GetNamespace())
 
@@ -1679,9 +1695,9 @@ func relocateToPreferredCluster(placementObj client.Object, fromCluster string) 
 }
 
 func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster string) {
-	setDRPCSpecExpectationTo(placementObj.GetNamespace(), fromCluster, toCluster, rmn.ActionFailover)
+	Expect(setDRPCSpecExpectationTo(placementObj.GetNamespace(), fromCluster, toCluster, rmn.ActionFailover)).To(Succeed())
 
-	updateManifestWorkStatus(toCluster, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)
+	Expect(updateManifestWorkStatus(toCluster, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
 
 	waitForDRPCProtected(placementObj.GetNamespace())
 
@@ -1807,7 +1823,7 @@ func resetdrCluster(cluster string) {
 //nolint:unparam
 func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster string) {
 	verifyVRGManifestWorkCreatedAsPrimary(userPlacement.GetNamespace(), preferredCluster)
-	updateManifestWorkStatus(preferredCluster, userPlacement.GetNamespace(), "vrg", ocmworkv1.WorkApplied)
+	Expect(updateManifestWorkStatus(preferredCluster, userPlacement.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
 	verifyUserPlacementRuleDecision(userPlacement.GetName(), userPlacement.GetNamespace(), preferredCluster)
 	verifyDRPCStatusPreferredClusterExpectation(userPlacement.GetNamespace(), rmn.Deployed)
 	Expect(getManifestWorkCount(preferredCluster)).Should(BeElementOf(3, 4)) // MWs for VRG, 2 namespaces, and DRCluster
@@ -2257,7 +2273,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should not failover to Secondary (West1ManagedCluster) till PV manifest is applied", func() {
 				By("\n\n*** Failover - 1\n\n")
 				setRestorePVsIncomplete()
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)).To(Succeed())
 				verifyUserPlacementRuleDecisionUnchanged(userPlacementRule.Name, userPlacementRule.Namespace, East1ManagedCluster)
 				// MWs for VRG, NS, DRCluster, and MMode
 				Expect(getManifestWorkCount(West1ManagedCluster)).Should(BeElementOf(3, 4))
@@ -2272,8 +2288,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("DRAction is Failover during hub recovery", func() {
 			It("Should reconstructs the DRPC state and points to Secondary (West1ManagedCluster)", func() {
 				By("\n\n*** Failover after \n\n")
-				clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)
-				clearDRPCStatus()
+				Expect(clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
+				Expect(clearDRPCStatus()).To(Succeed())
 				verifyFailoverToSecondary(userPlacementRule, West1ManagedCluster, false)
 			})
 		})
@@ -2381,7 +2397,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("DRAction changes to Failover using Placement with Subscription", func() {
 			It("Should not failover to Secondary (West1ManagedCluster) till PV manifest is applied", func() {
 				setRestorePVsIncomplete()
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)).To(Succeed())
 				verifyUserPlacementRuleDecisionUnchanged(placement.Name, placement.Namespace, East1ManagedCluster)
 				// MWs for VRG, NS, VRG DRCluster, and MMode
 				Expect(getManifestWorkCount(West1ManagedCluster)).Should(BeElementOf(3, 4))
@@ -2466,7 +2482,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("DRAction changes to Failover using Placement", func() {
 			It("Should not failover to Secondary (West1ManagedCluster) till PV manifest is applied", func() {
 				setRestorePVsIncomplete()
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)).To(Succeed())
 				verifyUserPlacementRuleDecisionUnchanged(placement.Name, placement.Namespace, East1ManagedCluster)
 				// MWs for VRG, NS, VRG DRCluster, and MMode
 				Expect(getManifestWorkCount(West1ManagedCluster)).Should(BeElementOf(3, 4))
@@ -2554,7 +2570,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("\n\n*** Failover - 1\n\n")
 				setRestorePVsIncomplete()
 				fenceCluster(East1ManagedCluster, false)
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, East2ManagedCluster, rmn.ActionFailover)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, East2ManagedCluster, rmn.ActionFailover)).To(Succeed())
 				verifyUserPlacementRuleDecisionUnchanged(userPlacementRule.Name, userPlacementRule.Namespace, East1ManagedCluster)
 				// MWs for VRG, VRG DRCluster and the MW for NetworkFence CR to fence off
 				Expect(getManifestWorkCount(East2ManagedCluster)).Should(BeElementOf(3, 4))
@@ -2632,7 +2648,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("\n\n*** Failover - 1\n\n")
 				setRestorePVsIncomplete()
 				fenceCluster(East1ManagedCluster, true)
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, East2ManagedCluster, rmn.ActionFailover)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, East2ManagedCluster, rmn.ActionFailover)).To(Succeed())
 				verifyUserPlacementRuleDecisionUnchanged(userPlacementRule.Name, userPlacementRule.Namespace, East1ManagedCluster)
 				// MWs for VRG, VRG DRCluster and the MW for NetworkFence CR to fence off
 				Expect(getManifestWorkCount(East2ManagedCluster)).Should(BeElementOf(3, 4))
@@ -2706,7 +2722,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				userPlacementRule1 = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule1).NotTo(BeNil())
 				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)
-				uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(""))
+				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(""))).To(Succeed())
 			})
 		})
 		//nolint:lll
@@ -2722,9 +2738,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("HubRecovery: DRAction is Initial deploy -> Secondary Down", func() {
 			It("Should reconstructs the DRPC state to completion. Primary is East1ManagedCluster", func() {
 				setClusterDown(West1ManagedCluster)
-				clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)
-				clearDRPCStatus()
-
+				Expect(clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
+				Expect(clearDRPCStatus()).To(Succeed())
 				expectedAction := rmn.DRAction("")
 				expectedPhase := rmn.Deployed
 				expectedPorgression := rmn.ProgressionCompleted
@@ -2748,8 +2763,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("HubRecovery: DRAction is Initial deploy -> Primary Down", func() {
 			It("Should pause and wait for user to trigger a failover. Primary East1ManagedCluster", func() {
 				setClusterDown(East1ManagedCluster)
-				clearDRPCStatus()
-
+				Expect(clearDRPCStatus()).To(Succeed())
 				expectedAction := rmn.DRAction("")
 				expectedPhase := rmn.WaitForUser
 				expectedPorgression := rmn.ProgressionActionPaused
@@ -2766,7 +2780,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				resetClusterDown()
 				runFailoverAction(userPlacementRule1, from, to, false, false)
 				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.FailedOver)
-				uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, West1ManagedCluster, rmn.VRGActionFailover)
+				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, West1ManagedCluster, rmn.VRGActionFailover)).To(Succeed())
 				resetClusterDown()
 			})
 		})
@@ -2784,11 +2798,11 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("HubRecovery: DRAction is Failover -> Primary Down", func() {
 			It("Should Pause, but allows failover. Primary West1ManagedCluster", func() {
 				setClusterDown(West1ManagedCluster)
-				clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)
-				clearDRPCStatus()
+				Expect(clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
+				Expect(clearDRPCStatus()).To(Succeed())
 				// TODO: Why did we shift the failover to deploy action here? It fails as VRG exists as Secondary now
 				// on the cluster to deploy to
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)).To(Succeed())
 				expectedAction := rmn.ActionFailover
 				expectedPhase := rmn.WaitForUser
 				expectedPorgression := rmn.ProgressionActionPaused
@@ -2797,7 +2811,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 				// User intervention is required (simulate user intervention)
 				resetClusterDown()
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionFailover)).To(Succeed())
 				expectedAction = rmn.ActionFailover
 				expectedPhase = rmn.FailedOver
 				expectedPorgression = rmn.ProgressionCompleted
@@ -2812,7 +2826,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				// ----------------------------- RELOCATION TO PRIMARY --------------------------------------
 				from := West1ManagedCluster
 				runRelocateAction(userPlacementRule1, from, false, false)
-				uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(rmn.ActionRelocate))
+				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(rmn.ActionRelocate))).To(Succeed())
 				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Relocated)
 			})
 		})
@@ -2829,9 +2843,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("HubRecovery: DRAction is Relocate -> Secondary Down", func() {
 			It("Should Continue given the primary East1ManagedCluster is up", func() {
 				setClusterDown(West1ManagedCluster)
-				clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)
-				clearDRPCStatus()
-
+				Expect(clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
+				Expect(clearDRPCStatus()).To(Succeed())
 				expectedAction := rmn.ActionRelocate
 				expectedPhase := rmn.DRState("")
 				expectedPorgression := rmn.ProgressionStatus("")
@@ -2839,7 +2852,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 				// User intervention is required (simulate user intervention)
 				resetClusterDown()
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionRelocate)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionRelocate)).To(Succeed())
 				expectedAction = rmn.ActionRelocate
 				expectedPhase = rmn.Relocated
 				expectedPorgression = rmn.ProgressionCompleted
@@ -2860,10 +2873,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("HubRecovery: DRAction is supposed to be Relocate -> Primary Down -> Action Cleared", func() {
 			It("Should Pause given the primary East1ManagedCluster is down, but allow failover", func() {
 				setClusterDown(East1ManagedCluster)
-				clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)
-				clearDRPCStatus()
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, "")
-
+				Expect(clearFakeUserPlacementRuleStatus(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
+				Expect(clearDRPCStatus()).To(Succeed())
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, "")).To(Succeed())
 				expectedAction := rmn.DRAction("")
 				expectedPhase := rmn.WaitForUser
 				expectedPorgression := rmn.ProgressionActionPaused
@@ -2872,7 +2884,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 				// User intervention is required (simulate user intervention)
 				resetClusterDown()
-				setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionRelocate)
+				Expect(setDRPCSpecExpectationTo(DefaultDRPCNamespace, East1ManagedCluster, West1ManagedCluster, rmn.ActionRelocate)).To(Succeed())
 				expectedAction = rmn.ActionRelocate
 				expectedPhase = rmn.Relocated
 				expectedPorgression = rmn.ProgressionCompleted
@@ -2934,7 +2946,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				userPlacementRule1 = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule1).NotTo(BeNil())
 				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)
-				uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(""))
+				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(""))).To(Succeed())
 				resetToggleUIDChecks()
 			})
 		})
@@ -3223,15 +3235,17 @@ func checkConditionAllowFailover(namespace string) {
 }
 
 //nolint:unparam
-func uploadVRGtoS3Store(name, namespace, dstCluster string, action rmn.VRGAction) {
+func uploadVRGtoS3Store(name, namespace, dstCluster string, action rmn.VRGAction) error {
 	vrg := buildVRG(name, namespace, dstCluster, action)
 	s3ProfileNames := []string{s3Profiles[0].S3ProfileName, s3Profiles[1].S3ProfileName}
 
 	objectStorer, _, err := drpcReconciler.ObjStoreGetter.ObjectStore(
 		ctx, apiReader, s3ProfileNames[0], "Hub Recovery", testLogger)
+	if err != nil {
+		return err
+	}
 
-	Expect(err).ToNot(HaveOccurred())
-	Expect(controllers.VrgObjectProtect(objectStorer, vrg)).To(Succeed())
+	return controllers.VrgObjectProtect(objectStorer, vrg)
 }
 
 // drpcRenconcile calls the drpc reconciler with the given drpc name and

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -607,17 +607,20 @@ func createDRPC(placementName, name, namespace, drPolicyName, preferredCluster s
 
 //nolint:unparam
 func deleteUserPlacementRule(name, namespace string) {
-	userPlacementRule := getLatestUserPlacementRule(name, namespace)
+	userPlacementRule, err := getLatestUserPlacementRule(name, namespace)
+	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient.Delete(context.TODO(), userPlacementRule)).Should(Succeed())
 }
 
 func deleteUserPlacement() {
-	userPlacement := getLatestUserPlacement(UserPlacementName, DefaultDRPCNamespace)
+	userPlacement, err := getLatestUserPlacement(UserPlacementName, DefaultDRPCNamespace)
+	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient.Delete(context.TODO(), userPlacement)).Should(Succeed())
 }
 
 func deleteDRPC() {
-	drpc := getLatestDRPC(DefaultDRPCNamespace)
+	drpc, err := getLatestDRPC(DefaultDRPCNamespace)
+	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient.Delete(context.TODO(), drpc)).Should(Succeed())
 }
 
@@ -662,22 +665,28 @@ func setDRPCSpecExpectationTo(namespace, preferredCluster, failoverCluster strin
 	Expect(retryErr).NotTo(HaveOccurred())
 
 	Eventually(func() bool {
-		latestDRPC = getLatestDRPC(namespace)
+		var err error
+		latestDRPC, err = getLatestDRPC(namespace)
+		if err != nil {
+			return false
+		}
 
 		return latestDRPC.Spec.Action == action
 	}, timeout, interval).Should(BeTrue(), "failed to update DRPC DR action on time")
 }
 
-func getLatestDRPC(namespace string) *rmn.DRPlacementControl {
+func getLatestDRPC(namespace string) (*rmn.DRPlacementControl, error) {
 	drpcLookupKey := types.NamespacedName{
 		Name:      DRPCCommonName,
 		Namespace: namespace,
 	}
 	latestDRPC := &rmn.DRPlacementControl{}
 	err := apiReader.Get(context.TODO(), drpcLookupKey, latestDRPC)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, err
+	}
 
-	return latestDRPC
+	return latestDRPC, nil
 }
 
 func clearDRPCStatus() {
@@ -1133,22 +1142,25 @@ func verifyVRGManifestWorkCreatedAsPrimary(namespace, managedCluster string) {
 	Expect(vrg.Spec.ReplicationState).Should(Equal(rmn.Primary))
 
 	// ensure DRPC copied KubeObjectProtection contents to VRG
-	drpc := getLatestDRPC(namespace)
+	drpc, err := getLatestDRPC(namespace)
+	Expect(err).NotTo(HaveOccurred())
 	Expect(vrg.Spec.KubeObjectProtection).Should(Equal(drpc.Spec.KubeObjectProtection))
 }
 
-func getManifestWorkCount(homeClusterNamespace string) int {
+func getManifestWorkCount(homeClusterNamespace string) (int, error) {
 	manifestWorkList := &ocmworkv1.ManifestWorkList{}
 	listOptions := &client.ListOptions{Namespace: homeClusterNamespace}
 
-	Expect(apiReader.List(context.TODO(), manifestWorkList, listOptions)).NotTo(HaveOccurred())
+	if err := apiReader.List(context.TODO(), manifestWorkList, listOptions); err != nil {
+		return 0, err
+	}
 
 	if len(manifestWorkList.Items) == 0 {
-		return 0
+		return 0, nil
 	}
 
 	// Reduce by one to accommodate for DRClusterConfig ManifestWork
-	return len(manifestWorkList.Items) - 1
+	return len(manifestWorkList.Items) - 1, nil
 }
 
 func verifyNSManifestWork(resourceName, namespaceString, managedCluster string) {
@@ -1166,13 +1178,15 @@ func verifyNSManifestWork(resourceName, namespaceString, managedCluster string) 
 }
 
 //nolint:unparam
-func getManagedClusterViewCount(homeClusterNamespace string) int {
+func getManagedClusterViewCount(homeClusterNamespace string) (int, error) {
 	mcvList := &viewv1beta1.ManagedClusterViewList{}
 	listOptions := &client.ListOptions{Namespace: homeClusterNamespace}
 
-	Expect(k8sClient.List(context.TODO(), mcvList, listOptions)).NotTo(HaveOccurred())
+	if err := k8sClient.List(context.TODO(), mcvList, listOptions); err != nil {
+		return 0, err
+	}
 
-	return len(mcvList.Items)
+	return len(mcvList.Items), nil
 }
 
 func verifyUserPlacementRuleDecision(name, namespace, homeCluster string) {
@@ -1214,7 +1228,10 @@ func verifyUserPlacementRuleDecision(name, namespace, homeCluster string) {
 
 func waitForDRPCProtected(namespace string) {
 	Eventually(func() bool {
-		drpc := getLatestDRPC(namespace)
+		drpc, err := getLatestDRPC(namespace)
+		if err != nil {
+			return false
+		}
 		_, cond := getDRPCCondition(&drpc.Status, rmn.ConditionProtected)
 
 		return cond != nil && cond.Status == metav1.ConditionTrue
@@ -1301,7 +1318,7 @@ func verifyDRPCStatusPreferredClusterExpectation(namespace string, drState rmn.D
 	Expect(condition.Reason).Should(Equal(string(drState)))
 }
 
-func getLatestUserPlacementRule(name, namespace string) *plrv1.PlacementRule {
+func getLatestUserPlacementRule(name, namespace string) (*plrv1.PlacementRule, error) {
 	usrPlRuleLookupKey := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -1309,15 +1326,18 @@ func getLatestUserPlacementRule(name, namespace string) *plrv1.PlacementRule {
 
 	usrPlRule := &plrv1.PlacementRule{}
 
-	Eventually(func() error {
-		return k8sClient.Get(context.TODO(), usrPlRuleLookupKey, usrPlRule)
-	}, timeout, interval).Should(Succeed(),
-		fmt.Sprintf("PlacementRule %s/%s not found", namespace, name))
+	if err := waitForCondition(timeout, interval,
+		fmt.Sprintf("PlacementRule %s/%s not found", namespace, name),
+		func() bool {
+			return k8sClient.Get(context.TODO(), usrPlRuleLookupKey, usrPlRule) == nil
+		}); err != nil {
+		return nil, err
+	}
 
-	return usrPlRule
+	return usrPlRule, nil
 }
 
-func getLatestUserPlacement(name, namespace string) *clrapiv1beta1.Placement {
+func getLatestUserPlacement(name, namespace string) (*clrapiv1beta1.Placement, error) {
 	key := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -1326,12 +1346,14 @@ func getLatestUserPlacement(name, namespace string) *clrapiv1beta1.Placement {
 	plmnt := &clrapiv1beta1.Placement{}
 
 	err := k8sClient.Get(context.TODO(), key, plmnt)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, err
+	}
 
-	return plmnt
+	return plmnt, nil
 }
 
-func getLatestUserPlacementDecision(name, namespace string) *clrapiv1beta1.ClusterDecision {
+func getLatestUserPlacementDecision(name, namespace string) (*clrapiv1beta1.ClusterDecision, error) {
 	key := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,
@@ -1344,24 +1366,26 @@ func getLatestUserPlacementDecision(name, namespace string) *clrapiv1beta1.Clust
 		return &clrapiv1beta1.ClusterDecision{
 			ClusterName: usrPlRule.Status.Decisions[0].ClusterName,
 			Reason:      "PlacementRule Testing",
-		}
+		}, nil
 	}
 
 	if k8serrors.IsNotFound(err) {
 		usrPlmnt := &clrapiv1beta1.Placement{}
 		err = k8sClient.Get(context.TODO(), key, usrPlmnt)
-		Expect(err).NotTo(HaveOccurred())
+		if err != nil {
+			return nil, err
+		}
 
 		plDecision := getPlacementDecision(usrPlmnt.GetName(), usrPlmnt.GetNamespace())
 		if plDecision != nil {
 			return &clrapiv1beta1.ClusterDecision{
 				ClusterName: plDecision.Status.Decisions[0].ClusterName,
 				Reason:      "Placement Testing",
-			}
+			}, nil
 		}
 	}
 
-	return nil
+	return nil, nil
 }
 
 func waitForCompletion(expectedState string) {
@@ -1374,7 +1398,10 @@ func waitForCompletion(expectedState string) {
 //nolint:unparam
 func waitForDRPCPhaseAndProgression(namespace string, drState rmn.DRState) {
 	Eventually(func() bool {
-		drpc := getLatestDRPC(namespace)
+		drpc, err := getLatestDRPC(namespace)
+		if err != nil {
+			return false
+		}
 
 		return drpc.Status.Phase == drState && drpc.Status.Progression == rmn.ProgressionCompleted
 	}, timeout, interval).Should(BeTrue(), fmt.Sprintf("Timed out waiting for Phase to match. Expected %s for drpcNS %s",
@@ -1405,7 +1432,8 @@ type drActionCounts struct {
 // accounted phase persisted in the dr-action-count annotation of the DRPC in
 // the given namespace
 func getDRActionCounts(namespace string) drActionCounts {
-	drpc := getLatestDRPC(namespace)
+	drpc, err := getLatestDRPC(namespace)
+	Expect(err).NotTo(HaveOccurred())
 
 	counts := drActionCounts{}
 
@@ -1452,7 +1480,8 @@ func runFailoverAction(placementObj client.Object, fromCluster, toCluster string
 
 	Expect(getManifestWorkCount(fromCluster)).Should(Equal(3)) // DRCluster + NS MW + VRG MW
 
-	drpc := getLatestDRPC(placementObj.GetNamespace())
+	drpc, err := getLatestDRPC(placementObj.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'FailedOver'
@@ -1465,7 +1494,8 @@ func runFailoverAction(placementObj client.Object, fromCluster, toCluster string
 	Expect(getDRActionCounts(placementObj.GetNamespace()).Failover).To(Equal(expectedFailoverCount),
 		"dr-action-count annotation should count the failover")
 
-	decision := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
+	decision, err := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	Expect(decision.ClusterName).To(Equal(toCluster))
 }
 
@@ -1516,7 +1546,8 @@ func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR 
 		Expect(getManifestWorkCount(fromCluster)).Should(BeElementOf(2, 3))
 	}
 
-	drpc := getLatestDRPC(placementObj.GetNamespace())
+	drpc, err := getLatestDRPC(placementObj.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'Relocated'
@@ -1528,7 +1559,8 @@ func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR 
 	Expect(getDRActionCounts(placementObj.GetNamespace()).Relocate).To(Equal(expectedRelocateCount),
 		"dr-action-count annotation should count the relocate")
 
-	decision := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
+	decision, err := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	Expect(decision.ClusterName).To(Equal(toCluster1))
 	Expect(condition.Reason).To(Equal(string(rmn.Relocated)))
 	Expect(drpc.GetAnnotations()[controllers.LastAppDeploymentCluster]).To(Equal(toCluster1))
@@ -1538,7 +1570,8 @@ func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferre
 	setDRPCSpecExpectationTo(userPlacementRule.GetNamespace(), preferredCluster, failoverCluster, "")
 	waitForCompletion(string(rmn.Deployed))
 
-	drpc := getLatestDRPC(userPlacementRule.GetNamespace())
+	drpc, err := getLatestDRPC(userPlacementRule.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state didn't change and it is 'Relocated' even though we tried to run
@@ -1548,7 +1581,8 @@ func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferre
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
 	Expect(condition.Reason).To(Equal(string(rmn.Deployed)))
 
-	decision := getLatestUserPlacementDecision(userPlacementRule.Name, userPlacementRule.Namespace)
+	decision, err := getLatestUserPlacementDecision(userPlacementRule.Name, userPlacementRule.Namespace)
+	Expect(err).NotTo(HaveOccurred())
 	Expect(decision.ClusterName).To(Equal(preferredCluster))
 }
 
@@ -1688,7 +1722,8 @@ func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster s
 	Expect(getManifestWorkCount(preferredCluster)).Should(BeElementOf(3, 4)) // MWs for VRG, 2 namespaces, and DRCluster
 	waitForCompletion(string(rmn.Deployed))
 
-	latestDRPC := getLatestDRPC(userPlacement.GetNamespace())
+	latestDRPC, err := getLatestDRPC(userPlacement.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'Deployed'
@@ -1722,7 +1757,8 @@ func verifyFailoverToSecondary(placementObj client.Object, toCluster string,
 
 	Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(3)) // DRClustern + NS + VRG-MW
 
-	drpc := getLatestDRPC(placementObj.GetNamespace())
+	drpc, err := getLatestDRPC(placementObj.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'FailedOver'
@@ -1731,7 +1767,8 @@ func verifyFailoverToSecondary(placementObj client.Object, toCluster string,
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
 	Expect(condition.Reason).To(Equal(string(rmn.FailedOver)))
 
-	decision := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
+	decision, err := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
+	Expect(err).NotTo(HaveOccurred())
 	Expect(decision.ClusterName).To(Equal(toCluster))
 	Expect(drpc.GetAnnotations()[controllers.LastAppDeploymentCluster]).To(Equal(toCluster))
 }
@@ -1979,7 +2016,10 @@ var _ = Describe("DRPlacementControl - EnableDiff Annotation Propagation", func(
 
 		// Set EnableDiffAnnotation on DRPC
 		retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			drpc := getLatestDRPC(DefaultDRPCNamespace)
+			drpc, err := getLatestDRPC(DefaultDRPCNamespace)
+			if err != nil {
+				return err
+			}
 
 			annotations := drpc.GetAnnotations()
 			if annotations == nil {
@@ -2063,7 +2103,10 @@ var _ = Describe("DRPlacementControl Reconciler Errors", func() {
 			previousDuration := metav1.Duration{Duration: time.Minute}
 
 			err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-				drpc := getLatestDRPC(DefaultDRPCNamespace)
+				drpc, err := getLatestDRPC(DefaultDRPCNamespace)
+				if err != nil {
+					return err
+				}
 				drpc.Status.ActionStartTime = previousStartTime.DeepCopy()
 				drpc.Status.ActionDuration = &previousDuration
 
@@ -2079,7 +2122,8 @@ var _ = Describe("DRPlacementControl Reconciler Errors", func() {
 			_, err = drpcReconcile(DRPCCommonName, DefaultDRPCNamespace)
 			Expect(err).To(HaveOccurred())
 
-			deletingDRPC := getLatestDRPC(DefaultDRPCNamespace)
+			deletingDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(deletingDRPC.Status.Phase).To(Equal(rmn.Deleting))
 			Expect(deletingDRPC.Status.Progression).To(Equal(rmn.ProgressionDeleting))
 			Expect(deletingDRPC.Status.ActionStartTime).NotTo(BeNil())
@@ -2113,7 +2157,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				userPlacementRule = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule).NotTo(BeNil())
 				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
-				verifyDRPCOwnedByPlacement(userPlacementRule, getLatestDRPC(DefaultDRPCNamespace))
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
 			})
 		})
 		When("DRAction changes to Failover", func() {
@@ -2236,7 +2282,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(placement).NotTo(BeNil())
 				verifyInitialDRPCDeployment(placement, East1ManagedCluster)
 				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)
-				verifyDRPCOwnedByPlacement(placement, getLatestDRPC(DefaultDRPCNamespace))
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				verifyDRPCOwnedByPlacement(placement, latestDRPC)
 			})
 		})
 		When("DRAction changes to Failover using Placement with Subscription", func() {
@@ -2271,8 +2319,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should cleanup DRPC", func() {
 				deleteUserPlacement()
 
-				drpc := getLatestDRPC(DefaultDRPCNamespace)
-				_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionPeerReady)
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				_, condition := getDRPCCondition(&latestDRPC.Status, rmn.ConditionPeerReady)
 				Expect(condition).NotTo(BeNil())
 			})
 		})
@@ -2319,7 +2368,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(placement).NotTo(BeNil())
 				verifyInitialDRPCDeployment(placement, East1ManagedCluster)
 				verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)
-				verifyDRPCOwnedByPlacement(placement, getLatestDRPC(DefaultDRPCNamespace))
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				verifyDRPCOwnedByPlacement(placement, latestDRPC)
 			})
 		})
 		When("DRAction changes to Failover using Placement", func() {
@@ -2366,8 +2417,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should cleanup DRPC", func() {
 				deleteUserPlacement()
 
-				drpc := getLatestDRPC(DefaultDRPCNamespace)
-				_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionPeerReady)
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				_, condition := getDRPCCondition(&latestDRPC.Status, rmn.ConditionPeerReady)
 				Expect(condition).NotTo(BeNil())
 			})
 		})
@@ -2404,7 +2456,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 				userPlacementRule, _ = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
 				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
-				verifyDRPCOwnedByPlacement(userPlacementRule, getLatestDRPC(DefaultDRPCNamespace))
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
 			})
 		})
 		When("DRAction changes to Failover", func() {
@@ -2480,7 +2534,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 				userPlacementRule, _ = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
 				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
-				verifyDRPCOwnedByPlacement(userPlacementRule, getLatestDRPC(DefaultDRPCNamespace))
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
 			})
 		})
 		When("DRAction changes to Failover", func() {
@@ -2887,7 +2943,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				userPlacementRule = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule).NotTo(BeNil())
 				verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)
-				verifyDRPCOwnedByPlacement(userPlacementRule, getLatestDRPC(DefaultDRPCNamespace))
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				verifyDRPCOwnedByPlacement(userPlacementRule, latestDRPC)
 			})
 		})
 		When("DRAction is changed to Failover", func() {
@@ -3002,10 +3060,14 @@ func getVRGFromManifestWork(clusterNamespace string) (*rmn.VolumeReplicationGrou
 	mwName := rmnutil.ManifestWorkName(DRPCCommonName, DefaultDRPCNamespace, rmnutil.MWTypeVRG)
 	mw := &ocmworkv1.ManifestWork{}
 
-	Eventually(func() error {
-		return k8sClient.Get(context.TODO(), types.NamespacedName{Name: mwName, Namespace: clusterNamespace}, mw)
-	}, timeout, interval).Should(Succeed(),
-		"timed out waiting for VRG ManifestWork %s in namespace %s", mwName, clusterNamespace)
+	if err := waitForCondition(timeout, interval,
+		fmt.Sprintf("timed out waiting for VRG ManifestWork %s in namespace %s", mwName, clusterNamespace),
+		func() bool {
+			return k8sClient.Get(context.TODO(),
+				types.NamespacedName{Name: mwName, Namespace: clusterNamespace}, mw) == nil
+		}); err != nil {
+		return nil, err
+	}
 
 	return rmnutil.ExtractVRGFromManifestWork(mw)
 }
@@ -3029,7 +3091,10 @@ func verifyDRPCStateAndProgression(expectedAction rmn.DRAction, expectedPhase rm
 	var progression rmn.ProgressionStatus
 
 	Eventually(func() bool {
-		drpc := getLatestDRPC(DefaultDRPCNamespace)
+		drpc, err := getLatestDRPC(DefaultDRPCNamespace)
+		if err != nil {
+			return false
+		}
 		phase = drpc.Status.Phase
 		progression = drpc.Status.Progression
 
@@ -3038,7 +3103,8 @@ func verifyDRPCStateAndProgression(expectedAction rmn.DRAction, expectedPhase rm
 		fmt.Sprintf("Phase has not been updated yet! Phase:%s Expected:%s - progression:%s expected:%s",
 			phase, expectedPhase, progression, expectedPorgression))
 
-	drpc := getLatestDRPC(DefaultDRPCNamespace)
+	drpc, err := getLatestDRPC(DefaultDRPCNamespace)
+	Expect(err).NotTo(HaveOccurred())
 	Expect(drpc.Spec.Action).Should(Equal(expectedAction))
 	Expect(drpc.Status.Phase).Should(Equal(expectedPhase))
 	Expect(drpc.Status.Progression).Should(Equal(expectedPorgression))
@@ -3050,7 +3116,11 @@ func checkConditionAllowFailover(namespace string) {
 	var availableCondition metav1.Condition
 
 	Eventually(func() bool {
-		drpc = getLatestDRPC(namespace)
+		var err error
+		drpc, err = getLatestDRPC(namespace)
+		if err != nil {
+			return false
+		}
 		for _, availableCondition = range drpc.Status.Conditions {
 			if availableCondition.Type != rmn.ConditionPeerReady {
 				if availableCondition.Status == metav1.ConditionTrue {

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -1318,8 +1318,8 @@ func verifyUserPlacementRuleDecision(name, namespace, homeCluster string) {
 	Expect(placementObj.GetAnnotations()[controllers.DRPCNamespaceAnnotation]).Should(Equal(namespace))
 }
 
-func waitForDRPCProtected(namespace string) {
-	Eventually(func() bool {
+func waitForDRPCProtected(namespace string) error {
+	return waitForCondition(timeout, interval, "DRPC to be protected", func() bool {
 		drpc, err := getLatestDRPC(namespace)
 		if err != nil {
 			return false
@@ -1327,7 +1327,7 @@ func waitForDRPCProtected(namespace string) {
 		_, cond := getDRPCCondition(&drpc.Status, rmn.ConditionProtected)
 
 		return cond != nil && cond.Status == metav1.ConditionTrue
-	}, timeout, interval).Should(BeTrue())
+	})
 }
 
 func getPlacementDecision(plName, plNamespace string) *clrapiv1beta1.PlacementDecision {
@@ -1480,24 +1480,25 @@ func getLatestUserPlacementDecision(name, namespace string) (*clrapiv1beta1.Clus
 	return nil, nil
 }
 
-func waitForCompletion(expectedState string) {
-	Eventually(func() bool {
+func waitForCompletion(expectedState string) error {
+	msg := fmt.Sprintf("failed waiting for state to match. expecting: %s, found %s", expectedState, drstate)
+
+	return waitForCondition(timeout*2, interval, msg, func() bool {
 		return drstate == expectedState
-	}, timeout*2, interval).Should(BeTrue(),
-		fmt.Sprintf("failed waiting for state to match. expecting: %s, found %s", expectedState, drstate))
+	})
 }
 
-//nolint:unparam
-func waitForDRPCPhaseAndProgression(namespace string, drState rmn.DRState) {
-	Eventually(func() bool {
+func waitForDRPCPhaseAndProgression(namespace string, drState rmn.DRState) error {
+	msg := fmt.Sprintf("Timed out waiting for Phase to match. Expected %s for drpcNS %s", drState, namespace)
+
+	return waitForCondition(timeout, interval, msg, func() bool {
 		drpc, err := getLatestDRPC(namespace)
 		if err != nil {
 			return false
 		}
 
 		return drpc.Status.Phase == drState && drpc.Status.Progression == rmn.ProgressionCompleted
-	}, timeout, interval).Should(BeTrue(), fmt.Sprintf("Timed out waiting for Phase to match. Expected %s for drpcNS %s",
-		drState, namespace))
+	})
 }
 
 func getDRPCCondition(status *rmn.DRPlacementControlStatus, conditionType string) (int, *metav1.Condition) {
@@ -1660,7 +1661,7 @@ func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR 
 
 func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferredCluster, failoverCluster string) {
 	Expect(setDRPCSpecExpectationTo(userPlacementRule.GetNamespace(), preferredCluster, failoverCluster, "")).To(Succeed())
-	waitForCompletion(string(rmn.Deployed))
+	Expect(waitForCompletion(string(rmn.Deployed))).To(Succeed())
 
 	drpc, err := getLatestDRPC(userPlacementRule.GetNamespace())
 	Expect(err).NotTo(HaveOccurred())
@@ -1685,13 +1686,13 @@ func relocateToPreferredCluster(placementObj client.Object, fromCluster string) 
 
 	Expect(updateManifestWorkStatus(toCluster1, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
 
-	waitForDRPCProtected(placementObj.GetNamespace())
+	Expect(waitForDRPCProtected(placementObj.GetNamespace())).To(Succeed())
 
 	verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster1)
 	verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.Relocated)
 	verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster1)
 
-	waitForCompletion(string(rmn.Relocated))
+	Expect(waitForCompletion(string(rmn.Relocated))).To(Succeed())
 }
 
 func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster string) {
@@ -1699,13 +1700,13 @@ func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster
 
 	Expect(updateManifestWorkStatus(toCluster, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
 
-	waitForDRPCProtected(placementObj.GetNamespace())
+	Expect(waitForDRPCProtected(placementObj.GetNamespace())).To(Succeed())
 
 	verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster)
 	verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.FailedOver)
 	verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster)
 
-	waitForCompletion(string(rmn.FailedOver))
+	Expect(waitForCompletion(string(rmn.FailedOver))).To(Succeed())
 }
 
 func createNamespacesSync() error {
@@ -1827,7 +1828,7 @@ func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster s
 	verifyUserPlacementRuleDecision(userPlacement.GetName(), userPlacement.GetNamespace(), preferredCluster)
 	verifyDRPCStatusPreferredClusterExpectation(userPlacement.GetNamespace(), rmn.Deployed)
 	Expect(getManifestWorkCount(preferredCluster)).Should(BeElementOf(3, 4)) // MWs for VRG, 2 namespaces, and DRCluster
-	waitForCompletion(string(rmn.Deployed))
+	Expect(waitForCompletion(string(rmn.Deployed))).To(Succeed())
 
 	latestDRPC, err := getLatestDRPC(userPlacement.GetNamespace())
 	Expect(err).NotTo(HaveOccurred())
@@ -2168,8 +2169,7 @@ var _ = Describe("DRPlacementControl Reconciler Errors", func() {
 		It("Should return an error", func(ctx SpecContext) {
 			_, _ = InitialDeploymentAsync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster,
 				UsePlacementRule)
-
-			waitForCompletion(string(rmn.Deployed))
+			Expect(waitForCompletion(string(rmn.Deployed))).To(Succeed())
 
 			err := retry.RetryOnConflict(retry.DefaultBackoff, deleteAllDRClusters)
 			Expect(err).ToNot(HaveOccurred())
@@ -2353,7 +2353,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG MW
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
@@ -2435,7 +2435,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG + NS MW
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
@@ -2532,7 +2532,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG + NS MW
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
 				ensureNamespaceMWsDeletedFromAllClusters(ApplicationNamespace)
@@ -2619,7 +2619,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should delete VRG from Primary (East1ManagedCluster)", func() {
 				By("\n\n*** DELETE DRPC ***\n\n")
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1)) // DRCluster
 				Expect(deleteDRPolicySync()).To(Succeed())
 				Expect(deleteDRClustersSync()).To(Succeed())
@@ -2693,7 +2693,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("\n\n*** DELETE DRPC ***\n\n")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + NS + VRG MW
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1)) // DRCluster
 				Expect(deleteDRPolicySync()).To(Succeed())
 				Expect(deleteDRClustersSync()).To(Succeed())
@@ -2721,7 +2721,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
 				userPlacementRule1 = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule1).NotTo(BeNil())
-				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)
+				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)).To(Succeed())
 				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(""))).To(Succeed())
 			})
 		})
@@ -2779,7 +2779,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 				resetClusterDown()
 				runFailoverAction(userPlacementRule1, from, to, false, false)
-				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.FailedOver)
+				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.FailedOver)).To(Succeed())
 				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, West1ManagedCluster, rmn.VRGActionFailover)).To(Succeed())
 				resetClusterDown()
 			})
@@ -2816,7 +2816,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				expectedPhase = rmn.FailedOver
 				expectedPorgression = rmn.ProgressionCompleted
 				verifyDRPCStateAndProgression(expectedAction, expectedPhase, expectedPorgression)
-				waitForCompletion(string(rmn.FailedOver))
+				Expect(waitForCompletion(string(rmn.FailedOver))).To(Succeed())
 			})
 		})
 
@@ -2827,7 +2827,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				from := West1ManagedCluster
 				runRelocateAction(userPlacementRule1, from, false, false)
 				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(rmn.ActionRelocate))).To(Succeed())
-				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Relocated)
+				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Relocated)).To(Succeed())
 			})
 		})
 		//nolint:lll
@@ -2857,7 +2857,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				expectedPhase = rmn.Relocated
 				expectedPorgression = rmn.ProgressionCompleted
 				verifyDRPCStateAndProgression(expectedAction, expectedPhase, expectedPorgression)
-				waitForCompletion(string(rmn.Relocated))
+				Expect(waitForCompletion(string(rmn.Relocated))).To(Succeed())
 			})
 		})
 		//nolint:lll
@@ -2889,7 +2889,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				expectedPhase = rmn.Relocated
 				expectedPorgression = rmn.ProgressionCompleted
 				verifyDRPCStateAndProgression(expectedAction, expectedPhase, expectedPorgression)
-				waitForCompletion(string(rmn.Relocated))
+				Expect(waitForCompletion(string(rmn.Relocated))).To(Succeed())
 			})
 		})
 
@@ -2911,7 +2911,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting DRPC", func() {
 			It("Should delete all VRGs", func() {
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
 			})
 		})
@@ -2945,7 +2945,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
 				userPlacementRule1 = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule1).NotTo(BeNil())
-				waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)
+				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)).To(Succeed())
 				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(""))).To(Succeed())
 				resetToggleUIDChecks()
 			})
@@ -2968,7 +2968,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting DRPC", func() {
 			It("Should delete all VRGs", func() {
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
 			})
 		})
@@ -3012,7 +3012,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		Specify("Cleanup after tests", func() {
 			deleteUserPlacement()
 			deleteDRPC()
-			waitForCompletion("deleted")
+			Expect(waitForCompletion("deleted")).To(Succeed())
 			Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 			Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
 			ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
@@ -3122,7 +3122,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG MW
 				Expect(deleteDRPC()).To(Succeed())
-				waitForCompletion("deleted")
+				Expect(waitForCompletion("deleted")).To(Succeed())
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -612,22 +612,43 @@ func createDRPC(placementName, name, namespace, drPolicyName, preferredCluster s
 }
 
 //nolint:unparam
-func deleteUserPlacementRule(name, namespace string) {
+func deleteUserPlacementRule(name, namespace string) error {
 	userPlacementRule, err := getLatestUserPlacementRule(name, namespace)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient.Delete(context.TODO(), userPlacementRule)).Should(Succeed())
+	if err != nil {
+		return err
+	}
+
+	if err := k8sClient.Delete(context.TODO(), userPlacementRule); err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func deleteUserPlacement() {
+func deleteUserPlacement() error {
 	userPlacement, err := getLatestUserPlacement(UserPlacementName, DefaultDRPCNamespace)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient.Delete(context.TODO(), userPlacement)).Should(Succeed())
+	if err != nil {
+		return err
+	}
+
+	if err := k8sClient.Delete(context.TODO(), userPlacement); err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func deleteDRPC() {
+func deleteDRPC() error {
 	drpc, err := getLatestDRPC(DefaultDRPCNamespace)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient.Delete(context.TODO(), drpc)).Should(Succeed())
+	if err != nil {
+		return err
+	}
+
+	if err := k8sClient.Delete(context.TODO(), drpc); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func ensureNamespaceMWsDeletedFromAllClusters(namespace string) {
@@ -838,7 +859,9 @@ func createDRClusters(inClusters []*spokeClusterV1.ManagedCluster) error {
 }
 
 func createPlacementDecision() error {
-	deletePlacementDecision()
+	if err := deletePlacementDecision(); err != nil {
+		return err
+	}
 
 	plDecision := placementDecision.DeepCopy()
 
@@ -891,48 +914,60 @@ func createAppSet() error {
 	return k8sClient.Create(context.TODO(), &appSet)
 }
 
-func deleteAppSet() {
-	Expect(k8sClient.Delete(context.TODO(), &appSet)).To(Succeed())
+func deleteAppSet() error {
+	if err := k8sClient.Delete(context.TODO(), &appSet); err != nil {
+		return err
+	}
 
-	Eventually(func() bool {
+	return waitForCondition(timeout, interval, "waiting for AppSet to be deleted", func() bool {
 		resource := &argocdv1alpha1hack.ApplicationSet{}
 
 		return k8serrors.IsNotFound(apiReader.Get(context.TODO(), types.NamespacedName{
 			Namespace: appSet.Namespace,
 			Name:      appSet.Name,
 		}, resource))
-	}, timeout, interval).Should(BeTrue())
+	})
 }
 
-func deleteDRCluster(inDRCluster *rmn.DRCluster) {
-	Expect(k8sClient.Delete(context.TODO(), inDRCluster)).To(Succeed())
+func deleteDRCluster(inDRCluster *rmn.DRCluster) error {
+	if err := k8sClient.Delete(context.TODO(), inDRCluster); err != nil {
+		return err
+	}
 
-	Eventually(func() bool {
+	return waitForCondition(timeout, interval, "waiting for DRCluster to be deleted", func() bool {
 		drcluster := &rmn.DRCluster{}
 
 		return k8serrors.IsNotFound(apiReader.Get(context.TODO(), types.NamespacedName{
 			Namespace: inDRCluster.Namespace,
 			Name:      inDRCluster.Name,
 		}, drcluster))
-	}, timeout, interval).Should(BeTrue())
+	})
 }
 
-func deleteDRClusters(inClusters []*spokeClusterV1.ManagedCluster) {
+func deleteDRClusters(inClusters []*spokeClusterV1.ManagedCluster) error {
 	for _, managedCluster := range inClusters {
 		for idx := range drClusters {
 			if managedCluster.Name == drClusters[idx].Name {
-				deleteDRCluster(&drClusters[idx])
+				if err := deleteDRCluster(&drClusters[idx]); err != nil {
+					return err
+				}
 			}
 		}
 	}
+
+	return nil
 }
 
-func deleteDRClustersAsync() {
-	deleteDRClusters(asyncClusters)
+func deleteDRClustersAsync() error {
+	return deleteDRClusters(asyncClusters)
 }
 
-func deleteDRPolicyAsync() {
-	Expect(k8sClient.Delete(context.TODO(), asyncDRPolicy)).To(Succeed())
+func deleteDRPolicyAsync() error {
+	if err := k8sClient.Delete(context.TODO(), asyncDRPolicy); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // createVRGMW creates a basic (always Primary) ManifestWork for a VRG, used to fake existing VRG MW
@@ -1697,26 +1732,31 @@ func createDRPolicySync() error {
 	return createDRPolicy(policy)
 }
 
-func deleteDRClustersSync() {
-	deleteDRClusters(syncClusters)
+func deleteDRClustersSync() error {
+	return deleteDRClusters(syncClusters)
 }
 
-func deleteDRPolicySync() {
-	Expect(k8sClient.Delete(context.TODO(), getSyncDRPolicy())).To(Succeed())
+func deleteDRPolicySync() error {
+	if err := k8sClient.Delete(context.TODO(), getSyncDRPolicy()); err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func deletePlacementDecision() {
-	err := k8sClient.Delete(context.TODO(), placementDecision)
-	Expect(client.IgnoreNotFound(err)).To(Succeed())
+func deletePlacementDecision() error {
+	if err := client.IgnoreNotFound(k8sClient.Delete(context.TODO(), placementDecision)); err != nil {
+		return err
+	}
 
-	Eventually(func() bool {
+	return waitForCondition(timeout, interval, "waiting for PlacementDecision to be deleted", func() bool {
 		resource := &clrapiv1beta1.PlacementDecision{}
 
 		return k8serrors.IsNotFound(apiReader.Get(context.TODO(), types.NamespacedName{
 			Namespace: placementDecision.Namespace,
 			Name:      placementDecision.Name,
 		}, resource))
-	}, timeout, interval).Should(BeTrue())
+	})
 }
 
 func fenceCluster(cluster string, manual bool) {
@@ -2031,12 +2071,12 @@ var _ = Describe("DRPlacementControl - Ensure do-not-delete PVC Annotation", fun
 			Expect(err).To(BeNil())
 
 			if plType == UsePlacementRule {
-				deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+				Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 			} else {
-				deleteUserPlacement()
+				Expect(deleteUserPlacement()).To(Succeed())
 			}
 
-			deleteDRPC()
+			Expect(deleteDRPC()).To(Succeed())
 		})
 	}
 
@@ -2118,7 +2158,7 @@ var _ = Describe("DRPlacementControl Reconciler Errors", func() {
 			err := retry.RetryOnConflict(retry.DefaultBackoff, deleteAllDRClusters)
 			Expect(err).ToNot(HaveOccurred())
 
-			deleteDRPC()
+			Expect(deleteDRPC()).To(Succeed())
 
 			errCount := 0
 
@@ -2267,7 +2307,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
 				// ----------------------------- DELETE DRPolicy  --------------------------------------
 				By("\n\n*** DELETE drpolicy ***\n\n")
-				deleteDRPolicyAsync()
+				Expect(deleteDRPolicyAsync()).To(Succeed())
 				ensureDRPolicyIsNotDeleted(drpc)
 			})
 		})
@@ -2282,7 +2322,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should cleanup DRPC", func() {
 				// ----------------------------- DELETE DRPC from PRIMARY --------------------------------------
 				By("\n\n*** DELETE User PlacementRule ***\n\n")
-				deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+				Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 
@@ -2296,7 +2336,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				drpolicyName = drpc.Spec.DRPolicyRef.Name
 
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG MW
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
@@ -2308,7 +2348,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			})
 		})
 		Specify("delete drclusters", func() {
-			deleteDRClustersAsync()
+			Expect(deleteDRClustersAsync()).To(Succeed())
 		})
 	})
 	// TEST WITH Placement AND Subscription
@@ -2362,14 +2402,13 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		When("Deleting DRPolicy with DRPC references when using Placement", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
-				deleteDRPolicyAsync()
+				Expect(deleteDRPolicyAsync()).To(Succeed())
 				ensureDRPolicyIsNotDeleted(drpc)
 			})
 		})
 		When("Deleting user Placement", func() {
 			It("Should cleanup DRPC", func() {
-				deleteUserPlacement()
-
+				Expect(deleteUserPlacement()).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
 				_, condition := getDRPCCondition(&latestDRPC.Status, rmn.ConditionPeerReady)
@@ -2379,7 +2418,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting DRPC when using Placement", func() {
 			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG + NS MW
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
@@ -2391,7 +2430,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			})
 		})
 		Specify("delete drclusters when using Placement", func() {
-			deleteDRClustersAsync()
+			Expect(deleteDRClustersAsync()).To(Succeed())
 		})
 	})
 	// TEST WITH Placement AND ApplicationSet
@@ -2460,14 +2499,13 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		When("Deleting DRPolicy with DRPC references when using Placement", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
-				deleteDRPolicyAsync()
+				Expect(deleteDRPolicyAsync()).To(Succeed())
 				ensureDRPolicyIsNotDeleted(drpc)
 			})
 		})
 		When("Deleting user Placement", func() {
 			It("Should cleanup DRPC", func() {
-				deleteUserPlacement()
-
+				Expect(deleteUserPlacement()).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
 				_, condition := getDRPCCondition(&latestDRPC.Status, rmn.ConditionPeerReady)
@@ -2477,13 +2515,12 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting DRPC when using Placement", func() {
 			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG + NS MW
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
 				ensureNamespaceMWsDeletedFromAllClusters(ApplicationNamespace)
-				deleteAppSet()
-
+				Expect(deleteAppSet()).To(Succeed())
 				UseApplicationSet = false
 			})
 			It("should delete the DRPC causing its referenced drpolicy to be deleted"+
@@ -2492,7 +2529,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			})
 		})
 		Specify("delete drclusters when using Placement", func() {
-			deleteDRClustersAsync()
+			Expect(deleteDRClustersAsync()).To(Succeed())
 		})
 	})
 	Context("DRPlacementControl Reconciler Sync DR", func() {
@@ -2559,17 +2596,17 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting user PlacementRule", func() {
 			It("Should cleanup DRPC", func() {
 				By("\n\n*** DELETE User PlacementRule ***\n\n")
-				deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+				Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 		When("Deleting DRPC", func() {
 			It("Should delete VRG from Primary (East1ManagedCluster)", func() {
 				By("\n\n*** DELETE DRPC ***\n\n")
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1)) // DRCluster
-				deleteDRPolicySync()
-				deleteDRClustersSync()
+				Expect(deleteDRPolicySync()).To(Succeed())
+				Expect(deleteDRClustersSync()).To(Succeed())
 			})
 		})
 
@@ -2631,7 +2668,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting user PlacementRule", func() {
 			It("Should cleanup DRPC", func() {
 				By("\n\n*** DELETE User PlacementRule ***\n\n")
-				deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+				Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 
@@ -2639,11 +2676,11 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should delete VRG from Primary (East1ManagedCluster)", func() {
 				By("\n\n*** DELETE DRPC ***\n\n")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + NS + VRG MW
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1)) // DRCluster
-				deleteDRPolicySync()
-				deleteDRClustersSync()
+				Expect(deleteDRPolicySync()).To(Succeed())
+				Expect(deleteDRClustersSync()).To(Succeed())
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
 			})
 		})
@@ -2848,26 +2885,26 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
 				// ----------------------------- DELETE DRPolicy  --------------------------------------
 				By("\n\n*** DELETE drpolicy ***\n\n")
-				deleteDRPolicyAsync()
+				Expect(deleteDRPolicyAsync()).To(Succeed())
 			})
 		})
 		When("Deleting user PlacementRule", func() {
 			It("Should cleanup DRPC", func() {
 				// ----------------------------- DELETE DRPC from PRIMARY --------------------------------------
 				By("\n\n*** DELETE User PlacementRule ***\n\n")
-				deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+				Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 
 		When("Deleting DRPC", func() {
 			It("Should delete all VRGs", func() {
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
 			})
 		})
 		Specify("delete drclusters", func() {
-			deleteDRClustersAsync()
+			Expect(deleteDRClustersAsync()).To(Succeed())
 		})
 	})
 
@@ -2905,27 +2942,27 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("Deleting DRPolicy with DRPC references", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
 				By("\n\n*** DELETE drpolicy ***\n\n")
-				deleteDRPolicyAsync()
+				Expect(deleteDRPolicyAsync()).To(Succeed())
 			})
 		})
 
 		When("Deleting user PlacementRule", func() {
 			It("Should cleanup DRPC", func() {
 				By("\n\n*** DELETE User PlacementRule ***\n\n")
-				deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+				Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 
 		When("Deleting DRPC", func() {
 			It("Should delete all VRGs", func() {
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				ensureNamespaceMWsDeletedFromAllClusters(DefaultDRPCNamespace)
 			})
 		})
 
 		Specify("delete drclusters", func() {
-			deleteDRClustersAsync()
+			Expect(deleteDRClustersAsync()).To(Succeed())
 		})
 	})
 
@@ -3059,20 +3096,20 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		When("Deleting DRPolicy with DRPC references", func() {
 			It("Should retain the deleted DRPolicy in the API server", func() {
-				deleteDRPolicyAsync()
+				Expect(deleteDRPolicyAsync()).To(Succeed())
 				ensureDRPolicyIsNotDeleted(drpc)
 			})
 		})
 		When("Deleting user PlacementRule", func() {
 			It("Should cleanup DRPC", func() {
-				deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+				Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
 			})
 		})
 
 		When("Deleting DRPC", func() {
 			It("Should delete VRG and NS MWs and MCVs from Primary (East1ManagedCluster)", func() {
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(BeElementOf(3, 4)) // DRCluster + VRG MW
-				deleteDRPC()
+				Expect(deleteDRPC()).To(Succeed())
 				waitForCompletion("deleted")
 				Expect(getManifestWorkCount(East1ManagedCluster)).Should(Equal(1))       // DRCluster
 				Expect(getManagedClusterViewCount(East1ManagedCluster)).Should(Equal(0)) // NS + VRG MCV
@@ -3085,8 +3122,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		Specify("delete drclusters", func() {
 			RunningVolSyncTests = false
-
-			deleteDRClustersAsync()
+			Expect(deleteDRClustersAsync()).To(Succeed())
 		})
 	})
 })

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -177,6 +177,30 @@ var (
 	}
 )
 
+func waitForCondition(d, poll time.Duration, desc string, cond func() bool) error {
+	deadline := time.Now().Add(d)
+	for {
+		if cond() {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out: %s", desc)
+		}
+		time.Sleep(poll)
+	}
+}
+
+func ensureConsistent(d, poll time.Duration, desc string, cond func() bool) error {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if !cond() {
+			return fmt.Errorf("consistency violated: %s", desc)
+		}
+		time.Sleep(poll)
+	}
+	return nil
+}
+
 func getSyncDRPolicy() *rmn.DRPolicy {
 	return &rmn.DRPolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -1118,59 +1118,87 @@ const (
 )
 
 func InitialDeploymentAsync(namespace, placementName, homeCluster string, plType PlacementType) (
-	client.Object, *rmn.DRPlacementControl,
+	client.Object, *rmn.DRPlacementControl, error,
 ) {
-	Expect(createNamespacesAsync(getNamespaceObj(namespace))).To(Succeed())
+	if err := createNamespacesAsync(getNamespaceObj(namespace)); err != nil {
+		return nil, nil, err
+	}
 
-	Expect(createManagedClusters(asyncClusters)).To(Succeed())
-	Expect(createDRClustersAsync()).To(Succeed())
-	Expect(createDRPolicyAsync()).To(Succeed())
-	Expect(createPlacementDecision()).To(Succeed())
+	if err := createManagedClusters(asyncClusters); err != nil {
+		return nil, nil, err
+	}
+
+	if err := createDRClustersAsync(); err != nil {
+		return nil, nil, err
+	}
+
+	if err := createDRPolicyAsync(); err != nil {
+		return nil, nil, err
+	}
+
+	if err := createPlacementDecision(); err != nil {
+		return nil, nil, err
+	}
 
 	return CreatePlacementAndDRPC(namespace, placementName, homeCluster, plType)
 }
 
 func CreatePlacementAndDRPC(namespace, placementName, homeCluster string, plType PlacementType) (
-	client.Object, *rmn.DRPlacementControl,
+	client.Object, *rmn.DRPlacementControl, error,
 ) {
 	var placementObj client.Object
-
 	var err error
 
 	switch plType {
 	case UsePlacementRule:
 		placementObj, err = createPlacementRule(placementName, namespace)
-		Expect(err).NotTo(HaveOccurred())
+		if err != nil {
+			return nil, nil, err
+		}
 	case UsePlacementWithSubscription:
 		placementObj, err = createPlacement(placementName, namespace)
-		Expect(err).NotTo(HaveOccurred())
+		if err != nil {
+			return nil, nil, err
+		}
 	case UsePlacementWithAppSet:
-		Expect(createAppSet()).To(Succeed())
+		if err := createAppSet(); err != nil {
+			return nil, nil, err
+		}
 
 		placementObj, err = createPlacement(placementName, namespace)
-		Expect(err).NotTo(HaveOccurred())
+		if err != nil {
+			return nil, nil, err
+		}
 	default:
-		Fail("Wrong placement type")
+		return nil, nil, fmt.Errorf("wrong placement type")
 	}
 
 	drpc, err := createDRPC(placementName, DRPCCommonName, namespace, AsyncDRPolicyName, homeCluster)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, nil, err
+	}
 
-	return placementObj, drpc
+	return placementObj, drpc, nil
 }
 
 func FollowOnDeploymentAsync(namespace, placementName, homeCluster string) (*plrv1.PlacementRule,
-	*rmn.DRPlacementControl,
+	*rmn.DRPlacementControl, error,
 ) {
-	Expect(createNamespace(appNamespace2)).To(Succeed())
+	if err := createNamespace(appNamespace2); err != nil {
+		return nil, nil, err
+	}
 
 	placementRule, err := createPlacementRule(placementName, namespace)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, nil, err
+	}
 
 	drpc, err := createDRPC(placementName, DRPCCommonName, namespace, AsyncDRPolicyName, homeCluster)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, nil, err
+	}
 
-	return placementRule, drpc
+	return placementRule, drpc, nil
 }
 
 func verifyVRGManifestWorkCreatedAsPrimary(namespace, managedCluster string) error {
@@ -1603,7 +1631,7 @@ func getDRActionCounts(namespace string) drActionCounts {
 //nolint:unparam
 func runFailoverAction(placementObj client.Object, fromCluster, toCluster string, isSyncDR bool,
 	manualFence bool,
-) {
+) error {
 	countsBefore := getDRActionCounts(placementObj.GetNamespace())
 
 	expectedFailoverCount := countsBefore.Failover + 1
@@ -1616,43 +1644,88 @@ func runFailoverAction(placementObj client.Object, fromCluster, toCluster string
 		fenceCluster(fromCluster, manualFence)
 	}
 
-	recoverToFailoverCluster(placementObj, fromCluster, toCluster)
+	if err := recoverToFailoverCluster(placementObj, fromCluster, toCluster); err != nil {
+		return err
+	}
+
 	// TODO: DRCluster as part of Unfence operation, first unfences
 	//       the NetworkFence CR and then deletes it. Hence, by the
 	//       time this test is made, depending upon whether NetworkFence
 	//       resource is cleaned up or not, number of MW may change.
+	toMWCount, err := getManifestWorkCount(toCluster)
+	if err != nil {
+		return err
+	}
+
 	if !isSyncDR {
-		Expect(getManifestWorkCount(toCluster)).Should(BeElementOf(3, 4)) // MW for VRG+DRCluster+NS
+		if toMWCount != 3 && toMWCount != 4 { // MW for VRG+DRCluster+NS
+			return fmt.Errorf("expected MW count 3 or 4 on %s, got %d", toCluster, toMWCount)
+		}
 	} else {
 		if manualFence {
-			Expect(getManifestWorkCount(toCluster)).Should(Equal(3)) // MW for VRG+DRCluster + NS
+			if toMWCount != 3 { // MW for VRG+DRCluster + NS
+				return fmt.Errorf("expected MW count 3 on %s, got %d", toCluster, toMWCount)
+			}
 		} else {
-			Expect(getManifestWorkCount(toCluster)).Should(Equal(4)) // MW for VRG+DRCluster + NS + NF
+			if toMWCount != 4 { // MW for VRG+DRCluster + NS + NF
+				return fmt.Errorf("expected MW count 4 on %s, got %d", toCluster, toMWCount)
+			}
 		}
 	}
 
-	Expect(getManifestWorkCount(fromCluster)).Should(Equal(3)) // DRCluster + NS MW + VRG MW
+	fromMWCount, err := getManifestWorkCount(fromCluster)
+	if err != nil {
+		return err
+	}
+
+	if fromMWCount != 3 { // DRCluster + NS MW + VRG MW
+		return fmt.Errorf("expected MW count 3 on %s, got %d", fromCluster, fromMWCount)
+	}
 
 	drpc, err := getLatestDRPC(placementObj.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return err
+	}
+
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'FailedOver'
-	Expect(drpc.Status.Phase).To(Equal(rmn.FailedOver))
-	Expect(len(drpc.Status.Conditions)).To(Equal(3))
-	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
-	Expect(condition.Reason).To(Equal(string(rmn.FailedOver)))
-	Expect(drpc.Status.ActionStartTime).ShouldNot(BeNil())
+	if drpc.Status.Phase != rmn.FailedOver {
+		return fmt.Errorf("expected phase FailedOver, got %v", drpc.Status.Phase)
+	}
 
-	Expect(getDRActionCounts(placementObj.GetNamespace()).Failover).To(Equal(expectedFailoverCount),
-		"dr-action-count annotation should count the failover")
+	if len(drpc.Status.Conditions) != 3 {
+		return fmt.Errorf("expected 3 conditions, got %d", len(drpc.Status.Conditions))
+	}
+
+	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
+	if condition.Reason != string(rmn.FailedOver) {
+		return fmt.Errorf("expected condition reason FailedOver, got %s", condition.Reason)
+	}
+
+	if drpc.Status.ActionStartTime == nil {
+		return fmt.Errorf("expected ActionStartTime to be non-nil")
+	}
+
+	failoverCount := getDRActionCounts(placementObj.GetNamespace()).Failover
+	if failoverCount != expectedFailoverCount {
+		return fmt.Errorf("expected dr-action-count annotation to count the failover: expected %v, got %v",
+			expectedFailoverCount, failoverCount)
+	}
 
 	decision, err := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
-	Expect(decision.ClusterName).To(Equal(toCluster))
+	if err != nil {
+		return err
+	}
+
+	if decision.ClusterName != toCluster {
+		return fmt.Errorf("expected decision cluster %s, got %s", toCluster, decision.ClusterName)
+	}
+
+	return nil
 }
 
-func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR bool, manualUnfence bool) {
+func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR bool, manualUnfence bool) error {
 	toCluster1 := "east1-cluster"
 
 	countsBefore := getDRActionCounts(placementObj.GetNamespace())
@@ -1682,91 +1755,176 @@ func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR 
 		resetdrCluster(toCluster1)
 	}
 
-	relocateToPreferredCluster(placementObj, fromCluster)
+	if err := relocateToPreferredCluster(placementObj, fromCluster); err != nil {
+		return err
+	}
+
 	// TODO: DRCluster as part of Unfence operation, first unfences
 	//       the NetworkFence CR and then deletes it. Hence, by the
 	//       time this test is made, depending upon whether NetworkFence
 	//       resource is cleaned up or not, number of MW may change.
+	fromMWCount, err := getManifestWorkCount(fromCluster)
+	if err != nil {
+		return err
+	}
 
-	// Expect(getManifestWorkCount(toCluster1)).Should(Equal(2)) // MWs for VRG+ROLES
 	if !isSyncDR {
-		Expect(getManifestWorkCount(fromCluster)).Should(BeElementOf(3, 4)) // DRClusters + NS MW + VRG MW
+		if fromMWCount != 3 && fromMWCount != 4 { // DRClusters + NS MW + VRG MW
+			return fmt.Errorf("expected MW count 3 or 4 on %s, got %d", fromCluster, fromMWCount)
+		}
 	} else {
 		// By the time this check is made, the NetworkFence CR in the
 		// cluster from where the application is migrated might not have
 		// been deleted. Hence, the number of MW expectation will be
 		// either of 2 or 3.
-		Expect(getManifestWorkCount(fromCluster)).Should(BeElementOf(2, 3))
+		if fromMWCount != 2 && fromMWCount != 3 {
+			return fmt.Errorf("expected MW count 2 or 3 on %s, got %d", fromCluster, fromMWCount)
+		}
 	}
 
 	drpc, err := getLatestDRPC(placementObj.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return err
+	}
+
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state is 'Relocated'
-	Expect(drpc.Status.Phase).To(Equal(rmn.Relocated))
-	Expect(len(drpc.Status.Conditions)).To(Equal(3))
-	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
-	Expect(condition.Reason).To(Equal(string(rmn.Relocated)))
+	if drpc.Status.Phase != rmn.Relocated {
+		return fmt.Errorf("expected phase Relocated, got %v", drpc.Status.Phase)
+	}
 
-	Expect(getDRActionCounts(placementObj.GetNamespace()).Relocate).To(Equal(expectedRelocateCount),
-		"dr-action-count annotation should count the relocate")
+	if len(drpc.Status.Conditions) != 3 {
+		return fmt.Errorf("expected 3 conditions, got %d", len(drpc.Status.Conditions))
+	}
+
+	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
+	if condition.Reason != string(rmn.Relocated) {
+		return fmt.Errorf("expected condition reason Relocated, got %s", condition.Reason)
+	}
+
+	relocateCount := getDRActionCounts(placementObj.GetNamespace()).Relocate
+	if relocateCount != expectedRelocateCount {
+		return fmt.Errorf("expected dr-action-count annotation to count the relocate: expected %v, got %v",
+			expectedRelocateCount, relocateCount)
+	}
 
 	decision, err := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
-	Expect(decision.ClusterName).To(Equal(toCluster1))
-	Expect(condition.Reason).To(Equal(string(rmn.Relocated)))
-	Expect(drpc.GetAnnotations()[controllers.LastAppDeploymentCluster]).To(Equal(toCluster1))
+	if err != nil {
+		return err
+	}
+
+	if decision.ClusterName != toCluster1 {
+		return fmt.Errorf("expected decision cluster %s, got %s", toCluster1, decision.ClusterName)
+	}
+
+	if drpc.GetAnnotations()[controllers.LastAppDeploymentCluster] != toCluster1 {
+		return fmt.Errorf("expected LastAppDeploymentCluster %s, got %s",
+			toCluster1, drpc.GetAnnotations()[controllers.LastAppDeploymentCluster])
+	}
+
+	return nil
 }
 
-func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferredCluster, failoverCluster string) {
-	Expect(setDRPCSpecExpectationTo(userPlacementRule.GetNamespace(), preferredCluster, failoverCluster, "")).To(Succeed())
-	Expect(waitForCompletion(string(rmn.Deployed))).To(Succeed())
+func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferredCluster, failoverCluster string) error {
+	if err := setDRPCSpecExpectationTo(userPlacementRule.GetNamespace(), preferredCluster, failoverCluster, ""); err != nil {
+		return err
+	}
+
+	if err := waitForCompletion(string(rmn.Deployed)); err != nil {
+		return err
+	}
 
 	drpc, err := getLatestDRPC(userPlacementRule.GetNamespace())
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return err
+	}
+
 	// At this point expect the DRPC status condition to have 2 types
 	// {Available and PeerReady}
 	// Final state didn't change and it is 'Relocated' even though we tried to run
 	// initial deployment
-	Expect(drpc.Status.Phase).To(Equal(rmn.Deployed))
-	Expect(len(drpc.Status.Conditions)).To(Equal(3))
+	if drpc.Status.Phase != rmn.Deployed {
+		return fmt.Errorf("expected phase Deployed, got %v", drpc.Status.Phase)
+	}
+
+	if len(drpc.Status.Conditions) != 3 {
+		return fmt.Errorf("expected 3 conditions, got %d", len(drpc.Status.Conditions))
+	}
+
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
-	Expect(condition.Reason).To(Equal(string(rmn.Deployed)))
+	if condition.Reason != string(rmn.Deployed) {
+		return fmt.Errorf("expected condition reason Deployed, got %s", condition.Reason)
+	}
 
 	decision, err := getLatestUserPlacementDecision(userPlacementRule.Name, userPlacementRule.Namespace)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(decision.ClusterName).To(Equal(preferredCluster))
+	if err != nil {
+		return err
+	}
+
+	if decision.ClusterName != preferredCluster {
+		return fmt.Errorf("expected decision cluster %s, got %s", preferredCluster, decision.ClusterName)
+	}
+
+	return nil
 }
 
-func relocateToPreferredCluster(placementObj client.Object, fromCluster string) {
+func relocateToPreferredCluster(placementObj client.Object, fromCluster string) error {
 	toCluster1 := "east1-cluster"
 
-	Expect(setDRPCSpecExpectationTo(placementObj.GetNamespace(), toCluster1, fromCluster, rmn.ActionRelocate)).To(Succeed())
+	if err := setDRPCSpecExpectationTo(placementObj.GetNamespace(), toCluster1, fromCluster, rmn.ActionRelocate); err != nil {
+		return err
+	}
 
-	Expect(updateManifestWorkStatus(toCluster1, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
+	if err := updateManifestWorkStatus(toCluster1, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied); err != nil {
+		return err
+	}
 
-	Expect(waitForDRPCProtected(placementObj.GetNamespace())).To(Succeed())
+	if err := waitForDRPCProtected(placementObj.GetNamespace()); err != nil {
+		return err
+	}
 
-	Expect(verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster1)).To(Succeed())
-	Expect(verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.Relocated)).To(Succeed())
-	Expect(verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster1)).To(Succeed())
+	if err := verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster1); err != nil {
+		return err
+	}
 
-	Expect(waitForCompletion(string(rmn.Relocated))).To(Succeed())
+	if err := verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.Relocated); err != nil {
+		return err
+	}
+
+	if err := verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster1); err != nil {
+		return err
+	}
+
+	return waitForCompletion(string(rmn.Relocated))
 }
 
-func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster string) {
-	Expect(setDRPCSpecExpectationTo(placementObj.GetNamespace(), fromCluster, toCluster, rmn.ActionFailover)).To(Succeed())
+func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster string) error {
+	if err := setDRPCSpecExpectationTo(placementObj.GetNamespace(), fromCluster, toCluster, rmn.ActionFailover); err != nil {
+		return err
+	}
 
-	Expect(updateManifestWorkStatus(toCluster, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied)).To(Succeed())
+	if err := updateManifestWorkStatus(toCluster, placementObj.GetNamespace(), "vrg", ocmworkv1.WorkApplied); err != nil {
+		return err
+	}
 
-	Expect(waitForDRPCProtected(placementObj.GetNamespace())).To(Succeed())
+	if err := waitForDRPCProtected(placementObj.GetNamespace()); err != nil {
+		return err
+	}
 
-	Expect(verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster)).To(Succeed())
-	Expect(verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.FailedOver)).To(Succeed())
-	Expect(verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster)).To(Succeed())
+	if err := verifyUserPlacementRuleDecision(placementObj.GetName(), placementObj.GetNamespace(), toCluster); err != nil {
+		return err
+	}
 
-	Expect(waitForCompletion(string(rmn.FailedOver))).To(Succeed())
+	if err := verifyDRPCStatusPreferredClusterExpectation(placementObj.GetNamespace(), rmn.FailedOver); err != nil {
+		return err
+	}
+
+	if err := verifyVRGManifestWorkCreatedAsPrimary(placementObj.GetNamespace(), toCluster); err != nil {
+		return err
+	}
+
+	return waitForCompletion(string(rmn.FailedOver))
 }
 
 func createNamespacesSync() error {
@@ -1782,21 +1940,35 @@ func createNamespacesSync() error {
 }
 
 func InitialDeploymentSync(namespace, placementName, homeCluster string) (*plrv1.PlacementRule,
-	*rmn.DRPlacementControl,
+	*rmn.DRPlacementControl, error,
 ) {
-	Expect(createNamespacesSync()).To(Succeed())
+	if err := createNamespacesSync(); err != nil {
+		return nil, nil, err
+	}
 
-	Expect(createManagedClusters(syncClusters)).To(Succeed())
-	Expect(createDRClustersSync()).To(Succeed())
-	Expect(createDRPolicySync()).To(Succeed())
+	if err := createManagedClusters(syncClusters); err != nil {
+		return nil, nil, err
+	}
+
+	if err := createDRClustersSync(); err != nil {
+		return nil, nil, err
+	}
+
+	if err := createDRPolicySync(); err != nil {
+		return nil, nil, err
+	}
 
 	placementRule, err := createPlacementRule(placementName, namespace)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, nil, err
+	}
 
 	drpc, err := createDRPC(UserPlacementRuleName, DRPCCommonName, DefaultDRPCNamespace, SyncDRPolicyName, homeCluster)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, nil, err
+	}
 
-	return placementRule, drpc
+	return placementRule, drpc, nil
 }
 
 func createDRClustersSync() error {
@@ -1949,7 +2121,9 @@ func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster s
 func verifyFailoverToSecondary(placementObj client.Object, toCluster string,
 	isSyncDR bool,
 ) error {
-	recoverToFailoverCluster(placementObj, East1ManagedCluster, toCluster)
+	if err := recoverToFailoverCluster(placementObj, East1ManagedCluster, toCluster); err != nil {
+		return err
+	}
 
 	// TODO: DRCluster as part of Unfence operation, first unfences
 	//       the NetworkFence CR and then deletes it. Hence, by the
@@ -2183,12 +2357,13 @@ var _ = Describe("DRPlacementControl - Ensure do-not-delete PVC Annotation", fun
 		}
 
 		It(fmt.Sprintf("Should handle annotation propagation for %s", resourceType), func(ctx SpecContext) {
-			placementObj, drpc := InitialDeploymentAsync(
+			placementObj, drpc, err := InitialDeploymentAsync(
 				DefaultDRPCNamespace,
 				placementName,
 				East1ManagedCluster,
 				plType, // UsePlacementRule or UsePlacement
 			)
+			Expect(err).NotTo(HaveOccurred())
 
 			vrg := getDefaultVRG(DefaultDRPCNamespace)
 
@@ -2215,7 +2390,7 @@ var _ = Describe("DRPlacementControl - Ensure do-not-delete PVC Annotation", fun
 			}
 
 			// Positive base case: Ramen is the scheduler - do nothing, no error
-			err := controllers.EnsureDoNotDeletePVCAnnotation(mwu, drpc, placementObj, vrg, East1ManagedCluster, mwu.Log)
+			err = controllers.EnsureDoNotDeletePVCAnnotation(mwu, drpc, placementObj, vrg, East1ManagedCluster, mwu.Log)
 			Expect(err).To(BeNil())
 
 			// Default scheduler
@@ -2291,10 +2466,11 @@ var _ = Describe("DRPlacementControl - EnableDiff Annotation Propagation", func(
 	})
 
 	It("Should propagate EnableDiffAnnotation from DRPC to VRG in ManifestWork", func(ctx SpecContext) {
-		_, _ = InitialDeploymentAsync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster,
+		_, _, err := InitialDeploymentAsync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster,
 			UsePlacementRule)
+		Expect(err).NotTo(HaveOccurred())
 
-		waitForCompletion(string(rmn.Deployed))
+		Expect(waitForCompletion(string(rmn.Deployed))).To(Succeed())
 
 		// Set EnableDiffAnnotation on DRPC
 		retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -2325,8 +2501,8 @@ var _ = Describe("DRPlacementControl - EnableDiff Annotation Propagation", func(
 			return vrg.GetAnnotations()[rmnutil.EnableDiffAnnotation]
 		}, timeout, interval).Should(Equal("true"))
 
-		deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
-		deleteDRPC()
+		Expect(deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)).To(Succeed())
+		Expect(deleteDRPC()).To(Succeed())
 	})
 })
 
@@ -2341,11 +2517,12 @@ var _ = Describe("DRPlacementControl Reconciler Errors", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should return an error", func(ctx SpecContext) {
-			_, _ = InitialDeploymentAsync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster,
+			_, _, err := InitialDeploymentAsync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster,
 				UsePlacementRule)
+			Expect(err).NotTo(HaveOccurred())
 			Expect(waitForCompletion(string(rmn.Deployed))).To(Succeed())
 
-			err := retry.RetryOnConflict(retry.DefaultBackoff, deleteAllDRClusters)
+			err = retry.RetryOnConflict(retry.DefaultBackoff, deleteAllDRClusters)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(deleteDRPC()).To(Succeed())
@@ -2374,16 +2551,16 @@ var _ = Describe("DRPlacementControl Reconciler Errors", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("Should reset actionStartTime and clear actionDuration for deletion", func(ctx SpecContext) {
-			_, _ = InitialDeploymentAsync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster,
+			_, _, err := InitialDeploymentAsync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster,
 				UsePlacementRule)
-
-			waitForCompletion(string(rmn.Deployed))
-			waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(waitForCompletion(string(rmn.Deployed))).To(Succeed())
+			Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)).To(Succeed())
 
 			previousStartTime := metav1.NewTime(time.Now().Add(-time.Hour))
 			previousDuration := metav1.Duration{Duration: time.Minute}
 
-			err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 				drpc, err := getLatestDRPC(DefaultDRPCNamespace)
 				if err != nil {
 					return err
@@ -2398,7 +2575,7 @@ var _ = Describe("DRPlacementControl Reconciler Errors", func() {
 			err = retry.RetryOnConflict(retry.DefaultBackoff, deleteAllDRClusters)
 			Expect(err).ToNot(HaveOccurred())
 
-			deleteDRPC()
+			Expect(deleteDRPC()).To(Succeed())
 
 			_, err = drpcReconcile(DRPCCommonName, DefaultDRPCNamespace)
 			Expect(err).To(HaveOccurred())
@@ -2432,9 +2609,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("Initial Deployment")
 
 				var placementObj client.Object
-
-				placementObj, drpc = InitialDeploymentAsync(
+				var err error
+				placementObj, drpc, err = InitialDeploymentAsync(
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
+				Expect(err).NotTo(HaveOccurred())
 				userPlacementRule = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule).NotTo(BeNil())
 				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
@@ -2471,21 +2649,21 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				// ----------------------------- RELOCATION TO PRIMARY --------------------------------------
 				By("\n\n*** Relocate - 1\n\n")
-				runRelocateAction(userPlacementRule, West1ManagedCluster, false, false)
+				Expect(runRelocateAction(userPlacementRule, West1ManagedCluster, false, false)).To(Succeed())
 			})
 		})
 		When("DRAction is changed to Failover after relocation", func() {
 			It("Should failover again to Secondary (West1ManagedCluster)", func() {
 				// ----------------------------- FAILOVER TO SECONDARY --------------------------------------
 				By("\n\n*** Failover - 3\n\n")
-				runFailoverAction(userPlacementRule, East1ManagedCluster, West1ManagedCluster, false, false)
+				Expect(runFailoverAction(userPlacementRule, East1ManagedCluster, West1ManagedCluster, false, false)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				// ----------------------------- RELOCATION TO PRIMARY --------------------------------------
 				By("\n\n*** relocate 2\n\n")
-				runRelocateAction(userPlacementRule, West1ManagedCluster, false, false)
+				Expect(runRelocateAction(userPlacementRule, West1ManagedCluster, false, false)).To(Succeed())
 			})
 		})
 		When("Get VRG from s3 store", func() {
@@ -2503,7 +2681,8 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		When("A DRPC is created referring to a deleted DRPolicy", func() {
 			It("Should fail DRPC reconciliaiton and not add a finalizer", func() {
-				_, drpc2 := FollowOnDeploymentAsync(DRPC2NamespaceName, UserPlacementRuleName, East1ManagedCluster)
+				_, drpc2, err := FollowOnDeploymentAsync(DRPC2NamespaceName, UserPlacementRuleName, East1ManagedCluster)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(checkIfDRPCFinalizerNotAdded(drpc2)).To(Succeed())
 				Expect(k8sClient.Delete(context.TODO(), drpc2)).Should(Succeed())
 			})
@@ -2556,9 +2735,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				By("Initial Deployment")
 
 				var placementObj client.Object
-
-				placementObj, drpc = InitialDeploymentAsync(
+				var err error
+				placementObj, drpc, err = InitialDeploymentAsync(
 					DefaultDRPCNamespace, UserPlacementName, East1ManagedCluster, UsePlacementWithSubscription)
+				Expect(err).NotTo(HaveOccurred())
 				placement = placementObj.(*clrapiv1beta1.Placement)
 				Expect(placement).NotTo(BeNil())
 				Expect(verifyInitialDRPCDeployment(placement, East1ManagedCluster)).To(Succeed())
@@ -2580,13 +2760,13 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				setRestorePVsComplete()
 			})
 			It("Should failover to Secondary (West1ManagedCluster) when using Subscription", func() {
-				runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)
+				Expect(runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)).To(Succeed())
 				Expect(verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithSubscription)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate using Placement with Subscriptioin", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
-				runRelocateAction(placement, West1ManagedCluster, false, false)
+				Expect(runRelocateAction(placement, West1ManagedCluster, false, false)).To(Succeed())
 				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)).To(Succeed())
 			})
 		})
@@ -2641,9 +2821,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				getBaseVRG(DefaultDRPCNamespace).ObjectMeta.Namespace = ApplicationNamespace
 
 				var placementObj client.Object
-
-				placementObj, drpc = InitialDeploymentAsync(
+				var err error
+				placementObj, drpc, err = InitialDeploymentAsync(
 					DefaultDRPCNamespace, UserPlacementName, East1ManagedCluster, UsePlacementWithAppSet)
+				Expect(err).NotTo(HaveOccurred())
 				placement = placementObj.(*clrapiv1beta1.Placement)
 				Expect(placement).NotTo(BeNil())
 				Expect(verifyInitialDRPCDeployment(placement, East1ManagedCluster)).To(Succeed())
@@ -2665,25 +2846,25 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				setRestorePVsComplete()
 			})
 			It("Should failover to Secondary (West1ManagedCluster)", func() {
-				runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)
+				Expect(runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)).To(Succeed())
 				Expect(verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate using Placement", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
-				runRelocateAction(placement, West1ManagedCluster, false, false)
+				Expect(runRelocateAction(placement, West1ManagedCluster, false, false)).To(Succeed())
 				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
 		When("DRAction is changed to Failover after relocation using Placement", func() {
 			It("Should failover again to Secondary (West1ManagedCluster)", func() {
-				runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)
+				Expect(runFailoverAction(placement, East1ManagedCluster, West1ManagedCluster, false, false)).To(Succeed())
 				Expect(verifyActionResultForPlacement(placement, West1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate again using Placement", func() {
 			It("Should relocate again to Primary (East1ManagedCluster)", func() {
-				runRelocateAction(placement, West1ManagedCluster, false, false)
+				Expect(runRelocateAction(placement, West1ManagedCluster, false, false)).To(Succeed())
 				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithAppSet)).To(Succeed())
 			})
 		})
@@ -2731,8 +2912,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("An Application is deployed for the first time", func() {
 			It("Should deploy to East1ManagedCluster", func() {
 				By("Initial Deployment")
-
-				userPlacementRule, _ = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
+				var err error
+				userPlacementRule, _, err = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
@@ -2760,27 +2942,27 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				// ----------------------------- RELOCATION TO PRIMARY FOR SYNC DR -------------------
 				By("\n\n*** relocate 2\n\n")
-				runRelocateAction(userPlacementRule, East2ManagedCluster, true, false)
+				Expect(runRelocateAction(userPlacementRule, East2ManagedCluster, true, false)).To(Succeed())
 			})
 		})
 		When("DRAction is cleared after relocation", func() {
 			It("Should not do anything", func() {
 				// ----------------------------- Clear DRAction --------------------------------------
-				clearDRActionAfterRelocate(userPlacementRule, East1ManagedCluster, East2ManagedCluster)
+				Expect(clearDRActionAfterRelocate(userPlacementRule, East1ManagedCluster, East2ManagedCluster)).To(Succeed())
 			})
 		})
 		When("DRAction is changed to Failover after relocation", func() {
 			It("Should failover again to Secondary (East2ManagedCluster)", func() {
 				// ----------------------------- FAILOVER TO SECONDARY FOR SYNC DR--------------------
 				By("\n\n*** Failover - 3\n\n")
-				runFailoverAction(userPlacementRule, East1ManagedCluster, East2ManagedCluster, true, false)
+				Expect(runFailoverAction(userPlacementRule, East1ManagedCluster, East2ManagedCluster, true, false)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				// ----------------------------- RELOCATION TO PRIMARY FOR SYNC DR------------------------
 				By("\n\n*** relocate 2\n\n")
-				runRelocateAction(userPlacementRule, East2ManagedCluster, true, false)
+				Expect(runRelocateAction(userPlacementRule, East2ManagedCluster, true, false)).To(Succeed())
 			})
 		})
 		When("Deleting user PlacementRule", func() {
@@ -2809,8 +2991,9 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("An Application is deployed for the first time", func() {
 			It("Should deploy to East1ManagedCluster", func() {
 				By("Initial Deployment")
-
-				userPlacementRule, _ = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
+				var err error
+				userPlacementRule, _, err = InitialDeploymentSync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
 				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
 				Expect(err).NotTo(HaveOccurred())
@@ -2838,21 +3021,21 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				// ----------------------------- RELOCATION TO PRIMARY FOR SYNC DR -------------------
 				By("\n\n*** relocate 2\n\n")
-				runRelocateAction(userPlacementRule, East2ManagedCluster, true, true)
+				Expect(runRelocateAction(userPlacementRule, East2ManagedCluster, true, true)).To(Succeed())
 			})
 		})
 		When("DRAction is changed to Failover after relocation", func() {
 			It("Should failover again to Secondary (East2ManagedCluster)", func() {
 				// ----------------------------- FAILOVER TO SECONDARY FOR SYNC DR--------------------
 				By("\n\n*** Failover - 3\n\n")
-				runFailoverAction(userPlacementRule, East1ManagedCluster, East2ManagedCluster, true, true)
+				Expect(runFailoverAction(userPlacementRule, East1ManagedCluster, East2ManagedCluster, true, true)).To(Succeed())
 			})
 		})
 		When("DRAction is set to Relocate", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				// ----------------------------- RELOCATION TO PRIMARY FOR SYNC DR------------------------
 				By("\n\n*** relocate 2\n\n")
-				runRelocateAction(userPlacementRule, East2ManagedCluster, true, false)
+				Expect(runRelocateAction(userPlacementRule, East2ManagedCluster, true, false)).To(Succeed())
 			})
 		})
 		When("Deleting user PlacementRule", func() {
@@ -2890,9 +3073,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(createDRPolicyAsync()).To(Succeed())
 
 				var placementObj client.Object
-
-				placementObj, _ = CreatePlacementAndDRPC(
+				var err error
+				placementObj, _, err = CreatePlacementAndDRPC(
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
+				Expect(err).NotTo(HaveOccurred())
 				userPlacementRule1 = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule1).NotTo(BeNil())
 				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)).To(Succeed())
@@ -2952,7 +3136,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				to := West1ManagedCluster
 
 				resetClusterDown()
-				runFailoverAction(userPlacementRule1, from, to, false, false)
+				Expect(runFailoverAction(userPlacementRule1, from, to, false, false)).To(Succeed())
 				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.FailedOver)).To(Succeed())
 				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, West1ManagedCluster, rmn.VRGActionFailover)).To(Succeed())
 				resetClusterDown()
@@ -2999,7 +3183,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				// ----------------------------- RELOCATION TO PRIMARY --------------------------------------
 				from := West1ManagedCluster
-				runRelocateAction(userPlacementRule1, from, false, false)
+				Expect(runRelocateAction(userPlacementRule1, from, false, false)).To(Succeed())
 				Expect(uploadVRGtoS3Store(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster, rmn.VRGAction(rmn.ActionRelocate))).To(Succeed())
 				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Relocated)).To(Succeed())
 			})
@@ -3114,9 +3298,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 				Expect(createVRGMW(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster)).To(Succeed())
 
 				var placementObj client.Object
-
-				placementObj, _ = CreatePlacementAndDRPC(
+				var err error
+				placementObj, _, err = CreatePlacementAndDRPC(
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
+				Expect(err).NotTo(HaveOccurred())
 				userPlacementRule1 = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule1).NotTo(BeNil())
 				Expect(waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)).To(Succeed())
@@ -3164,13 +3349,17 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 			It("Should deploy to East1ManagedCluster", func() {
 				By("Initial Deployment")
 				var placementObj client.Object
-				placementObj, drpc = InitialDeploymentAsync(
+				var err error
+				placementObj, drpc, err = InitialDeploymentAsync(
 					DefaultDRPCNamespace, UserPlacementName, East1ManagedCluster, UsePlacementWithSubscription)
+				Expect(err).NotTo(HaveOccurred())
 				placement = placementObj.(*clrapiv1beta1.Placement)
 				Expect(placement).NotTo(BeNil())
 				Expect(verifyInitialDRPCDeployment(placement, East1ManagedCluster)).To(Succeed())
 				Expect(verifyActionResultForPlacement(placement, East1ManagedCluster, UsePlacementWithSubscription)).To(Succeed())
-				verifyDRPCOwnedByPlacement(placement, getLatestDRPC(DefaultDRPCNamespace))
+				latestDRPC, err := getLatestDRPC(DefaultDRPCNamespace)
+				Expect(err).NotTo(HaveOccurred())
+				verifyDRPCOwnedByPlacement(placement, latestDRPC)
 			})
 		})
 		When("DRAction changes to Failover", func() {
@@ -3211,9 +3400,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("The Application is deployed for VolSync", func() {
 			It("Should deploy to East1ManagedCluster", func() {
 				var placementObj client.Object
-
-				placementObj, drpc = InitialDeploymentAsync(
+				var err error
+				placementObj, drpc, err = InitialDeploymentAsync(
 					DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster, UsePlacementRule)
+				Expect(err).NotTo(HaveOccurred())
 				userPlacementRule = placementObj.(*plrv1.PlacementRule)
 				Expect(userPlacementRule).NotTo(BeNil())
 				Expect(verifyInitialDRPCDeployment(userPlacementRule, East1ManagedCluster)).To(Succeed())
@@ -3224,14 +3414,14 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		When("DRAction is changed to Failover", func() {
 			It("Should failover to Secondary (West1ManagedCluster)", func() {
-				recoverToFailoverCluster(userPlacementRule, East1ManagedCluster, West1ManagedCluster)
+				Expect(recoverToFailoverCluster(userPlacementRule, East1ManagedCluster, West1ManagedCluster)).To(Succeed())
 				Expect(getVRGManifestWorkCount()).Should(Equal(2))
 				verifyRDSpecAfterActionSwitch(West1ManagedCluster, East1ManagedCluster, 2)
 			})
 		})
 		When("DRAction is set to Relocate", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
-				relocateToPreferredCluster(userPlacementRule, West1ManagedCluster)
+				Expect(relocateToPreferredCluster(userPlacementRule, West1ManagedCluster)).To(Succeed())
 				Expect(getVRGManifestWorkCount()).Should(Equal(2))
 				verifyRDSpecAfterActionSwitch(East1ManagedCluster, West1ManagedCluster, 2)
 			})
@@ -3239,8 +3429,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("DRAction is changed back to Failover using only 1 protectedPVC", func() {
 			It("Should failover to secondary (West1ManagedCluster)", func() {
 				ProtectedPVCCount = 1
-
-				recoverToFailoverCluster(userPlacementRule, East1ManagedCluster, West1ManagedCluster)
+				Expect(recoverToFailoverCluster(userPlacementRule, East1ManagedCluster, West1ManagedCluster)).To(Succeed())
 				Expect(getVRGManifestWorkCount()).Should(Equal(2))
 				verifyRDSpecAfterActionSwitch(West1ManagedCluster, East1ManagedCluster, 1)
 
@@ -3250,8 +3439,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("DRAction is set back to Relocate using only 1 protectedPVC", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				ProtectedPVCCount = 1
-
-				relocateToPreferredCluster(userPlacementRule, West1ManagedCluster)
+				Expect(relocateToPreferredCluster(userPlacementRule, West1ManagedCluster)).To(Succeed())
 				Expect(getVRGManifestWorkCount()).Should(Equal(2))
 				verifyRDSpecAfterActionSwitch(East1ManagedCluster, West1ManagedCluster, 1)
 
@@ -3261,8 +3449,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("DRAction is changed back to Failover using only 10 protectedPVC", func() {
 			It("Should failover to secondary (West1ManagedCluster)", func() {
 				ProtectedPVCCount = 10
-
-				recoverToFailoverCluster(userPlacementRule, East1ManagedCluster, West1ManagedCluster)
+				Expect(recoverToFailoverCluster(userPlacementRule, East1ManagedCluster, West1ManagedCluster)).To(Succeed())
 				Expect(getVRGManifestWorkCount()).Should(Equal(2))
 				verifyRDSpecAfterActionSwitch(West1ManagedCluster, East1ManagedCluster, 10)
 
@@ -3272,8 +3459,7 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		When("DRAction is set back to Relocate using only 10 protectedPVC", func() {
 			It("Should relocate to Primary (East1ManagedCluster)", func() {
 				ProtectedPVCCount = 10
-
-				relocateToPreferredCluster(userPlacementRule, West1ManagedCluster)
+				Expect(relocateToPreferredCluster(userPlacementRule, West1ManagedCluster)).To(Succeed())
 				Expect(getVRGManifestWorkCount()).Should(Equal(2))
 				verifyRDSpecAfterActionSwitch(East1ManagedCluster, West1ManagedCluster, 10)
 

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -396,8 +396,11 @@ func GetFakeVRGFromMCVUsingMW(managedCluster, resourceNamespace string,
 	}
 
 	vrg := &rmn.VolumeReplicationGroup{}
+
 	err = yaml.Unmarshal(mw.Spec.Workload.Manifests[0].Raw, vrg)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal VRG: %w", err)
+	}
 
 	vrg.Generation = 1
 	vrg.Status.ObservedGeneration = 1

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -525,7 +525,7 @@ func fakeVRGWithMModesProtectedPVC(vrgNamespace string) *rmn.VolumeReplicationGr
 	return vrg
 }
 
-func createPlacementRule(name, namespace string) *plrv1.PlacementRule {
+func createPlacementRule(name, namespace string) (*plrv1.PlacementRule, error) {
 	namereq := metav1.LabelSelectorRequirement{}
 	namereq.Key = "key1"
 	namereq.Operator = metav1.LabelSelectorOpIn
@@ -549,12 +549,14 @@ func createPlacementRule(name, namespace string) *plrv1.PlacementRule {
 	}
 
 	err := k8sClient.Create(context.TODO(), placementRule)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, err
+	}
 
-	return placementRule
+	return placementRule, nil
 }
 
-func createPlacement(name, namespace string) *clrapiv1beta1.Placement {
+func createPlacement(name, namespace string) (*clrapiv1beta1.Placement, error) {
 	var numberOfClustersToDeployTo int32 = 1
 
 	placement := &clrapiv1beta1.Placement{
@@ -572,12 +574,14 @@ func createPlacement(name, namespace string) *clrapiv1beta1.Placement {
 	}
 
 	err := k8sClient.Create(context.TODO(), placement)
-	Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		return nil, err
+	}
 
-	return placement
+	return placement, nil
 }
 
-func createDRPC(placementName, name, namespace, drPolicyName, preferredCluster string) *rmn.DRPlacementControl {
+func createDRPC(placementName, name, namespace, drPolicyName, preferredCluster string) (*rmn.DRPlacementControl, error) {
 	drpc := &rmn.DRPlacementControl{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -600,9 +604,11 @@ func createDRPC(placementName, name, namespace, drPolicyName, preferredCluster s
 			PreferredCluster:     preferredCluster,
 		},
 	}
-	Expect(k8sClient.Create(context.TODO(), drpc)).Should(Succeed())
+	if err := k8sClient.Create(context.TODO(), drpc); err != nil {
+		return nil, err
+	}
 
-	return drpc
+	return drpc, nil
 }
 
 //nolint:unparam
@@ -730,23 +736,32 @@ func clearFakeUserPlacementRuleStatus(name, namespace string) {
 	Expect(retryErr).NotTo(HaveOccurred())
 }
 
-func createNamespace(ns *corev1.Namespace) {
+func createNamespace(ns *corev1.Namespace) error {
 	nsName := types.NamespacedName{Name: ns.Name}
 
 	err := k8sClient.Get(context.TODO(), nsName, &corev1.Namespace{})
 	if err != nil {
-		Expect(k8sClient.Create(context.TODO(), ns)).NotTo(HaveOccurred(),
-			"failed to create %v managed cluster namespace", ns.Name)
+		if err := k8sClient.Create(context.TODO(), ns); err != nil {
+			return fmt.Errorf("failed to create %v managed cluster namespace: %w", ns.Name, err)
+		}
 	}
+
+	return nil
 }
 
-func createNamespacesAsync(appNamespace *corev1.Namespace) {
-	createNamespace(east1ManagedClusterNamespace)
-	createNamespace(west1ManagedClusterNamespace)
-	createNamespace(appNamespace)
+func createNamespacesAsync(appNamespace *corev1.Namespace) error {
+	if err := createNamespace(east1ManagedClusterNamespace); err != nil {
+		return err
+	}
+
+	if err := createNamespace(west1ManagedClusterNamespace); err != nil {
+		return err
+	}
+
+	return createNamespace(appNamespace)
 }
 
-func createManagedClusters(managedClusters []*spokeClusterV1.ManagedCluster) {
+func createManagedClusters(managedClusters []*spokeClusterV1.ManagedCluster) error {
 	for _, cl := range managedClusters {
 		mcLookupKey := types.NamespacedName{Name: cl.Name}
 		mcObj := &spokeClusterV1.ManagedCluster{}
@@ -756,7 +771,9 @@ func createManagedClusters(managedClusters []*spokeClusterV1.ManagedCluster) {
 			clinstance := cl.DeepCopy()
 
 			err := k8sClient.Create(context.TODO(), clinstance)
-			Expect(err).NotTo(HaveOccurred())
+			if err != nil {
+				return err
+			}
 
 			updateManagedClusterStatus(k8sClient, clinstance)
 
@@ -765,6 +782,8 @@ func createManagedClusters(managedClusters []*spokeClusterV1.ManagedCluster) {
 
 		updateManagedClusterStatus(k8sClient, mcObj)
 	}
+
+	return nil
 }
 
 func populateDRClusters() {
@@ -800,37 +819,47 @@ func populateDRClusters() {
 	)
 }
 
-func createDRClusters(inClusters []*spokeClusterV1.ManagedCluster) {
+func createDRClusters(inClusters []*spokeClusterV1.ManagedCluster) error {
 	for _, managedCluster := range inClusters {
 		for idx := range drClusters {
 			if managedCluster.Name == drClusters[idx].Name {
 				err := k8sClient.Create(context.TODO(), &drClusters[idx])
-				Expect(err).NotTo(HaveOccurred())
+				if err != nil {
+					return err
+				}
+
 				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drClusters[idx].Name)
 				updateDRClusterConfigMWStatus(k8sClient, apiReader, drClusters[idx].Name)
 			}
 		}
 	}
+
+	return nil
 }
 
-func createPlacementDecision() {
+func createPlacementDecision() error {
 	deletePlacementDecision()
 
 	plDecision := placementDecision.DeepCopy()
-	err := k8sClient.Create(context.TODO(), plDecision)
-	Expect(err).NotTo(HaveOccurred())
+
+	return k8sClient.Create(context.TODO(), plDecision)
 }
 
-func createDRClustersAsync() {
-	createDRClusters(asyncClusters)
+func createDRClustersAsync() error {
+	return createDRClusters(asyncClusters)
 }
 
-func createDRPolicy(inDRPolicy *rmn.DRPolicy) {
+func createDRPolicy(inDRPolicy *rmn.DRPolicy) error {
 	err := k8sClient.Create(context.TODO(), inDRPolicy)
-	Expect(err).NotTo(HaveOccurred())
-	Eventually(func() bool {
+	if err != nil {
+		return err
+	}
+
+	return waitForCondition(timeout, interval, "waiting for DRPolicy to be validated", func() bool {
 		drpolicy := &rmn.DRPolicy{}
-		Expect(apiReader.Get(context.TODO(), types.NamespacedName{Name: inDRPolicy.Name}, drpolicy)).To(Succeed())
+		if err := apiReader.Get(context.TODO(), types.NamespacedName{Name: inDRPolicy.Name}, drpolicy); err != nil {
+			return false
+		}
 
 		for _, condition := range drpolicy.Status.Conditions {
 			if condition.Type != rmn.DRPolicyValidated {
@@ -849,17 +878,17 @@ func createDRPolicy(inDRPolicy *rmn.DRPolicy) {
 		}
 
 		return false
-	}, timeout, interval).Should(BeTrue())
+	})
 }
 
-func createDRPolicyAsync() {
+func createDRPolicyAsync() error {
 	policy := asyncDRPolicy.DeepCopy()
-	createDRPolicy(policy)
+
+	return createDRPolicy(policy)
 }
 
-func createAppSet() {
-	err := k8sClient.Create(context.TODO(), &appSet)
-	Expect(err).NotTo(HaveOccurred())
+func createAppSet() error {
+	return k8sClient.Create(context.TODO(), &appSet)
 }
 
 func deleteAppSet() {
@@ -908,7 +937,7 @@ func deleteDRPolicyAsync() {
 
 // createVRGMW creates a basic (always Primary) ManifestWork for a VRG, used to fake existing VRG MW
 // to test upgrade cases for DRPC based UID adoption
-func createVRGMW(name, namespace, homeCluster string) {
+func createVRGMW(name, namespace, homeCluster string) error {
 	vrg := getDefaultVRG(namespace)
 	vrg.Generation = 1
 
@@ -922,7 +951,8 @@ func createVRGMW(name, namespace, homeCluster string) {
 	}
 
 	_, err := mwu.CreateOrUpdateVRGManifestWork(name, namespace, homeCluster, *vrg, nil)
-	Expect(err).To(Succeed())
+
+	return err
 }
 
 func updateManifestWorkStatus(clusterNamespace, vrgNamespace, mwType, workType string) {
@@ -1042,12 +1072,12 @@ const (
 func InitialDeploymentAsync(namespace, placementName, homeCluster string, plType PlacementType) (
 	client.Object, *rmn.DRPlacementControl,
 ) {
-	createNamespacesAsync(getNamespaceObj(namespace))
+	Expect(createNamespacesAsync(getNamespaceObj(namespace))).To(Succeed())
 
-	createManagedClusters(asyncClusters)
-	createDRClustersAsync()
-	createDRPolicyAsync()
-	createPlacementDecision()
+	Expect(createManagedClusters(asyncClusters)).To(Succeed())
+	Expect(createDRClustersAsync()).To(Succeed())
+	Expect(createDRPolicyAsync()).To(Succeed())
+	Expect(createPlacementDecision()).To(Succeed())
 
 	return CreatePlacementAndDRPC(namespace, placementName, homeCluster, plType)
 }
@@ -1057,29 +1087,40 @@ func CreatePlacementAndDRPC(namespace, placementName, homeCluster string, plType
 ) {
 	var placementObj client.Object
 
+	var err error
+
 	switch plType {
 	case UsePlacementRule:
-		placementObj = createPlacementRule(placementName, namespace)
+		placementObj, err = createPlacementRule(placementName, namespace)
+		Expect(err).NotTo(HaveOccurred())
 	case UsePlacementWithSubscription:
-		placementObj = createPlacement(placementName, namespace)
+		placementObj, err = createPlacement(placementName, namespace)
+		Expect(err).NotTo(HaveOccurred())
 	case UsePlacementWithAppSet:
-		createAppSet()
+		Expect(createAppSet()).To(Succeed())
 
-		placementObj = createPlacement(placementName, namespace)
+		placementObj, err = createPlacement(placementName, namespace)
+		Expect(err).NotTo(HaveOccurred())
 	default:
 		Fail("Wrong placement type")
 	}
 
-	return placementObj, createDRPC(placementName, DRPCCommonName, namespace, AsyncDRPolicyName, homeCluster)
+	drpc, err := createDRPC(placementName, DRPCCommonName, namespace, AsyncDRPolicyName, homeCluster)
+	Expect(err).NotTo(HaveOccurred())
+
+	return placementObj, drpc
 }
 
 func FollowOnDeploymentAsync(namespace, placementName, homeCluster string) (*plrv1.PlacementRule,
 	*rmn.DRPlacementControl,
 ) {
-	createNamespace(appNamespace2)
+	Expect(createNamespace(appNamespace2)).To(Succeed())
 
-	placementRule := createPlacementRule(placementName, namespace)
-	drpc := createDRPC(placementName, DRPCCommonName, namespace, AsyncDRPolicyName, homeCluster)
+	placementRule, err := createPlacementRule(placementName, namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	drpc, err := createDRPC(placementName, DRPCCommonName, namespace, AsyncDRPolicyName, homeCluster)
+	Expect(err).NotTo(HaveOccurred())
 
 	return placementRule, drpc
 }
@@ -1616,34 +1657,44 @@ func recoverToFailoverCluster(placementObj client.Object, fromCluster, toCluster
 	waitForCompletion(string(rmn.FailedOver))
 }
 
-func createNamespacesSync() {
-	createNamespace(east1ManagedClusterNamespace)
-	createNamespace(east2ManagedClusterNamespace)
-	createNamespace(appNamespace)
+func createNamespacesSync() error {
+	if err := createNamespace(east1ManagedClusterNamespace); err != nil {
+		return err
+	}
+
+	if err := createNamespace(east2ManagedClusterNamespace); err != nil {
+		return err
+	}
+
+	return createNamespace(appNamespace)
 }
 
 func InitialDeploymentSync(namespace, placementName, homeCluster string) (*plrv1.PlacementRule,
 	*rmn.DRPlacementControl,
 ) {
-	createNamespacesSync()
+	Expect(createNamespacesSync()).To(Succeed())
 
-	createManagedClusters(syncClusters)
-	createDRClustersSync()
-	createDRPolicySync()
+	Expect(createManagedClusters(syncClusters)).To(Succeed())
+	Expect(createDRClustersSync()).To(Succeed())
+	Expect(createDRPolicySync()).To(Succeed())
 
-	placementRule := createPlacementRule(placementName, namespace)
-	drpc := createDRPC(UserPlacementRuleName, DRPCCommonName, DefaultDRPCNamespace, SyncDRPolicyName, homeCluster)
+	placementRule, err := createPlacementRule(placementName, namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	drpc, err := createDRPC(UserPlacementRuleName, DRPCCommonName, DefaultDRPCNamespace, SyncDRPolicyName, homeCluster)
+	Expect(err).NotTo(HaveOccurred())
 
 	return placementRule, drpc
 }
 
-func createDRClustersSync() {
-	createDRClusters(syncClusters)
+func createDRClustersSync() error {
+	return createDRClusters(syncClusters)
 }
 
-func createDRPolicySync() {
+func createDRPolicySync() error {
 	policy := syncDRPolicy.DeepCopy()
-	createDRPolicy(policy)
+
+	return createDRPolicy(policy)
 }
 
 func deleteDRClustersSync() {
@@ -2606,10 +2657,10 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 		})
 		When("Application deployed for the first time", func() {
 			It("Should deploy drpc", func() {
-				createNamespacesAsync(getNamespaceObj(DefaultDRPCNamespace))
-				createManagedClusters(asyncClusters)
-				createDRClustersAsync()
-				createDRPolicyAsync()
+				Expect(createNamespacesAsync(getNamespaceObj(DefaultDRPCNamespace))).To(Succeed())
+				Expect(createManagedClusters(asyncClusters)).To(Succeed())
+				Expect(createDRClustersAsync()).To(Succeed())
+				Expect(createDRPolicyAsync()).To(Succeed())
 
 				var placementObj client.Object
 
@@ -2829,15 +2880,15 @@ var _ = Describe("DRPlacementControl Reconciler", func() {
 
 		When("Application deployed for the first time", func() {
 			It("Should deploy drpc", func() {
-				createNamespacesAsync(getNamespaceObj(DefaultDRPCNamespace))
-				createManagedClusters(asyncClusters)
-				createDRClustersAsync()
-				createDRPolicyAsync()
+				Expect(createNamespacesAsync(getNamespaceObj(DefaultDRPCNamespace))).To(Succeed())
+				Expect(createManagedClusters(asyncClusters)).To(Succeed())
+				Expect(createDRClustersAsync()).To(Succeed())
+				Expect(createDRPolicyAsync()).To(Succeed())
 				setToggleUIDChecks()
 
 				// Create an existing VRG MW on East, to simulate upgrade cases (West1 will report an
 				// orphan VRG for orphan cases)
-				createVRGMW(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster)
+				Expect(createVRGMW(DRPCCommonName, DefaultDRPCNamespace, East1ManagedCluster)).To(Succeed())
 
 				var placementObj client.Object
 


### PR DESCRIPTION
  Summary

  - Add Go-native polling utilities (waitForCondition, ensureConsistent) as
  alternatives to Gomega's Eventually/Consistently for use outside Ginkgo blocks
  - Convert ~60 test helper functions to return errors instead of calling
  Expect()/Fail() internally
  - Confine all Ginkgo/Gomega assertions (Expect, Eventually, Consistently, Fail, By)
  to within Describe/It/BeforeEach/AfterEach blocks
  - Helper functions outside those blocks now behave like regular Go functions with
  standard error propagation

  Motivation

  Mixing Ginkgo assertions into helper functions obscures where failures originate and
  makes helpers non-reusable outside Ginkgo contexts. This refactor makes the test code
   more idiomatic — helpers report errors, callers decide how to assert.

  Test plan

  - make test-drpc passes (91 specs, 31.7% coverage)
  - go vet ./internal/controller/... clean