### PR TITLE
Ramen ConfigMap default admin namespace incorrectly set to "ramen-ops" instead of "openshift-dr-ops"

### DIFF
--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -47,10 +47,12 @@ const (
 	drClusterOperatorClusterServiceVersionNameDefault = drClusterOperatorPackageNameDefault + ".v0.0.1"
 	DefaultCephFSCSIDriverName                        = "openshift-storage.cephfs.csi.ceph.com"
 	VeleroNamespaceNameDefault                        = "velero"
+	veleroNamespaceNameDefaultOCP                     = "openshift-adp"
 	DefaultVolSyncCopyMethod                          = "Snapshot"
 	defaultMaxConcurrentReconciles                    = 50
 	openshiftOperatorsNamespace                       = "openshift-operators"
 	openshiftDRSystemNamespace                        = "openshift-dr-system"
+	openshiftDROpsNamespace                           = "openshift-dr-ops"
 )
 
 // FIXME
@@ -506,6 +508,8 @@ func updateDrClusterOperatorFromSubscription(ctx context.Context, apiReader clie
 
 	if sub.Namespace == openshiftOperatorsNamespace {
 		cfg.DrClusterOperator.NamespaceName = openshiftDRSystemNamespace
+		cfg.KubeObjectProtection.VeleroNamespaceName = veleroNamespaceNameDefaultOCP
+		cfg.RamenOpsNamespace = openshiftDROpsNamespace
 	}
 }
 


### PR DESCRIPTION
ramenconfig: set Velero and RamenOps namespaces for hub in openshift-operators

When the hub OLM subscription lives in openshift-operators namespace, align config with the OCP layout: Velero namespace openshift-adp and Ramen ops namespace openshift-dr-ops, alongside the existing DR cluster operator install namespace.

Fixes: https://redhat.atlassian.net/browse/DFBUGS-6507