### PR TITLE
cmd: rename and restructure startup functions for clarity

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -28,6 +28,7 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
 	virtv1 "kubevirt.io/api/core/v1"
 	ocmv1 "open-cluster-management.io/api/cluster/v1"
 	clusterv1alpha1 "open-cluster-management.io/api/cluster/v1alpha1"
@@ -37,6 +38,7 @@ import (
 	gppv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	viewv1beta1 "open-cluster-management.io/multicloud-operators-subscription/pkg/apis/view/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -87,10 +89,22 @@ func bindFlags(bindfuncs ...func(*flag.FlagSet)) {
 	}
 }
 
-func buildOptions() (*ctrl.Options, *ramendrv1alpha1.RamenConfig) {
+func buildOptions(restCfg *rest.Config, ramenConfig *ramendrv1alpha1.RamenConfig) (*ctrl.Options, *ramendrv1alpha1.RamenConfig) {
 	ctrlOptions := ctrl.Options{Scheme: scheme}
 
-	ramenConfig := controllers.LoadControllerConfig(configFile, setupLog)
+	c, err := client.New(restCfg, client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "unable to create client for reading config")
+		os.Exit(1)
+	}
+
+	ramenConfig, err = controllers.CreateOrUpdateConfigMap(
+		context.Background(), c, c, ramenConfig, setupLog)
+	if err != nil {
+		setupLog.Error(err, "unable to ensure ramen config ConfigMap exists")
+		os.Exit(1)
+	}
+
 	controllers.LoadControllerOptions(&ctrlOptions, ramenConfig)
 
 	return &ctrlOptions, ramenConfig
@@ -264,25 +278,20 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(logOpts)))
 
-	ctrlOptions, ramenConfig := buildOptions()
+	ramenConfig := controllers.LoadControllerConfig(configFile, setupLog)
+
+	restCfg := ctrl.GetConfigOrDie()
 
 	if err := configureController(); err != nil {
 		setupLog.Error(err, "unable to configure controller")
 		os.Exit(1)
 	}
 
-	restCfg := ctrl.GetConfigOrDie()
+	ctrlOptions, ramenConfig := buildOptions(restCfg, ramenConfig)
 
 	mgr, err := ctrl.NewManager(restCfg, *ctrlOptions)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
-	}
-
-	ramenConfig, err = controllers.CreateOrUpdateConfigMap(context.Background(), mgr.GetClient(),
-		mgr.GetAPIReader(), ramenConfig, setupLog)
-	if err != nil {
-		setupLog.Error(err, "unable to ensure ramen config ConfigMap exists")
 		os.Exit(1)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -89,9 +89,7 @@ func bindFlags(bindfuncs ...func(*flag.FlagSet)) {
 	}
 }
 
