### PR TITLE
drenv: Pin ceph image to v20.2.0

### DIFF
--- a/test/drenv/addons/rook/cluster/__init__.py
+++ b/test/drenv/addons/rook/cluster/__init__.py
@@ -12,7 +12,7 @@ from drenv import commands
 from drenv import kubectl
 
 PACKAGE_DIR = Path(__file__).parent
-CACHE_KEY = "addons/rook-cluster-1.19.yaml"
+CACHE_KEY = "addons/rook-cluster-1.19-2.yaml"
 
 # The ceph, and ceph-csi images are very large (500m each), using larger
 # timeout to avoid timeouts with flaky network.

--- a/test/drenv/addons/rook/cluster/kustomization.yaml
+++ b/test/drenv/addons/rook/cluster/kustomization.yaml
@@ -29,3 +29,7 @@ patches:
           enabled: true
           periodicity: daily
           maxLogSize: 50M
+      # Last ceph image that worked on arm64. Since v20.2.1 rbd-mirror is broken on arm64.
+      - op: replace
+        path: /spec/cephVersion/image
+        value: quay.io/ceph/ceph:v20.2.0


### PR DESCRIPTION
Since ceph v20.2.1 was released rook test fail since rbd-mirror does not start on arm64. In drenv we see a timeout waiting for mirroring status in rbd-mirror addon when running on macOS (Apple silicon).

With this change we can run rook 1.19 on Apple silicon:

```console
% drenv start envs/rook.yaml
...
2026-05-20 20:22:16,319 INFO    [rook/0] Running addons/rbd-mirror/start
2026-05-20 20:23:22,409 INFO    [rook/0] addons/rbd-mirror/start completed in 66.09 seconds
2026-05-20 20:23:22,409 INFO    [rook/0] Running addons/rbd-mirror/test
2026-05-20 20:23:30,814 INFO    [rook/0] addons/rbd-mirror/test completed in 8.40 seconds
2026-05-20 20:23:30,814 INFO    [rook] Environment started in 236.08 seconds
```

Rook bug: https://github.com/rook/rook/issues/17568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rook cluster now pins Ceph to v20.2.0 to restore compatibility on arm64 and address known rbd-mirror failures.

* **Chores**
  * Updated cached addon manifest reference so deployments use the revised kustomization file.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramen/pull/2567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->