### PR TITLE
test/timestamp: Add timestamp tool for profiling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,10 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# Ignore all files which are not go type
-!**/*.go
-!**/*.mod
-!**/*.sum
+# Ignore everything
+*
+# Except what the Dockerfile needs.
+!go.mod
+!go.sum
+!api/
+!cmd/
+!internal/
+!LICENSE

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -192,3 +192,24 @@ jobs:
       - name: Run black
         run: make black
         working-directory: ramendev
+
+  timestamp:
+    name: timestamp
+    strategy:
+      matrix:
+        os:
+          - ubuntu-24.04
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Setup go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: test/timestamp/go.mod
+
+      - name: Run tests
+        run: make test
+        working-directory: test/timestamp

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ ginkgo.report
 
 # Output files
 out/
+
+# Test programs
+/test/timestamp/timestamp

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,9 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /
 COPY --from=builder /workspace/manager .
 
-# copy licenses to license folder
+# Copy the license.
 RUN mkdir -p licenses
-COPY LICENSES/Apache-2.0.txt licenses/Apache-2.0.txt
+COPY LICENSE licenses/Apache-2.0.txt
 
 USER 65532:65532
 

--- a/Makefile
+++ b/Makefile
@@ -100,11 +100,15 @@ help: ## Display this help.
 
 ##@ Development
 
+# Use import paths, not filesystem ./..., to avoid traversing nested modules.
+# https://github.com/kubernetes-sigs/controller-tools/issues/1421
+CONTROLLER_GEN_PATHS := {github.com/ramendr/ramen/...,github.com/ramendr/ramen/api/...}
+
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=operator-role crd:generateEmbeddedObjectMeta=true webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=operator-role crd:generateEmbeddedObjectMeta=true webhook paths='$(CONTROLLER_GEN_PATHS)' output:crd:artifacts:config=config/crd/bases
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths='$(CONTROLLER_GEN_PATHS)'
 
 
 # golangci-lint has a limitation that it doesn't lint subdirectories if

--- a/test/timestamp/Makefile
+++ b/test/timestamp/Makefile
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Use auto toolchain so go can satisfy go.mod on distros that default to local.
+export GOTOOLCHAIN := auto
+
+.PHONY: timestamp test
+
+timestamp:
+	CGO_ENABLED=0 go build -ldflags="-s -w" -o timestamp main.go
+
+test: timestamp
+	go test -v .

--- a/test/timestamp/README.md
+++ b/test/timestamp/README.md
@@ -1,0 +1,58 @@
+# timestamp
+
+Prefix each line of `stdout` and `stderr` with elapsed seconds since the command
+started (`[seconds.mmm]`). Useful for profiling commands that do not log timing
+themselves, such as `podman build`, `minikube start`, or long CI steps.
+
+## Build
+
+```console
+make
+```
+
+The binary is `timestamp` in this directory (gitignored).
+
+## Test
+
+```console
+make test
+```
+
+Builds `timestamp` first, then runs the tests.
+
+## Usage
+
+```console
+./timestamp <command> [arguments...]
+```
+
+Example:
+
+```console
+$ ./timestamp bash -c 'echo first; echo second; sleep 1.234; echo last'
+[    0.000] bash -c "echo first; echo second; sleep 1.234; echo last"
+[    0.020] first
+[    0.020] second
+[    1.259] last
+```
+
+The first line is printed at `0.000` with the command being timed. Without it,
+the first timestamp appears only when the command prints output, hiding startup
+time.
+
+Exit status matches the wrapped command.
+
+## Notes
+
+- Timestamps are per line (`\n`). Output without a newline is stamped when the
+  process exits. Elapsed time is measured from when the child process starts,
+  with millisecond precision.
+
+- The child uses pipes, not a TTY, so programs may buffer output. Timestamps
+  reflect when this tool reads a line, not when the child wrote it.
+
+- Stdin is passed through so the command can consume stdin. When a command stops
+  to wait for input, a plain wall-clock timer includes the wait; with
+  `timestamp` you can see exactly when output resumes after the prompt.
+
+- Arguments are quoted when needed so the line is copy-pasteable in a shell.

--- a/test/timestamp/go.mod
+++ b/test/timestamp/go.mod
@@ -1,0 +1,3 @@
+module github.com/ramendr/ramen/test/timestamp
+
+go 1.26

--- a/test/timestamp/main.go
+++ b/test/timestamp/main.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// shellSpecialChars lists characters that make an argv token unsafe to paste unquoted.
+const shellSpecialChars = ` '"\;|&$><*?#~!()[]{}` + "\t`"
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "Usage: timestamp <command> [arguments...]")
+		os.Exit(1)
+	}
+
+	targetCmd := os.Args[1]
+	targetArgs := os.Args[2:]
+
+	cmd := exec.Command(targetCmd, targetArgs...)
+
+	// Pass stdin to the child process so commands like "podman build -f -"
+	// can read from a heredoc or pipe.
+	cmd.Stdin = os.Stdin
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error allocating stdout pipe: %v\n", err)
+		os.Exit(1)
+	}
+
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error allocating stderr pipe: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error executing '%v': %v\n", cmd, err)
+		os.Exit(127) // Standard UNIX exit code for command not found
+	}
+
+	start := time.Now()
+
+	// Synthesize the start log at 0.000 to make the output clearer. Without it,
+	// the first timestamp appears when the command prints its first line.
+	// Quoting is reconstructed from argv so the line is copy-pasteable in a shell.
+	// [    0.000] bash -c "sleep 1; echo it works"
+	// [    1.022] it works
+	fmt.Fprintf(os.Stdout, "[%9.3f] %s\n", 0.0, quotedCommand(os.Args[1:]))
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		processStream(stdoutPipe, os.Stdout, start)
+	}()
+
+	go func() {
+		defer wg.Done()
+		processStream(stderrPipe, os.Stderr, start)
+	}()
+
+	wg.Wait()
+
+	if err := cmd.Wait(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitErr.ExitCode())
+		}
+		fmt.Fprintf(os.Stderr, "Error harvesting process termination status: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func quotedCommand(args []string) string {
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		if arg == "" || strings.ContainsAny(arg, shellSpecialChars) {
+			arg = strconv.Quote(arg)
+		}
+		quoted[i] = arg
+	}
+	return strings.Join(quoted, " ")
+}
+
+func processStream(pipe io.Reader, outputStream *os.File, start time.Time) {
+	reader := bufio.NewReader(pipe)
+	for {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			elapsed := time.Since(start).Seconds()
+			fmt.Fprintf(outputStream, "[%9.3f] %s", elapsed, line)
+		}
+		if err != nil {
+			if err != io.EOF {
+				elapsed := time.Since(start).Seconds()
+				fmt.Fprintf(os.Stderr, "[%9.3f] timestamp: error reading stream: %v\n", elapsed, err)
+			}
+			break // Pipe closed
+		}
+	}
+}

--- a/test/timestamp/main_test.go
+++ b/test/timestamp/main_test.go
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main_test
+
+import (
+	"bytes"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var linePrefix = regexp.MustCompile(`^\[\s*\d+\.\d{3}\] `)
+
+type result struct {
+	exit   int
+	stdout string
+	stderr string
+}
+
+func TestStdout(t *testing.T) {
+	r := run(t, "./timestamp", "echo", "hello")
+	checkExit(t, r.exit, 0)
+	checkTimestampStream(t, r.stdout, "echo hello", "hello")
+	checkTimestampStream(t, r.stderr)
+}
+
+func TestEmptyArgument(t *testing.T) {
+	r := run(t, "./timestamp", "echo", "")
+	checkExit(t, r.exit, 0)
+	checkTimestampStream(t, r.stdout, `echo ""`, "")
+	checkTimestampStream(t, r.stderr)
+}
+
+func TestQuotedCommand(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "apostrophe without space",
+			args: []string{"it's"},
+			want: `true "it's"`,
+		},
+		{
+			name: "space only",
+			args: []string{" "},
+			want: `true " "`,
+		},
+		{
+			name: "tab only",
+			args: []string{"\t"},
+			want: `true "\t"`,
+		},
+		{
+			name: "tab in argument",
+			args: []string{"a\tb"},
+			want: `true "a\tb"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command("./timestamp", append([]string{"true"}, tc.args...)...)
+			r := runCmd(t, cmd)
+			checkExit(t, r.exit, 0)
+			checkTimestampStream(t, r.stdout, tc.want)
+			checkTimestampStream(t, r.stderr)
+		})
+	}
+}
+
+func TestStderr(t *testing.T) {
+	r := run(t, "./timestamp", "sh", "-c", "echo err >&2")
+	checkExit(t, r.exit, 0)
+	checkTimestampStream(t, r.stdout, `sh -c "echo err >&2"`)
+	checkTimestampStream(t, r.stderr, "err")
+}
+
+func TestStdoutAndStderr(t *testing.T) {
+	r := run(t, "./timestamp", "sh", "-c", "echo out; echo err >&2")
+	checkExit(t, r.exit, 0)
+	checkTimestampStream(t, r.stdout, `sh -c "echo out; echo err >&2"`, "out")
+	checkTimestampStream(t, r.stderr, "err")
+}
+
+func TestExitFailure(t *testing.T) {
+	r := run(t, "./timestamp", "false")
+	checkExit(t, r.exit, 1)
+	checkTimestampStream(t, r.stdout, "false")
+	checkTimestampStream(t, r.stderr)
+}
+
+func TestNoCommand(t *testing.T) {
+	r := run(t, "./timestamp")
+	checkExit(t, r.exit, 1)
+	checkTimestampStream(t, r.stdout)
+	checkStream(t, r.stderr, "Usage: timestamp <command>")
+}
+
+func TestMissingCommand(t *testing.T) {
+	r := run(t, "./timestamp", "timestamp-test-nonexistent")
+	checkExit(t, r.exit, 127)
+	checkTimestampStream(t, r.stdout)
+	checkStream(t, r.stderr, "executable file not found")
+}
+
+func TestStdin(t *testing.T) {
+	cmd := exec.Command("./timestamp", "cat")
+	cmd.Stdin = strings.NewReader("hello from stdin\n")
+	r := runCmd(t, cmd)
+	checkExit(t, r.exit, 0)
+	checkTimestampStream(t, r.stdout, "cat", "hello from stdin")
+	checkTimestampStream(t, r.stderr)
+}
+
+func run(t *testing.T, program string, args ...string) result {
+	t.Helper()
+	cmd := exec.Command(program, args...)
+	return runCmd(t, cmd)
+}
+
+func runCmd(t *testing.T, cmd *exec.Cmd) result {
+	t.Helper()
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	r := result{stdout: stdout.String(), stderr: stderr.String()}
+	if err == nil {
+		return r
+	}
+
+	exit, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("run %v: %v", cmd, err)
+	}
+
+	r.exit = exit.ExitCode()
+	return r
+}
+
+func checkExit(t *testing.T, exit, want int) {
+	t.Helper()
+
+	if exit != want {
+		t.Fatalf("exit = %d, want %d", exit, want)
+	}
+}
+
+func checkStream(t *testing.T, got, want string) {
+	t.Helper()
+
+	if !strings.Contains(got, want) {
+		t.Fatalf("stderr = %q, want substring %q", got, want)
+	}
+}
+
+func checkTimestampStream(t *testing.T, got string, want ...string) {
+	t.Helper()
+
+	if len(want) == 0 {
+		if got != "" {
+			t.Fatalf("got %q, want empty", got)
+		}
+		return
+	}
+
+	lines := strings.Split(strings.TrimSuffix(got, "\n"), "\n")
+	if len(lines) != len(want) {
+		t.Fatalf("got %q, want %v", got, want)
+	}
+
+	for i, line := range lines {
+		if !linePrefix.MatchString(line) {
+			t.Fatalf("line %d missing timestamp: %q", i, line)
+		}
+		idx := strings.Index(line, "] ")
+		if got := line[idx+2:]; got != want[i] {
+			t.Fatalf("line %d: got %q, want %q", i, got, want[i])
+		}
+	}
+}


### PR DESCRIPTION
Adds a `timestamp` tool to wrap and profile arbitrary commands. This allows profiling commands which do not provide builtin timestamps like `podman build` to understand where time is spent.

## Example usage

```console
% ./timestamp bash -c 'echo first; echo second; sleep 1.234; echo last'
[    0.000] bash -c "echo first; echo second; sleep 1.234; echo last"
[    0.020] first
[    0.020] second
[    1.259] last
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a timestamp utility that prefixes each stdout/stderr line with an elapsed-seconds timestamp and preserves child exit codes.

* **Documentation**
  * Added a user guide with build/test instructions, CLI usage, examples, and notes on buffering and stdin behavior.

* **Tests**
  * Added integration tests validating timestamp prefixes, stream capture, exit codes, and error cases.

* **Chores**
  * Added CI job for the timestamp tests, updated ignore rules, and scoped generation/build targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->