### PR TITLE
DRPC shows "Sync" immediately after adding 2nd VM to shared protection

### DIFF
--- a/internal/controller/protected_condition.go
+++ b/internal/controller/protected_condition.go
@@ -166,8 +166,11 @@ func updateVRGDataProtectedAsPrimary(drpc *rmn.DRPlacementControl,
 	condition := meta.FindStatusCondition(vrg.Status.Conditions, VRGConditionTypeDataProtected)
 
 	if condition != nil && condition.ObservedGeneration == vrg.Generation {
-		// VRGConditionReasonReplicating reason is unique to VR based volumes
-		if condition.Reason == VRGConditionReasonReplicating && condition.Status == metav1.ConditionFalse {
+		// The following early return is for Sync DR only: aggregate DataProtected often stays
+		// False/Replicating (Ready overridden in setPVCDataProtectedCondition), which would keep DRPC Protected false
+		// and constant alerts; Async DR still uses genericUpdateProtectedForCondition below.
+		if condition.Reason == VRGConditionReasonReplicating && condition.Status == metav1.ConditionFalse &&
+			vrg.Spec.Sync != nil {
 			return !updated
 		}
 


### PR DESCRIPTION
When aggregate VRG DataProtected is False with reason Replicating on primary, whether DRPC ConditionProtected follows that signal differs by DR mode.

**Regional/async DR (vrg.Spec.Async)**: mapping the aggregate DataProtected condition through genericUpdateProtectedForCondition. so DRPC Protected stays Progressing until replication fully reports protected. This avoids DRPC (and UIs that mirror it) jumping straight to Healthy when a second VM/PVC is added under shared protection while volumes are still replicating.

**Metro/sync DR (vrg.Spec.Sync)**: retaining the early return, introduced for false/ Replicating aggregate DataProtected condition, so we do not drive DRPC Protected from that condition alone. Sync DR can report DataProtected as Ready then have setPVCDataProtectedCondition set it back to False/Replicating (see https://github.com/RamenDR/ramen/pull/1430); treating that like async DR would leave DRPC Protected false and trigger repeated alerts. 

**Solution**: The SyncDR bypass matches PR 1430; asyncDR paths still use genericUpdateProtectedForCondition. 

Related: https://github.com/RamenDR/ramen/pull/1430
Fixes: https://redhat.atlassian.net/browse/DFBUGS-5635