### PR TITLE
drenv: bump external-snapshotter to release-8.4 and rook to release-1.19 

### DIFF
--- a/test/drenv/addons/external_snapshotter/config.py
+++ b/test/drenv/addons/external_snapshotter/config.py
@@ -4,5 +4,5 @@
 from pathlib import Path
 
 PACKAGE_DIR = Path(__file__).parent
-CRDS_CACHE_KEY = "addons/external-snapshotter-crds-8.3.yaml"
-CONTROLLER_CACHE_KEY = "addons/external-snapshotter-controller-8.3.yaml"
+CRDS_CACHE_KEY = "addons/external-snapshotter-crds-8.4.yaml"
+CONTROLLER_CACHE_KEY = "addons/external-snapshotter-controller-8.4.yaml"

--- a/test/drenv/addons/external_snapshotter/start-data/controller/kustomization.yaml
+++ b/test/drenv/addons/external_snapshotter/start-data/controller/kustomization.yaml
@@ -1,7 +1,7 @@
 ---
 resources:
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
 namespace: kube-system
 patches:
   # Enable volume group replication support

--- a/test/drenv/addons/external_snapshotter/start-data/crds/kustomization.yaml
+++ b/test/drenv/addons/external_snapshotter/start-data/crds/kustomization.yaml
@@ -1,8 +1,8 @@
 ---
 resources:
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.3/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/client/config/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml

--- a/test/drenv/addons/odf_external_snapshotter/config.py
+++ b/test/drenv/addons/odf_external_snapshotter/config.py
@@ -4,4 +4,4 @@
 from pathlib import Path
 
 PACKAGE_DIR = Path(__file__).parent
-CACHE_KEY = "addons/odf-external-snapshotter-8.2.yaml"
+CACHE_KEY = "addons/odf-external-snapshotter-8.4.yaml"

--- a/test/drenv/addons/odf_external_snapshotter/start-data/crds/kustomization.yaml
+++ b/test/drenv/addons/odf_external_snapshotter/start-data/crds/kustomization.yaml
@@ -6,6 +6,6 @@ resources:
   - https://raw.githubusercontent.com/red-hat-storage/external-snapshotter/refs/heads/master/config/crd/bases/groupsnapshot.storage.openshift.io_volumegroupsnapshots.yaml
 
   # Standard CSI VolumeSnapshot CRDs
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
-  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.2/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+  - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.4/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml

--- a/test/drenv/addons/rook/cephfs/start-data/filesystem.yaml
+++ b/test/drenv/addons/rook/cephfs/start-data/filesystem.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable-line rule:line-length
-# Source: https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/filesystem-test.yaml
+# Source: https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/filesystem-test.yaml
 # Modifications:
 #  - Remove additional resource CephFilesystemSubVolumeGroup
 

--- a/test/drenv/addons/rook/cephfs/start-data/snapshot-class.yaml
+++ b/test/drenv/addons/rook/cephfs/start-data/snapshot-class.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable-line rule:line-length
-# Source: https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/csi/cephfs/snapshotclass.yaml
+# Source: https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/csi/cephfs/snapshotclass.yaml
 # Modifications:
 #  - Added storageID
 ---

--- a/test/drenv/addons/rook/cephfs/start-data/storage-class.yaml
+++ b/test/drenv/addons/rook/cephfs/start-data/storage-class.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable-line rule:line-length
-# Source: https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/csi/cephfs/storageclass.yaml
+# Source: https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/csi/cephfs/storageclass.yaml
 # Modifications:
 #  - Added storageID
 ---

--- a/test/drenv/addons/rook/cluster/__init__.py
+++ b/test/drenv/addons/rook/cluster/__init__.py
@@ -12,7 +12,7 @@ from drenv import commands
 from drenv import kubectl
 
 PACKAGE_DIR = Path(__file__).parent
-CACHE_KEY = "addons/rook-cluster-1.18.yaml"
+CACHE_KEY = "addons/rook-cluster-1.19.yaml"
 
 # The ceph, and ceph-csi images are very large (500m each), using larger
 # timeout to avoid timeouts with flaky network.

--- a/test/drenv/addons/rook/cluster/kustomization.yaml
+++ b/test/drenv/addons/rook/cluster/kustomization.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/cluster-test.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/cluster-test.yaml
 patches:
   - target:
       kind: CephCluster

--- a/test/drenv/addons/rook/operator/__init__.py
+++ b/test/drenv/addons/rook/operator/__init__.py
@@ -7,7 +7,7 @@ from drenv import cache as _cache
 from drenv import kubectl
 
 PACKAGE_DIR = Path(__file__).parent
-CACHE_KEY = "addons/rook-operator-1.18-5.yaml"
+CACHE_KEY = "addons/rook-operator-1.19.yaml"
 
 
 def start(cluster):

--- a/test/drenv/addons/rook/operator/kustomization.yaml
+++ b/test/drenv/addons/rook/operator/kustomization.yaml
@@ -4,9 +4,9 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/crds.yaml
-  - https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/common.yaml
-  - https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/operator.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/crds.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/common.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/operator.yaml
 
 patches:
   - target:

--- a/test/drenv/addons/rook/pool/snapshot-class.yaml
+++ b/test/drenv/addons/rook/pool/snapshot-class.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable rule:line-length
-# Drived from https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/csi/rbd/snapshotclass.yaml
+# Drived from https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/csi/rbd/snapshotclass.yaml
 ---
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass

--- a/test/drenv/addons/rook/toolbox/__init__.py
+++ b/test/drenv/addons/rook/toolbox/__init__.py
@@ -8,7 +8,7 @@ from drenv import ceph
 from drenv import kubectl
 
 PACKAGE_DIR = Path(__file__).parent
-CACHE_KEY = "addons/rook-toolbox-1.18.yaml"
+CACHE_KEY = "addons/rook-toolbox-1.19.yaml"
 
 
 def start(cluster):

--- a/test/drenv/addons/rook/toolbox/kustomization.yaml
+++ b/test/drenv/addons/rook/toolbox/kustomization.yaml
@@ -4,4 +4,4 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/toolbox.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/toolbox.yaml


### PR DESCRIPTION
1. Bump external-snapshotter to release-8.4 - point external_snapshotter and odf_external_snapshotter kustomize manifests at kubernetes-csi/external-snapshotter release-8.4 and rename addon cache keys so drenv rebuilds cached YAML.
2. Bump Rook drenv addon to release-1.19 - update remote manifests, source comments, and kustomize cache keys.
Rook version upgrade was added to this PR due to a dependency between it and newer external-snapshotter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped external-snapshotter references to release 8.4 across test manifests and configs.
  * Upgraded ODF external-snapshotter references to 8.4.
  * Updated Rook test manifests and tooling references from release 1.18 to 1.19.
  * Added a storage identifier label to the Rook CephFS snapshot class template.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramen/pull/2558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->