### PR TITLE
Adds selective owner reference removal

### DIFF
--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -292,8 +292,7 @@ func AddOwnerReference(obj, owner metav1.Object, scheme *runtime.Scheme) (bool, 
 func RemoveOwnerReference(obj, owner metav1.Object, scheme *runtime.Scheme) (bool, error) {
 	currentOwnerRefs := obj.GetOwnerReferences()
 
-	length := len(currentOwnerRefs)
-	if length < 1 {
+	if len(currentOwnerRefs) < 1 {
 		return false, nil // No owner references to remove
 	}
 

--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -296,10 +296,26 @@ func RemoveOwnerReference(obj, owner metav1.Object, scheme *runtime.Scheme) (boo
 		return false, nil // No owner references to remove
 	}
 
-	// TODO: Remove just the owner's Reference instead of blindly removing all ownerreferences.
-	obj.SetOwnerReferences(nil)
+	ownerUID := owner.GetUID()
 
-	return true, nil
+	newOwnerRefs := []metav1.OwnerReference{}
+	removed := false
+
+	for _, ref := range currentOwnerRefs {
+		if ref.UID == ownerUID {
+			removed = true
+
+			continue
+		}
+
+		newOwnerRefs = append(newOwnerRefs, ref)
+	}
+
+	// Always update ownerReferences to maintain consistency
+	// Return true only if we actually removed an owner
+	obj.SetOwnerReferences(newOwnerRefs)
+
+	return removed, nil
 }
 
 func AddFinalizer(obj client.Object, finalizer string) bool {


### PR DESCRIPTION
Resolves #2600


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where removing a specific owner reference could inadvertently clear all owner references. Now only the targeted owner reference is removed; other references are preserved. The operation is a no-op and returns false when no matching reference exists, improving reliability and preventing unintended loss of related ownership metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->