### PR TITLE
e2e: Delete namespaces after DRPC is fully deleted in Purge

### DIFF
--- a/e2e/deployers/appset.go
+++ b/e2e/deployers/appset.go
@@ -87,6 +87,17 @@ func (a ApplicationSet) Undeploy(ctx types.TestContext) error {
 		return err
 	}
 
+	// Delete namespaces only after resources are gone. Deleting the placement triggers
+	// DRPC deletion via the owner reference, and we must wait for the DRPC to be fully
+	// gone before deleting namespaces. See https://github.com/RamenDR/ramen/issues/2642
+	if err := a.DeleteNamespaces(ctx); err != nil {
+		return err
+	}
+
+	if err := a.WaitForNamespacesDelete(ctx); err != nil {
+		return err
+	}
+
 	log.Info("Workload undeployed")
 
 	return nil
@@ -105,7 +116,7 @@ func (a ApplicationSet) DeleteResources(ctx types.TestContext) error {
 		return err
 	}
 
-	return util.DeleteNamespaceOnManagedClusters(ctx, ctx.AppNamespace())
+	return nil
 }
 
 func (a ApplicationSet) WaitForResourcesDelete(ctx types.TestContext) error {
@@ -117,10 +128,14 @@ func (a ApplicationSet) WaitForResourcesDelete(ctx types.TestContext) error {
 		return err
 	}
 
-	if err := util.WaitForPlacementDelete(ctx, ctx.Env().Hub, ctx.Name(), ctx.ManagementNamespace()); err != nil {
-		return err
-	}
+	return util.WaitForPlacementDelete(ctx, ctx.Env().Hub, ctx.Name(), ctx.ManagementNamespace())
+}
 
+func (a ApplicationSet) DeleteNamespaces(ctx types.TestContext) error {
+	return util.DeleteNamespaceOnManagedClusters(ctx, ctx.AppNamespace())
+}
+
+func (a ApplicationSet) WaitForNamespacesDelete(ctx types.TestContext) error {
 	return util.WaitForNamespaceDeleteOnManagedClusters(ctx, ctx.AppNamespace())
 }
 

--- a/e2e/deployers/disapp.go
+++ b/e2e/deployers/disapp.go
@@ -108,6 +108,17 @@ func (d DiscoveredApp) Undeploy(ctx types.TestContext) error {
 		return err
 	}
 
+	// Delete namespaces only after resources are gone. Deleting the placement triggers
+	// DRPC deletion via the owner reference, and we must wait for the DRPC to be fully
+	// gone before deleting namespaces. See https://github.com/RamenDR/ramen/issues/2642
+	if err := d.DeleteNamespaces(ctx); err != nil {
+		return err
+	}
+
+	if err := d.WaitForNamespacesDelete(ctx); err != nil {
+		return err
+	}
+
 	log.Info("Workload undeployed")
 
 	return nil
@@ -137,7 +148,7 @@ func (d DiscoveredApp) DeleteResources(ctx types.TestContext) error {
 		}
 	}
 
-	return util.DeleteNamespaceOnManagedClusters(ctx, ctx.AppNamespace())
+	return nil
 }
 
 func (d DiscoveredApp) WaitForResourcesDelete(ctx types.TestContext) error {
@@ -154,6 +165,14 @@ func (d DiscoveredApp) WaitForResourcesDelete(ctx types.TestContext) error {
 		}
 	}
 
+	return nil
+}
+
+func (d DiscoveredApp) DeleteNamespaces(ctx types.TestContext) error {
+	return util.DeleteNamespaceOnManagedClusters(ctx, ctx.AppNamespace())
+}
+
+func (d DiscoveredApp) WaitForNamespacesDelete(ctx types.TestContext) error {
 	return util.WaitForNamespaceDeleteOnManagedClusters(ctx, ctx.AppNamespace())
 }
 

--- a/e2e/deployers/subscr.go
+++ b/e2e/deployers/subscr.go
@@ -115,6 +115,17 @@ func (s Subscription) Undeploy(ctx types.TestContext) error {
 		return err
 	}
 
