### PR TITLE
Bump black>=26.3.1 to fix CVE-2026-32274 and CVE-2026-31900

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black
+black>=26.3.1
 coverage
 flake8
 mdformat

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ mdformat
 mdformat-gfm
 mdformat-gfm-alerts
 pylint
-pytest
+pytest>=9.0.3
 setuptools


### PR DESCRIPTION
Pin black to >= 26.3.1 in requirements.txt to address:
- CVE-2026-32274 (HIGH, CVSS 7.5): Cache file path traversal via
  unsanitized --python-cell-magics option
- CVE-2026-31900 (HIGH): Additional black vulnerability fixed in 26.3.0

Fixes: DFBUGS-7690, DFBUGS-7689

Assisted-by: Claude Code/claude-opus-4-6
Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tool versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->