### PR TITLE
Hook failure is not obvious for a customer

### DIFF
--- a/internal/controller/protected_condition.go
+++ b/internal/controller/protected_condition.go
@@ -30,6 +30,11 @@ func updateDRPCProtectedCondition(
 	vrg *rmn.VolumeReplicationGroup,
 	clusterName string,
 ) {
+	// Check for hook failures first to provide clear visibility
+	if updateVRGHooksReady(drpc, vrg, clusterName) {
+		return
+	}
+
 	if updateVRGClusterDataReady(drpc, vrg, clusterName) {
 		return
 	}
@@ -210,6 +215,41 @@ func updateVRGDataProtectedAsSecondary(drpc *rmn.DRPlacementControl,
 
 	return genericUpdateProtectedForCondition(drpc, vrg, clusterName, VRGConditionTypeDataProtected,
 		"workload data protection", "protecting workload data", "protecting workload data")
+}
+
+// updateVRGHooksReady is a helper function to process VRG HooksReady condition and update DRPC
+// Protected condition. This provides clear visibility when hooks fail.
+//   - Returns a bool that is true if status was updated, and false otherwise
+func updateVRGHooksReady(drpc *rmn.DRPlacementControl,
+	vrg *rmn.VolumeReplicationGroup,
+	clusterName string,
+) bool {
+	updated := true
+
+	condition := meta.FindStatusCondition(vrg.Status.Conditions, VRGConditionTypeHooksReady)
+
+	// Ignore missing or stale hook condition for current VRG generation
+	if condition == nil || condition.ObservedGeneration != vrg.Generation {
+		return !updated
+	}
+
+	// If hooks succeeded for current generation, continue with other Protected checks
+	if condition.Status == metav1.ConditionTrue {
+		return !updated
+	}
+
+	// Hook failed - report it clearly in DRPC status
+	if condition.Status == metav1.ConditionFalse && condition.Reason == VRGConditionReasonHookFailed {
+		addOrUpdateCondition(&drpc.Status.Conditions, rmn.ConditionProtected, drpc.Generation,
+			metav1.ConditionFalse,
+			rmn.ReasonProtectedError,
+			fmt.Sprintf("VolumeReplicationGroup (%s/%s) on cluster %s hook execution failed: %s",
+				vrg.GetNamespace(), vrg.GetName(), clusterName, condition.Message))
+
+		return updated
+	}
+
+	return !updated
 }
 
 // genericUpdateProtectedForCondition is a common helper that processes passed in VRG condition with varying VRG reasons

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -59,6 +59,10 @@ const (
 	// Indicates whether all VRGs sharing the same global VGR label have
 	// reached the desired replication state.
 	VRGConditionTypeGlobalState = "GlobalState"
+
+	// Indicates the status of hook execution in recipes.
+	// This condition helps identify hook failures separately from other kube object protection issues.
+	VRGConditionTypeHooksReady = "HooksReady"
 )
 
 // VRG condition reasons
@@ -102,6 +106,10 @@ const (
 
 	ConditionReasonConsensusReached    = "ConsensusReached"
 	ConditionReasonConsensusNotReached = "ConsensusNotReached"
+
+	// Hook-specific condition reasons for better visibility of hook failures
+	VRGConditionReasonHookExecuted = "HookExecuted"
+	VRGConditionReasonHookFailed   = "HookFailed"
 )
 
 const (
@@ -546,4 +554,26 @@ func setVRGAutoCleanupCondition(conditions *[]metav1.Condition, observedGenerati
 		Message:            message,
 	}
 	util.SetStatusCondition(conditions, *autoCleanupCondition)
+}
+
+// sets conditions when hook execution succeeds
+func setVRGHookExecutedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	util.SetStatusCondition(conditions, metav1.Condition{
+		Type:               VRGConditionTypeHooksReady,
+		Reason:             VRGConditionReasonHookExecuted,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+}
+
+// sets conditions when hook execution fails
+func setVRGHookFailedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	util.SetStatusCondition(conditions, metav1.Condition{
+		Type:               VRGConditionTypeHooksReady,
+		Reason:             VRGConditionReasonHookFailed,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
 }

--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -274,6 +274,63 @@ func (v *VRGInstance) kubeObjectsCaptureStartOrResume(
 	)
 }
 
+// kubeObjectsHookExecute resolves and runs a recipe hook.
+// skip is true when the hook type is unsupported; the caller should continue the workflow loop.
+// On success, hooksSucceeded is set. On Execute failure, records anyHookFailed and the last
+// failure message; when shouldStopExecution applies, HooksReady is set failed. The caller stops
+// or continues per failOn. kubeObjectsHookWorkflowResult sets final HooksReady state.
+func (v *VRGInstance) kubeObjectsHookExecute(
+	hook kubeobjects.HookSpec,
+	log1 logr.Logger,
+	failOn string,
+	isEssentialStep bool,
+	hooksSucceeded *bool,
+	anyHookFailed *bool,
+	lastFailureMessage *string,
+) (skip bool, err error) {
+	hookCtx := hooks.HookContext{
+		Hook:           hook,
+		Client:         v.reconciler.Client,
+		Reader:         v.reconciler.APIReader,
+		Scheme:         v.reconciler.Scheme,
+		RecipeElements: v.recipeElements,
+	}
+
+	executor, err1 := hooks.GetHookExecutor(hookCtx)
+	if err1 != nil {
+		// continue if hook type is not supported. Supported types are "check" and "exec"
+		log1.Info("Hook type not supported", "hook", hook)
+
+		return true, err1
+	}
+
+	err = executor.Execute(log1)
+	if err != nil {
+		*anyHookFailed = true
+		*lastFailureMessage = fmt.Sprintf("Hook '%s' failed: %v", hook.Name, err)
+
+		if shouldStopExecution(failOn, isEssentialStep) {
+			setVRGHookFailedCondition(&v.instance.Status.Conditions, v.instance.Generation, *lastFailureMessage)
+		}
+	} else {
+		*hooksSucceeded = true
+	}
+
+	return false, err
+}
+
+// kubeObjectsHookWorkflowResult sets HooksReady from hook workflow flags.
+func (v *VRGInstance) kubeObjectsHookWorkflowResult(
+	hooksSucceeded, anyHookFailed bool,
+	hooksSucceededMessage, lastHookFailureMessage string,
+) {
+	if hooksSucceeded && !anyHookFailed {
+		setVRGHookExecutedCondition(&v.instance.Status.Conditions, v.instance.Generation, hooksSucceededMessage)
+	} else if anyHookFailed {
+		setVRGHookFailedCondition(&v.instance.Status.Conditions, v.instance.Generation, lastHookFailureMessage)
+	}
+}
+
 //nolint:gocognit,funlen,cyclop
 func (v *VRGInstance) executeCaptureSteps(result *ctrl.Result, pathName, capturePathName, namePrefix,
 	veleroNamespaceName string,
@@ -285,11 +342,16 @@ func (v *VRGInstance) executeCaptureSteps(result *ctrl.Result, pathName, capture
 	essentialStepsCount := 0
 	requestsProcessedCount := 0
 	requestsCompletedCount := 0
+	hooksSucceeded := false
+	anyHookFailed := false
+	lastCaptureHookFailureMessage := ""
 	labels := util.OwnerLabels(v.instance)
 	labels[util.VeleroKubevirtMetadataOnlyBackupLabel] = "true"
 
 	for groupNumber, captureGroup := range captureSteps {
 		var err error
+
+		var skip bool
 
 		var isEssentialStep bool
 
@@ -301,23 +363,10 @@ func (v *VRGInstance) executeCaptureSteps(result *ctrl.Result, pathName, capture
 		if cg.IsHook {
 			isEssentialStep = cg.Hook.Essential != nil && *cg.Hook.Essential
 
-			hookCtx := hooks.HookContext{
-				Hook:           cg.Hook,
-				Client:         v.reconciler.Client,
-				Reader:         v.reconciler.APIReader,
-				Scheme:         v.reconciler.Scheme,
-				RecipeElements: v.recipeElements,
-			}
-
-			executor, err1 := hooks.GetHookExecutor(hookCtx)
-			if err1 != nil {
-				// continue if hook type is not supported. Supported types are "check" and "exec"
-				log1.Info("Hook type not supported", "hook", cg.Hook)
-
+			if skip, err = v.kubeObjectsHookExecute(cg.Hook, log1, failOn, isEssentialStep, &hooksSucceeded,
+				&anyHookFailed, &lastCaptureHookFailureMessage); skip {
 				continue
 			}
-
-			err = executor.Execute(log1)
 		}
 
 		if !cg.IsHook {
@@ -356,6 +405,11 @@ func (v *VRGInstance) executeCaptureSteps(result *ctrl.Result, pathName, capture
 			}
 		}
 	}
+
+	v.kubeObjectsHookWorkflowResult(hooksSucceeded, anyHookFailed,
+		"Capture hooks executed successfully",
+		lastCaptureHookFailureMessage,
+	)
 
 	if essentialStepsCount == 0 {
 		allEssentialStepsFailed = false
@@ -758,11 +812,16 @@ func (v *VRGInstance) executeRecoverSteps(result *ctrl.Result, s3StoreAccessor s
 	failOn := v.recipeElements.RestoreFailOn
 	allEssentialStepsFailed := true
 	essentialStepsCount := 0
+	hooksSucceeded := false
+	anyHookFailed := false
+	lastRecoverHookFailureMessage := ""
 	labels := util.OwnerLabels(v.instance)
 
 	recoverSteps := v.recipeElements.RecoverWorkflow
 	for groupNumber, recoverGroup := range recoverSteps {
 		var err error
+
+		var skip bool
 
 		var isEssentialStep bool
 
@@ -772,23 +831,10 @@ func (v *VRGInstance) executeRecoverSteps(result *ctrl.Result, s3StoreAccessor s
 		if rg.IsHook {
 			isEssentialStep = rg.Hook.Essential != nil && *rg.Hook.Essential
 
-			hookCtx := hooks.HookContext{
-				Hook:           rg.Hook,
-				Client:         v.reconciler.Client,
-				Reader:         v.reconciler.APIReader,
-				Scheme:         v.reconciler.Scheme,
-				RecipeElements: v.recipeElements,
-			}
-
-			executor, err1 := hooks.GetHookExecutor(hookCtx)
-			if err1 != nil {
-				// continue if hook type is not supported. Supported types are "check" and "exec"
-				log1.Info("Hook type not supported", "hook", rg.Hook)
-
+			if skip, err = v.kubeObjectsHookExecute(rg.Hook, log1, failOn, isEssentialStep, &hooksSucceeded,
+				&anyHookFailed, &lastRecoverHookFailureMessage); skip {
 				continue
 			}
-
-			err = executor.Execute(log1)
 		}
 
 		if !rg.IsHook {
@@ -815,6 +861,11 @@ func (v *VRGInstance) executeRecoverSteps(result *ctrl.Result, s3StoreAccessor s
 			essentialStepsCount++
 		}
 	}
+
+	v.kubeObjectsHookWorkflowResult(hooksSucceeded, anyHookFailed,
+		"Recovery hooks executed successfully",
+		lastRecoverHookFailureMessage,
+	)
 
 	if essentialStepsCount == 0 {
 		allEssentialStepsFailed = false


### PR DESCRIPTION
This PR propagates hook failures to DRPC with clear error messages

Fixes: https://redhat.atlassian.net/browse/DFBUGS-6009

Assisted-By: IBM Bob version 1.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hook readiness is checked earlier so hook failures are surfaced before protection evaluations.
  * Capture and recovery workflows now record and aggregate hook execution outcomes (successes, failures, last failure messages) and set final workflow status accordingly.
  * New status conditions/reasons indicate when hooks executed or failed, improving visibility with clear reasons and messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramen/pull/2551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->