### PR TITLE
e2e: Report status in the PR

### DIFF
--- a/.github/workflows/e2e-auth.yaml
+++ b/.github/workflows/e2e-auth.yaml
@@ -18,6 +18,7 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
+  checks: write
   contents: read
 
 jobs:
@@ -45,3 +46,17 @@ jobs:
             print(f"::warning::User {actor} is not in the e2e group. "
                   "Add yourself to the OWNERS file to run the e2e workflow.")
             sys.exit(1)
+
+    # Create the e2e check run so it is visible in the PR while the
+    # e2e job is queued, waiting for a self-hosted runner. This is
+    # needed because workflow_run events don't appear in the PR checks.
+    - name: Create e2e check run
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh api repos/${{ github.repository }}/check-runs \
+          -X POST \
+          -f name="e2e" \
+          -f head_sha="${{ github.event.pull_request.head.sha }}" \
+          -f status="queued" \
+          -f external_id="${{ github.run_id }}"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,6 +22,9 @@ env:
   # Limit number of drenv workers.
   MAX_WORKERS: 4
   BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+  # For reporting check run status back to the PR.
+  CHECK_RUNS: repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/check-runs
+  DETAILS_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 # cancel the in-progress workflow when PR is refreshed.
 # workflow_run: use the PR branch name.
@@ -33,6 +36,9 @@ concurrency:
 jobs:
   e2e-rdr:
     runs-on: [self-hosted, e2e-rdr]
+    permissions:
+      contents: read
+      checks: write
     # workflow_run: run only if authorization succeeded.
     # workflow_dispatch: always run (requires write access).
     if: >-
@@ -40,6 +46,29 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
 
     steps:
+    # Find the e2e check run created by the triggering e2e-auth run.
+    # We match by external_id which e2e-auth sets to its own run_id,
+    # ensuring an exact 1:1 match even with concurrent e2e-auth runs.
+    - name: Find check run
+      id: check
+      if: github.event_name == 'workflow_run'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        check_id=$(gh api "${{ env.CHECK_RUNS }}?check_name=e2e" \
+          --jq '.check_runs[] | select(.external_id=="${{ github.event.workflow_run.id }}") | .id')
+        echo "id=$check_id" >> "$GITHUB_OUTPUT"
+
+    - name: Set check run to in_progress
+      if: github.event_name == 'workflow_run'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh api "repos/${{ github.repository }}/check-runs/${{ steps.check.outputs.id }}" \
+          -X PATCH \
+          -f status="in_progress" \
+          -f details_url="${{ env.DETAILS_URL }}"
+
     # workflow_run: checkout the PR commit.
     # workflow_dispatch: checkout the selected branch.
     - name: Checkout PR
@@ -156,3 +185,15 @@ jobs:
       run: |
         source ../venv
         drenv cleanup envs/regional-dr.yaml
+
+    # Report check run status back to the PR since workflow_run
+    # events don't appear in the PR checks list.
+    - name: Update check run
+      if: always() && github.event_name == 'workflow_run'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh api "repos/${{ github.repository }}/check-runs/${{ steps.check.outputs.id }}" \
+          -X PATCH \
+          -f status="completed" \
+          -f conclusion="${{ job.status }}"


### PR DESCRIPTION
Since PR #2615, the e2e workflow uses workflow_run to ensure the
workflow file always comes from main and cannot be modified by a PR.
This is required for secure operation on self-hosted runners, but
because the workflow does not run in the PR context, the job does
not appear in the PR checks list, hiding failures. A PR may look
ready to merge while the e2e tests are still queued or running.

Use the GitHub Checks API to report an "e2e" check run in the PR.
The Checks API provides rich status reporting with these states:

- queued: waiting for a runner (shown as grey pending icon)
- in_progress: tests are running (shown as yellow spinner)
- completed with conclusion: success (green), failure (red),
  or cancelled (grey)

## The flow works across two workflows

1. e2e-auth: after authorization succeeds, creates the check run
   in "queued" state. This makes the check visible immediately in
   the PR, even before a self-hosted runner picks up the job.

2. e2e: when the job starts, looks up the check run by commit SHA
   and external_id, saves the check ID as a step output, and
   updates the check to "in_progress" with a details_url linking
   to the workflow run. When the job ends, updates the same check
   to "completed" using job.status as the conclusion, which maps
   directly to success, failure, or cancelled.

The e2e-auth workflow tags each check run with its own run_id as
the external_id. The e2e workflow matches this against the
triggering workflow_run.id, ensuring an exact 1:1 match even
with concurrent e2e-auth runs for the same commit.

## Supported flows

- Push new commit / open PR: e2e-auth creates a new check run,
  e2e updates it through queued -> in_progress -> completed.

- Reopen PR (same commit): e2e-auth creates a new check run for
  the same SHA with a different external_id. Each e2e run finds
  its own check run by matching the triggering run_id.

- workflow_dispatch: no e2e-auth runs, no check run exists. The
  check reporting steps are skipped (conditioned on workflow_run).

- Manual re-run of the e2e job: no new e2e-auth run, no new check
  created. The e2e job finds the existing check run and updates it
  back to in_progress, then to completed with the new result.

Fixes: #2626