### PR TITLE
e2e: Fix incomplete object references

### DIFF
--- a/config/samples/ramendr_v1alpha1_drplacementcontrol.yaml
+++ b/config/samples/ramendr_v1alpha1_drplacementcontrol.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   preferredCluster: "east"
   drPolicyRef:
+    apiVersion: ramendr.openshift.io/v1alpha1
+    kind: DRPolicy
     name: drpolicy-sample
   placementRef:
     kind: PlacementRule

--- a/e2e/dractions/crud.go
+++ b/e2e/dractions/crud.go
@@ -133,7 +133,9 @@ func generateDRPC(name, namespace, clusterName, drPolicyName, placementName, app
 		Spec: ramen.DRPlacementControlSpec{
 			PreferredCluster: clusterName,
 			DRPolicyRef: v1.ObjectReference{
-				Name: drPolicyName,
+				APIVersion: ramen.GroupVersion.String(),
+				Kind:       "DRPolicy",
+				Name:       drPolicyName,
 			},
 			PlacementRef: v1.ObjectReference{
 				Kind:      "Placement",
@@ -216,7 +218,9 @@ func generateDRPCDiscoveredApps(name, namespace, clusterName, drPolicyName, plac
 		Spec: ramen.DRPlacementControlSpec{
 			PreferredCluster: clusterName,
 			DRPolicyRef: v1.ObjectReference{
-				Name: drPolicyName,
+				APIVersion: ramen.GroupVersion.String(),
+				Kind:       "DRPolicy",
+				Name:       drPolicyName,
 			},
 			PlacementRef: v1.ObjectReference{
 				Kind:      "Placement",

--- a/e2e/dractions/crud.go
+++ b/e2e/dractions/crud.go
@@ -138,9 +138,10 @@ func generateDRPC(name, namespace, clusterName, drPolicyName, placementName, app
 				Name:       drPolicyName,
 			},
 			PlacementRef: v1.ObjectReference{
-				Kind:      "Placement",
-				Name:      placementName,
-				Namespace: namespace,
+				APIVersion: clusterv1beta1.GroupVersion.String(),
+				Kind:       "Placement",
+				Name:       placementName,
+				Namespace:  namespace,
 			},
 			PVCSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"appname": appname},
@@ -223,9 +224,10 @@ func generateDRPCDiscoveredApps(name, namespace, clusterName, drPolicyName, plac
 				Name:       drPolicyName,
 			},
 			PlacementRef: v1.ObjectReference{
-				Kind:      "Placement",
-				Name:      placementName,
-				Namespace: namespace,
+				APIVersion: clusterv1beta1.GroupVersion.String(),
+				Kind:       "Placement",
+				Name:       placementName,
+				Namespace:  namespace,
 			},
 			PVCSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{"appname": appname},


### PR DESCRIPTION
- Fix incomplete drPolicyRef in e2e-created DRPCs by adding apiVersion and
  kind. Without apiVersion, tools like kubectl-gather cannot construct the GVR
  to fetch the referenced DRPolicy resource, causing ramenctl to fail validation.
- Add apiVersion to placementRef for consistency with DRPCs created by the
  OpenShift console. Ramen does not use this value.

Tested with ramenctl v0.23.