### PR TITLE
Fix documentation typos and clarify examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ When storage is already highly available and requires no replication, Ramen
 manages only workload resources. It ensures access guarantees through the
 csi-addon
 [fencing specification](https://github.com/csi-addons/spec/tree/main/fence)
-and and csi-addons
+and csi-addons
 [NetworkFence](https://github.com/csi-addons/kubernetes-csi-addons/blob/main/docs/networkfence.md)
 APIs.
 

--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -43,7 +43,7 @@ const (
 	Deploying = DRState("Deploying")
 
 	// Deployed, this is the state that will be recorded in the DRPC status
-	// when initial deplyment has been performed successfully
+	// when initial deployment has been performed successfully
 	Deployed = DRState("Deployed")
 
 	// FailingOver, state recorded in the DRPC status when the failover

--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -293,14 +293,14 @@ type StorageIdentifiers struct {
 	// on the StorageClass as the value for the label "ramendr.openshift.io/storageid", that identifies
 	// the storage backend that was used to provision the volume. It is used to label different StorageClasses
 	// across different kubernetes clusters, that potentially share the same storage backend.
-	// It also contains any maintenance modes that the storage backend requires during vaious Ramen actions
+	// It also contains any maintenance modes that the storage backend requires during various Ramen actions
 	//+optional
 	StorageID Identifier `json:"storageID,omitempty"`
 
 	// ReplicationID contains the globally unique replication identifier, as reported by the storage backend
 	// on the VolumeReplicationClass as the value for the label "ramendr.openshift.io/replicationid", that
 	// identifies the storage backends across 2 (or more) storage instances where the volume is replicated
-	// It also contains any maintenance modes that the replication backend requires during vaious Ramen actions
+	// It also contains any maintenance modes that the replication backend requires during various Ramen actions
 	//+optional
 	ReplicationID Identifier `json:"replicationID,omitempty"`
 }

--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -117,7 +117,7 @@ type VolSyncReplicationSourceSpec struct {
 	MoverConfig *MoverConfig `json:"moverConfig,omitempty"`
 }
 
-// VolSynccSpec defines the ReplicationDestination specs for the Secondary VRG, or
+// VolSyncSpec defines the ReplicationDestination specs for the Secondary VRG, or
 // the ReplicationSource specs for the Primary VRG
 type VolSyncSpec struct {
 	// rdSpec array contains the PVCs information that will/are be/being protected by VolSync

--- a/docs/drcluster-crd.md
+++ b/docs/drcluster-crd.md
@@ -190,7 +190,7 @@ spec:
    s3StoreProfiles:
      - s3ProfileName: s3-profile-east
        s3Bucket: ramen-dr-east
-       s3CompatibleEndpoint: https://s1.us-east-1.amazonaws.com
+       s3CompatibleEndpoint: https://s3.us-east-1.amazonaws.com
        s3Region: us-east-1
        s3SecretRef:
          name: s3-secret-east

--- a/docs/maintenancemode-crd.md
+++ b/docs/maintenancemode-crd.md
@@ -493,7 +493,7 @@ metadata:
 provisioner: your.csi.driver
 ```
 
-### 1. Watch MaintenanceMode Resources
+### 2. Watch MaintenanceMode Resources
 
 ```go
 // Filter for your provisioner
@@ -503,7 +503,7 @@ func (r *YourReconciler) filterMaintenanceMode(obj client.Object) bool {
 }
 ```
 
-### 1. Reconcile MaintenanceMode
+### 3. Reconcile MaintenanceMode
 
 ```go
 func (r *YourReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -539,7 +539,7 @@ func (r *YourReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 }
 ```
 
-### 1. Handle Modes
+### 4. Handle Modes
 
 ```go
 for _, mode := range mmode.Spec.Modes {

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 
 Metrics are collected using Prometheus, and registered with its global
 metrics registry in each controller. There are two ways where you can
-look at the metrics in ramen. One way is use prometheus stack(recommended)
+look at the metrics in ramen. One way is use Prometheus stack(recommended)
 and the other way is to use curl or postman. More details on
 each of these in the below sections.
 
@@ -30,7 +30,7 @@ Follow the next steps before configuring ramen.
 
 Quickstart instructions are [here](https://github.com/prometheus-operator/kube-prometheus#quickstart).
 
-#### Grant permission for prometheus to scrape metrics
+#### Grant permission for Prometheus to scrape metrics
 
 Go to `ramen/config/hub/default/k8s/kustomization.yaml`
 and uncomment `../../../prometheus`

--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -39,8 +39,8 @@ enough resources:
 
 1. Create python virtual environment
 
-   The *Ramen* project use python tool to create and provision test
-   environment and run tests. The create a virtual environment including
+   The *Ramen* project uses a python tool to create and provision test
+   environment and run tests. This creates a virtual environment including
    the tools run:
 
    ```
@@ -427,7 +427,7 @@ test/basic-test/deploy $env
 test/basic-test/enable-dr $env
 ```
 
-At this point you can run run manually failover, relocate one or more
+At this point you can manually failover, relocate one or more
 times as needed.
 
 To clean up the basic-test for regional-dr.yaml run this command:


### PR DESCRIPTION
Fix typo in README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed a malformed storage backend reference to include the NetworkFence fencing spec.
  * Clarified S3-compatible endpoint example format in DR cluster config.
  * Renumbered subsections in the Maintenance Mode provider guide for correct ordering.
  * Improved Prometheus wording and added explicit guidance to grant scrape permission.
  * Clarified the Python virtualenv step and updated basic-test phrasing.
  * Corrected wording and typos in DR state and storage identifier comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->