+	// Delete namespaces only after resources are gone. Deleting the placement triggers
+	// DRPC deletion via the owner reference, and we must wait for the DRPC to be fully
+	// gone before deleting namespaces. See https://github.com/RamenDR/ramen/issues/2642
+	if err := s.DeleteNamespaces(ctx); err != nil {
+		return err
+	}
+
+	if err := s.WaitForNamespacesDelete(ctx); err != nil {
+		return err
+	}
+
 	log.Info("Workload undeployed")
 
 	return nil
@@ -137,14 +148,18 @@ func (s Subscription) DeleteResources(ctx types.TestContext) error {
 		return err
 	}
 
-	return util.DeleteNamespaceOnManagedClusters(ctx, ctx.AppNamespace())
+	return nil
 }
 
 func (s Subscription) WaitForResourcesDelete(ctx types.TestContext) error {
-	if err := util.WaitForNamespaceDelete(ctx, ctx.Env().Hub, ctx.ManagementNamespace()); err != nil {
-		return err
-	}
+	return util.WaitForNamespaceDelete(ctx, ctx.Env().Hub, ctx.ManagementNamespace())
+}
 
+func (s Subscription) DeleteNamespaces(ctx types.TestContext) error {
+	return util.DeleteNamespaceOnManagedClusters(ctx, ctx.AppNamespace())
+}
+
+func (s Subscription) WaitForNamespacesDelete(ctx types.TestContext) error {
 	return util.WaitForNamespaceDeleteOnManagedClusters(ctx, ctx.AppNamespace())
 }
 

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -238,6 +238,17 @@ func Purge(ctx types.TestContext) error {
 		return err
 	}
 
