### PR TITLE
Apply dr-cluster OLM settings from hub Subscription

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	recipe "github.com/ramendr/recipe/api/v1alpha1"
 	groupsnapv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
@@ -105,6 +106,7 @@ func configureController() error {
 	setupLog.Info("controller type", "type", controllers.ControllerType)
 
 	if controllers.ControllerType == ramendrv1alpha1.DRHubType {
+		utilruntime.Must(operatorsv1alpha1.AddToScheme(scheme))
 		utilruntime.Must(plrv1.AddToScheme(scheme))
 		utilruntime.Must(ocmworkv1.AddToScheme(scheme))
 		utilruntime.Must(viewv1beta1.AddToScheme(scheme))

--- a/config/hub/rbac/role.yaml
+++ b/config/hub/rbac/role.yaml
@@ -148,6 +148,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ramendr.openshift.io
   resources:
   - drclusters

--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/go-logr/logr"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,6 +49,8 @@ const (
 	VeleroNamespaceNameDefault                        = "velero"
 	DefaultVolSyncCopyMethod                          = "Snapshot"
 	defaultMaxConcurrentReconciles                    = 50
+	openshiftOperatorsNamespace                       = "openshift-operators"
+	openshiftDRSystemNamespace                        = "openshift-dr-system"
 )
 
 // FIXME
@@ -88,9 +92,6 @@ func DefaultRamenConfig(controllerType ramendrv1alpha1.ControllerType) *ramendrv
 		VolumeUnprotectionEnabled: true,
 	}
 
-	cfg.DrClusterOperator.ChannelName = drClusterOperatorChannelNameDefault
-	cfg.DrClusterOperator.PackageName = drClusterOperatorPackageNameDefault
-	cfg.DrClusterOperator.CatalogSourceName = drClusterOperatorCatalogSourceNameDefault
 	cfg.DrClusterOperator.DeploymentAutomationEnabled = true
 	cfg.DrClusterOperator.S3SecretDistributionEnabled = true
 
@@ -243,6 +244,26 @@ func ramenOperatorConfigMapName() string {
 	}
 }
 
