### PR TITLE
cmd: fix ConfigMap overrides ignored for manager options

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,7 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
 	virtv1 "kubevirt.io/api/core/v1"
 	ocmv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
@@ -37,6 +38,7 @@ import (
 	gppv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	viewv1beta1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/view/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -87,10 +89,22 @@ func bindFlags(bindfuncs ...func(*flag.FlagSet)) {
 	}
 }
 
-func buildOptions() (*ctrl.Options, *ramendrv1alpha1.RamenConfig) {
+func buildOptions(restCfg *rest.Config, ramenConfig *ramendrv1alpha1.RamenConfig) (*ctrl.Options, *ramendrv1alpha1.RamenConfig) {
 	ctrlOptions := ctrl.Options{Scheme: scheme}
 
-	ramenConfig := controllers.LoadControllerConfig(configFile, setupLog)
+	c, err := client.New(restCfg, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "unable to create client for reading config")
+		os.Exit(1)
+	}
+
+	ramenConfig, err = controllers.CreateOrUpdateConfigMap(
+		context.Background(), c, c, ramenConfig, setupLog)
+	if err != nil {
+		setupLog.Error(err, "unable to ensure ramen config ConfigMap exists")
+		os.Exit(1)
+	}
+
 	controllers.LoadControllerOptions(&ctrlOptions, ramenConfig)
 
 	return &ctrlOptions, ramenConfig
@@ -264,25 +278,20 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(logOpts)))
 
-	ctrlOptions, ramenConfig := buildOptions()
+	ramenConfig := controllers.LoadControllerConfig(configFile, setupLog)
+
+	restCfg := ctrl.GetConfigOrDie()
 
 	if err := configureController(); err != nil {
 		setupLog.Error(err, "unable to configure controller")
 		os.Exit(1)
 	}
 
-	restCfg := ctrl.GetConfigOrDie()
+	ctrlOptions, ramenConfig := buildOptions(restCfg, ramenConfig)
 
 	mgr, err := ctrl.NewManager(restCfg, *ctrlOptions)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
-	}
-
-	ramenConfig, err = controllers.CreateOrUpdateConfigMap(context.Background(), mgr.GetClient(),
-		mgr.GetAPIReader(), ramenConfig, setupLog)
-	if err != nil {
-		setupLog.Error(err, "unable to ensure ramen config ConfigMap exists")
 		os.Exit(1)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -132,15 +132,6 @@ func configureController() error {
 	return nil
 }
 
-func newManager(options *ctrl.Options) (ctrl.Manager, error) {
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), *options)
-	if err != nil {
-		return mgr, fmt.Errorf("starting new manager failed %w", err)
-	}
-
-	return mgr, nil
-}
-
 func setupReconcilers(mgr ctrl.Manager, ramenConfig *ramendrv1alpha1.RamenConfig) {
 	if controllers.ControllerType == ramendrv1alpha1.DRHubType {
 		setupReconcilersHub(mgr, ramenConfig)
@@ -280,9 +271,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	mgr, err := newManager(ctrlOptions)
+	restCfg := ctrl.GetConfigOrDie()
+
+	mgr, err := ctrl.NewManager(restCfg, *ctrlOptions)
 	if err != nil {
-		setupLog.Error(err, "unable to Get new manager")
+		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
 	virtv1 "kubevirt.io/api/core/v1"
 	ocmv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
@@ -38,6 +39,7 @@ import (
 	gppv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	viewv1beta1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/view/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -88,10 +90,23 @@ func bindFlags(bindfuncs ...func(*flag.FlagSet)) {
 	}
 }
 
-func buildOptions() (*ctrl.Options, *ramendrv1alpha1.RamenConfig) {
+func buildOptions(restCfg *rest.Config, ramenConfig *ramendrv1alpha1.RamenConfig,
+) (*ctrl.Options, *ramendrv1alpha1.RamenConfig) {
 	ctrlOptions := ctrl.Options{Scheme: scheme}
 
-	ramenConfig := controllers.LoadControllerConfig(configFile, setupLog)
+	c, err := client.New(restCfg, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "unable to create client for reading config")
+		os.Exit(1)
+	}
+
+	ramenConfig, err = controllers.CreateOrUpdateConfigMap(
+		context.Background(), c, c, ramenConfig, setupLog)
+	if err != nil {
+		setupLog.Error(err, "unable to ensure ramen config ConfigMap exists")
+		os.Exit(1)
+	}
+
 	controllers.LoadControllerOptions(&ctrlOptions, ramenConfig)
 
 	return &ctrlOptions, ramenConfig
@@ -270,25 +285,20 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(logOpts)))
 
-	ctrlOptions, ramenConfig := buildOptions()
+	ramenConfig := controllers.LoadControllerConfig(configFile, setupLog)
+
+	restCfg := ctrl.GetConfigOrDie()
 
 	if err := configureController(); err != nil {
 		setupLog.Error(err, "unable to configure controller")
 		os.Exit(1)
 	}
 
-	restCfg := ctrl.GetConfigOrDie()
+	ctrlOptions, ramenConfig := buildOptions(restCfg, ramenConfig)
 
 	mgr, err := ctrl.NewManager(restCfg, *ctrlOptions)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
-	}
-
-	ramenConfig, err = controllers.CreateOrUpdateConfigMap(context.Background(), mgr.GetClient(),
-		mgr.GetAPIReader(), ramenConfig, setupLog)
-	if err != nil {
-		setupLog.Error(err, "unable to ensure ramen config ConfigMap exists")
 		os.Exit(1)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -134,15 +134,6 @@ func configureController() error {
 	return nil
 }
 
-func newManager(options *ctrl.Options) (ctrl.Manager, error) {
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), *options)
-	if err != nil {
-		return mgr, fmt.Errorf("starting new manager failed %w", err)
-	}
-
-	return mgr, nil
-}
-
 func setupReconcilers(mgr ctrl.Manager, ramenConfig *ramendrv1alpha1.RamenConfig) {
 	if controllers.ControllerType == ramendrv1alpha1.DRHubType {
 		setupReconcilersHub(mgr, ramenConfig)
@@ -286,9 +277,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	mgr, err := newManager(ctrlOptions)
+	restCfg := ctrl.GetConfigOrDie()
+
+	mgr, err := ctrl.NewManager(restCfg, *ctrlOptions)
 	if err != nil {
-		setupLog.Error(err, "unable to Get new manager")
+		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Summary

Manager options (health probe address, metrics bind address, leader election)
were set from hardcoded defaults before the ConfigMap was read, making
ConfigMap overrides for these fields ineffective. The ConfigMap was only read
after `ctrl.NewManager` was already created with those defaults.

### Fix

- Inline the `newManager` wrapper and pass the already-obtained REST config
  instead of calling `ctrl.GetConfigOrDie()` a second time
- Build a lightweight `client.New()` from the REST config to read and merge
  the ConfigMap **before** calling `ctrl.NewManager`, so user overrides take
  effect on the manager

## Test plan

- [ ] Verify the operator starts successfully with default ConfigMap values
- [ ] Set a non-default value (e.g. leader election or metrics bind address) in the ConfigMap and verify it takes effect on the manager
- [ ] Verify `ctrl.GetConfigOrDie()` is only called once (code inspection)