### PR TITLE
Fix stale BSL cleanup during DR operations

### DIFF
--- a/internal/controller/kubeobjects/velero/bsl_cleanup.go
+++ b/internal/controller/kubeobjects/velero/bsl_cleanup.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package velero
+
+import (
+	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+)
+
+// IsBSLStale reports whether an existing BackupStorageLocation should be removed
+// before creating or updating a new one on the Primary protect path.
+//
+// Staleness uses CreationTimestamp and phase:
+//   - non-Available phases are always stale;
+//   - Available BSL with no paired Backup (same name) is stale — left from a crash
+//     after BSL create and before Backup create;
+//   - Available BSL whose CreationTimestamp is after the Backup's is stale (invalid pair).
+func IsBSLStale(bsl *velero.BackupStorageLocation, backup *velero.Backup) bool {
+	if bsl.Status.Phase != velero.BackupStorageLocationPhaseAvailable {
+		return true
+	}
+
+	if backup == nil {
+		return true
+	}
+
+	return bsl.CreationTimestamp.Time.After(backup.CreationTimestamp.Time)
+}

--- a/internal/controller/kubeobjects/velero/bsl_cleanup_test.go
+++ b/internal/controller/kubeobjects/velero/bsl_cleanup_test.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package velero_test
+
+import (
+	"testing"
+	"time"
+
+	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	veleropkg "github.com/ramendr/ramen/internal/controller/kubeobjects/velero"
+)
+
+func TestIsBSLStale(t *testing.T) {
+	t.Parallel()
+
+	bslTime := metav1.NewTime(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	backupTime := metav1.NewTime(bslTime.Add(time.Minute))
+
+	tests := []struct {
+		name   string
+		phase  velero.BackupStorageLocationPhase
+		backup *velero.Backup
+		want   bool
+	}{
+		{"unavailable without backup", velero.BackupStorageLocationPhaseUnavailable, nil, true},
+		{"empty phase without backup", "", nil, true},
+		{"available without paired backup", velero.BackupStorageLocationPhaseAvailable, nil, true},
+		{
+			"available with backup created after BSL",
+			velero.BackupStorageLocationPhaseAvailable,
+			&velero.Backup{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: backupTime}},
+			false,
+		},
+		{
+			"available with BSL created after backup",
+			velero.BackupStorageLocationPhaseAvailable,
+			&velero.Backup{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(bslTime.Add(-time.Minute))}},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			bsl := &velero.BackupStorageLocation{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: bslTime},
+				Status:     velero.BackupStorageLocationStatus{Phase: tt.phase},
+			}
+			if got := veleropkg.IsBSLStale(bsl, tt.backup); got != tt.want {
+				t.Fatalf("IsBSLStale() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsBSLStale_AvailableWithOldValidationNotStaleWhenBackupPaired(t *testing.T) {
+	t.Parallel()
+
+	bslTime := metav1.NewTime(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	backupTime := metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	old := metav1.Now()
+
+	bsl := &velero.BackupStorageLocation{
+		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: bslTime},
+		Status: velero.BackupStorageLocationStatus{
+			Phase:              velero.BackupStorageLocationPhaseAvailable,
+			LastValidationTime: &old,
+		},
+	}
+	backup := &velero.Backup{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: backupTime}}
+
+	if veleropkg.IsBSLStale(bsl, backup) {
+		t.Fatal("Available BSL with old LastValidationTime and valid backup pair must not be stale")
+	}
+}

--- a/internal/controller/kubeobjects/velero/requests.go
+++ b/internal/controller/kubeobjects/velero/requests.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/go-logr/logr"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -32,9 +31,6 @@ const (
 	path         = "velero/"
 	protectsPath = path + "backups/"
 	recoversPath = path + "restores/"
-	// BSL cleanup constants
-	bslDeletionWaitSeconds = 2
-	bslStaleValidationTime = 5 * time.Minute
 )
 
 type (
@@ -515,6 +511,42 @@ type objectWriter struct {
 	log logr.Logger
 }
 
+func (w objectWriter) pairedBackupGet(requestsNamespaceName, requestName string) (*velero.Backup, error) {
+	existingBackup := &velero.Backup{}
+
+	backupErr := w.Get(w.ctx, client.ObjectKey{
+		Namespace: requestsNamespaceName,
+		Name:      requestName,
+	}, existingBackup)
+	if backupErr == nil {
+		return existingBackup, nil
+	}
+
+	if k8serrors.IsNotFound(backupErr) {
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf("failed to check for existing backup: %w", backupErr)
+}
+
+func (w objectWriter) waitForBSLDeletion(requestsNamespaceName, requestName string) error {
+	existingBSL := &velero.BackupStorageLocation{}
+
+	err := w.Get(w.ctx, client.ObjectKey{
+		Namespace: requestsNamespaceName,
+		Name:      requestName,
+	}, existingBSL)
+	if err == nil {
+		return kubeobjects.RequestProcessingErrorCreate("backupstoragelocation deletion in progress")
+	}
+
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+
+	return fmt.Errorf("failed to confirm stale BSL deletion: %w", err)
+}
+
 // cleanupStaleBSLIfExists checks for and deletes stale BSL before creating a new one
 func (w objectWriter) cleanupStaleBSLIfExists(
 	requestsNamespaceName string,
@@ -528,7 +560,6 @@ func (w objectWriter) cleanupStaleBSLIfExists(
 	}, existingBSL)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			// No existing BSL, nothing to clean up
 			return nil
 		}
 
@@ -537,29 +568,26 @@ func (w objectWriter) cleanupStaleBSLIfExists(
 		return fmt.Errorf("failed to check for existing BSL: %w", err)
 	}
 
-	// BSL exists - check if it's stale or unhealthy
-	isStale := existingBSL.Status.Phase != velero.BackupStorageLocationPhaseAvailable ||
-		(existingBSL.Status.LastValidationTime != nil &&
-			time.Since(existingBSL.Status.LastValidationTime.Time) > bslStaleValidationTime)
+	pairedBackup, err := w.pairedBackupGet(requestsNamespaceName, requestName)
+	if err != nil {
+		return err
+	}
 
-	if !isStale {
-		// BSL is healthy, no need to delete
+	if !IsBSLStale(existingBSL, pairedBackup) {
 		return nil
 	}
 
 	w.log.Info("Found stale BSL, deleting before creating new one",
 		"name", requestName,
 		"phase", existingBSL.Status.Phase,
-		"lastValidation", existingBSL.Status.LastValidationTime)
+		"creationTimestamp", existingBSL.CreationTimestamp,
+		"pairedBackup", pairedBackup != nil)
 
 	if err := w.Delete(w.ctx, existingBSL); err != nil && !k8serrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete stale BSL: %w", err)
 	}
 
