### PR TITLE
label all ramen-created resources with CreatedByRamen

### DIFF
--- a/internal/controller/cephfscg/replicationgroupdestination.go
+++ b/internal/controller/cephfscg/replicationgroupdestination.go
@@ -393,12 +393,16 @@ func (m *rgdMachine) CreateReplicationDestinations(
 // getMoverConfig maps the MoverConfig defined in the ReplicationDestination (RD) spec
 // into a VolSync MoverConfig
 func getMoverConfig(rdSpec ramendrv1alpha1.VolSyncReplicationDestinationSpec) volsyncv1alpha1.MoverConfig {
-	if rdSpec.MoverConfig == nil {
-		return volsyncv1alpha1.MoverConfig{}
+	mc := volsyncv1alpha1.MoverConfig{
+		MoverPodLabels: map[string]string{
+			util.CreatedByRamenLabel: "true",
+		},
 	}
 
-	return volsyncv1alpha1.MoverConfig{
-		MoverSecurityContext: rdSpec.MoverConfig.MoverSecurityContext,
-		MoverServiceAccount:  rdSpec.MoverConfig.MoverServiceAccount,
+	if rdSpec.MoverConfig != nil {
+		mc.MoverSecurityContext = rdSpec.MoverConfig.MoverSecurityContext
+		mc.MoverServiceAccount = rdSpec.MoverConfig.MoverServiceAccount
 	}
+
+	return mc
 }

--- a/internal/controller/cephfscg/volumegroupsourcehandler.go
+++ b/internal/controller/cephfscg/volumegroupsourcehandler.go
@@ -527,11 +527,15 @@ func (h *volumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVC
 			}
 
 			moverConfigVal := util.GetRSMoverConfig(originalPVCName, replicationSourceNamespace, vrg.Spec.VolSync.MoverConfig)
+			replicationSource.Spec.RsyncTLS.MoverConfig = volsyncv1alpha1.MoverConfig{
+				MoverPodLabels: map[string]string{
+					util.CreatedByRamenLabel: "true",
+				},
+			}
+
 			if moverConfigVal != nil {
-				replicationSource.Spec.RsyncTLS.MoverConfig = volsyncv1alpha1.MoverConfig{
-					MoverSecurityContext: moverConfigVal.MoverSecurityContext,
-					MoverServiceAccount:  moverConfigVal.MoverServiceAccount,
-				}
+				replicationSource.Spec.RsyncTLS.MoverConfig.MoverSecurityContext = moverConfigVal.MoverSecurityContext
+				replicationSource.Spec.RsyncTLS.MoverConfig.MoverServiceAccount = moverConfigVal.MoverServiceAccount
 			}
 
 			return nil

--- a/internal/controller/drcluster_mmode.go
+++ b/internal/controller/drcluster_mmode.go
@@ -179,6 +179,8 @@ func (u *drclusterInstance) activateRegionalFailoverPrequisite(identifier ramen.
 		},
 	}
 
+	util.AddLabel(&mMode, util.CreatedByRamenLabel, "true")
+
 	annotations := make(map[string]string)
 	annotations[DRClusterNameAnnotation] = u.object.GetName()
 

--- a/internal/controller/drclusters.go
+++ b/internal/controller/drclusters.go
@@ -96,6 +96,7 @@ var olmClusterRole = &rbacv1.ClusterRole{
 		Name: "open-cluster-management:klusterlet-work-sa:agent:olm-edit",
 		Labels: map[string]string{
 			util.ClusterRoleAggregateLabel: "true",
+			util.CreatedByRamenLabel:       "true",
 		},
 	},
 	Rules: []rbacv1.PolicyRule{
@@ -140,8 +141,14 @@ func objectsToDeploy(hubOperatorRamenConfig *rmn.RamenConfig) ([]interface{}, er
 
 func operatorGroup(namespaceName string) *operatorsv1.OperatorGroup {
 	return &operatorsv1.OperatorGroup{
-		TypeMeta:   metav1.TypeMeta{Kind: "OperatorGroup", APIVersion: "operators.coreos.com/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "ramen-operator-group", Namespace: namespaceName},
+		TypeMeta: metav1.TypeMeta{Kind: "OperatorGroup", APIVersion: "operators.coreos.com/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ramen-operator-group",
+			Namespace: namespaceName,
+			Labels: map[string]string{
+				util.CreatedByRamenLabel: "true",
+			},
+		},
 	}
 }
 
@@ -154,8 +161,14 @@ func subscription(
 	clusterServiceVersionName string,
 ) *operatorsv1alpha1.Subscription {
 	return &operatorsv1alpha1.Subscription{
-		TypeMeta:   metav1.TypeMeta{Kind: "Subscription", APIVersion: "operators.coreos.com/v1alpha1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "ramen-dr-cluster-subscription", Namespace: namespaceName},
+		TypeMeta: metav1.TypeMeta{Kind: "Subscription", APIVersion: "operators.coreos.com/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ramen-dr-cluster-subscription",
+			Namespace: namespaceName,
+			Labels: map[string]string{
+				util.CreatedByRamenLabel: "true",
+			},
+		},
 		Spec: &operatorsv1alpha1.SubscriptionSpec{
 			CatalogSource:          catalogSourceName,
 			CatalogSourceNamespace: catalogSourceNamespaceName,

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -1325,13 +1325,13 @@ func (r *DRPlacementControlReconciler) clonePlacementRule(ctx context.Context,
 
 	clonedPlRule := &plrv1.PlacementRule{}
 
-	rmnutil.AddLabel(clonedPlRule, rmnutil.CreatedByRamenLabel, "true")
-
 	userPlRule.DeepCopyInto(clonedPlRule)
 
 	clonedPlRule.Name = clonedPlRuleName
 	clonedPlRule.ResourceVersion = ""
 	clonedPlRule.Spec.SchedulerName = ""
+
+	rmnutil.AddLabel(clonedPlRule, rmnutil.CreatedByRamenLabel, "true")
 
 	err := r.addClusterPeersToPlacementRule(drPolicy, clonedPlRule, log)
 	if err != nil {

--- a/internal/controller/kubeobjects/velero/requests.go
+++ b/internal/controller/kubeobjects/velero/requests.go
@@ -724,7 +724,7 @@ func backupRequest(namespaceName, name string, spec velero.BackupSpec,
 	labels map[string]string,
 	annotations map[string]string,
 ) *velero.Backup {
-	return &velero.Backup{
+	backup := &velero.Backup{
 		TypeMeta: backupTypeMeta(),
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   namespaceName,
@@ -734,6 +734,10 @@ func backupRequest(namespaceName, name string, spec velero.BackupSpec,
 		},
 		Spec: spec,
 	}
+
+	util.AddLabel(backup, util.CreatedByRamenLabel, "true")
+
+	return backup
 }
 
 func restore(
@@ -750,7 +754,7 @@ func restore(
 		includeClusterResources = &falseValue
 	}
 
-	return &velero.Restore{
+	restoreObj := &velero.Restore{
 		TypeMeta: restoreTypeMeta(),
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: requestNamespaceName,
@@ -772,6 +776,10 @@ func restore(
 			// TODO: preserveNodePorts?
 		},
 	}
+
+	util.AddLabel(restoreObj, util.CreatedByRamenLabel, "true")
+
+	return restoreObj
 }
 
 func backupStatusLog(backup *velero.Backup, log logr.Logger) {

--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -25,6 +25,7 @@ import (
 
 	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
 	rameninternalconfig "github.com/ramendr/ramen/internal/config"
+	rmnutil "github.com/ramendr/ramen/internal/controller/util"
 )
 
 const (
@@ -416,6 +417,9 @@ func ConfigMapNew(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespaceName,
+			Labels: map[string]string{
+				rmnutil.CreatedByRamenLabel: "true",
+			},
 		},
 		Data: map[string]string{
 			ConfigMapRamenConfigKeyName: string(ramenConfigYaml),

--- a/internal/controller/util/mw_util.go
+++ b/internal/controller/util/mw_util.go
@@ -390,8 +390,13 @@ func (mwu *MWUtil) CreateOrUpdateNamespaceManifest(
 
 func Namespace(name string) *corev1.Namespace {
 	return &corev1.Namespace{
-		TypeMeta:   metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				CreatedByRamenLabel: "true",
+			},
+		},
 	}
 }
 
@@ -429,6 +434,8 @@ func prepareRecipeForMW(recipe *recipev1.Recipe) *recipev1.Recipe {
 		ObjectMeta: ObjectMetaEmbedded(&recipe.ObjectMeta),
 	}
 	recipeCopy.Spec = recipe.Spec
+
+	AddLabel(recipeCopy, CreatedByRamenLabel, "true")
 
 	return recipeCopy
 }
@@ -537,6 +544,7 @@ var (
 			Name: "open-cluster-management:klusterlet-work-sa:agent:volrepgroup-edit",
 			Labels: map[string]string{
 				ClusterRoleAggregateLabel: "true",
+				CreatedByRamenLabel:       "true",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -554,6 +562,7 @@ var (
 			Name: "open-cluster-management:klusterlet-work-sa:agent:mmode-edit",
 			Labels: map[string]string{
 				ClusterRoleAggregateLabel: "true",
+				CreatedByRamenLabel:       "true",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -571,6 +580,7 @@ var (
 			Name: "open-cluster-management:klusterlet-work-sa:agent:drclusterconfig-edit",
 			Labels: map[string]string{
 				ClusterRoleAggregateLabel: "true",
+				CreatedByRamenLabel:       "true",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -588,6 +598,7 @@ var (
 			Name: "open-cluster-management:klusterlet-work-sa:agent:networkfence-edit",
 			Labels: map[string]string{
 				ClusterRoleAggregateLabel: "true",
+				CreatedByRamenLabel:       "true",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -605,6 +616,7 @@ var (
 			Name: "open-cluster-management:klusterlet-work-sa:agent:recipe-edit",
 			Labels: map[string]string{
 				ClusterRoleAggregateLabel: "true",
+				CreatedByRamenLabel:       "true",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -144,6 +144,21 @@ func (v *VSHandler) SetWorkloadStatus(status string) {
 	v.workloadStatus = status
 }
 
+func buildMoverConfig(moverConfigSpec *ramendrv1alpha1.MoverConfig) volsyncv1alpha1.MoverConfig {
+	mc := volsyncv1alpha1.MoverConfig{
+		MoverPodLabels: map[string]string{
+			util.CreatedByRamenLabel: "true",
+		},
+	}
+
+	if moverConfigSpec != nil {
+		mc.MoverSecurityContext = moverConfigSpec.MoverSecurityContext
+		mc.MoverServiceAccount = moverConfigSpec.MoverServiceAccount
+	}
+
+	return mc
+}
+
 // returns replication destination only if create/update is successful and the RD is considered available.
 // Callers should assume getting a nil replication destination back means they should retry/requeue.
 //
@@ -398,14 +413,7 @@ func (v *VSHandler) createOrUpdateRD(
 		util.AddAnnotation(rd, OwnerNameAnnotation, v.owner.GetName())
 		util.AddAnnotation(rd, OwnerNamespaceAnnotation, v.owner.GetNamespace())
 
-		moverConfig := volsyncv1alpha1.MoverConfig{}
-
-		if moverConfigSpec != nil {
-			moverConfig = volsyncv1alpha1.MoverConfig{
-				MoverSecurityContext: moverConfigSpec.MoverSecurityContext,
-				MoverServiceAccount:  moverConfigSpec.MoverServiceAccount,
-			}
-		}
+		moverConfig := buildMoverConfig(moverConfigSpec)
 
 		if util.IsDiffSyncEnabled(v.owner.GetAnnotations()) {
 			params := map[string]string{
@@ -674,13 +682,7 @@ func (v *VSHandler) createOrUpdateRS(rsSpec ramendrv1alpha1.VolSyncReplicationSo
 			return err
 		}
 
-		moverConfig := &volsyncv1alpha1.MoverConfig{}
-		if moverConfigSpec != nil {
-			moverConfig = &volsyncv1alpha1.MoverConfig{
-				MoverSecurityContext: moverConfigSpec.MoverSecurityContext,
-				MoverServiceAccount:  moverConfigSpec.MoverServiceAccount,
-			}
-		}
+		moverConfig := buildMoverConfig(moverConfigSpec)
 
 		if util.IsDiffSyncEnabled(v.owner.GetAnnotations()) {
 			rs.Spec.External = &volsyncv1alpha1.ReplicationSourceExternalSpec{
@@ -708,7 +710,7 @@ func (v *VSHandler) createOrUpdateRS(rsSpec ramendrv1alpha1.VolSyncReplicationSo
 					StorageClassName:        rsSpec.ProtectedPVC.StorageClassName,
 					AccessModes:             rsSpec.ProtectedPVC.AccessModes,
 				},
-				MoverConfig: *moverConfig,
+				MoverConfig: moverConfig,
 			}
 		}
 
@@ -2702,13 +2704,7 @@ func (v *VSHandler) reconcileLocalRD(rdSpec ramendrv1alpha1.VolSyncReplicationDe
 			pvcAccessModes = rdSpec.ProtectedPVC.AccessModes
 		}
 
-		moverConfig := &volsyncv1alpha1.MoverConfig{}
-		if moverConfigSpec != nil {
-			moverConfig = &volsyncv1alpha1.MoverConfig{
-				MoverSecurityContext: moverConfigSpec.MoverSecurityContext,
-				MoverServiceAccount:  moverConfigSpec.MoverServiceAccount,
-			}
-		}
+		moverConfig := buildMoverConfig(moverConfigSpec)
 
 		lrd.Spec.External = nil
 		lrd.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationDestinationRsyncTLSSpec{
@@ -2722,7 +2718,7 @@ func (v *VSHandler) reconcileLocalRD(rdSpec ramendrv1alpha1.VolSyncReplicationDe
 				AccessModes:      pvcAccessModes,
 				DestinationPVC:   &rdSpec.ProtectedPVC.Name,
 			},
-			MoverConfig: *moverConfig,
+			MoverConfig: moverConfig,
 		}
 
 		return nil
@@ -2780,13 +2776,7 @@ func (v *VSHandler) reconcileLocalRS(rd *volsyncv1alpha1.ReplicationDestination,
 
 		lrs.Spec.SourcePVC = pvc.GetName()
 
-		moverConfig := &volsyncv1alpha1.MoverConfig{}
-		if moverConfigSpec != nil {
-			moverConfig = &volsyncv1alpha1.MoverConfig{
-				MoverSecurityContext: moverConfigSpec.MoverSecurityContext,
-				MoverServiceAccount:  moverConfigSpec.MoverServiceAccount,
-			}
-		}
+		moverConfig := buildMoverConfig(moverConfigSpec)
 
 		lrs.Spec.External = nil
 		lrs.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationSourceRsyncTLSSpec{
@@ -2796,7 +2786,7 @@ func (v *VSHandler) reconcileLocalRS(rd *volsyncv1alpha1.ReplicationDestination,
 			ReplicationSourceVolumeOptions: volsyncv1alpha1.ReplicationSourceVolumeOptions{
 				CopyMethod: volsyncv1alpha1.CopyMethodDirect,
 			},
-			MoverConfig: *moverConfig,
+			MoverConfig: moverConfig,
 		}
 
 		return nil


### PR DESCRIPTION
Add `ramendr.openshift.io/created-by-ramen: "true"` label to the remaining direct resources that were missing it (Namespace, ClusterRoles via MW, OperatorGroup, Subscription, ConfigMap, MaintenanceMode). Fix a pre-existing bug where the label on cloned PlacementRule was set before DeepCopyInto, causing it to be silently overwritten.

Pass `MoverPodLabels` with the CreatedByRamen label to VolSync MoverConfig so transitive mover pods created by VolSync also carry the label. Introduce a shared `buildMoverConfig()` helper in vshandler.go that replaces 4 inline MoverConfig construction sites, and update the CephFS getMoverConfig() and volumegroupsourcehandler similarly.

Add the CreatedByRamen label to Velero Backup and Restore objects which were previously missing it.

Assisted-by: Claude Code/claude-opus-4-6

Entire-Checkpoint: 5eb5f472942d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied consistent labeling to all Ramen-managed resources across system components for improved resource identification and tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->