### PR TITLE
ramendev: Remove deprecated ramenControllertype config

### DIFF
--- a/ramendev/ramendev/resources/configmap.yaml
+++ b/ramendev/ramendev/resources/configmap.yaml
@@ -21,7 +21,6 @@ data:
     leaderElection:
       leaderElect: true
       resourceName: hub.ramendr.openshift.io
-    ramenControllerType: dr-hub
     maxConcurrentReconciles: 50
     drClusterOperator:
       deploymentAutomationEnabled: $auto_deploy


### PR DESCRIPTION
Controller type is set using ramen deployment, and the config value is ignored.