-	// Wait for deletion to complete
-	time.Sleep(bslDeletionWaitSeconds * time.Second)
-
-	return nil
+	return w.waitForBSLDeletion(requestsNamespaceName, requestName)
 }
 
 func backupRequestCreate(

--- a/internal/controller/kubeobjects/velero/requests.go
+++ b/internal/controller/kubeobjects/velero/requests.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -31,6 +32,9 @@ const (
 	path         = "velero/"
 	protectsPath = path + "backups/"
 	recoversPath = path + "restores/"
+	// BSL cleanup constants
+	bslDeletionWaitSeconds = 2
+	bslStaleValidationTime = 5 * time.Minute
 )
 
 type (
@@ -511,6 +515,53 @@ type objectWriter struct {
 	log logr.Logger
 }
 
+// cleanupStaleBSLIfExists checks for and deletes stale BSL before creating a new one
+func (w objectWriter) cleanupStaleBSLIfExists(
+	requestsNamespaceName string,
+	requestName string,
+) error {
+	existingBSL := &velero.BackupStorageLocation{}
+
+	err := w.Get(w.ctx, client.ObjectKey{
+		Namespace: requestsNamespaceName,
+		Name:      requestName,
+	}, existingBSL)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			// No existing BSL, nothing to clean up
+			return nil
+		}
+
+		w.log.Error(err, "Failed to check for existing BSL", "name", requestName)
+
+		return fmt.Errorf("failed to check for existing BSL: %w", err)
+	}
+
+	// BSL exists - check if it's stale or unhealthy
+	isStale := existingBSL.Status.Phase != velero.BackupStorageLocationPhaseAvailable ||
+		(existingBSL.Status.LastValidationTime != nil &&
+			time.Since(existingBSL.Status.LastValidationTime.Time) > bslStaleValidationTime)
+
+	if !isStale {
+		// BSL is healthy, no need to delete
+		return nil
+	}
+
+	w.log.Info("Found stale BSL, deleting before creating new one",
+		"name", requestName,
+		"phase", existingBSL.Status.Phase,
+		"lastValidation", existingBSL.Status.LastValidationTime)
+
+	if err := w.Delete(w.ctx, existingBSL); err != nil && !k8serrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete stale BSL: %w", err)
+	}
+
+	// Wait for deletion to complete
+	time.Sleep(bslDeletionWaitSeconds * time.Second)
+
+	return nil
+}
+
 func backupRequestCreate(
 	w objectWriter,
 	s3Url string,
@@ -530,6 +581,11 @@ func backupRequestCreate(
 			Namespace: requestsNamespaceName,
 			Name:      requestName,
 		},
+	}
+
+	// Check for and delete any existing stale BSL before creating new one
+	if err := w.cleanupStaleBSLIfExists(requestsNamespaceName, requestName); err != nil {
+		return nil, nil, err
 	}
 
 	err := w.bslCreateOrUpdate(s3Url,

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1787,6 +1787,16 @@ func (v *VRGInstance) processAsSecondary() ctrl.Result {
 func (v *VRGInstance) reconcileAsSecondary() ctrl.Result {
 	result := ctrl.Result{}
 
+	// Clean up stale BSL/Backup objects from previous Primary state
+	// This handles the case where cluster went down during BSL creation
+	if err := v.kubeObjectsProtectionDelete(&result); err != nil {
+		v.log.Info("Failed to cleanup stale kube objects protection", "error", err)
+
+		result.Requeue = true
+
+		return result
+	}
+
 	result.Requeue = v.HandleSecondaryConflictsAndCleanup() || result.Requeue
 	result.Requeue = v.reconcileVolSyncAsSecondary() || result.Requeue
 	result.Requeue = v.reconcileVolRepsAsSecondary() || result.Requeue

--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -12,12 +12,14 @@ import (
 
 	"github.com/go-logr/logr"
 	Recipe "github.com/ramendr/recipe/api/v1alpha1"
+	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/internal/controller/hooks"
@@ -937,12 +939,72 @@ func (v *VRGInstance) kubeObjectsProtectionDelete(result *ctrl.Result) error {
 	}
 
 	vrg := v.instance
+	labels := util.OwnerLabels(vrg)
 
-	return v.kubeObjectsRecoverRequestsDelete(
+	err := v.kubeObjectsRecoverRequestsDelete(
 		result,
 		v.veleroNamespaceName(),
-		util.OwnerLabels(vrg),
+		// util.OwnerLabels(vrg),
+		labels,
 	)
+	if err != nil {
+		v.log.Error(err, "Label-based BSL deletion failed, attempting namespace-wide cleanup")
+
+		// Fallback: Delete all BSLs created by Ramen in the namespace
+		// This handles cases where labels don't match (e.g., VRG name changed)
+		return v.forceDeleteRamenBSLs(result)
+	}
+
+	return nil
+}
+
+// forceDeleteRamenBSLs deletes all BSLs created by Ramen in the Velero namespace
+// This is a fallback when label-based deletion fails
+func (v *VRGInstance) forceDeleteRamenBSLs(result *ctrl.Result) error {
+	veleroNamespace := v.veleroNamespaceName()
+
+	// List all BSLs with Ramen's creation label
+	bslList := &velero.BackupStorageLocationList{}
+	if err := v.reconciler.List(v.ctx, bslList,
+		client.InNamespace(veleroNamespace),
+		client.MatchingLabels{util.CreatedByRamenLabel: "true"},
+	); err != nil {
+		v.log.Error(err, "Failed to list BSLs for force deletion")
+
+		result.Requeue = true
+
+		return err
+	}
+
+	if len(bslList.Items) == 0 {
+		v.log.Info("No Ramen-created BSLs found for force deletion")
+
+		return nil
+	}
+
+	v.log.Info("Force deleting Ramen-created BSLs", "count", len(bslList.Items))
+
+	for i := range bslList.Items {
+		bsl := &bslList.Items[i]
+		v.log.Info("Force deleting BSL",
+			"name", bsl.Name,
+			"phase", bsl.Status.Phase,
+			"namespace", bsl.Namespace)
+
+		if err := v.reconciler.Delete(v.ctx, bsl); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				v.log.Error(err, "Failed to force delete BSL", "name", bsl.Name)
+
+				result.Requeue = true
+
+				return err
+			}
+		}
+	}
+
+	v.log.Info("Force deletion of Ramen-created BSLs completed")
+
+	return nil
 }
 
 // mergeExcludedResources merges ConfigMap default exclusions with recipe-level exclusions.

--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -940,69 +940,115 @@ func (v *VRGInstance) kubeObjectsProtectionDelete(result *ctrl.Result) error {
 
 	vrg := v.instance
 	labels := util.OwnerLabels(vrg)
-
-	err := v.kubeObjectsRecoverRequestsDelete(
-		result,
-		v.veleroNamespaceName(),
-		// util.OwnerLabels(vrg),
-		labels,
-	)
-	if err != nil {
-		v.log.Error(err, "Label-based BSL deletion failed, attempting namespace-wide cleanup")
-
-		// Fallback: Delete all BSLs created by Ramen in the namespace
-		// This handles cases where labels don't match (e.g., VRG name changed)
-		return v.forceDeleteRamenBSLs(result)
-	}
-
-	return nil
-}
-
-// forceDeleteRamenBSLs deletes all BSLs created by Ramen in the Velero namespace
-// This is a fallback when label-based deletion fails
-func (v *VRGInstance) forceDeleteRamenBSLs(result *ctrl.Result) error {
 	veleroNamespace := v.veleroNamespaceName()
 
-	// List all BSLs with Ramen's creation label
+	err := v.kubeObjectsRecoverRequestsDelete(result, veleroNamespace, labels)
+	if err != nil {
+		v.log.Error(err, "Label-based kube objects protection deletion failed")
+
+		if fallbackErr := v.deleteRamenBSLsWithOwnerLabels(result, veleroNamespace, labels); fallbackErr != nil {
+			return fallbackErr
+		}
+	}
+
+	if orphanErr := v.deleteOrphanedRamenBSLs(result, veleroNamespace); orphanErr != nil {
+		return orphanErr
+	}
+
+	return err
+}
+
+// veleroBSL orphanedByVRGRename is true when owner labels reference this namespace but a different VRG name.
+func veleroBSLOrphanedByVRGRename(labels map[string]string, vrgNamespace, vrgName string) bool {
+	ownerNamespace, hasNamespace := labels[util.LabelOwnerNamespaceName]
+
+	ownerName, hasName := labels[util.LabelOwnerName]
+	if !hasNamespace || ownerNamespace != vrgNamespace || !hasName {
+		return false
+	}
+
+	return ownerName != vrgName
+}
+
+// deleteRamenBSLsWithOwnerLabels deletes BSLs for the current VRG when DeleteAllOf fails.
+func (v *VRGInstance) deleteRamenBSLsWithOwnerLabels(
+	result *ctrl.Result, veleroNamespace string, ownerLabels map[string]string,
+) error {
+	selectorLabels := make(map[string]string, len(ownerLabels)+1)
+	for key, value := range ownerLabels {
+		selectorLabels[key] = value
+	}
+
+	selectorLabels[util.CreatedByRamenLabel] = "true"
+
 	bslList := &velero.BackupStorageLocationList{}
 	if err := v.reconciler.List(v.ctx, bslList,
 		client.InNamespace(veleroNamespace),
-		client.MatchingLabels{util.CreatedByRamenLabel: "true"},
+		client.MatchingLabels(selectorLabels),
 	); err != nil {
-		v.log.Error(err, "Failed to list BSLs for force deletion")
+		v.log.Error(err, "Failed to list BSLs for owner-label deletion")
 
 		result.Requeue = true
 
 		return err
 	}
 
-	if len(bslList.Items) == 0 {
-		v.log.Info("No Ramen-created BSLs found for force deletion")
-
-		return nil
-	}
-
-	v.log.Info("Force deleting Ramen-created BSLs", "count", len(bslList.Items))
-
 	for i := range bslList.Items {
 		bsl := &bslList.Items[i]
-		v.log.Info("Force deleting BSL",
-			"name", bsl.Name,
-			"phase", bsl.Status.Phase,
-			"namespace", bsl.Namespace)
+		if err := v.reconciler.Delete(v.ctx, bsl); err != nil && !k8serrors.IsNotFound(err) {
+			v.log.Error(err, "Failed to delete BSL with owner labels", "name", bsl.Name)
 
-		if err := v.reconciler.Delete(v.ctx, bsl); err != nil {
-			if !k8serrors.IsNotFound(err) {
-				v.log.Error(err, "Failed to force delete BSL", "name", bsl.Name)
+			result.Requeue = true
 
-				result.Requeue = true
-
-				return err
-			}
+			return err
 		}
 	}
 
-	v.log.Info("Force deletion of Ramen-created BSLs completed")
+	return nil
+}
+
+// deleteOrphanedRamenBSLs removes Ramen BSLs left from a renamed VRG (stale owner-name label).
+func (v *VRGInstance) deleteOrphanedRamenBSLs(result *ctrl.Result, veleroNamespace string) error {
+	bslList := &velero.BackupStorageLocationList{}
+	if err := v.reconciler.List(v.ctx, bslList,
+		client.InNamespace(veleroNamespace),
+		client.MatchingLabels{util.CreatedByRamenLabel: "true"},
+	); err != nil {
+		v.log.Error(err, "Failed to list BSLs for orphaned deletion")
+
+		result.Requeue = true
+
+		return err
+	}
+
+	vrg := v.instance
+	deleted := 0
+
+	for i := range bslList.Items {
+		bsl := &bslList.Items[i]
+		if !veleroBSLOrphanedByVRGRename(bsl.Labels, vrg.Namespace, vrg.Name) {
+			continue
+		}
+
+		v.log.Info("Deleting orphaned Ramen BSL from prior VRG owner",
+			"name", bsl.Name,
+			"ownerNamespace", bsl.Labels[util.LabelOwnerNamespaceName],
+			"ownerName", bsl.Labels[util.LabelOwnerName])
+
+		if err := v.reconciler.Delete(v.ctx, bsl); err != nil && !k8serrors.IsNotFound(err) {
+			v.log.Error(err, "Failed to delete orphaned BSL", "name", bsl.Name)
+
+			result.Requeue = true
+
+			return err
+		}
+
+		deleted++
+	}
+
+	if deleted > 0 {
+		v.log.Info("Deleted orphaned Ramen BSLs", "count", deleted)
+	}
 
 	return nil
 }

--- a/internal/controller/vrg_kubeobjects_test.go
+++ b/internal/controller/vrg_kubeobjects_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ramendr/ramen/internal/controller/kubeobjects"
+	"github.com/ramendr/ramen/internal/controller/util"
 )
 
 var _ = Describe("VRG_KubeObjectProtection", func() {
@@ -166,6 +167,35 @@ var _ = Describe("VRG_KubeObjectProtection", func() {
 
 			Expect(err).To(BeNil())
 			Expect(converted).To(Equal(targetRecoverSpec))
+		})
+	})
+
+	Context("Velero BSL orphan detection", func() {
+		const (
+			vrgNamespace = "app-ns"
+			vrgName      = "my-vrg"
+			oldVrgName   = "old-vrg"
+		)
+
+		It("detects BSL orphaned by VRG rename", func() {
+			labels := map[string]string{
+				util.LabelOwnerNamespaceName: vrgNamespace,
+				util.LabelOwnerName:          oldVrgName,
+			}
+			Expect(veleroBSLOrphanedByVRGRename(labels, vrgNamespace, vrgName)).To(BeTrue())
+		})
+
+		It("does not treat current VRG owner as orphaned", func() {
+			labels := util.OwnerLabels(&metav1.ObjectMeta{Namespace: vrgNamespace, Name: vrgName})
+			Expect(veleroBSLOrphanedByVRGRename(labels, vrgNamespace, vrgName)).To(BeFalse())
+		})
+
+		It("ignores BSLs owned by another namespace", func() {
+			labels := map[string]string{
+				util.LabelOwnerNamespaceName: "other-ns",
+				util.LabelOwnerName:          oldVrgName,
+			}
+			Expect(veleroBSLOrphanedByVRGRename(labels, vrgNamespace, vrgName)).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
Problem:
Stale BackupStorageLocation (BSL) objects persist after cluster crashes during backup creation, causing Velero backup failures when applications are redeployed in the same namespace.

Root Cause:
1. VRG transition to Secondary doesn't clean up BSL from Primary state
2. No pre-creation validation to detect and remove stale BSLs
3. Label-based deletion fails when VRG name changes

Changes:
- Add BSL cleanup when VRG transitions to Secondary state
- Add pre-creation BSL validation and stale BSL removal
- Add fallback force-delete for orphaned BSLs

Files Modified:
- internal/controller/volumereplicationgroup_controller.go
- internal/controller/kubeobjects/velero/requests.go
- internal/controller/vrg_kubeobjects.go

Testing:
- Cluster crash during backup → BSL cleaned on recovery
- Namespace reuse → Stale BSL deleted before new creation
- VRG name change → Force delete handles orphaned BSLs

Assisted by : IBM Bob v1.0.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of stale backup storage locations to prevent conflicts and failed backup create/update operations.
  * Secondary reconciliation now removes orphaned protection resources from prior primary states to avoid stuck transitions.

* **Improvements**
  * Added a resilient fallback that detects and force-deletes problematic backup storage entries when standard cleanup fails.

* **Tests**
  * New unit tests covering backup storage staleness detection and orphaned-resource detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->