### PR TITLE
drenv: Improve logging in registry containers and minikube start

### DIFF
--- a/test/drenv/providers/minikube/__init__.py
+++ b/test/drenv/providers/minikube/__init__.py
@@ -127,9 +127,6 @@ def start(profile, verbose=False, timeout=_START_TIMEOUT, local_registry=False):
         # Unlike --extra-config this requires one comma separated value.
         args.extend(("--feature-gates", ",".join(profile["feature_gates"])))
 
-    if verbose:
-        args.append("--alsologtostderr")
-
     if local_registry:
         args.append(f"--insecure-registry={LOCAL_REGISTRY}")
 

--- a/test/drenv/registry.py
+++ b/test/drenv/registry.py
@@ -319,6 +319,9 @@ def _container_command(name, config):
         f"{name}:/var/lib/registry",
         "--env",
         f"REGISTRY_PROXY_REMOTEURL={config['upstream']}",
+        # Default log level is debug, filling the logs with unneeded noise.
+        "--env",
+        "REGISTRY_LOG_LEVEL=info",
         "--label",
         f"{CONFIG_LABEL}=",
         CACHE_IMAGE,


### PR DESCRIPTION
Few cleanups found while testing drenv on the new e2e runner.

- Use log level info in the registry container
- Disable minikube logging to stderr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **local registry** option to the minikube startup configuration.

* **Bug Fixes**
  * Updated minikube **verbose** behavior so it no longer injects the extra verbose logging argument.
  * Updated the registry container’s logging level to **info** to reduce noise, improving consistency when the startup configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->