### PR TITLE
e2e: Authorize users via OWNERS file

### DIFF
--- a/.github/workflows/e2e-auth.yaml
+++ b/.github/workflows/e2e-auth.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# yamllint disable rule:line-length
+---
+# Authorization gate for e2e tests on self-hosted runners.
+#
+# Uses pull_request_target so the workflow and OWNERS file always come
+# from the base branch (main) and cannot be modified by the PR.
+#
+# If the PR author is in the e2e group in the OWNERS file, this
+# workflow succeeds. The e2e workflow triggers on successful
+# completion of this workflow and runs the actual tests.
+name: e2e-auth
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  authorize:
+    runs-on: ubuntu-24.04
+    if: github.repository == 'RamenDR/ramen'
+    steps:
+    - name: Checkout base branch
+      uses: actions/checkout@v6
+
+    - name: Install PyYAML
+      run: pip install pyyaml
+
+    - name: Check e2e authorization
+      shell: python3 {0}
+      run: |
+        import yaml, sys
+
+        with open("OWNERS") as f:
+            users = yaml.safe_load(f)["e2e"]
+
+        actor = "${{ github.actor }}"
+
+        if actor not in users:
+            print(f"::warning::User {actor} is not in the e2e group. "
+                  "Add yourself to the OWNERS file to run the e2e workflow.")
+            sys.exit(1)

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,8 +6,17 @@
 name: e2e
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # IMPORTANT: workflow_run ensures this workflow file always comes from
+  # main and cannot be modified by a PR. Using pull_request would allow
+  # a fork PR to remove the authorization check and run arbitrary code
+  # on self-hosted runners. Do NOT change this to pull_request.
+  workflow_run:
+    workflows: [e2e-auth]
+    types: [completed]
+
+  # Allow manual run from any branch for testing workflow changes.
+  # Only users with write access can trigger this (safe).
+  workflow_dispatch:
 
 env:
   # Limit number of drenv workers.
@@ -15,18 +24,28 @@ env:
   BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
 
 # cancel the in-progress workflow when PR is refreshed.
+# workflow_run: use the PR branch name.
+# workflow_dispatch: use the selected branch name.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   e2e-rdr:
     runs-on: [self-hosted, e2e-rdr]
-    if: github.repository == 'RamenDR/ramen' && github.event.pull_request.author_association == 'MEMBER'
+    # workflow_run: run only if authorization succeeded.
+    # workflow_dispatch: always run (requires write access).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
 
     steps:
-    - name: Checkout Repo
+    # workflow_run: checkout the PR commit.
+    # workflow_dispatch: checkout the selected branch.
+    - name: Checkout PR
       uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
     - name: Build ramen-operator container
       run: make docker-build

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# GitHub usernames authorized to run e2e workflows on self-hosted runners.
+e2e:
+  - BenamarMk
+  - ELENAGER
+  - ShyamsundarR
+  - am-agrawa
+  - asn1809
+  - kumarsgoyal
+  - nirs
+  - parikshithb
+  - pruthvitd
+  - raaizik
+  - raghavendra-talur
+  - rakeshgm


### PR DESCRIPTION
Replace the author_association check with a Kubernetes-style OWNERS file that lists GitHub usernames authorized to run e2e tests. Maintainers manage the list by editing the OWNERS file in a PR.

The authorization uses a two-workflow design:

1. e2e-auth (pull_request_target) - Runs on a GitHub-hosted runner. Checks out the base branch, parses the OWNERS file, and verifies the PR author is in the e2e group. If not, fails with a warning.

2. e2e (workflow_run) - Triggered when e2e-auth completes successfully. Checks out the PR code and runs the e2e tests on the self-hosted runner.

Both workflows use event types that always read the workflow file from the base branch (main), ensuring the authorization logic cannot be modified by a PR.

The e2e workflow also supports workflow_dispatch for testing changes before merging. Only users with write access can trigger it. To test:

1. Push your changes to a temporary test branch
2. Go to Actions → e2e → Run workflow → select the test branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an authorization gate to restrict e2e test execution on self-hosted runners to approved contributors only.
  * Updated e2e test CI to trigger only after the authorization gate completes successfully, with improved concurrency scoping and safer commit checkout.
  * Added a manual trigger option for running e2e tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->