### PR TITLE
drpc: Fix namespace ManifestWork deletion for discovered apps

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,6 +16,9 @@ linters:
       # default is false: such cases aren't reported by default.
       check-type-assertions: true
       check-blank: true
+      exclude-functions:
+        # crypto/rand.Read always returns nil error; it panics on failure (since Go 1.24).
+        - crypto/rand.Read
     gocognit:
       # minimal code complexity to report, 30 by default
       # (but we recommend 10-20)

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -2511,6 +2511,8 @@ func (d *DRPCInstance) ensureNamespaceManifestWork(homeCluster string) error {
 	return nil
 }
 
+// createOrUpdateNamespaces creates namespace ManifestWorks on the peer
+// clusters. See deleteNamespaceManifestWorks for the symmetric delete path.
 func (d *DRPCInstance) createOrUpdateNamespaces(homeCluster string) error {
 	if !isDiscoveredApp(d.instance) {
 		return d.createOrUpdateNSForNonDiscoveredApps(homeCluster)

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -2544,7 +2544,7 @@ func (d *DRPCInstance) createOrUpdateNSForDiscoveredApps(homeCluster string) err
 				continue
 			}
 
-			if err := d.mwu.CreateOrUpdateNamespaceManifest(d.instance.Name, protectedNamespaceObj.Name, dstCluster,
+			if err := d.mwu.CreateOrUpdateNamespaceManifestWork(d.instance.Name, protectedNamespaceObj.Name, dstCluster,
 				annotations, protectedNamespaceObj.Labels); err != nil {
 				return err
 			}
@@ -2560,7 +2560,7 @@ func (d *DRPCInstance) createOrUpdateNSForNonDiscoveredApps(homeCluster string) 
 	annotations[DRPCNameAnnotation] = d.instance.Name
 	annotations[DRPCNamespaceAnnotation] = d.instance.Namespace
 
-	err := d.mwu.CreateOrUpdateNamespaceManifest(d.instance.Name, d.vrgNamespace, homeCluster, annotations,
+	err := d.mwu.CreateOrUpdateNamespaceManifestWork(d.instance.Name, d.vrgNamespace, homeCluster, annotations,
 		map[string]string{})
 	if err != nil {
 		return fmt.Errorf("failed to create namespace '%s' on cluster %s: %w", d.vrgNamespace, homeCluster, err)

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -867,14 +867,10 @@ func deleteNamespaceManifestWorks(
 		namespaces = *drpc.Spec.ProtectedNamespaces
 	}
 
-	annotations := make(map[string]string)
-	annotations[DRPCNameAnnotation] = drpc.Name
-	annotations[DRPCNamespaceAnnotation] = drpc.Namespace
-
 	for _, ns := range namespaces {
 		for _, clusterName := range rmnutil.DRPolicyClusterNames(drPolicy) {
 			mwName := rmnutil.ManifestWorkName(drpc.Name, ns, rmnutil.MWTypeNS)
-			if err := mwu.DeleteNamespaceManifestWork(mwName, clusterName, annotations); err != nil {
+			if err := mwu.DeleteNamespaceManifestWork(mwName, clusterName); err != nil {
 				return err
 			}
 		}

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -2798,7 +2798,7 @@ func adoptOrphanVRG(
 	annotations[DRPCNamespaceAnnotation] = drpc.Namespace
 
 	// Adopt the namespace as well
-	err := mwu.CreateOrUpdateNamespaceManifest(drpc.Name, vrgNamespace, cluster, annotations, map[string]string{})
+	err := mwu.CreateOrUpdateNamespaceManifestWork(drpc.Name, vrgNamespace, cluster, annotations, map[string]string{})
 	if err != nil {
 		log.Info("error creating namespace via ManifestWork during adoption", "error", err, "cluster", cluster)
 

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -815,15 +815,8 @@ func (r *DRPlacementControlReconciler) finalizeDRPC(ctx context.Context, drpc *r
 		return err
 	}
 
-	// delete namespace manifestwork
-	for _, drClusterName := range rmnutil.DRPolicyClusterNames(drPolicy) {
-		annotations := make(map[string]string)
-		annotations[DRPCNameAnnotation] = drpc.Name
-		annotations[DRPCNamespaceAnnotation] = drpc.Namespace
-
-		if err := mwu.DeleteNamespaceManifestWork(drClusterName, annotations); err != nil {
-			return err
-		}
+	if err := deleteNamespaceManifestWorks(drpc, drPolicy, mwu, vrgNamespace); err != nil {
+		return err
 	}
 
 	// delete recipe manifestwork
@@ -856,6 +849,36 @@ func (r *DRPlacementControlReconciler) finalizeDRPC(ctx context.Context, drpc *r
 
 	globalActionLabels := GlobalActionLabels(drpc)
 	DeleteGlobalActionMetric(globalActionLabels)
+
+	return nil
+}
+
+// deleteNamespaceManifestWorks deletes namespace ManifestWorks for all
+// clusters in the DRPolicy, handling both discovered and non-discovered apps.
+// See createOrUpdateNamespaces for the symmetric create path.
+func deleteNamespaceManifestWorks(
+	drpc *rmn.DRPlacementControl,
+	drPolicy *rmn.DRPolicy,
+	mwu rmnutil.MWUtil,
+	vrgNamespace string,
+) error {
+	namespaces := []string{vrgNamespace}
+	if isDiscoveredApp(drpc) {
+		namespaces = *drpc.Spec.ProtectedNamespaces
+	}
+
+	annotations := make(map[string]string)
+	annotations[DRPCNameAnnotation] = drpc.Name
+	annotations[DRPCNamespaceAnnotation] = drpc.Namespace
+
+	for _, ns := range namespaces {
+		for _, clusterName := range rmnutil.DRPolicyClusterNames(drPolicy) {
+			mwName := rmnutil.ManifestWorkName(drpc.Name, ns, rmnutil.MWTypeNS)
+			if err := mwu.DeleteNamespaceManifestWork(mwName, clusterName, annotations); err != nil {
+				return err
+			}
+		}
+	}
 
 	return nil
 }

--- a/internal/controller/util/mw_util.go
+++ b/internal/controller/util/mw_util.go
@@ -711,8 +711,7 @@ func (mwu *MWUtil) createOrUpdateManifestWork(
 	return ctrlutil.OperationResultNone, nil
 }
 
-func (mwu *MWUtil) DeleteNamespaceManifestWork(clusterName string, annotations map[string]string) error {
-	mwName := mwu.BuildManifestWorkName(MWTypeNS)
+func (mwu *MWUtil) DeleteNamespaceManifestWork(mwName string, clusterName string, annotations map[string]string) error {
 	mw := &ocmworkv1.ManifestWork{}
 
 	err := mwu.Client.Get(mwu.Ctx, types.NamespacedName{Name: mwName, Namespace: clusterName}, mw)

--- a/internal/controller/util/mw_util.go
+++ b/internal/controller/util/mw_util.go
@@ -353,7 +353,7 @@ func (mwu *MWUtil) IsManifestApplied(cluster, mwType string) bool {
 }
 
 // Namespace MW creation
-func (mwu *MWUtil) CreateOrUpdateNamespaceManifest(
+func (mwu *MWUtil) CreateOrUpdateNamespaceManifestWork(
 	name string, namespaceName string, managedClusterNamespace string,
 	annotations map[string]string, labels map[string]string,
 ) error {
@@ -730,10 +730,10 @@ func (mwu *MWUtil) DeleteNamespaceManifestWork(clusterName string, annotations m
 	}
 
 	// check if the manifestwork has delete Option set
-	// if not set, call CreateOrUpdateNamespaceManifest such that it is
+	// if not set, call CreateOrUpdateNamespaceManifestWork such that it is
 	// updated with the delete option
 	if mw.Spec.DeleteOption == nil {
-		err = mwu.CreateOrUpdateNamespaceManifest(mwu.InstName, mwu.TargetNamespace, clusterName, annotations,
+		err = mwu.CreateOrUpdateNamespaceManifestWork(mwu.InstName, mwu.TargetNamespace, clusterName, annotations,
 			map[string]string{})
 		if err != nil {
 			mwu.Log.Info("error creating namespace via ManifestWork", "error", err, "cluster", clusterName)

--- a/internal/controller/util/mw_util.go
+++ b/internal/controller/util/mw_util.go
@@ -711,7 +711,7 @@ func (mwu *MWUtil) createOrUpdateManifestWork(
 	return ctrlutil.OperationResultNone, nil
 }
 
-func (mwu *MWUtil) DeleteNamespaceManifestWork(mwName string, clusterName string, annotations map[string]string) error {
+func (mwu *MWUtil) DeleteNamespaceManifestWork(mwName string, clusterName string) error {
 	mw := &ocmworkv1.ManifestWork{}
 
 	err := mwu.Client.Get(mwu.Ctx, types.NamespacedName{Name: mwName, Namespace: clusterName}, mw)
@@ -728,14 +728,17 @@ func (mwu *MWUtil) DeleteNamespaceManifestWork(mwName string, clusterName string
 		return nil
 	}
 
-	// check if the manifestwork has delete Option set
-	// if not set, call CreateOrUpdateNamespaceManifestWork such that it is
-	// updated with the delete option
 	if mw.Spec.DeleteOption == nil {
-		err = mwu.CreateOrUpdateNamespaceManifestWork(mwu.InstName, mwu.TargetNamespace, clusterName, annotations,
-			map[string]string{})
-		if err != nil {
-			mwu.Log.Info("error creating namespace via ManifestWork", "error", err, "cluster", clusterName)
+		if err := mwu.ensureOrphanDeleteOption(mwName, clusterName); err != nil {
+			if k8serrors.IsNotFound(err) {
+				// The MW was deleted without the orphan delete option, so the managed
+				// resource (user namespace) may have been deleted on the managed cluster.
+				// This should not happen but we must log it clearly for diagnosis.
+				mwu.Log.Error(nil, "ManifestWork deleted without orphan delete option",
+					"name", mwName, "namespace", clusterName)
+
+				return nil
+			}
 
 			return err
 		}
@@ -745,6 +748,30 @@ func (mwu *MWUtil) DeleteNamespaceManifestWork(mwName string, clusterName string
 	if err != nil {
 		return fmt.Errorf("%w", err)
 	}
+
+	return nil
+}
+
+// ensureOrphanDeleteOption sets the orphan delete option on a ManifestWork.  This is typically not needed since
+// CreateOrUpdateNamespaceManifestWork always sets the delete option, but is needed for MWs created by older versions.
+func (mwu *MWUtil) ensureOrphanDeleteOption(mwName string, clusterName string) error {
+	mw := &ocmworkv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      mwName,
+			Namespace: clusterName,
+		},
+	}
+
+	// Using a merge patch to update only the deleteOption field. The patch is applied server-side, avoiding conflicts
+	// with concurrent updates to other fields.
+	patch := client.RawPatch(types.MergePatchType,
+		[]byte(`{"spec":{"deleteOption":{"propagationPolicy":"Orphan"}}}`))
+
+	if err := mwu.Client.Patch(mwu.Ctx, mw, patch); err != nil {
+		return fmt.Errorf("failed to set orphan delete option on ManifestWork %s/%s: %w", clusterName, mwName, err)
+	}
+
+	mwu.Log.Info("Patched ManifestWork delete option", "name", mwName, "namespace", clusterName)
 
 	return nil
 }

--- a/internal/controller/util/mw_util_test.go
+++ b/internal/controller/util/mw_util_test.go
@@ -4,12 +4,21 @@
 package util_test
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ocmworkv1 "open-cluster-management.io/api/work/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rmnutil "github.com/ramendr/ramen/internal/controller/util"
 )
@@ -261,3 +270,115 @@ var _ = Describe("IsManifestInAppliedState", func() {
 		})
 	})
 })
+
+var _ = Describe("DeleteNamespaceManifestWork", Ordered, func() {
+	var (
+		ctx         context.Context
+		clusterName string
+		mwu         rmnutil.MWUtil
+	)
+
+	// Use a unique namespace per test run since envtest does not support namespace
+	// deletion (the kube-controller-manager is not running).
+	// https://book.kubebuilder.io/reference/envtest#testing-considerations
+	BeforeAll(func() {
+		ctx = context.TODO()
+		randomBytes := make([]byte, 8)
+		rand.Read(randomBytes) // panics on failure
+		clusterName = fmt.Sprintf("delete-ns-mw-%s", hex.EncodeToString(randomBytes))
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterName,
+			},
+		}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+
+		mwu = rmnutil.MWUtil{
+			Client: k8sClient,
+			Ctx:    ctx,
+			Log:    ctrl.Log.WithName("test"),
+		}
+	})
+
+	It("sets orphan delete option on ManifestWork without one", func() {
+		mwName := "without-delete-option"
+		mw := &ocmworkv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       mwName,
+				Namespace:  clusterName,
+				Finalizers: []string{"test.ramendr.openshift.io/keep-for-inspection"},
+			},
+		}
+		Expect(k8sClient.Create(ctx, mw)).To(Succeed())
+		DeferCleanup(deleteManifestWork, ctx, mwName, clusterName)
+
+		Expect(mwu.DeleteNamespaceManifestWork(mwName, clusterName)).To(Succeed())
+
+		key := types.NamespacedName{Name: mwName, Namespace: clusterName}
+		Expect(k8sClient.Get(ctx, key, mw)).To(Succeed())
+		Expect(mw.DeletionTimestamp.IsZero()).To(BeFalse())
+		Expect(mw.Spec.DeleteOption).To(Equal(&ocmworkv1.DeleteOption{
+			PropagationPolicy: ocmworkv1.DeletePropagationPolicyTypeOrphan,
+		}))
+	})
+
+	It("keeps existing orphan delete option", func() {
+		mwName := "with-delete-option"
+		mw := &ocmworkv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       mwName,
+				Namespace:  clusterName,
+				Finalizers: []string{"test.ramendr.openshift.io/keep-for-inspection"},
+			},
+			Spec: ocmworkv1.ManifestWorkSpec{
+				DeleteOption: &ocmworkv1.DeleteOption{
+					PropagationPolicy: ocmworkv1.DeletePropagationPolicyTypeOrphan,
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, mw)).To(Succeed())
+		DeferCleanup(deleteManifestWork, ctx, mwName, clusterName)
+
+		Expect(mwu.DeleteNamespaceManifestWork(mwName, clusterName)).To(Succeed())
+
+		key := types.NamespacedName{Name: mwName, Namespace: clusterName}
+		Expect(k8sClient.Get(ctx, key, mw)).To(Succeed())
+		Expect(mw.DeletionTimestamp.IsZero()).To(BeFalse())
+		Expect(mw.Spec.DeleteOption).To(Equal(&ocmworkv1.DeleteOption{
+			PropagationPolicy: ocmworkv1.DeletePropagationPolicyTypeOrphan,
+		}))
+	})
+})
+
+// deleteManifestWork is a best-effort cleanup helper that removes finalizers and deletes a
+// ManifestWork. Errors are logged but do not fail the test.
+func deleteManifestWork(ctx context.Context, name, namespace string) {
+	mw := &ocmworkv1.ManifestWork{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+
+	patch := client.RawPatch(types.MergePatchType,
+		[]byte(`{"metadata":{"finalizers":null}}`))
+
+	if err := k8sClient.Patch(ctx, mw, patch); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return
+		}
+
+		testLogger.Error(err, "Failed to remove finalizers", "name", name, "namespace", namespace)
+
+		return
+	}
+
+	if err := k8sClient.Delete(ctx, mw); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return
+		}
+
+		testLogger.Error(err, "Failed to delete ManifestWork", "name", name, "namespace", namespace)
+	}
+}

--- a/internal/controller/util/util_suite_test.go
+++ b/internal/controller/util/util_suite_test.go
@@ -21,6 +21,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	ocmworkv1 "open-cluster-management.io/api/work/v1"
 	cpcv1 "open-cluster-management.io/config-policy-controller/api/v1"
 	gppv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -114,6 +115,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = snapv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = ocmworkv1.Install(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Creating a k8s client")

--- a/internal/controller/volsync/secretgen.go
+++ b/internal/controller/volsync/secretgen.go
@@ -40,10 +40,7 @@ func ReconcileVolSyncReplicationSecret(ctx context.Context, k8sClient client.Cli
 		return existingSecret, nil
 	}
 
-	secret, err := generateNewVolSyncReplicationSecret(secretName, secretNamespace, log)
-	if err != nil {
-		return nil, err
-	}
+	secret := generateNewVolSyncReplicationSecret(secretName, secretNamespace)
 
 	if err := ctrl.SetControllerReference(ownerObject, secret, k8sClient.Scheme()); err != nil {
 		log.Error(err, "unable to set controller reference on secret")
@@ -64,14 +61,8 @@ func ReconcileVolSyncReplicationSecret(ctx context.Context, k8sClient client.Cli
 }
 
 // Pre-shared key for rsync TLS mover
-func generateNewVolSyncReplicationSecret(secretName, secretNamespace string, log logr.Logger) (*corev1.Secret, error,
-) {
-	tlsKey, err := genTLSPreSharedKey(log)
-	if err != nil {
-		log.Error(err, "Unable to generate new tls secret for VolSync replication")
-
-		return nil, err
-	}
+func generateNewVolSyncReplicationSecret(secretName, secretNamespace string) *corev1.Secret {
+	tlsKey := genTLSPreSharedKey()
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -88,16 +79,12 @@ func generateNewVolSyncReplicationSecret(secretName, secretNamespace string, log
 
 	rmnutil.AddLabel(secret, rmnutil.CreatedByRamenLabel, "true")
 
-	return secret, nil
+	return secret
 }
 
-func genTLSPreSharedKey(log logr.Logger) (string, error) {
+func genTLSPreSharedKey() string {
 	pskData := make([]byte, tlsPSKDataSize)
-	if _, err := rand.Read(pskData); err != nil {
-		log.Error(err, "error generating tls key")
+	rand.Read(pskData) // panics on failure
 
-		return "", err
-	}
-
-	return hex.EncodeToString(pskData), nil
+	return hex.EncodeToString(pskData)
 }


### PR DESCRIPTION
This change fixes 2 problems when deleting ManifestWork for discovered
applications, adds unit tests, and cleans up unnecessary error handling.

## Problem 1: Wrong ManifestWork name during deletion

When deleting a DRPC for a discovered app, namespace ManifestWorks are
never deleted. The deletion code used mwu.TargetNamespace (the
management namespace, e.g. "ramen-ops") to build the ManifestWork name,
but discovered apps create namespace ManifestWorks using each protected
namespace name (e.g. "test-multi-1"). The resulting name mismatch causes
a silent NotFound, leaving orphaned ManifestWorks on the hub cluster.

Change DeleteNamespaceManifestWork to accept the ManifestWork name from
the caller, consistent with CreateOrUpdateNamespaceManifestWork which
already accepts explicit name and namespace arguments. The new
deleteNamespaceManifestWorks helper in finalizeDRPC builds the correct
ManifestWork name for each namespace, iterating ProtectedNamespaces for
discovered apps and using vrgNamespace for non-discovered apps.

## Problem 2: Wrong ManifestWork updated for orphan delete option

When DeleteNamespaceManifestWork needed to set the orphan delete option
on a ManifestWork created by an older version, it called
CreateOrUpdateNamespaceManifestWork using mwu.TargetNamespace. For
discovered apps, this is the management namespace (e.g. "ramen-ops"),
not the protected namespace, so it would update or create the wrong
ManifestWork.

Replace the CreateOrUpdateNamespaceManifestWork call with a new
ensureOrphanDeleteOption helper that uses a server-side merge patch
to set only the deleteOption field, avoiding conflicts with concurrent
updates to other fields.

## Disable errcheck for crypto/rand.Read

Since Go 1.24, crypto/rand.Read always returns nil error and panics on
failure. Remove unnecessary error handling from genTLSPreSharedKey and
exclude crypto/rand.Read from the errcheck linter project-wide.

## Unit tests for DeleteNamespaceManifestWork

The ensureOrphanDeleteOption code path is never exercised in e2e tests
since test environments always create ManifestWorks with the delete
option already set. Only ManifestWorks created by older versions are
missing it, so the first time this code would run is on a real user
cluster during an upgrade.

Add envtest-based tests to verify both cases:
- ManifestWork without a delete option: the orphan delete option is set
  via a merge patch before deletion
- ManifestWork with a delete option: the existing option is preserved

---
Fixes: #2650
Fixes: #2651
Assisted-by: Cursor/Claude Opus 4