### PR TITLE
Restrict dryRun test failover for CephFS volumes and raise proper errors if done so

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -579,25 +579,44 @@ func (d *DRPCInstance) monitorTestFailoverCleanup() (bool, error) {
 	return false, nil
 }
 
+func (d *DRPCInstance) validateDryRunConfiguration() error {
+	if d.instance.Spec.Action != rmn.ActionFailover {
+		err := fmt.Errorf("dryRun is enabled but action is not failover")
+		d.reconciler.recordFailure(d.ctx, d.instance, d.userPlacement, "ValidationFailed", err.Error(), d.log)
+
+		return err
+	}
+
+	// During dryRun, last-app-deployment-cluster always points to where the app is currently running
+	// (it's not updated during test failover). We cannot test failover to the same cluster.
+	lastAppCluster := d.instance.GetAnnotations()[LastAppDeploymentCluster]
+	if d.instance.Spec.FailoverCluster == lastAppCluster {
+		err := fmt.Errorf(
+			"dryRun is enabled, but cannot test failover to cluster %s where the application is currently running",
+			lastAppCluster)
+		d.reconciler.recordFailure(d.ctx, d.instance, d.userPlacement, "ValidationFailed", err.Error(), d.log)
+
+		return err
+	}
+
+	// Check if workload uses VolSync (CephFS) - DryRun test failover only supports VolumeReplication (RBD)
+	if lastAppCluster != "" {
+		vrg, err := d.getVRGFromManifestWork(lastAppCluster)
+		if err == nil && vrg != nil && len(vrg.Spec.VolSync.RDSpec) > 0 {
+			err := fmt.Errorf("dryRun test failover is not supported for VolSync (CephFS) volumes")
+			d.reconciler.recordFailure(d.ctx, d.instance, d.userPlacement, "ValidationFailed", err.Error(), d.log)
+
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (d *DRPCInstance) executeAction() (bool, error) {
 	// Validate dryRun configuration
 	if d.instance.Spec.DryRun {
-		if d.instance.Spec.Action != rmn.ActionFailover {
-			err := fmt.Errorf("dryRun is enabled but action is not failover")
-			d.reconciler.recordFailure(d.ctx, d.instance, d.userPlacement, "ValidationFailed", err.Error(), d.log)
-
-			return false, err
-		}
-
-		// During dryRun, last-app-deployment-cluster always points to where the app is currently running
-		// (it's not updated during test failover). We cannot test failover to the same cluster.
-		lastAppCluster := d.instance.GetAnnotations()[LastAppDeploymentCluster]
-		if d.instance.Spec.FailoverCluster == lastAppCluster {
-			err := fmt.Errorf(
-				"dryRun is enabled, but cannot test failover to cluster %s where the application is currently running",
-				lastAppCluster)
-			d.reconciler.recordFailure(d.ctx, d.instance, d.userPlacement, "ValidationFailed", err.Error(), d.log)
-
+		if err := d.validateDryRunConfiguration(); err != nil {
 			return false, err
 		}
 	}

--- a/internal/controller/drplacementcontrol_dryrun_test.go
+++ b/internal/controller/drplacementcontrol_dryrun_test.go
@@ -5,14 +5,17 @@ package controllers_test
 
 import (
 	"context"
+	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	clrapiv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	ocmworkv1 "open-cluster-management.io/api/work/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
@@ -348,6 +351,89 @@ var _ = Describe("DRPCDryRunTestFailover", func() {
 
 				Expect(drpc.Spec.DryRun).To(BeFalse())
 				Expect(drpc.Spec.Action).To(Equal(rmn.ActionFailover))
+			})
+		})
+
+		Context("When DryRun is set on VolSync workload", func() {
+			It("should reject DryRun - CephFS not supported", func() {
+				// Setup: Create VRG with VolSync RDSpec (indicates CephFS workload)
+				vrg := &rmn.VolumeReplicationGroup{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "VolumeReplicationGroup",
+						APIVersion: "ramendr.openshift.io/v1alpha1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-vrg",
+						Namespace: drpc.Namespace,
+					},
+					Spec: rmn.VolumeReplicationGroupSpec{
+						PVCSelector:      drpc.Spec.PVCSelector,
+						ReplicationState: rmn.Primary,
+						VolSync: rmn.VolSyncSpec{
+							RDSpec: []rmn.VolSyncReplicationDestinationSpec{
+								{
+									ProtectedPVC: rmn.ProtectedPVC{
+										Name: "test-cephfs-pvc",
+									},
+								},
+							},
+						},
+					},
+				}
+
+				// Create VRG ManifestWork on East1 (current primary cluster)
+				mwName := "ramen-vrg-test-drpc"
+
+				// Properly serialize VRG to JSON for ManifestWork
+				vrgJSON, err := json.Marshal(vrg)
+				Expect(err).NotTo(HaveOccurred())
+
+				mw := &ocmworkv1.ManifestWork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      mwName,
+						Namespace: East1ManagedCluster,
+					},
+					Spec: ocmworkv1.ManifestWorkSpec{
+						Workload: ocmworkv1.ManifestsTemplate{
+							Manifests: []ocmworkv1.Manifest{
+								{
+									RawExtension: runtime.RawExtension{
+										Raw: vrgJSON,
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(context.TODO(), mw)).To(Succeed())
+
+				// Setup DRPC with last-app-deployment-cluster annotation BEFORE creating it
+				if drpc.Annotations == nil {
+					drpc.Annotations = make(map[string]string)
+				}
+
+				drpc.Annotations["drplacementcontrol.ramendr.openshift.io/last-app-deployment-cluster"] = East1ManagedCluster
+				drpc.Spec.Action = rmn.ActionFailover
+				drpc.Spec.PreferredCluster = East1ManagedCluster
+				drpc.Spec.FailoverCluster = West1ManagedCluster
+				drpc.Spec.DryRun = true
+
+				Expect(k8sClient.Create(context.TODO(), drpc)).To(Succeed())
+
+				// Verify DRPC was created
+				Eventually(func() error {
+					return apiReader.Get(context.TODO(), drpcNamespacedName, drpc)
+				}, timeout, interval).Should(Succeed())
+
+				// The controller should reject DryRun for VolSync and not progress
+				// Verify Phase remains empty (validation blocks progression)
+				Consistently(func() rmn.DRState {
+					if err := apiReader.Get(context.TODO(), drpcNamespacedName, drpc); err != nil {
+						return ""
+					}
+
+					return drpc.Status.Phase
+				}, "3s", interval).Should(BeEmpty(), "Phase should remain empty - DryRun rejected for VolSync workload")
 			})
 		})
 	})

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -3501,13 +3501,6 @@ func (v *VRGInstance) ensureSnapshotsForDryRun() error {
 		return fmt.Errorf("filtering non-CephFS PVCs: %w", err)
 	}
 
-	// If no PVCs need snapshots, we're done
-	if len(nonCephFSPVCs) == 0 {
-		v.log.Info("No snapshots needed - all PVCs are CephFS")
-
-		return nil
-	}
-
 	// Collect unique namespaces from non-CephFS PVCs only
 	namespaces := make(map[string]bool)
 	for _, pvc := range nonCephFSPVCs {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dry-run validation for disaster recovery failover to reject invalid configurations when VolSync uses CephFS storage.
  * Enhanced dry-run snapshot creation to properly filter and handle non-CephFS volumes.

* **Tests**
  * Added test coverage for dry-run validation scenarios with VolSync/CephFS workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->