### PR TITLE
e2e: Authorize users via OWNERS file

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,9 +20,46 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Check if the PR author is authorized to run e2e tests.  Runs on a free
+  # GitHub runner to avoid wasting self-hosted runner resources. The e2e job
+  # depends on this job and skips the run if the user is not authorized.
+  check:
+    runs-on: ubuntu-24.04
+    if: github.repository == 'RamenDR/ramen'
+    outputs:
+      authorized: ${{ steps.authorize.outputs.authorized }}
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v6
+
+    - name: Install PyYAML
+      run: pip install pyyaml
+
+    - name: Check e2e authorization
+      id: authorize
+      shell: python3 {0}
+      run: |
+        import yaml, os
+
+        with open("OWNERS") as f:
+            users = yaml.safe_load(f)["e2e"]
+
+        actor = "${{ github.actor }}"
+        authorized = actor in users
+
+        if not authorized:
+            print(f"::warning::User {actor} is not in the e2e group. "
+                  "Add yourself to the OWNERS file to run the e2e workflow.")
+
+        with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+            f.write(f"authorized={'true' if authorized else 'false'}\n")
+
+  # IMPORTANT: The authorization check must never be removed. It prevents
+  # unauthorized users from running workloads on self-hosted runners.
   e2e-rdr:
+    needs: check
     runs-on: [self-hosted, e2e-rdr]
-    if: github.repository == 'RamenDR/ramen' && github.event.pull_request.author_association == 'MEMBER'
+    if: needs.check.outputs.authorized == 'true'
 
     steps:
     - name: Checkout Repo

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# GitHub usernames authorized to run e2e workflows.
+e2e:
+  - BenamarMk
+  - ELENAGER
+  - ShyamsundarR
+  - am-agrawa
+  - asn1809
+  - kumarsgoyal
+  - nirs
+  - parikshithb
+  - pruthvitd
+  - raaizik
+  - raghavendra-talur
+  - rakeshgm


### PR DESCRIPTION
The e2e workflow runs on self-hosted runners with access to infrastructure resources. Previously it checked if the PR author was an org member (author_association == 'MEMBER'), but org membership includes inactive and former contributors who should not trigger expensive e2e runs.

Checking team membership via the GitHub API was considered, but it requires a token with read:org scope. The default GITHUB_TOKEN cannot query team membership, so we would need either a Personal Access Token (tied to a person, expires) or a GitHub App (the private key is passed through the runner environment). Neither option is ideal for a permission check.

Instead, use a Kubernetes-style OWNERS file at the repo root. The file lists GitHub usernames authorized to run e2e tests. Maintainers add or remove users by editing the file in a PR.

Authorization flow:

  1. PR opened/updated
  2. "check" job runs on a free GitHub-hosted runner
  3. Checks out the repo and parses the OWNERS file
  4. Sets job output: authorized=true/false
  5. "e2e-rdr" job depends on "check" via needs/if
  6. If authorized: runs on self-hosted runner
  7. If not authorized: skipped, warning shown

Security: for PRs from forks (the normal contributor flow), GitHub runs the workflow from the base branch (main), not from the PR branch. This means the PR cannot modify the workflow or the OWNERS file to bypass the check. Only users with write access to the repo can push branches directly, and they are already trusted.

Assisted-by: Cursor/Claude Opus 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authorization for end-to-end tests to use an OWNERS file for access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->