### PR TITLE
Improvement - use existing function addPVCToGroupPVCs

### DIFF
--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -149,8 +149,7 @@ func (v *VRGInstance) processPVCsAsPrimary() map[types.NamespacedName][]*corev1.
 		}
 
 		if cg, ok := v.isCGEnabled(pvc); ok {
-			vgrKey := v.vgrNamespacedName(cg, pvc.Namespace)
-			groupPVCs[vgrKey] = append(groupPVCs[vgrKey], pvc)
+			v.addPVCToGroupPVCs(pvc, cg, groupPVCs)
 
 			continue
 		}
@@ -1095,8 +1094,7 @@ func (v *VRGInstance) pvcsUnprotectVolRep(pvcs []corev1.PersistentVolumeClaim) {
 				cg = grID
 			}
 
-			vgrKey := v.vgrNamespacedName(cg, pvc.Namespace)
-			groupPVCs[vgrKey] = append(groupPVCs[vgrKey], pvc)
+			v.addPVCToGroupPVCs(pvc, cg, groupPVCs)
 
 			continue
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency of internal PVC grouping operations during reconciliation and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->