### PR TITLE
test: Add provider stress test environment

### DIFF
--- a/test/envs/provider.yaml
+++ b/test/envs/provider.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Environment for stress testing cluster creation by starting multiple clusters
+# in parallel.
+---
+name: "provider"
+
+templates:
+  - name: "cluster"
+    driver: "$vm"
+    container_runtime: containerd
+    network: "$network"
+    cpus: 2
+    memory: "3g"
+
+profiles:
+  - name: "c1"
+    template: "cluster"
+  - name: "c2"
+    template: "cluster"
+  - name: "c3"
+    template: "cluster"
+  - name: "c4"
+    template: "cluster"
+  - name: "c5"
+    template: "cluster"
+  - name: "c6"
+    template: "cluster"


### PR DESCRIPTION
Add envs/provider.yaml creating 6 tiny clusters in parallel for testing minikube parallel clusters creation.

Related-to: https://github.com/kubernetes/minikube/pull/23112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an environment configuration for parallel cluster creation stress testing, including a reusable cluster template and multiple selectable profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->