+func copyDrClusterOperatorSubscriptionFields(dst, src *ramendrv1alpha1.RamenConfig) {
+	// In-memory src carries the hub subscription overlay (or compiled defaults).
+	// Re-apply onto dst after user YAML merge. DR-cluster controllers skip this:
+	// ConfigMap content comes from the hub via ManifestWork and must not be
+	// replaced with local defaults.
+	if ControllerType != ramendrv1alpha1.DRHubType || dst == nil || src == nil {
+		return
+	}
+
+	s := src.DrClusterOperator
+	d := &dst.DrClusterOperator
+
+	d.ChannelName = s.ChannelName
+	d.PackageName = s.PackageName
+	d.NamespaceName = s.NamespaceName
+	d.CatalogSourceName = s.CatalogSourceName
+	d.CatalogSourceNamespaceName = s.CatalogSourceNamespaceName
+	d.ClusterServiceVersionName = s.ClusterServiceVersionName
+}
+
 func CreateOrUpdateConfigMap(
 	ctx context.Context,
 	c client.Client,
@@ -261,6 +282,8 @@ func CreateOrUpdateConfigMap(
 		Namespace: RamenOperatorNamespace(),
 		Name:      configMapName,
 	}
+
+	updateDrClusterOperatorFromSubscription(ctx, r, defaultRamenConfig, log)
 
 	if err := r.Get(ctx, key, configMap); err != nil {
 		if !k8serrors.IsNotFound(err) {
@@ -281,6 +304,8 @@ func CreateOrUpdateConfigMap(
 	if err != nil {
 		return nil, err
 	}
+
+	copyDrClusterOperatorSubscriptionFields(&merged, defaultRamenConfig)
 
 	return configMapUpdate(ctx, c, configMap, &merged, log)
 }
@@ -386,6 +411,70 @@ func ConfigMapGet(
 
 func RamenOperatorNamespace() string {
 	return os.Getenv("POD_NAMESPACE")
+}
+
+func findHubOperatorSubscription(ctx context.Context, apiReader client.Reader,
+	log logr.Logger,
+) *operatorsv1alpha1.Subscription {
+	const hubOperatorSuffix = "-hub-operator"
+
+	ns := RamenOperatorNamespace()
+
+	subList := &operatorsv1alpha1.SubscriptionList{}
+	if err := apiReader.List(ctx, subList, client.InNamespace(ns)); err != nil {
+		log.Info("list operators.coreos.com subscriptions; continuing without hub subscription",
+			"namespace", ns, "error", err)
+
+		return nil
+	}
+
+	for i := range subList.Items {
+		sub := &subList.Items[i]
+		if sub.Spec != nil && strings.HasSuffix(sub.Spec.Package, hubOperatorSuffix) {
+			return sub
+		}
+	}
+
+	return nil
+}
+
+func applyDrClusterOperatorFromSubscriptionSpec(
+	spec *operatorsv1alpha1.SubscriptionSpec,
+	cfg *ramendrv1alpha1.RamenConfig,
+) {
+	const (
+		hubSubstring     = "-hub-"
+		clusterSubstring = "-cluster-"
+	)
+
+	dco := &cfg.DrClusterOperator
+
+	dco.ChannelName = spec.Channel
+	dco.PackageName = strings.Replace(spec.Package, hubSubstring, clusterSubstring, 1)
+	dco.CatalogSourceName = spec.CatalogSource
+	dco.CatalogSourceNamespaceName = spec.CatalogSourceNamespace
+	dco.ClusterServiceVersionName = strings.Replace(spec.StartingCSV, hubSubstring, clusterSubstring, 1)
+}
+
+func updateDrClusterOperatorFromSubscription(ctx context.Context, apiReader client.Reader,
+	cfg *ramendrv1alpha1.RamenConfig,
+	log logr.Logger,
+) {
+	if ControllerType != ramendrv1alpha1.DRHubType || cfg == nil {
+		return
+	}
+
+	sub := findHubOperatorSubscription(ctx, apiReader, log)
+
+	if sub == nil || sub.Spec == nil {
+		return
+	}
+
+	applyDrClusterOperatorFromSubscriptionSpec(sub.Spec, cfg)
+
+	if sub.Namespace == openshiftOperatorsNamespace {
+		cfg.DrClusterOperator.NamespaceName = openshiftDRSystemNamespace
+	}
 }
 
 func RamenOperandsNamespace(config ramendrv1alpha1.RamenConfig) string {

--- a/ramendev/ramendev/resources/configmap.yaml
+++ b/ramendev/ramendev/resources/configmap.yaml
@@ -25,12 +25,6 @@ data:
     drClusterOperator:
       deploymentAutomationEnabled: $auto_deploy
       s3SecretDistributionEnabled: true
-      channelName: alpha
-      packageName: ramen-dr-cluster-operator
-      namespaceName: ramen-system
-      catalogSourceName: ramen-catalog
-      catalogSourceNamespaceName: ramen-system
-      clusterServiceVersionName: ramen-dr-cluster-operator.v0.0.1
     kubeObjectProtection:
       veleroNamespaceName: velero
     volSync:


### PR DESCRIPTION
## Summary

This PR fixes a **ConfigMap / `drClusterOperator` values** problem introduced by #2473.

Previously, the `drClusterOperator` section in the ConfigMap was effectively filled by **OLM**. After moving to **default ConfigMap + user-set values**, that section could end up **empty** while the operator fell back to generic defaults, which broke the intended behavior.

## What this PR does

- **Apply DR-cluster OLM settings from the hub `Subscription`**
  - On the hub, the OLM `Subscription` is the **source of truth** for how the Ramen hub operator is installed.
  - At runtime we populate `DrClusterOperator` (channel, package/catalog with `-hub-` → `-cluster-` mapping, CSV) from that object so **managed-cluster operator settings stay aligned with the hub** and pick up OLM upgrades.
  - If no hub `Subscription` is found (e.g. **drenv** / non-OLM), compiled **`DefaultRamenConfig()`** defaults for `DrClusterOperator` are used instead.

- **Scheme / RBAC**
  - Register OLM `operators.coreos.com/v1alpha1` types on the **hub** manager scheme so the client/cache can decode `Subscription` objects.
  - Grant **get / list / watch** on `subscriptions` so the reconciler is allowed to read them.

- **Defaults**
  - `DefaultRamenConfig` carries baseline `drClusterOperator` defaults; the hub **subscription overlay** runs before ConfigMap create/update (see `CreateOrUpdateConfigMap` + `updateDrClusterOperatorFromSubscription`). Existing `*OrDefault` helpers still cover reads when a field is empty.

- **Hub operator in `openshift-operators`**
  - If the hub operator `Subscription` lives in **`openshift-operators`**, set **`DrClusterOperator.NamespaceName`** to **`openshift-dr-system`** so DR-cluster operator placement matches that install layout.

## Case A — Hub **without** OLM (e.g. drenv / no hub operator `Subscription`)

- **Behavior:** `updateDrClusterOperatorFromSubscription` finds no suitable `Subscription` and returns. `drClusterOperator` stays what `DefaultRamenConfig()` set (channel, package, catalog, CSV, namespaces from `POD_NAMESPACE`, etc.).

### A.1 — Startup, **empty** hub ConfigMap (first install)

- There is no ConfigMap yet.
- The operator **creates** `ramen-hub-operator-config` from the current in-memory `RamenConfig` (**no merge**; there is no existing user YAML in the cluster).

**Example `drClusterOperator`:**

```yaml
drClusterOperator:
  deploymentAutomationEnabled: true
  s3SecretDistributionEnabled: true
  channelName: alpha
  packageName: ramen-dr-cluster-operator
  namespaceName: ramen-system
  catalogSourceName: ramen-catalog
  catalogSourceNamespaceName: ramen-system
  clusterServiceVersionName: ramen-dr-cluster-operator.v0.0.1
```

### A.2 — Merge with user data (ConfigMap **already** exists)

- On later starts (or after an admin saved the ConfigMap), the operator loads user YAML from `ramen_manager_config.yaml`, **merges** it with freshly marshaled defaults (still **no** subscription overlay), then `copyDrClusterOperatorSubscriptionFields` **overwrites** the merged `drClusterOperator` with the in-memory hub defaults (same shape as **A.1**).

**Example user `ramen_manager_config.yaml` fragment** (the user may also add `s3StoreProfiles` and other keys; only `drClusterOperator` is shown here. That block is merged for the rest of the document, then replaced from in-memory defaults.)

```yaml
apiVersion: ramendr.openshift.io/v1alpha1
kind: RamenConfig
drClusterOperator:
  channelName: stable-4.22
  packageName: other-package
```

**Effective `drClusterOperator` after merge + copy** (matches hub in-memory defaults, not the user fragment above):

```yaml
drClusterOperator:
  deploymentAutomationEnabled: true
  s3SecretDistributionEnabled: true
  channelName: alpha
  packageName: ramen-dr-cluster-operator
  namespaceName: ramen-system
  catalogSourceName: ramen-catalog
  catalogSourceNamespaceName: ramen-system
  clusterServiceVersionName: ramen-dr-cluster-operator.v0.0.1
```

---

## Case B — Hub **with** OLM (hub operator installed via `Subscription`)

- **Behavior:** `updateDrClusterOperatorFromSubscription` lists `Subscription`s in the operator namespace, selects the hub operator subscription (package name **suffix** `-hub-operator`), copies channel / catalog / namespaces / package / starting CSV into `drClusterOperator`, mapping hub names to cluster operator names (`-hub-` → `-cluster-` in package and CSV). If the subscription namespace is `openshift-operators`, `namespaceName` is set to `openshift-dr-system`.

### B.1 — Startup, **empty** hub ConfigMap (first install)

- **Same control flow as case A.1:** ConfigMap missing → **create** from in-memory config.
- Here the in-memory config **already** has `drClusterOperator` filled from the hub `Subscription` (not only `DefaultRamenConfig()`).

**Example `drClusterOperator` after subscription overlay:**

```yaml
drClusterOperator:
  deploymentAutomationEnabled: true
  s3SecretDistributionEnabled: true
  channelName: stable-4.22
  packageName: odr-cluster-operator
  namespaceName: openshift-dr-system
  catalogSourceName: redhat-operators
  catalogSourceNamespaceName: openshift-marketplace
  clusterServiceVersionName: odr-cluster-operator.v4.22.0-57.stable
```

### B.2 — Merge with user data (ConfigMap **already** exists)

- User YAML is merged with marshaled defaults + subscription snapshot from memory, then `copyDrClusterOperatorSubscriptionFields` **forces** `drClusterOperator` on the merge result to match the **current** in-memory hub config (subscription-based values), not whatever merge produced for that subtree.

**Example user fragment** (merged for the rest of the document; `drClusterOperator` is still replaced by copy):

```yaml
apiVersion: ramendr.openshift.io/v1alpha1
kind: RamenConfig
s3StoreProfiles: []
drClusterOperator:
  channelName: alpha
  packageName: ramen-dr-cluster-operator
```

**Effective `drClusterOperator` after merge + copy** (subscription-driven values):

```yaml
drClusterOperator:
  deploymentAutomationEnabled: true
  s3SecretDistributionEnabled: true
  channelName: stable-4.22
  packageName: odr-cluster-operator
  namespaceName: openshift-dr-system
  catalogSourceName: redhat-operators
  catalogSourceNamespaceName: openshift-marketplace
  clusterServiceVersionName: odr-cluster-operator.v4.22.0-57.stable
```

Fixes: https://redhat.atlassian.net/browse/DFBUGS-6409

Assisted by AI