### PR TITLE
Fix peerClasses grID assignment for shared SID

### DIFF
--- a/internal/controller/drpolicy_peerclass.go
+++ b/internal/controller/drpolicy_peerclass.go
@@ -252,10 +252,13 @@ func getVRID(scName string, cl classLists, vrcIdx int, inSID string, schedule st
 	return rID
 }
 
-// getVGRID inspects VolumeGroupReplicationClass in the passed in classLists at the specified index, and returns,
-// - an empty string if the VGRClass fails to match the passed in storageID, schedule or provisioner, or
-// - the value of GroupReplicationID on the VGRClass
-func getVGRID(scName string, cl classLists, vgrcIdx int, inSID string, schedule string) string {
+// getVGRID returns:
+//   - GroupReplicationID of the VGRClass at vgrcIdx if it matches the passed in
+//     storageID, schedule, provisioner, and scGrID (when non-empty)
+//   - empty string if no match found
+//
+// scGrID is required when multiple VGRClasses share the same storageID to select the correct one.
+func getVGRID(scName string, cl classLists, vgrcIdx int, inSID string, schedule string, scGrID string) string {
 	sID := cl.vgrClasses[vgrcIdx].GetLabels()[StorageIDLabel]
 	if sID == "" || inSID != sID {
 		return ""
@@ -270,6 +273,9 @@ func getVGRID(scName string, cl classLists, vgrcIdx int, inSID string, schedule 
 	}
 
 	grID := cl.vgrClasses[vgrcIdx].GetLabels()[GroupReplicationIDLabel]
+	if scGrID != "" && scGrID != grID {
+		return ""
+	}
 
 	return grID
 }
@@ -300,19 +306,20 @@ func getAsyncVRClassPeer(scName string, clA, clB classLists, sIDA, sIDB string, 
 	return ""
 }
 
-// getAsyncVGRClassPeer inspects if there is a common GroupReplicationID among the vgrClasses in the passed
-// in classLists, that relate to the corresponding storageIDs and schedule, and returns the GroupReplicationID or ""
-// if there is no match.
-func getAsyncVGRClassPeer(scName string, clA, clB classLists, sIDA, sIDB string, schedule string) string {
+// getAsyncVGRClassPeer returns:
+//   - common GroupReplicationID if a matching VGRClass pair is found across clA and clB for the
+//     given storageIDs, schedule, and scGrID (when non-empty)
+//   - empty string if no match found
+func getAsyncVGRClassPeer(scName string, clA, clB classLists, sIDA, sIDB string, schedule, scGrID string) string {
 	for vgrcAidx := range clA.vgrClasses {
-		grIDA := getVGRID(scName, clA, vgrcAidx, sIDA, schedule)
+		grIDA := getVGRID(scName, clA, vgrcAidx, sIDA, schedule, scGrID)
 
 		if grIDA == "" {
 			continue
 		}
 
 		for vgrcBidx := range clB.vgrClasses {
-			grIDB := getVGRID(scName, clB, vgrcBidx, sIDB, schedule)
+			grIDB := getVGRID(scName, clB, vgrcBidx, sIDB, schedule, scGrID)
 			if grIDB == "" {
 				continue
 			}
@@ -354,7 +361,7 @@ func isAsyncVGRClassPeerGlobal(clA, clB classLists, grID string) bool {
 //     not necessarily requiring them to have identical ReplicationIDs.
 //   - Snapshots: Uses VGSC and VSC, grouping = true when VGSC exists on both clusters for the same storageClass
 //
-// nolint:gocognit,cyclop,ineffassign,funlen
+// nolint:gocognit,cyclop,ineffassign,funlen,gocyclo
 func getAsyncPeers(scName, clusterID, sID string, offloaded bool, cls []classLists, schedule string) []peerInfo {
 	peers := []peerInfo{}
 
@@ -378,7 +385,19 @@ func getAsyncPeers(scName, clusterID, sID string, offloaded bool, cls []classLis
 				continue
 			}
 
-			grID = getAsyncVGRClassPeer(scName, cls[0], cl, sID, sIDcl, schedule)
+			// read scGrID from the SC on cls[0] to select the correct VGRClass when multiple
+			// VGRClasses share the same storageID, schedule, and provisioner
+			scGrID := ""
+
+			for clsIndx := range cls[0].sClasses {
+				if cls[0].sClasses[clsIndx].GetName() == scName {
+					scGrID = cls[0].sClasses[clsIndx].GetLabels()[GroupReplicationIDLabel]
+
+					break
+				}
+			}
+
+			grID = getAsyncVGRClassPeer(scName, cls[0], cl, sID, sIDcl, schedule, scGrID)
 			if offloaded && grID == "" {
 				continue
 			}

--- a/internal/controller/drpolicy_peerclass_internal_test.go
+++ b/internal/controller/drpolicy_peerclass_internal_test.go
@@ -1949,6 +1949,150 @@ var _ = Describe("updatePeerClassesInternal", func() {
 				},
 			},
 		),
+		Entry("Async peers sharing storageID with multiple VGRCs, each reports correct grID",
+			[]classLists{
+				{
+					clusterID: "cl-1",
+					sClasses: []*storagev1.StorageClass{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "sc1",
+								Labels: map[string]string{
+									StorageIDLabel:          "cl-1-sID",
+									StorageOffloadedLabel:   "",
+									GroupReplicationIDLabel: "cl-1-2-grID1",
+								},
+							},
+							Provisioner: "sample.csi.com",
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "sc2",
+								Labels: map[string]string{
+									StorageIDLabel:          "cl-1-sID",
+									StorageOffloadedLabel:   "",
+									GroupReplicationIDLabel: "cl-1-2-grID2",
+								},
+							},
+							Provisioner: "sample.csi.com",
+						},
+					},
+					vgrClasses: []*volrep.VolumeGroupReplicationClass{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "vgrc1",
+								Labels: map[string]string{
+									StorageIDLabel:          "cl-1-sID",
+									GroupReplicationIDLabel: "cl-1-2-grID1",
+								},
+							},
+							Spec: volrep.VolumeGroupReplicationClassSpec{
+								Provisioner: "sample.csi.com",
+								Parameters: map[string]string{
+									ReplicationClassScheduleKey: "1m",
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "vgrc2",
+								Labels: map[string]string{
+									StorageIDLabel:          "cl-1-sID",
+									GroupReplicationIDLabel: "cl-1-2-grID2",
+								},
+							},
+							Spec: volrep.VolumeGroupReplicationClassSpec{
+								Provisioner: "sample.csi.com",
+								Parameters: map[string]string{
+									ReplicationClassScheduleKey: "1m",
+								},
+							},
+						},
+					},
+				},
+				{
+					clusterID: "cl-2",
+					sClasses: []*storagev1.StorageClass{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "sc1",
+								Labels: map[string]string{
+									StorageIDLabel:          "cl-2-sID",
+									StorageOffloadedLabel:   "",
+									GroupReplicationIDLabel: "cl-1-2-grID1",
+								},
+							},
+							Provisioner: "sample.csi.com",
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "sc2",
+								Labels: map[string]string{
+									StorageIDLabel:          "cl-2-sID",
+									StorageOffloadedLabel:   "",
+									GroupReplicationIDLabel: "cl-1-2-grID2",
+								},
+							},
+							Provisioner: "sample.csi.com",
+						},
+					},
+					vgrClasses: []*volrep.VolumeGroupReplicationClass{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "vgrc2",
+								Labels: map[string]string{
+									StorageIDLabel:          "cl-2-sID",
+									GroupReplicationIDLabel: "cl-1-2-grID2",
+								},
+							},
+							Spec: volrep.VolumeGroupReplicationClassSpec{
+								Provisioner: "sample.csi.com",
+								Parameters: map[string]string{
+									ReplicationClassScheduleKey: "1m",
+								},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "vgrc1",
+								Labels: map[string]string{
+									StorageIDLabel:          "cl-2-sID",
+									GroupReplicationIDLabel: "cl-1-2-grID1",
+								},
+							},
+							Spec: volrep.VolumeGroupReplicationClassSpec{
+								Provisioner: "sample.csi.com",
+								Parameters: map[string]string{
+									ReplicationClassScheduleKey: "1m",
+								},
+							},
+						},
+					},
+				},
+			},
+			"1m",
+			[]peerInfo{},
+			[]peerInfo{
+				{
+					replicationID:      "",
+					groupReplicationID: "cl-1-2-grID1",
+					storageIDs:         []string{"cl-1-sID", "cl-2-sID"},
+					storageClassName:   "sc1",
+					clusterIDs:         []string{"cl-1", "cl-2"},
+					offloaded:          true,
+					grouping:           true,
+				},
+				{
+					replicationID:      "",
+					groupReplicationID: "cl-1-2-grID2",
+					storageIDs:         []string{"cl-1-sID", "cl-2-sID"},
+					storageClassName:   "sc2",
+					clusterIDs:         []string{"cl-1", "cl-2"},
+					offloaded:          true,
+					grouping:           true,
+				},
+			},
+		),
 		Entry("Offloaded async peer, with a single sync peer, reports no async peers",
 			[]classLists{
 				{


### PR DESCRIPTION
When multiple StorageClasses share the same storageID (e.g. multiple pools on the same storage cluster), getAsyncVGRClassPeer returns the first matching VGRClass for all SCs, causing all peerClass entries to get the same groupreplicationID instead of each SC's pool-specific one.

Fix by reading the SC's own groupreplicationID label from cls[0] and passing it to getVGRID as scGrID, which narrows the VGRClass match to the one that belongs to the specific StorageClass.

Add a test case covering multiple async peers sharing the same storageID with distinct VGRCs, verifying each peerClass reports its own correct groupreplicationID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved async peer matching so the correct replication group is selected when multiple peer classes share the same storage and scheduling settings.
  * Ensured storage class selection uses the matching replication group identifier, helping pair the right peers in offloaded/global replication setups.
  * Expanded test coverage for cases where multiple peers share storage IDs but belong to different replication groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes: [DFBUGS-8065](https://redhat.atlassian.net/browse/DFBUGS-8065)