### PR TITLE
config: Enable scc retention across peers by default

### DIFF
--- a/config/samples/ramendr_v1alpha1_ramenconfig.yaml
+++ b/config/samples/ramendr_v1alpha1_ramenconfig.yaml
@@ -32,4 +32,4 @@ drClusterOperator:
   catalogSourceNamespaceName: ramen-system
   clusterServiceVersionName: ramen-dr-cluster-operator.v0.0.1
 veleroNamespaceName: "openshift-adp"
-retainNamespaceSCCAcrossPeers: false
+retainNamespaceSCCAcrossPeers: true

--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -90,8 +90,9 @@ func DefaultRamenConfig(controllerType ramendrv1alpha1.ControllerType) *ramendrv
 			LeaderElect:  &leaderElect,
 			ResourceName: leaderElectionResourceName,
 		},
-		RamenOpsNamespace:         "ramen-ops",
-		VolumeUnprotectionEnabled: true,
+		RamenOpsNamespace:             "ramen-ops",
+		VolumeUnprotectionEnabled:     true,
+		RetainNamespaceSCCAcrossPeers: true,
 	}
 
 	cfg.DrClusterOperator.DeploymentAutomationEnabled = true


### PR DESCRIPTION
Default retainNamespaceSCCAcrossPeers to true

Retain Security Context Constraints annotations when creating namespaces on secondary clusters during DR enablement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration to enable namespace SCC retention across peers, ensuring consistent Security Context Constraint settings are maintained throughout the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramen/pull/2565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->