### PR TITLE
Preserve PVCs during disable DR

### DIFF
--- a/internal/controller/cephfscg/cghandler.go
+++ b/internal/controller/cephfscg/cghandler.go
@@ -265,41 +265,7 @@ func (c *cgHandler) disownRSManagedPVCsBeforeRGSDeletion(
 // disownRDManagedPVCs removes RD ownership from PVCs before RGD deletion
 // This ensures PVCs are not automatically deleted when RDs are removed
 func (c *cgHandler) disownRDManagedPVCs(rdSpecs []ramendrv1alpha1.VolSyncReplicationDestinationSpec) error {
-	log := c.logger.WithName("disownRDManagedPVCs")
-
-	for _, rdSpec := range rdSpecs {
-		pvcName := rdSpec.ProtectedPVC.Name
-		pvcNamespace := rdSpec.ProtectedPVC.Namespace
-
-		// Get the RD that was created from this RDSpec
-		rdName := util.GetReplicationDestinationName(pvcName)
-
-		// Get the RD object
-		rd := &volsyncv1alpha1.ReplicationDestination{}
-		if err := c.Client.Get(c.ctx, types.NamespacedName{
-			Name:      rdName,
-			Namespace: pvcNamespace,
-		}, rd); err != nil {
-			if k8serrors.IsNotFound(err) {
-				log.V(1).Info("RD not found, skipping PVC disownership", "RD", rdName)
-
-				continue
-			}
-
-			log.Error(err, "Failed to get RD for PVC disownership", "RD", rdName)
-
-			return err
-		}
-
-		// Remove RD ownership from the PVC
-		if err := c.VSHandler.RemoveOwnerFromPVC(rd, pvcName, pvcNamespace); err != nil {
-			log.Error(err, "Failed to remove RD ownership from PVC", "RD", rdName, "PVC", pvcName)
-
-			return err
-		}
-	}
-
-	return nil
+	return disownRDManagedPVCs(c.ctx, c.Client, c.VSHandler, rdSpecs, c.logger.WithName("disownRDManagedPVCs"))
 }
 
 // disownRDManagedPVCsBeforeRGDDeletion disowns RD-managed PVCs before RGD deletion
@@ -614,42 +580,7 @@ func (c *cgHandler) ensureRSsOwnTheirPVCs(rsSpecsInGroup []ramendrv1alpha1.VolSy
 // disownRSManagedPVCs removes RS ownership from PVCs before RGS deletion
 // This ensures PVCs are not automatically deleted when RSs are removed
 func (c *cgHandler) disownRSManagedPVCs(rsSpecs []ramendrv1alpha1.VolSyncReplicationSourceSpec) error {
-	log := c.logger.WithName("disownRSManagedPVCs")
-
-	for _, rsSpec := range rsSpecs {
-		pvcName := rsSpec.ProtectedPVC.Name
-		pvcNamespace := rsSpec.ProtectedPVC.Namespace
-
-		// The RS name is the same as the PVC name (following volsync handler pattern)
-		rsName := pvcName
-
-		// Get the RS object
-		rs := &volsyncv1alpha1.ReplicationSource{}
-
-		if err := c.Client.Get(c.ctx, types.NamespacedName{
-			Name:      rsName,
-			Namespace: pvcNamespace,
-		}, rs); err != nil {
-			if k8serrors.IsNotFound(err) {
-				log.V(1).Info("RS not found, skipping PVC disownership", "RS", rsName)
-
-				continue
-			}
-
-			log.Error(err, "Failed to get RS for PVC disownership", "RS", rsName)
-
-			return err
-		}
-
-		// Remove RS ownership from the PVC
-		if err := c.VSHandler.RemoveOwnerFromPVC(rs, pvcName, pvcNamespace); err != nil {
-			log.Error(err, "Failed to remove RS ownership from PVC", "RS", rsName, "PVC", pvcName)
-
-			return err
-		}
-	}
-
-	return nil
+	return disownRSManagedPVCs(c.ctx, c.Client, c.VSHandler, rsSpecs, c.logger.WithName("disownRSManagedPVCs"))
 }
 
 func (c *cgHandler) GetLatestImageFromRGD(rgd *ramendrv1alpha1.ReplicationGroupDestination, pvcName string,
@@ -838,6 +769,7 @@ func (c *cgHandler) GetRDInCG() ([]ramendrv1alpha1.VolSyncReplicationDestination
 }
 
 func DeleteRGS(ctx context.Context, k8sClient client.Client, ownerName, ownerNamespace string, logger logr.Logger,
+	vsHandler *volsync.VSHandler, skipPVCDisownership bool,
 ) error {
 	rgsList := &ramendrv1alpha1.ReplicationGroupSourceList{}
 
@@ -846,10 +778,22 @@ func DeleteRGS(ctx context.Context, k8sClient client.Client, ownerName, ownerNam
 		return err
 	}
 
+	if !skipPVCDisownership && vsHandler != nil {
+		for i := range rgsList.Items {
+			rgs := &rgsList.Items[i]
+			if len(rgs.Spec.RSSpec) > 0 {
+				if err := disownRSManagedPVCs(ctx, k8sClient, vsHandler, rgs.Spec.RSSpec, logger); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
 	return DeleteTypedObjectList(ctx, k8sClient, ToPointerSlice(rgsList.Items), logger)
 }
 
 func DeleteRGD(ctx context.Context, k8sClient client.Client, ownerName, ownerNamespace string, logger logr.Logger,
+	vsHandler *volsync.VSHandler, skipPVCDisownership bool,
 ) error {
 	rgdList := &ramendrv1alpha1.ReplicationGroupDestinationList{}
 
@@ -858,7 +802,86 @@ func DeleteRGD(ctx context.Context, k8sClient client.Client, ownerName, ownerNam
 		return err
 	}
 
+	if !skipPVCDisownership && vsHandler != nil {
+		for i := range rgdList.Items {
+			rgd := &rgdList.Items[i]
+			if len(rgd.Spec.RDSpecs) > 0 {
+				if err := disownRDManagedPVCs(ctx, k8sClient, vsHandler, rgd.Spec.RDSpecs, logger); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
 	return DeleteTypedObjectList(ctx, k8sClient, ToPointerSlice(rgdList.Items), logger)
+}
+
+func disownRSManagedPVCs(ctx context.Context, k8sClient client.Client, vsHandler *volsync.VSHandler,
+	rsSpecs []ramendrv1alpha1.VolSyncReplicationSourceSpec, log logr.Logger,
+) error {
+	for _, rsSpec := range rsSpecs {
+		pvcName := rsSpec.ProtectedPVC.Name
+		pvcNamespace := rsSpec.ProtectedPVC.Namespace
+		rsName := pvcName
+
+		rs := &volsyncv1alpha1.ReplicationSource{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      rsName,
+			Namespace: pvcNamespace,
+		}, rs); err != nil {
+			if k8serrors.IsNotFound(err) {
+				log.V(1).Info("RS not found, skipping PVC disownership", "RS", rsName)
+
+				continue
+			}
+
+			log.Error(err, "Failed to get RS for PVC disownership", "RS", rsName)
+
+			return err
+		}
+
+		if err := vsHandler.RemoveOwnerFromPVC(rs, pvcName, pvcNamespace); err != nil {
+			log.Error(err, "Failed to remove RS ownership from PVC", "RS", rsName, "PVC", pvcName)
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+func disownRDManagedPVCs(ctx context.Context, k8sClient client.Client, vsHandler *volsync.VSHandler,
+	rdSpecs []ramendrv1alpha1.VolSyncReplicationDestinationSpec, log logr.Logger,
+) error {
+	for _, rdSpec := range rdSpecs {
+		pvcName := rdSpec.ProtectedPVC.Name
+		pvcNamespace := rdSpec.ProtectedPVC.Namespace
+		rdName := util.GetReplicationDestinationName(pvcName)
+
+		rd := &volsyncv1alpha1.ReplicationDestination{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{
+			Name:      rdName,
+			Namespace: pvcNamespace,
+		}, rd); err != nil {
+			if k8serrors.IsNotFound(err) {
+				log.V(1).Info("RD not found, skipping PVC disownership", "RD", rdName)
+
+				continue
+			}
+
+			log.Error(err, "Failed to get RD for PVC disownership", "RD", rdName)
+
+			return err
+		}
+
+		if err := vsHandler.RemoveOwnerFromPVC(rd, pvcName, pvcNamespace); err != nil {
+			log.Error(err, "Failed to remove RD ownership from PVC", "RD", rdName, "PVC", pvcName)
+
+			return err
+		}
+	}
+
+	return nil
 }
 
 func ListReplicationGroupByOwner(ctx context.Context, k8sClient client.Client, objList client.ObjectList, ownerName,

--- a/internal/controller/cephfscg/cghandler_test.go
+++ b/internal/controller/cephfscg/cghandler_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Cghandler", func() {
 				}})
 			Expect(err).To(BeNil())
 			Expect(len(rgd.Spec.RDSpecs)).To(Equal(1))
-			Expect(cephfscg.DeleteRGD(Ctx, k8sClient, vgdName, "default", testLogger)).To(BeNil())
+			Expect(cephfscg.DeleteRGD(Ctx, k8sClient, vgdName, "default", testLogger, nil, true)).To(BeNil())
 			Eventually(func() bool {
 				err := k8sClient.Get(Ctx, types.NamespacedName{
 					Name:      rgdName,
@@ -204,7 +204,7 @@ var _ = Describe("Cghandler", func() {
 			Expect(finalSync).To(BeFalse())
 			Expect(rgs.Spec.Trigger.Schedule).NotTo(BeNil())
 			Expect(*rgs.Spec.Trigger.Schedule).NotTo(BeEmpty())
-			Expect(cephfscg.DeleteRGS(Ctx, k8sClient, vrgName, "default", testLogger)).To(BeNil())
+			Expect(cephfscg.DeleteRGS(Ctx, k8sClient, vrgName, "default", testLogger, nil, true)).To(BeNil())
 			Eventually(func() bool {
 				err := k8sClient.Get(Ctx, types.NamespacedName{
 					Name:      rgsName,

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -897,12 +897,11 @@ func (v *VRGInstance) pvcUnprotectVolSync(pvc corev1.PersistentVolumeClaim, log 
 		}
 	}
 
-	// Determine if VRG is being deleted to decide whether to skip PVC disownership
-	vrgBeingDeleted := util.ResourceIsDeleted(v.instance)
+	skipPVCDisownership := v.shouldSkipPVCDisownership()
 
-	log.Info("Unprotecting VolSync PVC", "PVC", pvc.Name, "vrgBeingDeleted", vrgBeingDeleted)
+	log.Info("Unprotecting VolSync PVC", "PVC", pvc.Name, "skipPVCDisownership", skipPVCDisownership)
 	// This call is only from Primary cluster. delete ReplicationSource/CG and related resources.
-	if err := v.volSyncHandler.UnprotectVolSyncPVC(&pvc, vrgBeingDeleted); err != nil {
+	if err := v.volSyncHandler.UnprotectVolSyncPVC(&pvc, skipPVCDisownership); err != nil {
 		log.Error(err, "Failed to unprotect VolSync PVC", "PVC", pvc.Name)
 
 		return
@@ -960,14 +959,16 @@ func (v *VRGInstance) cleanupResources() error {
 }
 
 func (v *VRGInstance) doCleanupResources(name, namespace string) error {
-	if err := v.volSyncHandler.DeleteRS(name, namespace, true); err != nil {
+	skipPVCDisownership := v.shouldSkipPVCDisownership()
+
+	if err := v.volSyncHandler.DeleteRS(name, namespace, skipPVCDisownership); err != nil {
 		return err
 	}
 
-	// Here, we don't remove the RD as an owner of the PVC as the RD is being deleted because the workload is being
-	// deleted. Instead, we want garbage collection to clean up the PVC as part of that RD deletion (because it is on
-	// the secondary.)
-	if err := v.volSyncHandler.DeleteRD(name, namespace, true); err != nil {
+	// When the workload is being deleted, we don't remove the RD as an owner of the PVC as the RD is being deleted.
+	// Instead, we want garbage collection to clean up the PVC as part of that RD deletion (because it is on
+	// the secondary.) During disable DR (do-not-delete-pvc), disown the PVC from the RD first so it survives.
+	if err := v.volSyncHandler.DeleteRD(name, namespace, skipPVCDisownership); err != nil {
 		return err
 	}
 
@@ -975,15 +976,27 @@ func (v *VRGInstance) doCleanupResources(name, namespace string) error {
 		return err
 	}
 
-	if err := cephfscg.DeleteRGS(v.ctx, v.reconciler.Client, v.instance.Name, v.instance.Namespace, v.log); err != nil {
+	if err := cephfscg.DeleteRGS(v.ctx, v.reconciler.Client, v.instance.Name, v.instance.Namespace, v.log,
+		v.volSyncHandler, skipPVCDisownership); err != nil {
 		return err
 	}
 
-	if err := cephfscg.DeleteRGD(v.ctx, v.reconciler.Client, v.instance.Name, v.instance.Namespace, v.log); err != nil {
+	if err := cephfscg.DeleteRGD(v.ctx, v.reconciler.Client, v.instance.Name, v.instance.Namespace, v.log,
+		v.volSyncHandler, skipPVCDisownership); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// shouldSkipPVCDisownership returns true when PVCs should be garbage-collected with VolSync resources
+// (workload deletion). Returns false during disable DR when do-not-delete-pvc is set and PVCs must survive.
+func (v *VRGInstance) shouldSkipPVCDisownership() bool {
+	if v.instance.GetAnnotations()[DoNotDeletePVCAnnotation] == DoNotDeletePVCAnnotationVal {
+		return false
+	}
+
+	return util.ResourceIsDeleted(v.instance)
 }
 
 func (v *VRGInstance) isSecondaryWithVolSyncProtectedPVCs() bool {

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -892,6 +892,7 @@ func (v *VRGInstance) pvcUnprotectVolSync(pvc corev1.PersistentVolumeClaim, log 
 
 		if err := markRGSResourceForDeletion(v.ctx, v.reconciler.Client, cg, pvc.Namespace); err != nil {
 			log.Error(err, "Failed to mark RGS for deletion", "CG", cg)
+			v.requeue()
 
 			return
 		}
@@ -903,6 +904,7 @@ func (v *VRGInstance) pvcUnprotectVolSync(pvc corev1.PersistentVolumeClaim, log 
 	// This call is only from Primary cluster. delete ReplicationSource/CG and related resources.
 	if err := v.volSyncHandler.UnprotectVolSyncPVC(&pvc, skipPVCDisownership); err != nil {
 		log.Error(err, "Failed to unprotect VolSync PVC", "PVC", pvc.Name)
+		v.requeue()
 
 		return
 	}


### PR DESCRIPTION
PR #2602 skipped PVC disownership whenever the VRG was deleting, which is correct for workload teardown but breaks disable DR: with do-not-delete-pvc set, PVCs must survive while VRG/RS/RD/RGS/RGD are removed.

Fixes disable DR regression where PVCs entered Terminating because RS ownership was retained and deleted with the ReplicationSource.

## Test results

### E2E
```
--- PASS: TestDR (6.14s)
    --- PASS: TestDR/appset-deploy-cephfs (49.37s)
        --- PASS: TestDR/appset-deploy-cephfs/Disable (49.37s)
PASS
```

```
--- PASS: TestDR/disapp-deploy-cephfs/Disable
PASS
```

### Manual checks shown for managed apps (same results for discovered apps)
```export APP_NS=test-appset-deploy-cephfs
kubectl --context dr1 get pvc -n $APP_NS \
  -o custom-columns=NAME:.metadata.name,PHASE:.status.phase,DELETING:.metadata.deletionTimestamp
kubectl --context dr1 get deploy,pod,vrg -n $APP_NS
NAME          PHASE   DELETING
busybox-pvc   Bound   <none>
NAME                      READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/busybox   1/1     1            1           6m51s
NAME                           READY   STATUS    RESTARTS   AGE
pod/busybox-54d5b75d6c-jkbql   1/1     Running   0          6m51s
```
```
kubectl --context dr1 logs -n ramen-system deploy/ramen-dr-cluster-operator | \
  grep -E 'skipPVCDisownership|Unprotecting VolSync PVC'
2026-07-02T10:33:15.585Z	INFO	vrg	controller/vrg_volsync.go:902	Unprotecting VolSync PVC	{"vrg": {"name":"appset-deploy-cephfs","namespace":"test-appset-deploy-cephfs"}, "rid": "03516936", "State": "primary", "Finalize": true, "PVC": "busybox-pvc", "skipPVCDisownership": false}
2026-07-02T10:33:15.585Z	INFO	vrg	volsync/vshandler.go:3355	Unprotecting VolSync PVC	{"vrg": {"name":"appset-deploy-cephfs","namespace":"test-appset-deploy-cephfs"}, "rid": "03516936", "pvcName": "busybox-pvc", "pvcNamespace": "test-appset-deploy-cephfs", "skipPVCDisownership": false}
```
```
kubectl --context dr1 get pvc -n $APP_NS busybox-pvc -o json | jq '{
  phase: .status.phase,
  deletionTimestamp: .metadata.deletionTimestamp,
  ownerReferences: .metadata.ownerReferences
}'
{
  "phase": "Bound",
  "deletionTimestamp": null,
  "ownerReferences": null
}
```
```
kubectl --context dr2 get pvc -n $APP_NS \
  -o custom-columns=NAME:.metadata.name,PHASE:.status.phase,DELETING:.metadata.deletionTimestamp
kubectl --context dr2 get deploy,pod,vrg -n $APP_NS
NAME          PHASE   DELETING
busybox-pvc   Bound   <none>
No resources found in test-appset-deploy-cephfs namespace.
```
```
for ctx in dr1 dr2; do
  echo "=== $ctx: PVCs with deletionTimestamp ==="
  kubectl --context $ctx get pvc -A -o json | \
    jq -r '.items[] | select(.metadata.deletionTimestamp != null) |
      "\(.metadata.namespace)/\(.metadata.name) phase=\(.status.phase) deleting=\(.metadata.deletionTimestamp)"'
done
=== dr1: PVCs with deletionTimestamp ===
=== dr2: PVCs with deletionTimestamp ===
```
### Result

- PVC busybox-pvc stays Bound with no `deletionTimestamp` on dr1 and dr2
- PVC disowned (ownerReferences: null)
- Operator logs show `skipPVCDisownership=false` during disable. QE's must gather logs pre-fix ignored annotation, skipped PVC disownership:

```
2026-06-30T13:30:19.637Z  INFO  vrg  Unprotecting VolSync PVC  {"PVC": "busybox-pvc-1", "vrgBeingDeleted": true}
2026-06-30T13:30:19.637Z  INFO  vrg  Unprotecting VolSync PVC  {"pvcName": "busybox-pvc-1", "skipPVCDisownership": true}
2026-06-30T13:30:19.656Z  INFO  vrg  Unprotecting VolSync PVC  {"pvcName": "busybox-pvc-2", "skipPVCDisownership": true}
2026-06-30T13:30:19.742Z  INFO  vrg  Unprotecting VolSync PVC  {"pvcName": "busybox-pvc-3", "skipPVCDisownership": true}
2026-06-30T13:30:19.582Z  INFO  pvcmap  Skipping PVC, as it is marked for deletion and not yet protected  {"pvc": "test-cephfs/busybox-pvc-2"}
```

- Workload Running on dr1; VRG/DRPC removed after disable

## TODO

- [x] Verify for non-CG path
- [ ] Verify for CG path - stuck due to issues with ELENAGER:drenv_cg_new