### PR TITLE
Disown OLM-managed ramen operator ConfigMap on merge/update

### DIFF
--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -311,6 +311,36 @@ func configMapCreate(
 	return desiredRamenConfig, nil
 }
 
+func disownOLMManagedConfigMap(cm *corev1.ConfigMap, log logr.Logger) {
+	// Older OLM installs created this ConfigMap from the CSV bundle.
+	// When upgrading to a non-OLM-owned ConfigMap, remove ownership metadata so
+	// the ConfigMap is not garbage collected when the old CSV is deleted.
+	if len(cm.OwnerReferences) > 0 {
+		log.Info("Removing ramen configmap owner references",
+			"name", cm.Name,
+			"namespace", cm.Namespace,
+			"ownerReferences", cm.OwnerReferences)
+		cm.OwnerReferences = nil
+	}
+
+	// OLM adds these labels so it can track and reconcile bundle-owned objects.
+	// Remove them when taking ownership of the ConfigMap so OLM no longer treats
+	// it as part of the Subscription/CSV lifecycle.
+	for _, key := range []string{
+		"olm.managed",
+		"operators.coreos.com/odr-hub-operator.openshift-operators",
+	} {
+		if v, ok := cm.Labels[key]; ok {
+			log.Info("Remove ramen config map label",
+				"key", key,
+				"value", v,
+				"name", cm.Name,
+				"namespace", cm.Namespace)
+			delete(cm.Labels, key)
+		}
+	}
+}
+
 func configMapUpdate(
 	ctx context.Context,
 	c client.Client,
@@ -318,6 +348,8 @@ func configMapUpdate(
 	desiredRamenConfig *ramendrv1alpha1.RamenConfig,
 	log logr.Logger,
 ) (*ramendrv1alpha1.RamenConfig, error) {
+	disownOLMManagedConfigMap(userConfigMap, log)
+
 	desiredBytes, err := yaml.Marshal(desiredRamenConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Remove CSV owner references and olm.managed / operators.coreos.com labels before updating the ConfigMap so it survives deletion of the old CSV after moving to operator-managed configuration.

### Testing flow
### Part 1: Reproduce the Problem (Before Fix)

1. Install Old Ramen Version
2. Check ConfigMap has OwnerReferences pointing to CSV
3. Check ConfigMap has OLM labels (olm.managed, operators.coreos.com/...)
4. Trigger OLM upgrade to newer version, but still before this PR
5. Observe that ConfigMap gets garbage collected and deleted

### Part 2: Verify the Fix Works (With PR #2532)

1. Install Old Ramen Version
2. Check ConfigMap has OwnerReferences pointing to CSV
3. Check ConfigMap has OLM labels (olm.managed, operators.coreos.com/...)
4. Trigger OLM upgrade to newer version, with this PR changes
5. Check ConfigMap exists and OwnerReferences and OLM labels are removed
6. Check operator logs for "Removing ramen configmap owner references" messages
7. Check operator logs for "Remove ramen config map label" messages

Fixes: https://github.com/RamenDR/ramen/issues/2529
Fixes: https://redhat.atlassian.net/browse/DFBUGS-6473