### PR TITLE
drenv: expose original exception in commands.Error.cause

### DIFF
--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -45,7 +45,7 @@ class Error(Exception):
 
     def with_exception(self, exc):
         """
-        Return a new error preserving the traceback from another excpetion.
+        Return a new error preserving the traceback from another exception.
         """
         self.__cause__ = None
         self.cause = exc

--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -33,6 +33,10 @@ _READ_BUF = 32 * 1024
 
 class Error(Exception):
 
+    # Set by with_exception() to the original exception that caused
+    # this error (e.g. FileNotFoundError for missing executables).
+    cause = None
+
     def __init__(self, command, error, exitcode=None, output=None):
         self.command = command
         self.error = error
@@ -44,6 +48,7 @@ class Error(Exception):
         Return a new error preserving the traceback from another excpetion.
         """
         self.__cause__ = None
+        self.cause = exc
         return self.with_traceback(exc.__traceback__)
 
     def __str__(self):

--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -304,7 +304,9 @@ def pipeline(*commands, input=None, decode=True, timeout=_DEFAULT_TIMEOUT):
                     proc.kill()
                 for proc in procs:
                     proc.wait()
-                raise PipelineError([Failure(cmd, None, f"Could not execute: {e}")])
+                raise PipelineError(
+                    [Failure(cmd, None, f"Could not execute: {e}")]
+                ).with_exception(e)
 
             # Close our reference so the previous process gets SIGPIPE if this
             # one exits.

--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -252,6 +252,7 @@ def test_watch_error_missing_executable():
         r"Could not execute: .*'no-such-executable-in-path'.*",
         e.value.error,
     )
+    assert e.value.__cause__ is None
 
 
 def test_watch_error_empty():
@@ -399,6 +400,7 @@ def test_run_error_missing_executable():
         r"Could not execute: .*'no-such-executable-in-path'.*",
         e.value.error,
     )
+    assert e.value.__cause__ is None
 
 
 def test_run_error_empty():

--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -253,6 +253,7 @@ def test_watch_error_missing_executable():
         e.value.error,
     )
     assert e.value.__cause__ is None
+    assert isinstance(e.value.cause, FileNotFoundError)
 
 
 def test_watch_error_empty():
@@ -401,6 +402,7 @@ def test_run_error_missing_executable():
         e.value.error,
     )
     assert e.value.__cause__ is None
+    assert isinstance(e.value.cause, FileNotFoundError)
 
 
 def test_run_error_empty():
@@ -411,6 +413,7 @@ def test_run_error_empty():
     assert e.value.exitcode == 1
     assert e.value.output == ""
     assert e.value.error == ""
+    assert e.value.cause is None
 
 
 def test_run_error():
@@ -561,6 +564,7 @@ def test_pipeline_error_missing_executable():
             ["true"],
         )
     assert e.value.__cause__ is None
+    assert isinstance(e.value.cause, FileNotFoundError)
 
 
 def test_pipeline_second_fail():

--- a/test/drenv/commands_test.py
+++ b/test/drenv/commands_test.py
@@ -554,6 +554,15 @@ def test_pipeline_first_fail():
     ]
 
 
+def test_pipeline_error_missing_executable():
+    with pytest.raises(commands.PipelineError) as e:
+        commands.pipeline(
+            ["no-such-executable-in-path"],
+            ["true"],
+        )
+    assert e.value.__cause__ is None
+
+
 def test_pipeline_second_fail():
     with pytest.raises(commands.PipelineError) as e:
         commands.pipeline(


### PR DESCRIPTION
- Add `cause` attribute to `commands.Error` exposing the original
  exception (e.g. `FileNotFoundError`) without breaking the unified
  traceback
- Fix `PipelineError` to preserve the traceback from the original
  `OSError` using `with_exception()`
- Add tests for `__cause__` suppression and the new `cause` attribute
- Fix typo in doctoring