### PR TITLE
Stabilize flaky unit tests

### DIFF
--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -2882,8 +2882,10 @@ func getVRGFromManifestWork(clusterNamespace string) (*rmn.VolumeReplicationGrou
 	mwName := rmnutil.ManifestWorkName(DRPCCommonName, DefaultDRPCNamespace, rmnutil.MWTypeVRG)
 	mw := &ocmworkv1.ManifestWork{}
 
-	err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: mwName, Namespace: clusterNamespace}, mw)
-	Expect(err).NotTo(HaveOccurred())
+	Eventually(func() error {
+		return k8sClient.Get(context.TODO(), types.NamespacedName{Name: mwName, Namespace: clusterNamespace}, mw)
+	}, timeout, interval).Should(Succeed(),
+		"timed out waiting for VRG ManifestWork %s in namespace %s", mwName, clusterNamespace)
 
 	return rmnutil.ExtractVRGFromManifestWork(mw)
 }

--- a/internal/controller/volsync/vshandler_diff_test.go
+++ b/internal/controller/volsync/vshandler_diff_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -263,8 +264,19 @@ var _ = Describe("VolSync Handler - Diff sync rollback", func() {
 			currentStateSnapName := "current-state-" + pvcName
 			address := "10.0.0.1"
 
-			lrs, err := vsHandler.ReconcileDiffLocalRS(rd, rdSpec, snapshotRef,
-				currentStateSnapName, pskSecretName, address)
+			// Use retry to handle potential conflicts when updating snapshot labels
+			// The conflict can occur in validateAndProtectSnapshot when it tries to update
+			// the snapshot with labels. Each retry will fetch a fresh snapshot object.
+			var lrs *volsyncv1alpha1.ReplicationSource
+
+			err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				var retryErr error
+
+				lrs, retryErr = vsHandler.ReconcileDiffLocalRS(rd, rdSpec, snapshotRef,
+					currentStateSnapName, pskSecretName, address)
+
+				return retryErr
+			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(lrs).NotTo(BeNil())
 

--- a/internal/controller/volsync/vshandler_diff_test.go
+++ b/internal/controller/volsync/vshandler_diff_test.go
@@ -5,6 +5,7 @@ package volsync_test
 
 import (
 	"fmt"
+	"strings"
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -161,7 +162,24 @@ var _ = Describe("VolSync Handler - Diff sync rollback", func() {
 				},
 			}
 
-			lrd, err := vsHandler.ReconcileDiffLocalRD(rdSpec, pskSecretName)
+			var lrd *volsyncv1alpha1.ReplicationDestination
+
+			var err error
+
+			// Retry PVC optimistic-lock conflicts (409). Stop without retry when reconcile succeeds or
+			// returns the expected "waiting for address" terminal state (return nil so RetryOnConflict exits).
+			retryErr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				lrd, err = vsHandler.ReconcileDiffLocalRD(rdSpec, pskSecretName)
+
+				// Stop retrying on success or on the expected terminal "waiting" state.
+				if err == nil || strings.Contains(err.Error(), "waiting for address") {
+					return nil
+				}
+
+				return err
+			})
+
+			Expect(retryErr).NotTo(HaveOccurred())
 			// RD is created but address may not be populated yet — expect waiting error
 			if err != nil {
 				Expect(err.Error()).To(ContainSubstring("waiting for address"))

--- a/internal/controller/vrg_volrep_test.go
+++ b/internal/controller/vrg_volrep_test.go
@@ -511,9 +511,6 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 						Expect(k8sClient.Update(context.TODO(), &pvc)).To(Succeed())
 					})
 				})
-				It("updates the status", func() {
-					Eventually(vrgResourceVersionGet, vrgReconcileTimeout, interval).ShouldNot(Equal(vrgResourceVersion))
-				})
 				It("keeps the selected protected", func() {
 					pvcsVerify(pvcNamesSelected, pvcProtectedVerify)
 				})


### PR DESCRIPTION
### Flakes this branch addresses

1. VolSync diff RS: API conflict flakes → RetryOnConflict around ReconcileDiffLocalRS.
2. VolSync RD diff: Transient "waiting for address" → retry until stable expected state.
3. DRPC tests: Transient ManifestWork NotFound after DRPC changes → Eventually in getVRGFromManifestWork.
4. VRG VolRep deselection: Wrong expectation on status/resource version when unprotection is disabled (sometimes passed due to unrelated status writes) → remove that It.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by waiting asynchronously for cluster resources to appear before asserting, reducing flaky failures.
  * Added retry-based handling for optimistic-lock/conflict scenarios in VolSync reconciliation tests to tolerate transient update conflicts and ensure deterministic outcomes.
  * Refined assertions in volume protection and selection restore tests to validate expected protection states without relying on brittle resource-version checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramen/pull/2548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->