### PR TITLE
recipe: clean up recipe MW/MCV on finalization and skip built-in VM recipe

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -3590,7 +3590,15 @@ func (d *DRPCInstance) filterSCCAnnotations(annotations map[string]string) (map[
 }
 
 func (d *DRPCInstance) ensureRecipeManifestWork(srcCluster, dstCluster string) error {
-	if d.instance.Spec.KubeObjectProtection == nil || d.instance.Spec.KubeObjectProtection.RecipeRef == nil {
+	if d.instance.Spec.KubeObjectProtection == nil ||
+		d.instance.Spec.KubeObjectProtection.RecipeRef == nil {
+		return nil
+	}
+
+	// Built-in VM recipe is embedded in the VRG controller and does not need
+	// to be propagated via ManifestWork.
+	if d.instance.Spec.KubeObjectProtection.RecipeRef.Name == recipecore.VMRecipeName &&
+		d.instance.Spec.KubeObjectProtection.RecipeRef.Namespace == RamenOperandsNamespace(*d.ramenConfig) {
 		return nil
 	}
 

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -881,6 +881,13 @@ func (r *DRPlacementControlReconciler) finalizeDRPC(ctx context.Context, drpc *r
 		}
 	}
 
+	// delete recipe manifestwork
+	for _, drClusterName := range rmnutil.DRPolicyClusterNames(drPolicy) {
+		if err := mwu.DeleteRecipeManifestWork(drClusterName); err != nil {
+			return err
+		}
+	}
+
 	// delete metrics if matching labels are found
 	syncTimeMetricLabels := SyncTimeMetricLabels(drPolicy, drpc)
 	DeleteSyncTimeMetric(syncTimeMetricLabels)
@@ -1003,6 +1010,18 @@ func (r *DRPlacementControlReconciler) deleteAllManagedClusterViews(
 		err = r.MCVGetter.DeleteNamespaceManagedClusterView(drpc.Name, drpc.Namespace, drClusterName, rmnutil.MWTypeNS)
 		if err != nil {
 			return fmt.Errorf("failed to delete namespace MCV %w", err)
+		}
+
+		// Delete MCV for Recipe
+		if drpc.Spec.KubeObjectProtection != nil &&
+			drpc.Spec.KubeObjectProtection.RecipeRef != nil {
+			recipeRef := drpc.Spec.KubeObjectProtection.RecipeRef
+
+			err = r.MCVGetter.DeleteRecipeManagedClusterView(
+				recipeRef.Name, recipeRef.Namespace, drClusterName)
+			if err != nil {
+				return fmt.Errorf("failed to delete recipe MCV %w", err)
+			}
 		}
 	}
 

--- a/internal/controller/fake_mcv_test.go
+++ b/internal/controller/fake_mcv_test.go
@@ -209,3 +209,9 @@ func (f FakeMCVGetter) GetRecipeFromManagedCluster(managedCluster, resourceName,
 ) (*recipev1.Recipe, error) {
 	return nil, nil
 }
+
+func (f FakeMCVGetter) DeleteRecipeManagedClusterView(
+	resourceName, resourceNamespace, clusterName string,
+) error {
+	return nil
+}

--- a/internal/controller/util/mcv_util.go
+++ b/internal/controller/util/mcv_util.go
@@ -106,6 +106,8 @@ type ManagedClusterViewGetter interface {
 	DeleteNamespaceManagedClusterView(resourceName, resourceNamespace, clusterName, resourceType string) error
 
 	DeleteNFManagedClusterView(resourceName, resourceNamespace, clusterName, resourceType string) error
+
+	DeleteRecipeManagedClusterView(resourceName, resourceNamespace, clusterName string) error
 }
 
 type ManagedClusterViewGetterImpl struct {
@@ -653,6 +655,15 @@ func (m ManagedClusterViewGetterImpl) DeleteDRClusterConfigManagedClusterView(cl
 	mcvNameDRCConfig := BuildManagedClusterViewName(clusterName, "", MWTypeDRCConfig)
 
 	return m.DeleteManagedClusterView(clusterName, mcvNameDRCConfig, logger)
+}
+
+func (m ManagedClusterViewGetterImpl) DeleteRecipeManagedClusterView(
+	resourceName, resourceNamespace, clusterName string,
+) error {
+	logger := ctrl.Log.WithName("MCV").WithValues("resouceName", resourceName)
+	mcvName := BuildManagedClusterViewName(resourceName, resourceNamespace, "recipe")
+
+	return m.DeleteManagedClusterView(clusterName, mcvName, logger)
 }
 
 func (m ManagedClusterViewGetterImpl) DeleteManagedClusterView(clusterName, mcvName string, logger logr.Logger) error {

--- a/internal/controller/util/mw_util.go
+++ b/internal/controller/util/mw_util.go
@@ -735,6 +735,31 @@ func (mwu *MWUtil) DeleteNamespaceManifestWork(clusterName string, annotations m
 	return nil
 }
 
+func (mwu *MWUtil) DeleteRecipeManifestWork(clusterName string) error {
+	mwName := mwu.BuildManifestWorkName(MWTypeRecipe)
+	mw := &ocmworkv1.ManifestWork{}
+
+	err := mwu.Client.Get(mwu.Ctx, types.NamespacedName{Name: mwName, Namespace: clusterName}, mw)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to retrieve manifestwork for type: %s. Error: %w", mwName, err)
+	}
+
+	if ResourceIsDeleted(mw) {
+		return nil
+	}
+
+	err = mwu.DeleteManifestWork(mwName, clusterName)
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	return nil
+}
+
 func (mwu *MWUtil) DeleteManifestWork(mwName, mwNamespace string) error {
 	mwu.Log.Info("Delete ManifestWork from", "namespace", mwNamespace, "name", mwName)
 


### PR DESCRIPTION
Fix two issues in Recipe ManifestWork propagation introduced in commit
235e849d:

1. Add cleanup of Recipe ManifestWork and ManagedClusterView during DRPC
   finalization. Previously only Namespace MWs and MCVs were cleaned up,
   leaving Recipe MW and MCV objects on the hub as orphans.

2. Skip Recipe MW propagation for the built-in VM recipe (vm-recipe).
   The VM recipe is an embedded constant in the VRG controller
   (core/recipes.go) and never exists as a CR on any managed cluster.
   Attempting to fetch it via MCV would fail. The VRG controller on the
   destination already loads it from the embedded YAML.

Assisted-by: Claude Code/claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents nil-reference errors when recipe protection settings are missing.

* **Improvements**
  * Skips redundant propagation for the built-in VM recipe to avoid unnecessary remote lookups.
  * Enhances finalization to remove recipe-related ManifestWork and view artifacts from DR clusters.

* **Tests**
  * Added/updated test stubs to validate recipe-related cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->