### PR TITLE
Fix VGR selector logic for offloaded storage and improve logging

### DIFF
--- a/internal/controller/util/secrets_util.go
+++ b/internal/controller/util/secrets_util.go
@@ -478,7 +478,7 @@ func (sutil *SecretsUtil) deletePolicyResources(
 ) error {
 	policyName, plBindingName, plRuleName, _ := GeneratePolicyResourceNames(secret.Name, format)
 
-	sutil.Log.Info("Deleting secret policy", "secret", secret.Name)
+	sutil.Log.Info("Deleting secret policy", "secret", secret.Name, "namespace", namespace)
 
 	plRuleBindingObject := &gppv1.PlacementBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -510,6 +510,7 @@ func (sutil *SecretsUtil) deletePolicyResources(
 			Namespace: namespace,
 		},
 	}
+
 	if err := sutil.Client.Delete(sutil.Ctx, plRuleObject); err != nil && !k8serrors.IsNotFound(err) {
 		sutil.Log.Error(err, "unable to delete placement rule", "secret", secret.Name)
 

--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -841,9 +841,10 @@ func (v *VRGInstance) createVGR(vrNamespacedName types.NamespacedName,
 	isGlobal := v.hasGlobalVGRLabel()
 
 	var selector *metav1.LabelSelector
-	if isGlobal {
+	if isGlobal || offloaded {
 		// Global VGRs are shared across VRGs, so select by consistency group only
 		// to include PVCs from all VRGs.
+		// Offloaded follow the same logic as global since they are also shared and not owned by VRG.
 		selector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				rmnutil.ConsistencyGroupLabel: cg,


### PR DESCRIPTION
Include offloaded volumes in the VGR label selector. PVC filtering is based on CG label only.

Fixes: https://redhat.atlassian.net/browse/DFBUGS-6756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made offloaded volume group replications use the same persistent volume claim selection logic as global configurations for improved consistency.
  * Improved logging when managing secret policy resources to include namespace information for better operational visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramen/pull/2570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->