### PR TITLE
submariner: make start hook idempotent with ensure model

### DIFF
--- a/test/addons/submariner/start
+++ b/test/addons/submariner/start
@@ -26,12 +26,16 @@ CLUSTER_DEPLOYMENTS = (
 )
 
 
-def deploy_broker(broker):
-    print(f"Waiting until broker '{broker}' is ready")
-    drenv_cluster.wait_until_ready(broker)
+def is_broker_deployed(broker, broker_info):
+    """Check if broker deployments are healthy and broker info file exists."""
+    if not os.path.exists(broker_info):
+        return False
+    return are_deployments_available(broker, BROKER_DEPLOYMENTS, NAMESPACE)
 
-    broker_dir = os.path.join(drenv.config_dir(broker), "submariner")
-    broker_info = os.path.join(broker_dir, subctl.BROKER_INFO)
+
+def do_deploy_broker(broker, broker_info):
+    """Deploy the submariner broker on the given cluster."""
+    broker_dir = os.path.dirname(broker_info)
 
     print(f"Creating submariner configuration directory '{broker_dir}'")
     os.makedirs(broker_dir, exist_ok=True)
@@ -48,12 +52,37 @@ def deploy_broker(broker):
     print(f"Waiting for submariner broker deployments in cluster '{broker}'")
     wait_for_deployments(broker, BROKER_DEPLOYMENTS, NAMESPACE)
 
+
+def ensure_broker(broker):
+    """Ensure the submariner broker is deployed, skipping if already healthy."""
+    print(f"Waiting until broker '{broker}' is ready")
+    drenv_cluster.wait_until_ready(broker)
+
+    broker_dir = os.path.join(drenv.config_dir(broker), "submariner")
+    broker_info = os.path.join(broker_dir, subctl.BROKER_INFO)
+
+    if is_broker_deployed(broker, broker_info):
+        print(f"Broker already deployed on '{broker}', skipping")
+    else:
+        do_deploy_broker(broker, broker_info)
+
     return broker_info
 
 
-def join_cluster(cluster, broker_info):
-    print(f"Waiting until cluster '{cluster}' is ready")
-    drenv_cluster.wait_until_ready(cluster)
+def is_cluster_joined(cluster):
+    """Check if the cluster's submariner deployments are healthy."""
+    return are_deployments_available(cluster, CLUSTER_DEPLOYMENTS, NAMESPACE)
+
+
+def do_join_cluster(cluster, broker_info):
+    """Join a cluster to the submariner broker.
+
+    Cleans up stale state first (e.g. broker has the cluster ID registered
+    from a previous partial join, but the cluster has no deployments).
+    """
+    print(f"Cleaning up stale submariner state on '{cluster}'")
+    subctl.uninstall(context=cluster)
+    clean_broker_registration(cluster)
 
     print(f"Annotating nodes in '{cluster}'")
     annotate_nodes(cluster)
@@ -66,6 +95,17 @@ def join_cluster(cluster, broker_info):
         cable_driver="vxlan",
         version=VERSION,
     )
+
+
+def ensure_cluster_joined(cluster, broker_info):
+    """Ensure a cluster is joined to the broker, skipping if already joined."""
+    print(f"Waiting until cluster '{cluster}' is ready")
+    drenv_cluster.wait_until_ready(cluster)
+
+    if is_cluster_joined(cluster):
+        print(f"Cluster '{cluster}' already joined, skipping")
+    else:
+        do_join_cluster(cluster, broker_info)
 
 
 def annotate_nodes(cluster):
@@ -91,8 +131,67 @@ def annotate_nodes(cluster):
         )
 
 
+BROKER_NAMESPACE = "submariner-k8s-broker"
+
+
+def clean_broker_registration(cluster):
+    """Remove stale cluster and endpoint registrations from the broker.
+
+    When a cluster is uninstalled but the broker still has its registration,
+    subctl join will refuse with "existing joined cluster with the same ID".
+    """
+    broker = sys.argv[1]
+
+    # Delete the cluster registration.
+    try:
+        kubectl.delete(
+            f"clusters.submariner.io/{cluster}",
+            f"--namespace={BROKER_NAMESPACE}",
+            context=broker,
+        )
+        print(f"Deleted stale cluster registration '{cluster}' from broker")
+    except Exception:
+        pass  # Not found is fine.
+
+    # Delete any endpoints for this cluster.
+    try:
+        out = kubectl.get(
+            "endpoints.submariner.io",
+            f"--namespace={BROKER_NAMESPACE}",
+            "--output=jsonpath={.items[*].metadata.name}",
+            context=broker,
+        )
+        for name in out.split():
+            if name.startswith(f"{cluster}-"):
+                kubectl.delete(
+                    f"endpoints.submariner.io/{name}",
+                    f"--namespace={BROKER_NAMESPACE}",
+                    context=broker,
+                )
+                print(f"Deleted stale endpoint '{name}' from broker")
+    except Exception:
+        pass  # Not found is fine.
+
+
+def are_deployments_available(cluster, names, namespace):
+    """Check if all named deployments exist and have the Available condition."""
+    for name in names:
+        try:
+            out = kubectl.get(
+                f"deploy/{name}",
+                f"--namespace={namespace}",
+                "--output=jsonpath={.status.conditions[?(@.type=='Available')].status}",
+                context=cluster,
+            )
+            if out.strip() != "True":
+                return False
+        except Exception:
+            return False
+    return True
+
+
 def wait_for_cluster(cluster):
-    print(f"Waiting for submariner deployuments in cluster '{cluster}'")
+    print(f"Waiting for submariner deployments in cluster '{cluster}'")
     wait_for_deployments(cluster, CLUSTER_DEPLOYMENTS, NAMESPACE)
 
 
@@ -129,10 +228,10 @@ clusters = sys.argv[2:]
 for cluster in [broker, *clusters]:
     drenv_cluster.wait_until_ready(cluster)
 
-broker_info = deploy_broker(broker)
+broker_info = ensure_broker(broker)
 
 for cluster in clusters:
-    join_cluster(cluster, broker_info)
+    ensure_cluster_joined(cluster, broker_info)
 
 for cluster in clusters:
     wait_for_cluster(cluster)

--- a/test/drenv/subctl.py
+++ b/test/drenv/subctl.py
@@ -49,6 +49,14 @@ def join(broker_info, context, clusterid, cable_driver=None, version=None, log=p
     _watch(*args, log=log)
 
 
+def uninstall(context, log=print):
+    """
+    Run subctl uninstall ... logging progress messages.
+    """
+    args = ["uninstall", "--context", context, "--yes"]
+    _watch(*args, log=log)
+
+
 def export(what, name, context, namespace=None, log=print):
     """
     Run subctl export ... logging progress messages.


### PR DESCRIPTION
Refactor the submariner start hook to check whether the broker and cluster joins are already healthy before re-running them. This avoids the "existing joined cluster with the same ID" error when re-running start on a partially deployed environment.

- Split deploy_broker/join_cluster into is_*/do_*/ensure_* functions
- Add are_deployments_available() to check deployment health
- Add clean_broker_registration() to remove stale broker-side state (clusters.submariner.io and endpoints.submariner.io) before re-joining
- Add subctl.uninstall() wrapper in drenv/subctl.py
- Fix typo: "deployuments" -> "deployments"

Assisted-by: Claude Code/claude-opus-4-6