### PR TITLE
Fix dryRun test failover abort for discovered apps and remove unnecessary validation

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -3411,16 +3411,9 @@ func (d *DRPCInstance) setDiscoveredAppGCProgression(clusterName string) {
 			d.setProgression(rmn.ProgressionWaitOnUserToCleanUp)
 		}
 	} else {
-		// For non-VM discovered apps, check if VRG has reached Secondary state
-		// indicating that manual cleanup is complete
-		vrg := d.getCleanupSecondaryVRG(clusterName)
-		if vrg != nil && vrg.Status.State == rmn.SecondaryState && vrg.Status.ObservedGeneration == vrg.Generation {
-			d.log.V(1).Info("Setting progression - Cleaning Up (non-VM app cleanup complete, VRG is Secondary)")
-			d.setProgression(rmn.ProgressionCleaningUp)
-		} else {
-			d.log.V(1).Info("Setting progression - WaitOnUserToCleanUp (waiting for manual cleanup)")
-			d.setProgression(rmn.ProgressionWaitOnUserToCleanUp)
-		}
+		// For non-VM discovered apps, always wait for user to manually delete workload.
+		// VRG state transitions are automatic and independent of user cleanup actions.
+		d.setProgression(rmn.ProgressionWaitOnUserToCleanUp)
 	}
 }
 

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -350,17 +350,11 @@ func validateTestFailoverRevertScenario(drpc *rmn.DRPlacementControl, _ string) 
 		return rmn.Relocated, nil
 
 	case "":
-		// Saved action was empty: User must set action="" and failoverCluster=""
+		// Saved action was empty: User must set action="" to return to Deployed state
 		if drpc.Spec.Action != "" {
 			return "", fmt.Errorf(
 				"revert validation failed: saved last-action=empty requires action=empty, got action=%s",
 				drpc.Spec.Action)
-		}
-
-		if drpc.Spec.FailoverCluster != "" {
-			return "", fmt.Errorf(
-				"revert validation failed: saved last-action=empty requires failoverCluster=empty, got %s",
-				drpc.Spec.FailoverCluster)
 		}
 
 		return rmn.Deployed, nil

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -209,12 +209,6 @@ func (v *VRGInstance) reconcileVolRepsAsSecondary() bool {
 	// This happens when user sets spec.dryRun=false or removes dryRun field from DRPC spec
 	// The VRG must delete all dry-run snapshots BEFORE proceeding
 	if v.shouldCleanupDryRunSnapshots() {
-		if v.instance.Spec.ReplicationState == ramendrv1alpha1.Secondary {
-			v.log.Info("Dry-run reverted, cleaning up snapshots before transitioning to Secondary")
-		} else {
-			v.log.Info("Promoting test failover to real, cleaning up dry-run snapshots while staying Primary")
-		}
-
 		if err := cleanupDryRunSnapshots(v.ctx, v.reconciler.Client, v.log, v.instance, v.volRepPVCs); err != nil {
 			v.log.Error(err, "Failed to cleanup dry-run snapshots")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed a revert validation so returning to the Deployed state now checks only that the action is cleared.
  * Improved progression handling for discovered apps so non-VM apps consistently wait for the user to clean up, avoiding unintended state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->