### PR TITLE
Fix PVC leftover issue for subscription apps

### DIFF
--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -910,16 +910,22 @@ func (v *VRGInstance) pvcUnprotectVolSync(pvc corev1.PersistentVolumeClaim, log 
 
 // disownPVCs this function is disassociating all PVCs (targeted for VolSync replication) from its owner (VRG)
 func (v *VRGInstance) disownPVCs() error {
-	if v.instance.GetAnnotations()[DoNotDeletePVCAnnotation] != DoNotDeletePVCAnnotationVal {
-		return nil
-	}
+	vrgHasAnnotation := v.instance.GetAnnotations()[DoNotDeletePVCAnnotation] == DoNotDeletePVCAnnotationVal
 
 	for idx := range v.volSyncPVCs {
 		pvc := &v.volSyncPVCs[idx]
 
-		err := v.volSyncHandler.DisownVolSyncManagedPVC(pvc)
-		if err != nil {
-			return err
+		pvcHasAnnotation := pvc.GetAnnotations()[volsync.ACMAppSubDoNotDeleteAnnotation] ==
+			volsync.ACMAppSubDoNotDeleteAnnotationVal
+
+		// The VRG annotation is only set when Ramen is not the scheduler (ApplicationSet apps with
+		// default scheduler). For Subscription apps using Ramen scheduler, the VRG annotation is never
+		// set, but the PVC has the ACM annotation. Check both to handle all app types.
+		if vrgHasAnnotation || pvcHasAnnotation {
+			err := v.volSyncHandler.DisownVolSyncManagedPVC(pvc)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Change

The previous fix (PR #2504) only worked for ApplicationSet apps because it relied on a VRG annotation that is only set when using the default scheduler. Subscription apps use the Ramen scheduler, so the VRG annotation is never set and the cleanup code never runs.

This fix checks for both the VRG annotation (for ApplicationSet apps) and the PVC's ACM annotation (for subscription apps), ensuring PVCs are properly cleaned up for both app types.

Related: PR #2504

## Test results

Post deploying and enabling DR:

```bash
$ NAMESPACE=$(kubectl get drpc -A -o jsonpath='{.items[0].metadata.namespace}')
$ kubectl get drpc -n $NAMESPACE
NAME                   AGE     PREFERREDCLUSTER   FAILOVERCLUSTER   DESIREDSTATE   CURRENTSTATE
subscr-deploy-cephfs   3m34s   dr1                                                 Deployed

$ kubectl get vrg -n $NAMESPACE --context dr1
NAME                   DESIREDSTATE   CURRENTSTATE
subscr-deploy-cephfs   primary        Primary
```

```bash
$ kubectl get pvc -n $NAMESPACE --context dr1 -o yaml | grep "apps.open-cluster-management.io/do-not-delete"
      apps.open-cluster-management.io/do-not-delete: "true"
```

```bash
$ kubectl annotate vrg subscr-deploy-cephfs -n $NAMESPACE --context dr1 \
    drplacementcontrol.ramendr.openshift.io/do-not-delete-pvc- --overwrite
volumereplicationgroup.ramendr.openshift.io/subscr-deploy-cephfs annotated

$ kubectl get vrg subscr-deploy-cephfs -n $NAMESPACE --context dr1 -o yaml | \
    grep "drplacementcontrol.ramendr.openshift.io/do-not-delete-pvc" || \
    echo "VRG annotation REMOVED"
  VRG annotation REMOVED
```

```bash
$ kubectl delete drpc subscr-deploy-cephfs -n $NAMESPACE
drplacementcontrol.ramendr.openshift.io "subscr-deploy-cephfs" deleted
```

```bash
$ kubectl get pvc -n $NAMESPACE --context dr1 -w
NAME          STATUS        VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS      AGE
busybox-pvc   Terminating   pvc-ee7b4fab-f434-4d94-b267-cb5ca303599b   1Gi        RWX            rook-cephfs-fs1   5m43s
```

**Note**: PVC stuck in Terminating because pod was still using it

Unblock PVC Deletion:
```bash
$ kubectl delete pods --all -n $NAMESPACE --context dr1
pod "busybox-pvc" deleted
```

```bash
$ kubectl get pvc -n $NAMESPACE --context dr1
No resources found in test-subscr-deploy-cephfs namespace.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VolSync-managed volume disassociation logic to properly respect deletion policies configured at both the cluster level and per-volume level, enabling more flexible control over persistent volume retention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramen/pull/2572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->