### PR TITLE
doc: Add python3 to macOS brew packages

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -183,6 +183,7 @@ environment.
        kustomize \
        minikube \
        minio-mc \
+       python3 \
        qemu \
        velero \
        vfkit \


### PR DESCRIPTION
Adding python3 to the brew install
list ensures macOS users get a modern Python version for running the drenv test framework and related Python tooling.

Fixes #2476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS setup instructions to include `python3` as a required package in the Homebrew installation command.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramen/pull/2545)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->