### PR TITLE
fix: restore ObservedGeneration tie-breaker and improve VM conflict d…

### DIFF
--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -2992,8 +2992,7 @@ func (r *DRPlacementControlReconciler) twoDRPCsConflict(
 		return fmt.Errorf("failed to get protected namespaces for drpc: %v, %w", otherDRPC.Name, err)
 	}
 
-	independentVMProtection := r.drpcProtectVMInNS(drpc, otherDRPC, ramenConfig)
-	if independentVMProtection {
+	if vmDRPCsProtectIndependentResources(drpc, otherDRPC, ramenConfig) {
 		return nil
 	}
 
@@ -3031,10 +3030,9 @@ func (r *DRPlacementControlReconciler) drpcHaveCommonClusters(ctx context.Contex
 	return drpolicyClusters.Intersection(otherDrpolicyClusters).Len() > 0, nil
 }
 
-// drpcMetaAndOtherHaveVMRecipe is a pre-check helper that encapsulates VM recipe validation
-// to keep cyclomatic complexity low.
-func (r *DRPlacementControlReconciler) drpcMetaAndOtherHaveVMRecipe(drpc *rmn.DRPlacementControl,
-	otherdrpc *rmn.DRPlacementControl,
+// bothDRPCsUseVMRecipe returns true when both DRPCs reference the VM recipe
+// in the ramen operands namespace.
+func bothDRPCsUseVMRecipe(drpc, otherdrpc *rmn.DRPlacementControl,
 	ramenConfig *rmn.RamenConfig,
 ) bool {
 	if drpc.Spec.KubeObjectProtection == nil || drpc.Spec.KubeObjectProtection.RecipeRef == nil {
@@ -3059,32 +3057,54 @@ func (r *DRPlacementControlReconciler) drpcMetaAndOtherHaveVMRecipe(drpc *rmn.DR
 	return true
 }
 
-func (r *DRPlacementControlReconciler) drpcProtectVMInNS(drpc *rmn.DRPlacementControl,
-	otherdrpc *rmn.DRPlacementControl,
-	ramenConfig *rmn.RamenConfig,
-) bool {
-	// Consolidate pre-checks in helper to keep complexity low
-	if !r.drpcMetaAndOtherHaveVMRecipe(drpc, otherdrpc, ramenConfig) {
-		return false
-	}
-
+// vmRecipeParametersOverlap returns true when any of the VM recipe parameter
+// keys (VM list, k8s label selector, PVC label selector) have common values
+// between the two DRPCs, AND the ObservedGeneration state indicates a real
+// conflict (not a transient state during initial creation).
+func vmRecipeParametersOverlap(drpc, otherdrpc *rmn.DRPlacementControl) bool {
 	drpcParams := drpc.Spec.KubeObjectProtection.RecipeParameters
 	otherParams := otherdrpc.Spec.KubeObjectProtection.RecipeParameters
 
 	keys := []string{core.VMList, core.K8SLabelSelector, core.PVCLabelSelector}
 
+	hasOverlap := false
+
 	for _, k := range keys {
-		// If any recipe parameter key has overlapping values between the two DRPCs,
-		// they are protecting the same VM resources — not independent, so return false
-		// to let the namespace-conflict check run and produce an error.
 		if sets.NewString(drpcParams[k]...).Intersection(sets.NewString(otherParams[k]...)).Len() > 0 {
-			return false
+			hasOverlap = true
+
+			break
 		}
 	}
 
-	// No overlap on any key: both DRPCs use vm-recipe and protect disjoint VMs
-	// in the same namespace — this is explicitly supported, skip the conflict check.
-	return true
+	if !hasOverlap {
+		return false
+	}
+
+	// Only flag overlapping resources as a conflict when the current DRPC is
+	// brand new (not yet reconciled) or both DRPCs have been reconciled at
+	// least once. When the current DRPC is established but the other is
+	// brand new, skip the conflict: the other DRPC will detect it on its
+	// own reconciliation pass, avoiding both DRPCs rejecting each other.
+	if drpc.Status.ObservedGeneration == 0 {
+		return true
+	}
+
+	return otherdrpc.Status.ObservedGeneration > 0
+}
+
+// vmDRPCsProtectIndependentResources returns true when both DRPCs use the VM
+// recipe and protect non-overlapping VM resources — meaning they can safely
+// coexist without conflict. Returns false in all other cases (not both VM
+// recipe, or resources overlap).
+func vmDRPCsProtectIndependentResources(drpc, otherdrpc *rmn.DRPlacementControl,
+	ramenConfig *rmn.RamenConfig,
+) bool {
+	if !bothDRPCsUseVMRecipe(drpc, otherdrpc, ramenConfig) {
+		return false
+	}
+
+	return !vmRecipeParametersOverlap(drpc, otherdrpc)
 }
 
 // EnsureDoNotDeletePVCAnnotation ensures that the "do-not-delete-pvc" annotation is propagated from the DRPC

--- a/internal/controller/drplacementcontrol_vm_conflict_test.go
+++ b/internal/controller/drplacementcontrol_vm_conflict_test.go
@@ -1,0 +1,187 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	rmn "github.com/ramendr/ramen/api/v1alpha1"
+	core "github.com/ramendr/ramen/internal/controller/core"
+)
+
+const testRamenOpsNamespace = "ramen-ops"
+
+func makeRamenConfig() *rmn.RamenConfig {
+	return &rmn.RamenConfig{
+		RamenOpsNamespace: testRamenOpsNamespace,
+	}
+}
+
+func makeDRPC(recipeRef *rmn.RecipeRef, params map[string][]string, observedGen int64) *rmn.DRPlacementControl {
+	drpc := &rmn.DRPlacementControl{}
+	drpc.Status.ObservedGeneration = observedGen
+
+	if recipeRef != nil {
+		drpc.Spec.KubeObjectProtection = &rmn.KubeObjectProtectionSpec{
+			RecipeRef:        recipeRef,
+			RecipeParameters: params,
+		}
+	}
+
+	return drpc
+}
+
+func vmRecipeRef() *rmn.RecipeRef {
+	return &rmn.RecipeRef{
+		Name:      core.VMRecipeName,
+		Namespace: testRamenOpsNamespace,
+	}
+}
+
+func nonVMRecipeRef() *rmn.RecipeRef {
+	return &rmn.RecipeRef{
+		Name:      "some-other-recipe",
+		Namespace: testRamenOpsNamespace,
+	}
+}
+
+var _ = Describe("bothDRPCsUseVMRecipe", func() {
+	cfg := makeRamenConfig()
+
+	It("returns false when first DRPC has no KubeObjectProtection", func() {
+		drpc := makeDRPC(nil, nil, 1)
+		other := makeDRPC(vmRecipeRef(), nil, 1)
+		Expect(bothDRPCsUseVMRecipe(drpc, other, cfg)).To(BeFalse())
+	})
+
+	It("returns false when second DRPC has no KubeObjectProtection", func() {
+		drpc := makeDRPC(vmRecipeRef(), nil, 1)
+		other := makeDRPC(nil, nil, 1)
+		Expect(bothDRPCsUseVMRecipe(drpc, other, cfg)).To(BeFalse())
+	})
+
+	It("returns false when first DRPC uses a non-VM recipe", func() {
+		drpc := makeDRPC(nonVMRecipeRef(), nil, 1)
+		other := makeDRPC(vmRecipeRef(), nil, 1)
+		Expect(bothDRPCsUseVMRecipe(drpc, other, cfg)).To(BeFalse())
+	})
+
+	It("returns false when recipe namespace does not match ramen ops", func() {
+		wrongNS := &rmn.RecipeRef{Name: core.VMRecipeName, Namespace: "wrong-ns"}
+		drpc := makeDRPC(wrongNS, nil, 1)
+		other := makeDRPC(vmRecipeRef(), nil, 1)
+		Expect(bothDRPCsUseVMRecipe(drpc, other, cfg)).To(BeFalse())
+	})
+
+	It("returns true when both DRPCs use vm-recipe in ramen-ops namespace", func() {
+		drpc := makeDRPC(vmRecipeRef(), nil, 1)
+		other := makeDRPC(vmRecipeRef(), nil, 1)
+		Expect(bothDRPCsUseVMRecipe(drpc, other, cfg)).To(BeTrue())
+	})
+})
+
+var _ = Describe("vmRecipeParametersOverlap", func() {
+	DescribeTable("overlap detection",
+		func(drpcParams, otherParams map[string][]string, drpcGen, otherGen int64, expected bool) {
+			drpc := makeDRPC(vmRecipeRef(), drpcParams, drpcGen)
+			other := makeDRPC(vmRecipeRef(), otherParams, otherGen)
+			Expect(vmRecipeParametersOverlap(drpc, other)).To(Equal(expected))
+		},
+		Entry("no overlap in any key — returns false",
+			map[string][]string{core.VMList: {"vm-a"}, core.K8SLabelSelector: {"label-a"}},
+			map[string][]string{core.VMList: {"vm-b"}, core.K8SLabelSelector: {"label-b"}},
+			int64(1), int64(1),
+			false,
+		),
+		Entry("VM list overlaps, both observed — returns true",
+			map[string][]string{core.VMList: {"vm-a", "vm-b"}},
+			map[string][]string{core.VMList: {"vm-b", "vm-c"}},
+			int64(1), int64(1),
+			true,
+		),
+		Entry("K8S label selector overlaps, both observed — returns true",
+			map[string][]string{core.K8SLabelSelector: {"label-x"}},
+			map[string][]string{core.K8SLabelSelector: {"label-x", "label-y"}},
+			int64(1), int64(1),
+			true,
+		),
+		Entry("PVC label selector overlaps, both observed — returns true",
+			map[string][]string{core.PVCLabelSelector: {"pvc-a"}},
+			map[string][]string{core.PVCLabelSelector: {"pvc-a"}},
+			int64(1), int64(1),
+			true,
+		),
+		Entry("overlap exists but drpc is brand new (gen=0) — returns true (new DRPC should be rejected)",
+			map[string][]string{core.VMList: {"vm-a"}},
+			map[string][]string{core.VMList: {"vm-a"}},
+			int64(0), int64(1),
+			true,
+		),
+		Entry("overlap exists, drpc established but other is brand new (gen=0) — returns false (other will detect on its turn)",
+			map[string][]string{core.VMList: {"vm-a"}},
+			map[string][]string{core.VMList: {"vm-a"}},
+			int64(1), int64(0),
+			false,
+		),
+		Entry("overlap exists, both brand new (gen=0) — returns true",
+			map[string][]string{core.VMList: {"vm-a"}},
+			map[string][]string{core.VMList: {"vm-a"}},
+			int64(0), int64(0),
+			true,
+		),
+		Entry("empty parameters — returns false",
+			map[string][]string{},
+			map[string][]string{},
+			int64(1), int64(1),
+			false,
+		),
+		Entry("nil parameters — returns false",
+			nil,
+			nil,
+			int64(1), int64(1),
+			false,
+		),
+	)
+})
+
+var _ = Describe("vmDRPCsProtectIndependentResources", func() {
+	cfg := makeRamenConfig()
+
+	It("returns false when DRPCs don't both use VM recipe", func() {
+		drpc := makeDRPC(nil, nil, 1)
+		other := makeDRPC(vmRecipeRef(), nil, 1)
+		Expect(vmDRPCsProtectIndependentResources(drpc, other, cfg)).To(BeFalse())
+	})
+
+	It("returns true when both use VM recipe with non-overlapping VMs", func() {
+		drpc := makeDRPC(vmRecipeRef(), map[string][]string{core.VMList: {"vm-a"}}, 1)
+		other := makeDRPC(vmRecipeRef(), map[string][]string{core.VMList: {"vm-b"}}, 1)
+		Expect(vmDRPCsProtectIndependentResources(drpc, other, cfg)).To(BeTrue())
+	})
+
+	It("returns false when both use VM recipe with overlapping VMs (both established)", func() {
+		drpc := makeDRPC(vmRecipeRef(), map[string][]string{core.VMList: {"vm-a"}}, 1)
+		other := makeDRPC(vmRecipeRef(), map[string][]string{core.VMList: {"vm-a"}}, 1)
+		Expect(vmDRPCsProtectIndependentResources(drpc, other, cfg)).To(BeFalse())
+	})
+
+	It("returns false when drpc is new and VMs overlap — new DRPC conflicts", func() {
+		drpc := makeDRPC(vmRecipeRef(), map[string][]string{core.VMList: {"vm-a"}}, 0)
+		other := makeDRPC(vmRecipeRef(), map[string][]string{core.VMList: {"vm-a"}}, 1)
+		Expect(vmDRPCsProtectIndependentResources(drpc, other, cfg)).To(BeFalse())
+	})
+
+	It("returns true when drpc is established and other is new with overlapping VMs — let other detect on its turn", func() {
+		drpc := makeDRPC(vmRecipeRef(), map[string][]string{core.VMList: {"vm-a"}}, 1)
+		other := makeDRPC(vmRecipeRef(), map[string][]string{core.VMList: {"vm-a"}}, 0)
+		Expect(vmDRPCsProtectIndependentResources(drpc, other, cfg)).To(BeTrue())
+	})
+
+	It("returns true when both use VM recipe with empty parameters", func() {
+		drpc := makeDRPC(vmRecipeRef(), map[string][]string{}, 1)
+		other := makeDRPC(vmRecipeRef(), map[string][]string{}, 1)
+		Expect(vmDRPCsProtectIndependentResources(drpc, other, cfg)).To(BeTrue())
+	})
+})


### PR DESCRIPTION
…etection clarity

Commit 4c31ef6a fixed the inverted boolean in drpcProtectVMInNS, but the refactor in 99b99857 ("Suppresses DRPC logs") also dropped the ObservedGeneration tie-breaker from the original twoVMDRPCsConflict.

The original code only flagged overlapping VM resources as a conflict when the current DRPC was brand new (ObservedGeneration == 0) or both DRPCs had been reconciled (both > 0). This prevented two DRPCs from mutually rejecting each other during creation. Without it, both sides of a conflict can fail simultaneously.

Restore the ObservedGeneration check and rename functions for clarity:
- drpcMetaAndOtherHaveVMRecipe -> bothDRPCsUseVMRecipe
- drpcProtectVMInNS -> vmDRPCsProtectIndependentResources
- Extract vmRecipeParametersOverlap as a separate function with the ObservedGeneration logic restored

Each function name now states what a true return value means, removing the confusing negation chain that led to the original inversion.

Add unit tests covering overlap detection, ObservedGeneration tie-breaker edge cases, precondition checks, and nil/empty parameters.

Assisted-by: Claude Code/claude-opus-4-6