### PR TITLE
Restore PV volume handle from annotation

### DIFF
--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -2869,6 +2869,17 @@ func (v *VRGInstance) cleanupPVForRestore(pv *corev1.PersistentVolume) error {
 		pv.Spec.ClaimRef.APIVersion = ""
 	}
 
+	// If the PV was annotated with a destination volume handle during S3 upload,
+	// replace the CSI volumeHandle so the PV references the correct volume on
+	// this (destination) cluster.
+	if pv.Spec.CSI != nil && pv.Annotations != nil {
+		if destHandle, ok := pv.Annotations[destinationVolumeHandleAnnotation]; ok && destHandle != "" {
+			v.log.V(1).Info("Set PV volume handle from destination handle", "PV", pv.Name, "handle", destHandle)
+			pv.Spec.CSI.VolumeHandle = destHandle
+			delete(pv.Annotations, destinationVolumeHandleAnnotation)
+		}
+	}
+
 	return v.processPVSecrets(pv)
 }
 


### PR DESCRIPTION
When restoring a PV, use the peer volume handle annotation to set the volume handle if it is present.
This restores the missing logic from the original volume group implementation.

Fixes: https://redhat.atlassian.net/browse/DFBUGS-6343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed CSI volume handle reconciliation during restore operations to properly maintain volume configuration consistency when restoring persistent volumes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramen/pull/2576?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->