### PR TITLE
fix: restore correct boolean semantics in drpcProtectVMInNS

### DIFF
--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -3074,15 +3074,17 @@ func (r *DRPlacementControlReconciler) drpcProtectVMInNS(drpc *rmn.DRPlacementCo
 	keys := []string{core.VMList, core.K8SLabelSelector, core.PVCLabelSelector}
 
 	for _, k := range keys {
-		// Default to marking conflict when overlap is found (matches prior behavior)
-		// Note: original observed generation-based tie-breaker preserved behavior omitted here;
-		// this logic marks overlap as conflict, which matches the earlier refactor decisions.
+		// If any recipe parameter key has overlapping values between the two DRPCs,
+		// they are protecting the same VM resources — not independent, so return false
+		// to let the namespace-conflict check run and produce an error.
 		if sets.NewString(drpcParams[k]...).Intersection(sets.NewString(otherParams[k]...)).Len() > 0 {
-			return true
+			return false
 		}
 	}
 
-	return false
+	// No overlap on any key: both DRPCs use vm-recipe and protect disjoint VMs
+	// in the same namespace — this is explicitly supported, skip the conflict check.
+	return true
 }
 
 // EnsureDoNotDeletePVCAnnotation ensures that the "do-not-delete-pvc" annotation is propagated from the DRPC


### PR DESCRIPTION
The refactor in commit 99b99857 ("Suppresses DRPC logs") inverted the return values of drpcProtectVMInNS while consolidating twoVMDRPCsConflict into it. The function is used as an early-exit exemption gate in twoDRPCsConflict: returning true means "both DRPCs protect independent VMs in the same namespace, skip the conflict check".

After the refactor the loop returned true on parameter overlap (conflict) and false on disjoint parameters (safe), which is the opposite of what the call-site expects. This caused twoDRPCsConflict to incorrectly fire the namespace conflict error when two DRPCs protected different VMs (disjoint PROTECTED_VMS, K8S_RESOURCE_SELECTOR, PVC_RESOURCE_SELECTOR) from the same namespace using separate DRPolicies.

Fix: return false when any recipe parameter key has overlapping values (real conflict), and return true when all keys are disjoint (independent VM protection is safe and explicitly supported).

Fixes: protecting multiple VMs in the same namespace under separate DRPCs with vm-recipe fails with:
  "conditions:
  - lastTransitionTime: "2026-06-25T13:59:32Z" message: 'drpc: disc5-vm2-drpc and drpc: disc5-drpc protect common resources from the same namespace'
    observedGeneration: 1 reason: Error status: "False" type: Available "

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected namespace conflict handling for VM protection so overlapping recipe parameters now properly trigger the conflict check.
  * Allowed protection of disjoint VMs in the same namespace when their recipe parameters do not overlap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->