### PR TITLE
e2e-daily: log podman state before pruning runner images

### DIFF
--- a/.github/workflows/e2e-daily.yaml
+++ b/.github/workflows/e2e-daily.yaml
@@ -41,7 +41,7 @@ jobs:
             source ../venv
             drenv cache envs/regional-dr.yaml
 
-  prune-images:
+  podman-maintenance:
     strategy:
       fail-fast: false
       matrix:
@@ -51,5 +51,20 @@ jobs:
     runs-on: ${{ matrix.runner }}
     if: github.repository == 'RamenDR/ramen'
     steps:
+      - name: Log podman info
+        run: podman info
+
+      - name: Log containers
+        run: podman ps -a
+
+      - name: Log volumes
+        run: podman volume ls
+
+      - name: Log podman storage
+        run: podman system df
+
+      - name: Log images
+        run: podman image ls
+
       - name: Prune images
         run: podman image prune -f


### PR DESCRIPTION
Self-hosted e2e runners keep long-lived drenv-cache containers between jobs. When podman namespace state drifts (e.g. stale conmon), PR builds log conmon warnings until someone cleans up manually.

Rename the daily prune job to podman-maintenance and log podman info, containers, volumes, storage, and images before image prune. Daily logs give a baseline to spot unhealthy runners and debug intermittent prune failures without SSHing into the VMs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved testing infrastructure with enhanced daily end-to-end testing diagnostics. Added comprehensive logging steps to capture detailed system and container environment information before maintenance operations. This provides better visibility into the testing environment, enabling faster identification and resolution of testing-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->