### PR TITLE
test: bump Rook drenv addon to release-1.19

### DIFF
--- a/test/drenv/addons/rook/cephfs/start-data/filesystem.yaml
+++ b/test/drenv/addons/rook/cephfs/start-data/filesystem.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable-line rule:line-length
-# Source: https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/filesystem-test.yaml
+# Source: https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/filesystem-test.yaml
 # Modifications:
 #  - Remove additional resource CephFilesystemSubVolumeGroup
 

--- a/test/drenv/addons/rook/cephfs/start-data/snapshot-class.yaml
+++ b/test/drenv/addons/rook/cephfs/start-data/snapshot-class.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable-line rule:line-length
-# Source: https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/csi/cephfs/snapshotclass.yaml
+# Source: https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/csi/cephfs/snapshotclass.yaml
 # Modifications:
 #  - Added storageID
 ---

--- a/test/drenv/addons/rook/cephfs/start-data/storage-class.yaml
+++ b/test/drenv/addons/rook/cephfs/start-data/storage-class.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable-line rule:line-length
-# Source: https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/csi/cephfs/storageclass.yaml
+# Source: https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/csi/cephfs/storageclass.yaml
 # Modifications:
 #  - Added storageID
 ---

--- a/test/drenv/addons/rook/cluster/__init__.py
+++ b/test/drenv/addons/rook/cluster/__init__.py
@@ -12,7 +12,7 @@ from drenv import commands
 from drenv import kubectl
 
 PACKAGE_DIR = Path(__file__).parent
-CACHE_KEY = "addons/rook-cluster-1.18.yaml"
+CACHE_KEY = "addons/rook-cluster-1.19.yaml"
 
 # The ceph, and ceph-csi images are very large (500m each), using larger
 # timeout to avoid timeouts with flaky network.

--- a/test/drenv/addons/rook/cluster/kustomization.yaml
+++ b/test/drenv/addons/rook/cluster/kustomization.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/cluster-test.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/cluster-test.yaml
 patches:
   - target:
       kind: CephCluster

--- a/test/drenv/addons/rook/operator/__init__.py
+++ b/test/drenv/addons/rook/operator/__init__.py
@@ -7,7 +7,7 @@ from drenv import cache as _cache
 from drenv import kubectl
 
 PACKAGE_DIR = Path(__file__).parent
-CACHE_KEY = "addons/rook-operator-1.18-5.yaml"
+CACHE_KEY = "addons/rook-operator-1.19.yaml"
 
 
 def start(cluster):

--- a/test/drenv/addons/rook/operator/kustomization.yaml
+++ b/test/drenv/addons/rook/operator/kustomization.yaml
@@ -4,9 +4,9 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/crds.yaml
-  - https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/common.yaml
-  - https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/operator.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/crds.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/common.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/operator.yaml
 
 patches:
   - target:

--- a/test/drenv/addons/rook/pool/snapshot-class.yaml
+++ b/test/drenv/addons/rook/pool/snapshot-class.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable rule:line-length
-# Drived from https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/csi/rbd/snapshotclass.yaml
+# Drived from https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/csi/rbd/snapshotclass.yaml
 ---
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass

--- a/test/drenv/addons/rook/toolbox/__init__.py
+++ b/test/drenv/addons/rook/toolbox/__init__.py
@@ -8,7 +8,7 @@ from drenv import ceph
 from drenv import kubectl
 
 PACKAGE_DIR = Path(__file__).parent
-CACHE_KEY = "addons/rook-toolbox-1.18.yaml"
+CACHE_KEY = "addons/rook-toolbox-1.19.yaml"
 
 
 def start(cluster):

--- a/test/drenv/addons/rook/toolbox/kustomization.yaml
+++ b/test/drenv/addons/rook/toolbox/kustomization.yaml
@@ -4,4 +4,4 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://raw.githubusercontent.com/rook/rook/release-1.18/deploy/examples/toolbox.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/toolbox.yaml


### PR DESCRIPTION
Update remote manifests, source comments, and kustomize cache keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Rook addon components and dependencies from version 1.18 to 1.19, updating all upstream example source references.
  * Updated internal cache keys across cluster, operator, and toolbox modules to reference newer Rook 1.19 manifests.
  * Enhanced CephFS storage class and snapshot class configurations with improved storage ID labeling for resource identification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramen/pull/2560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->