### PR TITLE
ramenconfig: refresh dr-cluster CSV from hub subscription status

### DIFF
--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -475,8 +475,8 @@ func findHubOperatorSubscription(ctx context.Context, apiReader client.Reader,
 	return nil
 }
 
-func applyDrClusterOperatorFromSubscriptionSpec(
-	spec *operatorsv1alpha1.SubscriptionSpec,
+func applyDrClusterOperatorFromSubscription(
+	sub *operatorsv1alpha1.Subscription,
 	cfg *ramendrv1alpha1.RamenConfig,
 ) {
 	const (
@@ -484,13 +484,20 @@ func applyDrClusterOperatorFromSubscriptionSpec(
 		clusterSubstring = "-cluster-"
 	)
 
+	spec := sub.Spec
 	dco := &cfg.DrClusterOperator
 
 	dco.ChannelName = spec.Channel
 	dco.PackageName = strings.Replace(spec.Package, hubSubstring, clusterSubstring, 1)
 	dco.CatalogSourceName = spec.CatalogSource
 	dco.CatalogSourceNamespaceName = spec.CatalogSourceNamespace
-	dco.ClusterServiceVersionName = strings.Replace(spec.StartingCSV, hubSubstring, clusterSubstring, 1)
+	csvName := sub.Status.CurrentCSV
+
+	if csvName == "" {
+		csvName = spec.StartingCSV
+	}
+
+	dco.ClusterServiceVersionName = strings.Replace(csvName, hubSubstring, clusterSubstring, 1)
 }
 
 func updateDrClusterOperatorFromSubscription(ctx context.Context, apiReader client.Reader,
@@ -507,7 +514,7 @@ func updateDrClusterOperatorFromSubscription(ctx context.Context, apiReader clie
 		return
 	}
 
-	applyDrClusterOperatorFromSubscriptionSpec(sub.Spec, cfg)
+	applyDrClusterOperatorFromSubscription(sub, cfg)
 
 	if sub.Namespace == openshiftOperatorsNamespace {
 		cfg.DrClusterOperator.NamespaceName = openshiftDRSystemNamespace


### PR DESCRIPTION
### Problem: 
After an ODF hub upgrade clusterServiceVersionName in ramen-hub-operator-config stayed on subscription.spec.startingCSV

### Solution:
Use subscription.status.currentCSV so managed-cluster subscriptions target the installed hub CSV.

Fixes: https://redhat.atlassian.net/browse/DFBUGS-6919

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected DR cluster operator configuration to read the current active version from subscription status instead of the initial version specification, ensuring accurate cluster operator tracking.

* **Refactor**
  * Streamlined configuration code by consolidating duplicate helper functions and improving internal structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramen/pull/2563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->