### PR TITLE
docs: move comment outside code block in CVE guide

### DIFF
--- a/docs/dev/cve.md
+++ b/docs/dev/cve.md
@@ -125,8 +125,9 @@ Where `<version>` corresponds to the ODF version.
 
 #### Step 2: Pull the downstream image
 
+Example for ODF 4.18:
+
 ```bash
-# Example for ODF 4.18
 podman pull quay.io/rhceph-dev/odf4-odr-rhel9-operator:v4.18
 ```
 


### PR DESCRIPTION
Addresses review comment from PR #2492 to move the example comment outside the bash code block for better documentation formatting.

Fixes: https://github.com/RamenDR/ramen/pull/2492#discussion_r3318061656

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced guidance for identifying downstream operator images with additional examples to clarify configuration procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->