### PR TITLE
test: Add mdformat-gfm-alerts for GFM alert blocks

### DIFF
--- a/.github/workflows/ramen.yaml
+++ b/.github/workflows/ramen.yaml
@@ -46,7 +46,7 @@ jobs:
           echo 'APT::Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/80-retries
           sudo apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip
-          sudo pip3 install mdformat mdformat-gfm yamllint
+          sudo pip3 install mdformat mdformat-gfm mdformat-gfm-alerts yamllint
 
       - name: Run linters
         run: ./hack/pre-commit.sh

--- a/docs/drenv/stress-test.md
+++ b/docs/drenv/stress-test.md
@@ -40,8 +40,8 @@ Because the failures are random, a run may fail very quickly or only after many
 hours. As drenv becomes more reliable debugging random failures will become
 harder.
 
-> [!IMPORTANT] After debugging the failure, you need to delete the environment
-> manually.
+> [!IMPORTANT]
+> After debugging the failure, you need to delete the environment manually.
 
 ## Generating a report
 

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -10,7 +10,8 @@ predefined workloads and deployment methods.
 
 ## Running End to End tests
 
-> [!IMPORTANT] All commands must be ran from the e2e directory.
+> [!IMPORTANT]
+> All commands must be ran from the e2e directory.
 
 ### Preparing a `config.yaml` file
 
@@ -99,8 +100,9 @@ To run all the DR tests run the TestDR test:
 The test perform a full DR flow with a tiny workload with multiple deployemnet
 methods and storage configurations.
 
-> [!TIP] The tests typically complete in 10 minutes, depending the machine
-> running the tests.
+> [!TIP]
+> The tests typically complete in 10 minutes, depending the machine running the
+> tests.
 
 When all tests complete we will see a test summary showing the status of all
 tests and the time to complete every step:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -74,8 +74,9 @@ running the tests, you need to deploy a channel pointing this repo:
 kubectl apply -k https://github.com/RamenDR/ocm-ramen-samples.git/channel?ref=main --context hub
 ```
 
-> [!NOTE] To test applications from your repo, you need to deploy a channel
-> pointing to your repo.
+> [!NOTE]
+> To test applications from your repo, you need to deploy a channel pointing to
+> your repo.
 
 To run basic tests using regional-dr environment run:
 

--- a/hack/pre-commit.sh
+++ b/hack/pre-commit.sh
@@ -40,7 +40,7 @@ check_tool() {
         echo "You can install it by running:"
         case "$1" in
             mdformat)
-                echo "  pip install mdformat mdformat-gfm"
+                echo "  pip install mdformat mdformat-gfm mdformat-gfm-alerts"
                 ;;
             shellcheck)
                 echo "  dnf install ShellCheck"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ coverage
 flake8
 mdformat
 mdformat-gfm
+mdformat-gfm-alerts
 pylint
 pytest
 setuptools

--- a/test/README.md
+++ b/test/README.md
@@ -167,7 +167,8 @@ environment.
 
 ## Setup on macOS 26+
 
-> [!IMPORTANT] Older macOS are not supported.
+> [!IMPORTANT]
+> Older macOS are not supported.
 
 1. Install the [Homebrew package manager](https://brew.sh/)
 

--- a/test/registry-cache/README.md
+++ b/test/registry-cache/README.md
@@ -8,7 +8,8 @@ SPDX-License-Identifier: Apache-2.0
 The registry cache provides pull-through caching for upstream container
 registries. This speeds up image pulls and reduces network traffic.
 
-> [!TIP] See [Initial setup - Linux](#initial-setup---linux) or
+> [!TIP]
+> See [Initial setup - Linux](#initial-setup---linux) or
 > [Initial setup - macOS](#initial-setup---macos) for first-time configuration.
 
 ## Architecture

--- a/test/registry/README.md
+++ b/test/registry/README.md
@@ -64,7 +64,8 @@ sudo systemctl daemon-reload
 sudo systemctl start registry.service
 ```
 
-> [!NOTE] The service does not need to be enabled.
+> [!NOTE]
+> The service does not need to be enabled.
 
 ## Initial setup - macOS
 


### PR DESCRIPTION
## Summary

Follow-up to #2546 addressing review feedback from RamenDR/ramenctl#465.

- Add `mdformat-gfm-alerts` to `requirements.txt`
- Reformat GFM alert blocks (`[!NOTE]`, `[!TIP]`, `[!IMPORTANT]`) so the alert
  type and content are on separate lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Markdown formatting across multiple documentation files for improved readability.
  * Clarified registry service setup instructions on Linux systems.

* **Chores**
  * Added `mdformat-gfm-alerts` dependency to project requirements and development tooling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->