### PR TITLE
Assign reference to original PVC and NOT to the restored PVC

### DIFF
--- a/internal/controller/cephfscg/volumegroupsourcehandler.go
+++ b/internal/controller/cephfscg/volumegroupsourcehandler.go
@@ -549,7 +549,7 @@ func (h *volumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVC
 		createdOrUpdated = createdOrUpdated ||
 			(op == ctrlutil.OperationResultCreated || op == ctrlutil.OperationResultUpdated)
 
-		if err := h.assignRSOwnershipToPVC(replicationSource, restoredPVC.RestoredPVCName,
+		if err := h.assignRSOwnershipToPVC(replicationSource, originalPVCName,
 			replicationSourceNamespace, logger); err != nil {
 			return nil, createdOrUpdated, err
 		}


### PR DESCRIPTION
Ownerreference assignment are on the original PVC and not the restore PVC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how ownership is assigned for restored protected PVCs, improving replication source handling after restore operations.
  * This helps ensure the original PVC is properly associated in the target namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->