### PR TITLE
e2e/config: support multiple test instances with explicit names

### DIFF
--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -269,3 +269,28 @@ tests using a specific one. Example usage:
 ```sh
 ./run.sh -config my_config.yaml
 ```
+
+### Stress testing
+
+Stress test configurations run multiple instances of the same application
+concurrently to investigate storage performance under load. This is useful
+for detecting issues like CephFS quiesce serialization during failover.
+
+Available stress test configurations:
+
+- `config-stress-cephfs.yaml.sample` - 8 CephFS applications
+- `config-stress-rbd.yaml.sample` - 8 RBD applications
+
+To run a CephFS stress test:
+
+```sh
+cat config-stress-cephfs.yaml.sample ~/.config/drenv/rdr/config.yaml > config.yaml
+./run.sh -test.run TestDR
+```
+
+To run an RBD stress test:
+
+```sh
+cat config-stress-rbd.yaml.sample ~/.config/drenv/rdr/config.yaml > config.yaml
+./run.sh -test.run TestDR
+```

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -176,7 +176,7 @@ tests:
   ...
 ```
 
-The tests are generated from the configuration as
+By default, the test name is generated from the configuration as
 "TestDR/{deployer}-{workload}-{pvcspec}".
 See [Running DR tests](#running-dr-tests) section for complete test list.
 
@@ -187,6 +187,40 @@ has a name, type, and description. The type is used to identify the deployer
 implementation. There are 3 types available, appset, subscr, and disapp. For
 disapp, optional fields for recipe are added. The description provides
 additional context about the deployer.
+
+#### Testing multiple applications
+
+By default, each combination of deployer, workload, and pvcSpec must be unique.
+To run multiple applications with the same configuration, add an explicit
+`name` to each test. This is useful for stress testing storage by running
+multiple applications concurrently on the same storage class.
+
+For example, testing 4 CephFS applications concurrently using the discovered
+application deployer:
+
+```yaml
+tests:
+  - name: cephfs-1
+    deployer: disapp
+    workload: deploy
+    pvcspec: cephfs
+  - name: cephfs-2
+    deployer: disapp
+    workload: deploy
+    pvcspec: cephfs
+  - name: cephfs-3
+    deployer: disapp
+    workload: deploy
+    pvcspec: cephfs
+  - name: cephfs-4
+    deployer: disapp
+    workload: deploy
+    pvcspec: cephfs
+```
+
+Each test gets its own namespace (`test-cephfs-1`, `test-cephfs-2`, etc.) and
+independent DR resources. The name must be a valid DNS label (lowercase
+alphanumeric and hyphens, max 63 characters including the namespace prefix).
 
 ### Run specific DR tests
 

--- a/e2e/config-stress-cephfs.yaml.sample
+++ b/e2e/config-stress-cephfs.yaml.sample
@@ -1,0 +1,68 @@
+# Stress test configuration for CephFS disaster recovery.
+#
+# Runs 8 CephFS applications concurrently using the discovered application
+# deployer. Useful for investigating storage performance under load, such as
+# CephFS quiesce serialization during failover.
+
+---
+repo:
+  url: "https://github.com/RamenDR/ocm-ramen-samples.git"
+  branch: main
+
+drPolicy: dr-policy-1m
+
+clusterSet: default
+
+pvcspecs:
+  - name: cephfs
+    storageclassname: rook-cephfs-fs1
+    accessmodes: ReadWriteMany
+
+deployers:
+  - name: disapp
+    type: disapp
+    description: "Discovered Application without recipe"
+
+tests:
+  - name: cephfs-1
+    deployer: disapp
+    workload: deploy
+    pvcspec: cephfs
+  - name: cephfs-2
+    deployer: disapp
+    workload: deploy
+    pvcspec: cephfs
+  - name: cephfs-3
+    deployer: disapp
+    workload: deploy
+    pvcspec: cephfs
+  - name: cephfs-4
+    deployer: disapp
+    workload: deploy
+    pvcspec: cephfs
+  - name: cephfs-5
+    deployer: disapp
+    workload: deploy
+    pvcspec: cephfs
+  - name: cephfs-6
+    deployer: disapp
+    workload: deploy
+    pvcspec: cephfs
+  - name: cephfs-7
+    deployer: disapp
+    workload: deploy
+    pvcspec: cephfs
+  - name: cephfs-8
+    deployer: disapp
+    workload: deploy
+    pvcspec: cephfs
+
+# Uncomment and edit the following lines to set the cluster
+# kubeconfig paths for the hub and managed clusters.
+# clusters:
+#   hub:
+#     kubeconfig: hub/config
+#   c1:
+#     kubeconfig: dr1/config
+#   c2:
+#     kubeconfig: dr2/config

--- a/e2e/config-stress-rbd.yaml.sample
+++ b/e2e/config-stress-rbd.yaml.sample
@@ -1,0 +1,67 @@
+# Stress test configuration for RBD disaster recovery.
+#
+# Runs 8 RBD applications concurrently using the discovered application
+# deployer. Useful for investigating storage performance under load.
+
+---
+repo:
+  url: "https://github.com/RamenDR/ocm-ramen-samples.git"
+  branch: main
+
+drPolicy: dr-policy-1m
+
+clusterSet: default
+
+pvcspecs:
+  - name: rbd
+    storageclassname: rook-ceph-block
+    accessmodes: ReadWriteOnce
+
+deployers:
+  - name: disapp
+    type: disapp
+    description: "Discovered Application without recipe"
+
+tests:
+  - name: rbd-1
+    deployer: disapp
+    workload: deploy
+    pvcspec: rbd
+  - name: rbd-2
+    deployer: disapp
+    workload: deploy
+    pvcspec: rbd
+  - name: rbd-3
+    deployer: disapp
+    workload: deploy
+    pvcspec: rbd
+  - name: rbd-4
+    deployer: disapp
+    workload: deploy
+    pvcspec: rbd
+  - name: rbd-5
+    deployer: disapp
+    workload: deploy
+    pvcspec: rbd
+  - name: rbd-6
+    deployer: disapp
+    workload: deploy
+    pvcspec: rbd
+  - name: rbd-7
+    deployer: disapp
+    workload: deploy
+    pvcspec: rbd
+  - name: rbd-8
+    deployer: disapp
+    workload: deploy
+    pvcspec: rbd
+
+# Uncomment and edit the following lines to set the cluster
+# kubeconfig paths for the hub and managed clusters.
+# clusters:
+#   hub:
+#     kubeconfig: hub/config
+#   c1:
+#     kubeconfig: dr1/config
+#   c2:
+#     kubeconfig: dr2/config

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -123,9 +123,25 @@ type Cluster struct {
 }
 
 type Test struct {
+	// Name is an optional unique name for the test. If empty, ContextName()
+	// generates a name from the deployer, workload, and pvcSpec fields.
+	// Use an explicit name to create multiple tests with the same
+	// deployer, workload, and pvcSpec.
+	Name     string `json:"name,omitempty"`
 	Workload string `json:"workload"`
 	Deployer string `json:"deployer"`
 	PVCSpec  string `json:"pvcSpec"`
+}
+
+// ContextName returns the test context name. If Name is set, it is returned
+// as-is. Otherwise, a name is generated from the deployer, workload, and
+// pvcSpec.
+func (t Test) ContextName() string {
+	if t.Name != "" {
+		return t.Name
+	}
+
+	return t.Deployer + "-" + t.Workload + "-" + t.PVCSpec
 }
 
 // Config keeps configuration for e2e tests.
@@ -345,6 +361,11 @@ func validateAccessModes(pvcSpecs []PVCSpec) error {
 	return nil
 }
 
+// validateTests ensures:
+// - All tests have unique context names (see Test.ContextName()).
+// - Tests with explicit names can share the same deployer, workload, and pvcSpec.
+// - The test context name is a valid DNS label.
+// - The test namespace (namespacePrefix + context name) is a valid DNS label.
 func validateTests(config *Config, options *Options) error {
 	// We allow an empty test list so one can run the validation tests or unit tests without a fully configured file.
 	if len(config.Tests) == 0 {
@@ -361,12 +382,19 @@ func validateTests(config *Config, options *Options) error {
 		deployerNames = append(deployerNames, deployer.Name)
 	}
 
-	testsSeen := map[Test]struct{}{}
+	seen := map[string]Test{}
 
 	for _, t := range config.Tests {
-		if _, ok := testsSeen[t]; ok {
-			return fmt.Errorf("duplicate test (deployer: %q, workload: %q, pvcSpec: %q)",
-				t.Deployer, t.Workload, t.PVCSpec)
+		name := t.ContextName()
+
+		if existing, ok := seen[name]; ok {
+			return fmt.Errorf("duplicate test %q:\n\t%+v\n\t%+v", name, existing, t)
+		}
+
+		namespace := config.NamespacePrefix + name
+		if errs := validation.NameIsDNSLabel(namespace, false); len(errs) > 0 {
+			return fmt.Errorf("invalid test name %q: namespace %q is not a valid DNS label: %v",
+				name, namespace, errs)
 		}
 
 		if !slices.Contains(deployerNames, t.Deployer) {
@@ -381,7 +409,7 @@ func validateTests(config *Config, options *Options) error {
 			return fmt.Errorf("invalid test pvcSpec: %q (available %q)", t.PVCSpec, pvcSpecNames)
 		}
 
-		testsSeen[t] = struct{}{}
+		seen[name] = t
 	}
 
 	return nil

--- a/e2e/config/config_test.go
+++ b/e2e/config/config_test.go
@@ -236,6 +236,12 @@ func TestConfigNotEqual(t *testing.T) {
 			},
 		},
 		{
+			Name: "different test name",
+			Modify: func(c *Config) {
+				c.Tests[0].Name = "modified-name"
+			},
+		},
+		{
 			Name: "different test workload",
 			Modify: func(c *Config) {
 				c.Tests[0].Workload = "modified-workload"
@@ -376,6 +382,173 @@ func TestValidateDeployers(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateTests(t *testing.T) {
+	options := &Options{
+		Workloads: []string{"deploy"},
+		Deployers: []string{"appset", "disapp"},
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			config *Config
+		}{
+			{
+				name: "implicit name",
+				config: &Config{
+					NamespacePrefix: "test-",
+					PVCSpecs:        []PVCSpec{{Name: "rbd"}},
+					Deployers:       []Deployer{{Name: "appset", Type: "appset"}},
+					Tests: []Test{
+						{Deployer: "appset", Workload: "deploy", PVCSpec: "rbd"},
+					},
+				},
+			},
+			{
+				name: "max length name",
+				config: &Config{
+					NamespacePrefix: "test-",
+					PVCSpecs:        []PVCSpec{{Name: "rbd"}},
+					Deployers:       []Deployer{{Name: "disapp", Type: "disapp"}},
+					Tests: []Test{
+						{
+							// 58 char name + 5 char prefix "test-" = 63 (max DNS label length).
+							Name:     "a012345678901234567890123456789012345678901234567890123456",
+							Deployer: "disapp",
+							Workload: "deploy",
+							PVCSpec:  "rbd",
+						},
+					},
+				},
+			},
+			{
+				name: "explicit names allow same deployer workload pvcSpec",
+				config: &Config{
+					NamespacePrefix: "test-",
+					PVCSpecs:        []PVCSpec{{Name: "rbd"}},
+					Deployers:       []Deployer{{Name: "disapp", Type: "disapp"}},
+					Tests: []Test{
+						{Name: "app-1", Deployer: "disapp", Workload: "deploy", PVCSpec: "rbd"},
+						{Name: "app-2", Deployer: "disapp", Workload: "deploy", PVCSpec: "rbd"},
+					},
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if err := validateTests(tt.config, options); err != nil {
+					t.Errorf("valid config %+v, failed: %s", tt.config.Tests, err)
+				}
+			})
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			config *Config
+		}{
+			{
+				name: "duplicate implicit names",
+				config: &Config{
+					PVCSpecs:  []PVCSpec{{Name: "rbd"}},
+					Deployers: []Deployer{{Name: "appset", Type: "appset"}},
+					Tests: []Test{
+						{Deployer: "appset", Workload: "deploy", PVCSpec: "rbd"},
+						{Deployer: "appset", Workload: "deploy", PVCSpec: "rbd"},
+					},
+				},
+			},
+			{
+				name: "duplicate explicit names",
+				config: &Config{
+					PVCSpecs:  []PVCSpec{{Name: "rbd"}},
+					Deployers: []Deployer{{Name: "disapp", Type: "disapp"}},
+					Tests: []Test{
+						{Name: "same", Deployer: "disapp", Workload: "deploy", PVCSpec: "rbd"},
+						{Name: "same", Deployer: "disapp", Workload: "deploy", PVCSpec: "rbd"},
+					},
+				},
+			},
+			{
+				name: "explicit name collides with implicit name",
+				config: &Config{
+					PVCSpecs:  []PVCSpec{{Name: "rbd"}},
+					Deployers: []Deployer{{Name: "appset", Type: "appset"}},
+					Tests: []Test{
+						{Deployer: "appset", Workload: "deploy", PVCSpec: "rbd"},
+						{Name: "appset-deploy-rbd", Deployer: "appset", Workload: "deploy", PVCSpec: "rbd"},
+					},
+				},
+			},
+			{
+				name: "explicit name with uppercase",
+				config: &Config{
+					NamespacePrefix: "test-",
+					PVCSpecs:        []PVCSpec{{Name: "rbd"}},
+					Deployers:       []Deployer{{Name: "disapp", Type: "disapp"}},
+					Tests: []Test{
+						{Name: "MyTest", Deployer: "disapp", Workload: "deploy", PVCSpec: "rbd"},
+					},
+				},
+			},
+			{
+				name: "explicit name with underscores",
+				config: &Config{
+					NamespacePrefix: "test-",
+					PVCSpecs:        []PVCSpec{{Name: "rbd"}},
+					Deployers:       []Deployer{{Name: "disapp", Type: "disapp"}},
+					Tests: []Test{
+						{Name: "my_test", Deployer: "disapp", Workload: "deploy", PVCSpec: "rbd"},
+					},
+				},
+			},
+			{
+				name: "explicit name too long",
+				config: &Config{
+					NamespacePrefix: "test-",
+					PVCSpecs:        []PVCSpec{{Name: "rbd"}},
+					Deployers:       []Deployer{{Name: "disapp", Type: "disapp"}},
+					Tests: []Test{
+						{
+							// 59 char name + 5 char prefix "test-" = 64 (exceeds max DNS label length).
+							Name:     "a0123456789012345678901234567890123456789012345678901234567",
+							Deployer: "disapp",
+							Workload: "deploy",
+							PVCSpec:  "rbd",
+						},
+					},
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				if err := validateTests(tt.config, options); err == nil {
+					t.Errorf("invalid config %+v, did not fail", tt.config.Tests)
+				}
+			})
+		}
+	})
+}
+
+func TestContextName(t *testing.T) {
+	t.Run("implicit name", func(t *testing.T) {
+		test := Test{Deployer: "appset", Workload: "deploy", PVCSpec: "rbd"}
+		if test.ContextName() != "appset-deploy-rbd" {
+			t.Errorf("expected %q, got %q", "appset-deploy-rbd", test.ContextName())
+		}
+	})
+
+	t.Run("explicit name", func(t *testing.T) {
+		test := Test{Name: "my-test", Deployer: "appset", Workload: "deploy", PVCSpec: "rbd"}
+		if test.ContextName() != "my-test" {
+			t.Errorf("expected %q, got %q", "my-test", test.ContextName())
+		}
+	})
 }
 
 func marshal(t *testing.T, obj any) []byte {

--- a/e2e/dr_test.go
+++ b/e2e/dr_test.go
@@ -64,7 +64,7 @@ func TestDR(dt *testing.T) {
 			panic(err)
 		}
 
-		ctx := test.NewContext(Ctx, workload, deployer)
+		ctx := test.NewContext(Ctx, tc.ContextName(), workload, deployer)
 		t.Run(ctx.Name(), func(dt *testing.T) {
 			t := test.WithLog(dt, ctx.Logger())
 			t.Parallel()

--- a/e2e/recipes/recipes_test.go
+++ b/e2e/recipes/recipes_test.go
@@ -25,6 +25,10 @@ import (
 	"github.com/ramendr/ramen/e2e/workloads"
 )
 
+// Matches the deployer name, workload type, and first pvcSpec name from
+// testdata/config.yaml.
+const testContextName = "disapp-deploy-rbd"
+
 func TestGenerateWithNoHooks(t *testing.T) {
 	recipeConfig := &config.Recipe{
 		Type: "generate",
@@ -116,7 +120,7 @@ func TestGenerateWithNoChecks(t *testing.T) {
 	deployer := createDeployer(t, recipeConfig)
 
 	parent := app.NewContext(context.Background(), cfg, &types.Env{}, zap.NewExample().Sugar())
-	testContext := test.NewContext(parent, workload, deployer)
+	testContext := test.NewContext(parent, testContextName, workload, deployer)
 
 	_, err := recipes.Generate(&testContext, recipeConfig)
 	if err == nil {
@@ -139,7 +143,7 @@ func TestGenerateWithNoOperations(t *testing.T) {
 	deployer := createDeployer(t, recipeConfig)
 
 	parent := app.NewContext(context.Background(), cfg, &types.Env{}, zap.NewExample().Sugar())
-	testContext := test.NewContext(parent, workload, deployer)
+	testContext := test.NewContext(parent, testContextName, workload, deployer)
 
 	_, err := recipes.Generate(&testContext, recipeConfig)
 	if err == nil {
@@ -225,7 +229,7 @@ func createTestContext(t *testing.T, rc *config.Recipe) types.TestContext {
 	deployer := createDeployer(t, rc)
 
 	parent := app.NewContext(context.Background(), cfg, &types.Env{}, zap.NewExample().Sugar())
-	tc := test.NewContext(parent, workload, deployer)
+	tc := test.NewContext(parent, testContextName, workload, deployer)
 
 	return &tc
 }

--- a/e2e/test/context.go
+++ b/e2e/test/context.go
@@ -6,7 +6,6 @@ package test
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -29,11 +28,10 @@ type Context struct {
 
 func NewContext(
 	parent types.Context,
+	name string,
 	w types.Workload,
 	d types.Deployer,
 ) Context {
-	name := strings.ToLower(d.GetName() + "-" + w.GetName())
-
 	return Context{
 		parent:   parent,
 		context:  parent.Context(),


### PR DESCRIPTION
When testing 6 concurrent applications (3 RBD, 3 CephFS), we observed suspicious staggered failover times for CephFS applications, suggesting possible serialization of CephFS quiesce operations. To investigate this we need to run multiple instances of the same application (e.g., 4 CephFS apps with the same deployer and workload) and compare the results.

The existing config validation rejected duplicate (deployer, workload, pvcSpec) tuples, making this impossible. Add an optional "name" field to the test configuration. When set, multiple tests can share the same deployer, workload, and pvcSpec as long as each has a unique name. When not set, the name is generated as before ({deployer}-{workload}-{pvcSpec}).

Example configuration:

```yaml
tests:
- name: cephfs-1
  deployer: disapp
  workload: deploy
  pvcspec: cephfs
- name: cephfs-2
  deployer: disapp
  workload: deploy
  pvcspec: cephfs
```

The test name is validated as a DNS label to ensure it produces a valid namespace when combined with the namespace prefix.

Test name generation was previously done in test.NewContext by combining deployer.GetName() and workload.GetName(). This is now moved to config.Test.ContextName(), which returns the explicit name if set, or generates one from the deployer, workload, and pvcSpec fields. test.NewContext accepts the name as a parameter instead of computing it.

Added TestValidateTests covering duplicate detection (implicit names, explicit names, and collisions between explicit and implicit names) and name format validation (uppercase, underscores, namespace too long). Added TestContextName covering implicit and explicit name generation. Previously validateTests had no dedicated tests and was only exercised indirectly through TestReadConfig with valid data.

Includes ready-to-use stress test configurations for CephFS (8 apps) and RBD (8 apps), and documentation on how to run stress tests.