### PR TITLE
Ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ out/
 
 # Test programs
 /test/timestamp/timestamp
+
+# macOS system files
+.DS_Store


### PR DESCRIPTION
Add .DS_Store to .gitignore to prevent macOS metadata files from being accidentally committed.

Fixes #2618

---Payment info---
PayPal: n6085530@gmail.com


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` to exclude macOS system metadata files (including `.DS_Store`) from being tracked in version control.
  * Added a macOS-specific comment to clarify the purpose of the ignore rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->