### PR TITLE
label transitive resources with created-by-ramen

### DIFF
--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -47,6 +47,16 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - batch
   resources:
   - jobs
@@ -96,6 +106,16 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - groupsnapshot.storage.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -63,6 +63,16 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - addon.open-cluster-management.io
   resources:
   - managedclusteraddons
@@ -212,6 +222,16 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - groupsnapshot.storage.k8s.io

--- a/internal/controller/util/secrets_util.go
+++ b/internal/controller/util/secrets_util.go
@@ -335,7 +335,7 @@ func newVeleroSecret(s3SecretRef corev1.SecretReference, fromNS, veleroNS, keyNa
 }
 
 func newConfigurationPolicy(name string, object *runtime.RawExtension) *cpcv1.ConfigurationPolicy {
-	return &cpcv1.ConfigurationPolicy{
+	cp := &cpcv1.ConfigurationPolicy{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigurationPolicy",
 			APIVersion: "policy.open-cluster-management.io/v1",
@@ -354,6 +354,10 @@ func newConfigurationPolicy(name string, object *runtime.RawExtension) *cpcv1.Co
 			},
 		},
 	}
+
+	AddLabel(cp, CreatedByRamenLabel, "true")
+
+	return cp
 }
 
 func newPolicy(name, namespace, triggerValue string, object runtime.RawExtension) *gppv1.Policy {

--- a/internal/controller/volsync/secret_propagator.go
+++ b/internal/controller/volsync/secret_propagator.go
@@ -216,6 +216,9 @@ func (sp *secretPropagator) getEmbeddedConfigPolicy() (*cfgpolicyv1.Configuratio
 		"metadata": map[string]interface{}{
 			"name":      sp.DestSecretName,
 			"namespace": sp.DestSecretNamespace,
+			"labels": map[string]string{
+				util.CreatedByRamenLabel: "true",
+			},
 		},
 		"type": "Opaque",
 		"data": secretData,
@@ -249,6 +252,8 @@ func (sp *secretPropagator) getEmbeddedConfigPolicy() (*cfgpolicyv1.Configuratio
 			Severity:          "low",
 		},
 	}
+
+	util.AddLabel(embeddedConfigPolicy, util.CreatedByRamenLabel, "true")
 
 	return embeddedConfigPolicy, nil
 }

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -17,6 +17,7 @@ import (
 	vgsv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1869,7 +1870,49 @@ func (v *VSHandler) ReconcileServiceExportForRD(rd *volsyncv1alpha1.ReplicationD
 		return fmt.Errorf("error creating or updating ServiceExport (%w)", err)
 	}
 
+	v.ensureVolSyncServiceLabels(serviceName, rd.GetNamespace())
+
 	return nil
+}
+
+func (v *VSHandler) ensureVolSyncServiceLabels(serviceName, namespace string) {
+	svc := &corev1.Service{}
+
+	err := v.client.Get(v.ctx, types.NamespacedName{Name: serviceName, Namespace: namespace}, svc)
+	if err != nil {
+		v.log.V(1).Info("VolSync Service not found yet, skipping label", "serviceName", serviceName)
+
+		return
+	}
+
+	err = util.NewResourceUpdater(svc).
+		AddLabel(util.CreatedByRamenLabel, "true").
+		Update(v.ctx, v.client)
+	if err != nil {
+		v.log.V(1).Info("Failed to label VolSync Service", "serviceName", serviceName, "error", err)
+	}
+
+	epSliceList := &discoveryv1.EndpointSliceList{}
+
+	err = v.client.List(v.ctx, epSliceList,
+		client.InNamespace(namespace),
+		client.MatchingLabels{"kubernetes.io/service-name": serviceName},
+	)
+	if err != nil {
+		v.log.V(1).Info("Failed to list EndpointSlices, skipping label", "serviceName", serviceName)
+
+		return
+	}
+
+	for i := range epSliceList.Items {
+		err = util.NewResourceUpdater(&epSliceList.Items[i]).
+			AddLabel(util.CreatedByRamenLabel, "true").
+			Update(v.ctx, v.client)
+		if err != nil {
+			v.log.V(1).Info("Failed to label VolSync EndpointSlice",
+				"endpointSlice", epSliceList.Items[i].Name, "error", err)
+		}
+	}
 }
 
 func (v *VSHandler) listRSByOwner(rsNamespace string) (volsyncv1alpha1.ReplicationSourceList, error) {
@@ -2269,6 +2312,7 @@ func (v *VSHandler) validateAndProtectSnapshot(
 	err = updater.AddLabel(util.VRGOwnerNameLabel, v.owner.GetName()).
 		AddLabel(util.VRGOwnerNamespaceLabel, v.owner.GetNamespace()).
 		AddLabel(VolSyncDoNotDeleteLabel, VolSyncDoNotDeleteLabelVal).
+		AddLabel(util.CreatedByRamenLabel, "true").
 		Update(v.ctx, v.client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add owner/label to snapshot %s (%w)", volSnap.GetName(), err)

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -431,6 +431,8 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=multicluster.x-k8s.io,resources=serviceexports,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;create;patch;update
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ramendr.openshift.io,resources=recipes,verbs=get;list;watch

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -3692,8 +3692,9 @@ func (v *VRGInstance) createSnapshot(pvc *corev1.PersistentVolumeClaim, snapshot
 			Name:      snapName,
 			Namespace: pvc.Namespace,
 			Labels: map[string]string{
-				dryRunSnapshotLabel: "true",
-				dryRunVRGLabel:      v.instance.Name,
+				dryRunSnapshotLabel:         "true",
+				dryRunVRGLabel:              v.instance.Name,
+				rmnutil.CreatedByRamenLabel: "true",
 			},
 		},
 		Spec: snapv1.VolumeSnapshotSpec{


### PR DESCRIPTION
Add `ramendr.openshift.io/created-by-ramen: "true"` label to transitive resources that ramen controls indirectly:

Secret propagator (secret_propagator.go): add the label to the embedded ConfigurationPolicy and to the Secret object-template metadata, so both the ConfigurationPolicy on the hub and the Secret created on managed clusters carry the label.

S3 secret policy (secrets_util.go): add the label inside newConfigurationPolicy() so S3-related ConfigurationPolicies also carry it.

VolSync Service and EndpointSlices (vshandler.go): add ensureVolSyncServiceLabels() helper that post-creation labels the VolSync-created Service and its associated EndpointSlices. Called from ReconcileServiceExportForRD().

VolSync VolumeSnapshot (vshandler.go): extend the ResourceUpdater chain in validateAndProtectSnapshot() to add the label to VolSync-created VolumeSnapshots when ramen first discovers them.

Assisted-by: Claude Code/claude-opus-4-6

Entire-Checkpoint: cd2a7c897042

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added consistent tracking labels (`CreatedByRamenLabel=true`) to resources created or managed by the system, including ConfigurationPolicy objects, embedded Secret metadata, Services and EndpointSlices, and VolumeSnapshots (including snapshot-protection protected snapshots).

* **Chores**
  * Expanded RBAC permissions to support labeling and related behavior by allowing `get`, `list`, `patch`, `update`, and `watch` on core `services` and `discovery.k8s.io` `endpointslices` (updated in both cluster and DR cluster RBAC manifests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->