### PR TITLE
drenv: Persist minio storge

### DIFF
--- a/test/drenv/addons/minio/start-data/minio.yaml
+++ b/test/drenv/addons/minio/start-data/minio.yaml
@@ -21,7 +21,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: /mnt/minio
+    path: /data/minio
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim


### PR DESCRIPTION
We used `/mnt/minio` which is on tmpfs and deleted when stopping a cluster.  Use `/data/minio` which is on the vm disk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MinIO storage configuration path in test environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->