### PR TITLE
e2e-daily: Update runner names

### DIFF
--- a/.github/workflows/e2e-daily.yaml
+++ b/.github/workflows/e2e-daily.yaml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - e2e-rdr-2
-          - e2e-rdr-3
+          - ramen-e2e-01
+          - ramen-e2e-02
     runs-on: ${{ matrix.runner }}
     if: github.repository == 'RamenDR/ramen'
     steps:
@@ -46,8 +46,8 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - e2e-rdr-2
-          - e2e-rdr-3
+          - ramen-e2e-01
+          - ramen-e2e-02
     runs-on: ${{ matrix.runner }}
     if: github.repository == 'RamenDR/ramen'
     steps:


### PR DESCRIPTION
We replaced e2e-rdr-* with ramen-e2e-*. Update the runs-on configuration to use the new runners.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure configuration for daily end-to-end testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->