### PR TITLE
Fix PVC orphaning during VRG deletion

### DIFF
--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -3303,10 +3303,11 @@ func (v *VSHandler) IsVRGInAdminNamespace() bool {
 	return v.vrgInAdminNamespace
 }
 
-func (v *VSHandler) UnprotectVolSyncPVC(pvc *corev1.PersistentVolumeClaim) error {
-	v.log.Info("Unprotecting VolSync PVC", "pvcName", pvc.GetName(), "pvcNamespace", pvc.GetNamespace())
+func (v *VSHandler) UnprotectVolSyncPVC(pvc *corev1.PersistentVolumeClaim, skipPVCDisownership bool) error {
+	v.log.Info("Unprotecting VolSync PVC", "pvcName", pvc.GetName(), "pvcNamespace", pvc.GetNamespace(),
+		"skipPVCDisownership", skipPVCDisownership)
 
-	err := v.DeleteRS(pvc.GetName(), pvc.GetNamespace(), false)
+	err := v.DeleteRS(pvc.GetName(), pvc.GetNamespace(), skipPVCDisownership)
 	if err != nil {
 		v.log.Info("Failed to delete RS", "rs name", pvc.GetName(), "error", err)
 

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -897,9 +897,12 @@ func (v *VRGInstance) pvcUnprotectVolSync(pvc corev1.PersistentVolumeClaim, log 
 		}
 	}
 
-	log.Info("Unprotecting VolSync PVC", "PVC", pvc.Name)
+	// Determine if VRG is being deleted to decide whether to skip PVC disownership
+	vrgBeingDeleted := util.ResourceIsDeleted(v.instance)
+
+	log.Info("Unprotecting VolSync PVC", "PVC", pvc.Name, "vrgBeingDeleted", vrgBeingDeleted)
 	// This call is only from Primary cluster. delete ReplicationSource/CG and related resources.
-	if err := v.volSyncHandler.UnprotectVolSyncPVC(&pvc); err != nil {
+	if err := v.volSyncHandler.UnprotectVolSyncPVC(&pvc, vrgBeingDeleted); err != nil {
 		log.Error(err, "Failed to unprotect VolSync PVC", "PVC", pvc.Name)
 
 		return


### PR DESCRIPTION
Propagate VRG deletion context to prevent RS ownership removal from PVCs. When VRG is deleted, skipPVCDisownership=true preserves RS ownership, allowing proper garbage collection. During PVC deselection, skipPVCDisownership=false removes RS ownership as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced resource cleanup during VolSync unprotection with improved control over persistent volume ownership handling in deletion scenarios, providing more flexible cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->