### PR TITLE
Add HeadBucket check to S3 profile validation

### DIFF
--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -598,6 +598,10 @@ func s3ProfileValidate(ctx context.Context, apiReader client.Reader,
 		return "s3ConnectionFailed", fmt.Errorf("%s: %w", s3ProfileName, err)
 	}
 
+	if err := objectStore.HeadBucket(); err != nil {
+		return "s3BucketNotFound", fmt.Errorf("%s: %w", s3ProfileName, err)
+	}
+
 	if _, err := objectStore.ListKeys(listKeyPrefix); err != nil {
 		return "s3ListFailed", fmt.Errorf("%s: %w", s3ProfileName, err)
 	}

--- a/internal/controller/s3utils.go
+++ b/internal/controller/s3utils.go
@@ -91,6 +91,7 @@ type ObjectStoreGetter interface {
 }
 
 type ObjectStorer interface {
+	HeadBucket() error
 	UploadObject(key string, object interface{}) error
 	DownloadObject(key string, objectPointer interface{}) error
 	ListKeys(keyPrefix string) (keys []string, err error)
@@ -242,6 +243,20 @@ func (s *s3ObjectStore) CreateBucket(bucket string) (err error) {
 					bucket, aerr.Code(), aerr.Message())
 			}
 		}
+	}
+
+	return nil
+}
+
+func (s *s3ObjectStore) HeadBucket() error {
+	ctx, cancel := context.WithDeadline(context.TODO(), time.Now().Add(s3Timeout))
+	defer cancel()
+
+	_, err := s.client.HeadBucketWithContext(ctx, &s3.HeadBucketInput{
+		Bucket: &s.s3Bucket,
+	})
+	if err != nil {
+		return processAwsError(fmt.Errorf("bucket %s does not exist or is not accessible", s.s3Bucket), err)
 	}
 
 	return nil

--- a/internal/controller/s3utils_test.go
+++ b/internal/controller/s3utils_test.go
@@ -160,6 +160,10 @@ func (f *fakeObjectStorer) DeleteObjects(keys ...string) error {
 	return nil
 }
 
+func (f *fakeObjectStorer) HeadBucket() error {
+	return nil
+}
+
 func (f *fakeObjectStorer) DeleteObjectsWithKeyPrefix(keyPrefix string) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()


### PR DESCRIPTION
## Summary

- Add explicit `HeadBucket` API call before `ListKeys` in DRCluster S3 profile validation
- Introduces `HeadBucket()` to the `ObjectStorer` interface with implementations for both the real S3 client and the test fake
- DRCluster validation now fails with reason `s3BucketNotFound` when the configured S3 bucket does not exist

## Problem

S3 profile validation during DRCluster reconciliation relies solely on `ListObjectsV2` to verify bucket accessibility. Per the [S3 API spec](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html), `ListObjectsV2` on a non-existent bucket should return `404 NoSuchBucket`. However, some S3-compatible stores (e.g., MinIO `RELEASE.2024-08-29`) return `200 OK` with an empty `ListBucketResult` instead. This causes DRCluster and DRPolicy to be marked as `Validated=True` even when the S3 bucket name in the ramen configmap is wrong, which is only discovered later during failover/relocate when PV data upload fails.

## Fix

`HeadBucket` is the canonical S3 API for verifying bucket existence and is more reliably implemented across S3-compatible stores. By calling `HeadBucket` before `ListKeys`, the validation now catches non-existent buckets early regardless of the S3 implementation's `ListObjectsV2` behavior.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Existing unit tests pass (`go test ./internal/controller/ --ginkgo.focus="FakeObjectStorer"`)
- [ ] Deploy with a wrong S3 bucket name in the ramen configmap and verify DRCluster shows `Validated=False` with reason `s3BucketNotFound`
- [ ] Deploy with the correct S3 bucket name and verify DRCluster and DRPolicy validate successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * S3 profile validation now checks bucket availability earlier, helping catch missing or inaccessible buckets before continuing.
  * When the bucket cannot be found, validation now returns a clearer bucket-not-found error.
  * Existing S3 object access checks still run after the bucket check succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->