+	// Delete namespaces only after the DRPC is fully deleted. We could delete them
+	// right after waitForProtectionResourcesDelete, but we keep the same order as
+	// Undeploy for consistency. See https://github.com/RamenDR/ramen/issues/2642
+	if err := ctx.Deployer().DeleteNamespaces(ctx); err != nil {
+		return err
+	}
+
+	if err := ctx.Deployer().WaitForNamespacesDelete(ctx); err != nil {
+		return err
+	}
+
 	log.Info("Workload purged")
 
 	return nil

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -211,16 +211,8 @@ func Relocate(ctx types.TestContext) error {
 func Purge(ctx types.TestContext) error {
 	log := ctx.Logger()
 
-	cluster, err := util.GetCurrentCluster(ctx, ctx.ManagementNamespace(), ctx.Name())
-	if err != nil {
-		if !k8serrors.IsNotFound(err) {
-			return err
-		}
-
-		log.Info("Purging workload")
-	} else {
-		log.Infof("Purging workload in cluster %q", cluster.Name)
-	}
+	// We cannot get the current cluster since the placement decision may be missing during relocate.
+	log.Info("Purging workload")
 
 	if err := deleteProtectionResources(ctx); err != nil {
 		return err

--- a/e2e/types/types.go
+++ b/e2e/types/types.go
@@ -43,6 +43,8 @@ type WorkloadStatus struct {
 }
 
 // Deployer interface has methods to deploy a workload to a cluster
+//
+//nolint:interfacebloat
 type Deployer interface {
 	Deploy(TestContext) error
 	Undeploy(TestContext) error
@@ -52,10 +54,16 @@ type Deployer interface {
 	// IsDiscovered returns true for OCM discovered application, false for OCM managed applications.
 	IsDiscovered() bool
 
-	// DeleteResources removes all resources that were deployed as part of the workload
+	// DeleteResources removes all resources that were deployed as part of the workload, except namespaces.
 	DeleteResources(TestContext) error
-	// WaitForResourcesDelete waits for all workload resources to be deleted
+	// WaitForResourcesDelete waits for all workload resources to be deleted, except namespaces.
 	WaitForResourcesDelete(TestContext) error
+
+	// DeleteNamespaces deletes the application namespaces on managed clusters.  Must be called only after the DRPC is
+	// fully deleted. For more info see https://github.com/RamenDR/ramen/issues/2642
+	DeleteNamespaces(TestContext) error
+	// WaitForNamespacesDelete waits for the application namespaces to be deleted on managed clusters.
+	WaitForNamespacesDelete(TestContext) error
 
 	// GetRecipe returns the recipe if the deployer is configured to use one.
 	// Returns nil if the deployer is not configured to use a recipe.


### PR DESCRIPTION
When Purge deletes namespaces concurrently with DRPC deletion, the
namespaces are recreated by OCM from the namespace ManifestWork while
DRPC finalization is still in progress. After finalization completes,
the MWs are deleted with Orphan policy, leaving empty namespaces on
managed clusters that cause the cleanup to time out.

Additionally, deleting namespaces while the DRPC is still active
deletes the VRGs on both clusters simultaneously, bypassing ramen's
secondary-first VRG deletion order, which can lead to stuck
replication requiring manual image cleanup.

Split namespace deletion out of DeleteResources/WaitForResourcesDelete
into separate DeleteNamespaces/WaitForNamespacesDelete methods on the
Deployer interface. Purge now deletes namespaces only after the DRPC
is fully gone, letting ramen handle VRG cleanup in the correct order.

## Testing

Tested with 8 discovered apps on minikube clusters.

```yaml
tests:
- name: multi-1
  workload: deploy
  deployer: disapp
  pvcSpec: rbd
- name: multi-2
  workload: deploy
  deployer: disapp
  pvcSpec: rbd
- name: multi-3
  workload: deploy
  deployer: disapp
  pvcSpec: rbd
- name: multi-4
  workload: deploy
  deployer: disapp
  pvcSpec: rbd
- name: multi-5
  workload: deploy
  deployer: disapp
  pvcSpec: rbd
- name: multi-6
  workload: deploy
  deployer: disapp
  pvcSpec: rbd
- name: multi-7
  workload: deploy
  deployer: disapp
  pvcSpec: rbd
- name: multi-8
  workload: deploy
  deployer: disapp
  pvcSpec: rbd
```

### Before the fix

Cancel a test run mid-failover and run test clean:

```console
% ramenctl test run -o out/multi-purge
...
✅ Application "multi-4" protected
^C

% ramenctl test clean -o out/multi-purge
⭐ Using config "config.yaml"
⭐ Using report "out/multi-purge"

🔎 Validate config ...
   ✅ Config validated

🔎 Clean tests ...
   ✅ Application "multi-1" cleaned up
   ✅ Application "multi-4" cleaned up
   ✅ Application "multi-8" cleaned up
   ✅ Application "multi-7" cleaned up
   ❌ Failed to purge application "multi-6"
   ❌ Failed to purge application "multi-3"
   ❌ Failed to purge application "multi-5"
   ❌ Failed to purge application "multi-2"

❌ Test clean failed (4 passed, 4 failed, 0 skipped, 0 canceled)
```

4 of 8 apps timed out waiting for namespace deletion. The namespaces
were recreated by OCM right after purge deleted them:

```console
% kubectl get ns --context dr1 | grep test-multi-
test-multi-3   Active   3m38s
test-multi-6   Active   3m37s

% kubectl get ns --context dr2 | grep test-multi-
test-multi-2   Active   3m6s
test-multi-5   Active   3m6s
```

A second cleanup was needed to clean the recreated namespaces.

### After the fix

Deploy and protect 8 apps, then purge:

```console
% ./run.sh -config ../../ramenctl/config.yaml -test.run TestDR//Deploy
% ./run.sh -config ../../ramenctl/config.yaml -test.run TestDR//Enable

% ramenctl test clean -o out/purge-manual
⭐ Using config "config.yaml"
⭐ Using report "out/purge-manual"

🔎 Validate config ...
   ✅ Config validated

🔎 Clean tests ...
   ✅ Application "multi-5" cleaned up
   ✅ Application "multi-8" cleaned up
   ✅ Application "multi-4" cleaned up
   ✅ Application "multi-2" cleaned up
   ✅ Application "multi-3" cleaned up
   ✅ Application "multi-6" cleaned up
   ✅ Application "multi-1" cleaned up
   ✅ Application "multi-7" cleaned up

🔎 Clean environment ...
   ✅ Environment cleaned

✅ Test clean passed (8 passed, 0 failed, 0 skipped, 0 canceled)
```

No leftover namespaces:

```console
% kubectl get ns --context dr1 | grep test-multi-
% kubectl get ns --context dr2 | grep test-multi-
```

---
Fixes: #2642
Tested-with: #2641
Assisted-by: Cursor/Claude Opus 4