### PR TITLE
fix: prevent stale ramen_progression_state metrics from persisting

### DIFF
--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -68,6 +68,11 @@ const (
 
 var ErrInitialWaitTimeForDRPCPlacementRule = errors.New("waiting for DRPC Placement to produces placement decision")
 
+// Extend this metric to other DR progression(rmn.ProgressionState) states by adding them to the `states` slice.
+var trackedDRProgressionStates = []string{
+	string(rmn.ProgressionWaitOnUserToCleanUp),
+}
+
 // ProgressCallback of function type
 type ProgressCallback func(string, string)
 
@@ -419,15 +424,10 @@ func (r *DRPlacementControlReconciler) setDRProgressionStateMetric(drpc *rmn.DRP
 
 	log.Info(fmt.Sprintf("setting metric: (%s)", DRProgressionState))
 
-	// Extend this metric to other DR progression(rmn.ProgressionState) states by adding them to the `states` slice.
-	states := []string{
-		string(rmn.ProgressionWaitOnUserToCleanUp),
-	}
-
 	currentState := string(drpc.Status.Progression)
-	for _, state := range states {
-		labels := DRProgressionStateMetricLabels(drpc)
-		if state == currentState {
+	for _, trackedState := range trackedDRProgressionStates {
+		labels := DRProgressionStateMetricLabels(drpc, trackedState)
+		if trackedState == currentState {
 			drpcProgressionState.With(labels).Set(1)
 		} else {
 			drpcProgressionState.With(labels).Set(0)
@@ -553,17 +553,6 @@ func (r *DRPlacementControlReconciler) createCGEnabledMetricsInstance(
 
 	return &CGEnabledMetrics{
 		CGEnabled: cgEnabledMetrics.CGEnabled,
-	}
-}
-
-func (r *DRPlacementControlReconciler) createDRProgressionStateMetricsInstance(
-	drpc *rmn.DRPlacementControl,
-) *DRProgressionStateMetrics {
-	drProgressionStateLabels := DRProgressionStateMetricLabels(drpc)
-	drProgressionStateMetrics := NewDRPCProgressionStateMetric(drProgressionStateLabels)
-
-	return &DRProgressionStateMetrics{
-		DRProgressionState: drProgressionStateMetrics.DRProgressionState,
 	}
 }
 
@@ -852,8 +841,10 @@ func (r *DRPlacementControlReconciler) finalizeDRPC(ctx context.Context, drpc *r
 	cgEnabledMetricLabels := CGEnabledMetricLabels(drpc)
 	DeleteCGEnabledMetric(cgEnabledMetricLabels)
 
-	DRProgressionStateMetricsLabels := DRProgressionStateMetricLabels(drpc)
-	DeleteDRPCProgressionStateMetric(DRProgressionStateMetricsLabels)
+	for _, trackedState := range trackedDRProgressionStates {
+		labels := DRProgressionStateMetricLabels(drpc, trackedState)
+		DeleteDRPCProgressionStateMetric(labels)
+	}
 
 	globalActionLabels := GlobalActionLabels(drpc)
 	DeleteGlobalActionMetric(globalActionLabels)
@@ -1769,8 +1760,7 @@ func (r *DRPlacementControlReconciler) setDRPCMetrics(ctx context.Context,
 		r.setLastSyncBytesMetric(&syncMetrics.SyncDataBytesMetrics, drpc.Status.LastGroupSyncBytes, log)
 	}
 
-	appDRCleanupMetrics := r.createDRProgressionStateMetricsInstance(drpc)
-	r.setDRProgressionStateMetric(drpc, appDRCleanupMetrics, log)
+	r.setDRProgressionStateMetric(drpc, &DRProgressionStateMetrics{}, log)
 
 	return nil
 }

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -375,12 +375,13 @@ func DeleteInvalidCIDRsDetectedMetric(labels prometheus.Labels) bool {
 }
 
 func DRProgressionStateMetricLabels(drpc *rmn.DRPlacementControl,
+	state string,
 ) prometheus.Labels {
 	return prometheus.Labels{
 		ObjType:               "DRPlacementControl",
 		ObjName:               drpc.Name,
 		ObjNamespace:          drpc.Namespace,
-		ProgressionStateLabel: string(drpc.Status.Progression),
+		ProgressionStateLabel: state,
 	}
 }
 


### PR DESCRIPTION
The ramen_progression_state metric was not being properly unset when the DRPC progression state changed, causing stale metrics to persist with value 1 even after transitioning to a different state.

Root cause: The metric label included the current progression state, so when the state changed from "WaitOnUserToCleanUp" to "Cleaning Up", a new metric series was created with the new state in the label, while the old series remained unchanged at value 1.

Fix: Modified setDRProgressionStateMetric() to iterate through all tracked states and explicitly set each to either 1 (current state) or 0 (all other states). This ensures no stale metrics persist across state transitions.

Changes:
- Updated DRProgressionStateMetricLabels() to accept state as parameter instead of reading from drpc.Status.Progression
- Modified setDRProgressionStateMetric() to loop through trackedStates array and set each metric appropriately
- Ensures metric series are reused (set to 0) rather than left stale

The trackedStates array currently contains only WaitOnUserToCleanUp but can be easily extended to track additional progression states.

Fixes: Metric persistence issue where ramen_progression_state remained at 1 after DRPC transitioned from WaitOnUserToCleanUp to Cleaning Up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed progression-state metrics so each tracked state has explicit labels; metric value is 1 only for the current state and 0 for all other tracked states, improving accuracy.
  * Removed separate metric initialization; progression-state metrics are now set directly during status updates.
  * During finalization, progression-state metric entries are cleaned up per tracked state to prevent stale metric labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramen/pull/2555)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->