### PR TITLE
Use gsed for all macOS architectures in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,10 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # Set sed command appropriately
+GOHOSTOS ?= $(shell go env GOHOSTOS)
 SED_CMD:=sed
 ifeq ($(GOHOSTOS),darwin)
-	ifeq ($(GOHOSTARCH),amd64)
-		SED_CMD:=gsed
-	endif
+	SED_CMD:=gsed
 endif
 
 


### PR DESCRIPTION
Previously, the Makefile only used gsed (GNU sed) for macOS amd64 architecture. This change extends gsed usage to all macOS architectures (including arm64/Apple Silicon)

Also adds GOHOSTOS variable detection to properly identify the host OS.