### PR TITLE
use AddLabel for ConfigMap and mark transitive resources

### DIFF
--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -49,6 +49,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
   - services
   verbs:
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,17 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  - services
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create
@@ -62,16 +73,6 @@ rules:
   - pods/exec
   verbs:
   - create
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - addon.open-cluster-management.io
   resources:

--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -412,19 +412,20 @@ func ConfigMapNew(
 		return nil, fmt.Errorf("config map yaml marshal %w", err)
 	}
 
-	return &corev1.ConfigMap{
+	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespaceName,
-			Labels: map[string]string{
-				rmnutil.CreatedByRamenLabel: "true",
-			},
 		},
 		Data: map[string]string{
 			ConfigMapRamenConfigKeyName: string(ramenConfigYaml),
 		},
-	}, nil
+	}
+
+	rmnutil.AddLabel(cm, rmnutil.CreatedByRamenLabel, "true")
+
+	return cm, nil
 }
 
 func ConfigMapGet(

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -1886,10 +1886,24 @@ func (v *VSHandler) ensureVolSyncServiceLabels(serviceName, namespace string) {
 	}
 
 	err = util.NewResourceUpdater(svc).
-		AddLabel(util.CreatedByRamenLabel, "true").
+		AddLabel(util.CreatedByRamenLabel, "transitive").
 		Update(v.ctx, v.client)
 	if err != nil {
 		v.log.V(1).Info("Failed to label VolSync Service", "serviceName", serviceName, "error", err)
+	}
+
+	ep := &corev1.Endpoints{}
+
+	err = v.client.Get(v.ctx, types.NamespacedName{Name: serviceName, Namespace: namespace}, ep)
+	if err != nil {
+		v.log.V(1).Info("VolSync Endpoints not found yet, skipping label", "serviceName", serviceName)
+	} else {
+		err = util.NewResourceUpdater(ep).
+			AddLabel(util.CreatedByRamenLabel, "transitive").
+			Update(v.ctx, v.client)
+		if err != nil {
+			v.log.V(1).Info("Failed to label VolSync Endpoints", "serviceName", serviceName, "error", err)
+		}
 	}
 
 	epSliceList := &discoveryv1.EndpointSliceList{}
@@ -1906,7 +1920,7 @@ func (v *VSHandler) ensureVolSyncServiceLabels(serviceName, namespace string) {
 
 	for i := range epSliceList.Items {
 		err = util.NewResourceUpdater(&epSliceList.Items[i]).
-			AddLabel(util.CreatedByRamenLabel, "true").
+			AddLabel(util.CreatedByRamenLabel, "transitive").
 			Update(v.ctx, v.client)
 		if err != nil {
 			v.log.V(1).Info("Failed to label VolSync EndpointSlice",

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -432,6 +432,7 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=multicluster.x-k8s.io,resources=serviceexports,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;create;patch;update
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
Standardize label-setting by using AddLabel for the ramen ConfigMap instead of setting it directly in the struct literal.

Use "transitive" as the label value for Services and EndpointSlices that are created by VolSync rather than Ramen directly, to distinguish them from resources Ramen creates.

Assisted-by: Claude Code/claude-opus-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RBAC permissions to grant cluster controllers access to Kubernetes endpoints resources alongside existing service permissions.
  * Refined label handling for services and endpoints with improved label assignment logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->