-func buildOptions(restCfg *rest.Config, ramenConfig *ramendrv1alpha1.RamenConfig) (*ctrl.Options, *ramendrv1alpha1.RamenConfig) {
-	ctrlOptions := ctrl.Options{Scheme: scheme}
-
+func syncConfig(restCfg *rest.Config, ramenConfig *ramendrv1alpha1.RamenConfig) *ramendrv1alpha1.RamenConfig {
 	c, err := client.New(restCfg, client.Options{Scheme: scheme})
 	if err != nil {
 		setupLog.Error(err, "unable to create client for reading config")
@@ -105,9 +103,14 @@ func buildOptions(restCfg *rest.Config, ramenConfig *ramendrv1alpha1.RamenConfig
 		os.Exit(1)
 	}
 
-	controllers.LoadControllerOptions(&ctrlOptions, ramenConfig)
+	return ramenConfig
+}
 
-	return &ctrlOptions, ramenConfig
+func buildManagerOptions(ramenConfig *ramendrv1alpha1.RamenConfig) *ctrl.Options {
+	options := ctrl.Options{Scheme: scheme}
+	controllers.LoadControllerOptions(&options, ramenConfig)
+
+	return &options
 }
 
 func configureController() error {
@@ -287,7 +290,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctrlOptions, ramenConfig := buildOptions(restCfg, ramenConfig)
+	ramenConfig = syncConfig(restCfg, ramenConfig)
+
+	ctrlOptions := buildManagerOptions(ramenConfig)
 
 	mgr, err := ctrl.NewManager(restCfg, *ctrlOptions)
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -113,7 +113,7 @@ func buildManagerOptions(ramenConfig *ramendrv1alpha1.RamenConfig) *ctrl.Options
 	return &options
 }
 
-func configureController() error {
+func registerSchemes() error {
 	if !(controllers.ControllerType == ramendrv1alpha1.DRClusterType ||
 		controllers.ControllerType == ramendrv1alpha1.DRHubType) {
 		return fmt.Errorf("invalid controller type specified (%s), should be one of [%s|%s]",
@@ -285,11 +285,6 @@ func main() {
 
 	restCfg := ctrl.GetConfigOrDie()
 
-	if err := configureController(); err != nil {
-		setupLog.Error(err, "unable to configure controller")
-		os.Exit(1)
-	}
-
 	ramenConfig = syncConfig(restCfg, ramenConfig)
 
 	ctrlOptions := buildManagerOptions(ramenConfig)
@@ -297,6 +292,11 @@ func main() {
 	mgr, err := ctrl.NewManager(restCfg, *ctrlOptions)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	if err := registerSchemes(); err != nil {
+		setupLog.Error(err, "unable to register schemes")
 		os.Exit(1)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -132,15 +132,6 @@ func configureController() error {
 	return nil
 }
 
-func newManager(options *ctrl.Options) (ctrl.Manager, error) {
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), *options)
-	if err != nil {
-		return mgr, fmt.Errorf("starting new manager failed %w", err)
-	}
-
-	return mgr, nil
-}
-
 func setupReconcilers(mgr ctrl.Manager, ramenConfig *ramendrv1alpha1.RamenConfig) {
 	if controllers.ControllerType == ramendrv1alpha1.DRHubType {
 		setupReconcilersHub(mgr, ramenConfig)
@@ -280,9 +271,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	mgr, err := newManager(ctrlOptions)
+	restCfg := ctrl.GetConfigOrDie()
+
+	mgr, err := ctrl.NewManager(restCfg, *ctrlOptions)
 	if err != nil {
-		setupLog.Error(err, "unable to Get new manager")
+		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,9 +51,8 @@ import (
 )
 
 var (
-	scheme     = runtime.NewScheme()
-	setupLog   = ctrl.Log.WithName("setup")
-	configFile string
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
 )
 
 func init() {
@@ -79,11 +78,6 @@ func configureLogOptions() *zap.Options {
 // bindFlags takes a list of functions that bind flags to variables.
 // In addition, any ramen specific flags are bound here.
 func bindFlags(bindfuncs ...func(*flag.FlagSet)) {
-	flag.StringVar(&configFile, "config", "",
-		"The controller will load its initial configuration from this file. "+
-			"Omit this flag to use the default configuration values. "+
-			"Command-line flags override configuration from this file.")
-
 	for _, f := range bindfuncs {
 		f(flag.CommandLine)
 	}
@@ -281,7 +275,7 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(logOpts)))
 
-	ramenConfig := controllers.InitControllerDefaults(configFile, setupLog)
+	ramenConfig := controllers.InitControllerDefaults(setupLog)
 
 	restCfg := ctrl.GetConfigOrDie()
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -278,7 +278,7 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(logOpts)))
 
-	ramenConfig := controllers.LoadControllerConfig(configFile, setupLog)
+	ramenConfig := controllers.InitControllerDefaults(configFile, setupLog)
 
 	restCfg := ctrl.GetConfigOrDie()
 

--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -107,7 +107,7 @@ func DefaultRamenConfig(controllerType ramendrv1alpha1.ControllerType) *ramendrv
 	return cfg
 }
 
-func LoadControllerConfig(configFile string,
+func InitControllerDefaults(configFile string,
 	log logr.Logger,
 ) (ramenConfig *ramendrv1alpha1.RamenConfig) {
 	controllerType := os.Getenv("RAMEN_CONTROLLER_TYPE")

--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -107,7 +107,7 @@ func DefaultRamenConfig(controllerType ramendrv1alpha1.ControllerType) *ramendrv
 	return cfg
 }
 
-func InitControllerDefaults(configFile string,
+func InitControllerDefaults(
 	log logr.Logger,
 ) (ramenConfig *ramendrv1alpha1.RamenConfig) {
 	controllerType := os.Getenv("RAMEN_CONTROLLER_TYPE")


### PR DESCRIPTION
## Summary

Follow-up to #2552. Renames and restructures the startup functions to better
reflect what they do, with no behavior change.

- Rename `LoadControllerConfig` → `InitControllerDefaults` (it sets
  hardcoded defaults, not loads config)
- Split `buildOptions` into `syncConfig` (reads/merges ConfigMap) and
  `buildManagerOptions` (translates RamenConfig → ctrl.Options)
- Rename `configureController` → `registerSchemes` (reflects what it
  actually does); move the call after manager creation since only the
  base scheme is needed at that point
- Remove the unused `--config` flag and `configFile` variable (vestige
  of a file-based config path that no longer exists)

### New startup sequence

```
InitControllerDefaults → syncConfig → buildManagerOptions →
ctrl.NewManager → registerSchemes → setupReconcilers
```

## Test plan

- [ ] Verify the operator starts successfully (no behavior change expected)

Depends on #2552.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined controller startup and manager initialization for more reliable boot sequence.
  * Removed reliance on a file-based --config flag in favor of runtime config discovery.
  * Added automatic synchronization of controller configuration at startup.
  * Simplified flag binding and consolidated defaults initialization (internal API adjusted).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramen/pull/2553)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->