### PR TITLE
Add Prometheus metrics scraping RBAC

### DIFF
--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -78,7 +78,7 @@ func DefaultRamenConfig(controllerType ramendrv1alpha1.ControllerType) *ramendrv
 			HealthProbeBindAddress: ":8081",
 		},
 		Metrics: ramendrv1alpha1.ControllerMetrics{
-			BindAddress: "127.0.0.1:9289",
+			BindAddress: "0.0.0.0:9289",
 		},
 		LeaderElection: &configv1alpha1.LeaderElectionConfiguration{
 			LeaderElect:  &leaderElect,
@@ -136,9 +136,13 @@ func LoadControllerOptions(options *ctrl.Options, ramenConfig *ramendrv1alpha1.R
 	if ramenConfig.Metrics.BindAddress == "0" {
 		options.Metrics = metricsserver.Options{BindAddress: "0"}
 	} else {
+		// Use /etc/metrics-certs for OpenShift Service CA certificates
+		// Falls back to auto-generated certs if directory doesn't exist
+		certDir := "/etc/metrics-certs"
 		options.Metrics = metricsserver.Options{
 			BindAddress:    ramenConfig.Metrics.BindAddress,
 			SecureServing:  true,
+			CertDir:        certDir,
 			FilterProvider: filters.WithAuthenticationAndAuthorization,
 		}
 	}


### PR DESCRIPTION
Add Prometheus metrics scraping RBAC
Fixes issue where Prometheus cannot scrape Ramen operator metrics due to
missing RBAC permissions.

Changes:
- Bind metrics server to 0.0.0.0:9289 (was 127.0.0.1:9289)
- Enable TLS with Service CA certificates

Verified:
- Prometheus successfully scrapes metrics from hub operator
- Three policies monitored: odr-policy-5m, policy1, policy2

Result from ODF Cluster:
```
% oc exec -n openshift-monitoring prometheus-k8s-0 -- \
  curl -G -s 'http://localhost:9090/api/v1/query?query=ramen_policy_schedule_interval_seconds' | jq
{
  "status": "success",
  "data": {
    "resultType": "vector",
    "result": [
      {
        "metric": {
          "__name__": "ramen_policy_schedule_interval_seconds",
          "endpoint": "https",
          "instance": "10.128.0.252:9289",
          "job": "ramen-hub-operator-metrics-service",
          "namespace": "openshift-operators",
          "pod": "ramen-hub-operator-59f5895596-nbzbd",
          "policyname": "odr-policy-5m",
          "service": "ramen-hub-operator-metrics-service"
        },
        "value": [
          1778060556.887,
          "300"
        ]
      },
      {
        "metric": {
          "__name__": "ramen_policy_schedule_interval_seconds",
          "endpoint": "https",
          "instance": "10.128.0.252:9289",
          "job": "ramen-hub-operator-metrics-service",
          "namespace": "openshift-operators",
          "pod": "ramen-hub-operator-59f5895596-nbzbd",
          "policyname": "policy1",
          "service": "ramen-hub-operator-metrics-service"
        },
        "value": [
          1778060556.887,
          "300"
        ]
      },
      {
        "metric": {
          "__name__": "ramen_policy_schedule_interval_seconds",
          "endpoint": "https",
          "instance": "10.128.0.252:9289",
          "job": "ramen-hub-operator-metrics-service",
          "namespace": "openshift-operators",
          "pod": "ramen-hub-operator-59f5895596-nbzbd",
          "policyname": "policy2",
          "service": "ramen-hub-operator-metrics-service"
        },
        "value": [
          1778060556.887,
          "900"
        ]
      }
    ]
  }
}
```

Assisted by : IBM BOB v1.0.1