### PR TITLE
drenv: Update argocd & helm to latest versions

### DIFF
--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -222,7 +222,7 @@ clusters. *Ramen* makes this easy using minikube, but you need enough resources:
 1. Install the `argocd` tool
 
    ```
-   curl -L -o argocd https://github.com/argoproj/argo-cd/releases/download/v2.11.3/argocd-linux-amd64
+   curl -L -o argocd https://github.com/argoproj/argo-cd/releases/download/v3.4.4/argocd-linux-amd64
    sudo install argocd /usr/local/bin/
    rm argocd
    argocd version --client

--- a/test/README.md
+++ b/test/README.md
@@ -102,7 +102,7 @@ environment.
    ```
 
    See [Installing Helm](https://helm.sh/docs/intro/install/) for other options
-   Tested with version v4.0.1.
+   Tested with version v4.2.2.
 
 1. Install the `virtctl` tool
 

--- a/test/README.md
+++ b/test/README.md
@@ -143,7 +143,7 @@ environment.
 1. Install the `argocd` tool
 
    ```
-   curl -L -o argocd https://github.com/argoproj/argo-cd/releases/download/v2.11.3/argocd-linux-amd64
+   curl -L -o argocd https://github.com/argoproj/argo-cd/releases/download/v3.4.4/argocd-linux-amd64
    sudo install argocd /usr/local/bin/
    rm argocd
    argocd version --client

--- a/test/drenv/addons/argocd/config.py
+++ b/test/drenv/addons/argocd/config.py
@@ -4,4 +4,4 @@
 from pathlib import Path
 
 PACKAGE_DIR = Path(__file__).parent
-CACHE_KEY = "addons/argocd-2.11-1.yaml"
+CACHE_KEY = "addons/argocd-3.4-1.yaml"

--- a/test/drenv/addons/argocd/start-data/kustomization.yaml
+++ b/test/drenv/addons/argocd/start-data/kustomization.yaml
@@ -6,7 +6,7 @@
 resources:
   - argocd-ns.yaml
   - argocd-mcsb.yaml
-  - https://raw.githubusercontent.com/argoproj/argo-cd/release-2.11/manifests/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.4.4/manifests/install.yaml
 
 # In argocd appset DR e2e test, an appset CR will be created that uses placementdecision
 # resource to decide which cluster to deploy application. So here need add role for

--- a/test/drenv/addons/argocd/start.py
+++ b/test/drenv/addons/argocd/start.py
@@ -29,7 +29,17 @@ def wait_for_clusters(clusters):
 def deploy_argocd(cluster):
     print("Deploying argocd")
     path = _cache.get(str(PACKAGE_DIR / "start-data"), CACHE_KEY)
-    kubectl.apply("--filename", path, "--namespace", "argocd", context=cluster)
+    # Using Server-side Apply to avoid this failure:
+    #   The CustomResourceDefinition "applicationsets.argoproj.io" is invalid:
+    #   metadata.annotations: Too long: may not be more than 262144 bytes
+    kubectl.apply(
+        "--filename",
+        path,
+        "--namespace",
+        "argocd",
+        "--server-side=true",
+        context=cluster,
+    )
 
 
 def wait_for_deployments(cluster):

--- a/test/scripts/bootstrap-linux
+++ b/test/scripts/bootstrap-linux
@@ -138,9 +138,9 @@ TOOLS = [
     },
     {
         "name": "argocd",
-        "version": "v2.11.3",
+        "version": "v3.4.4",
         "url": "https://github.com/argoproj/argo-cd/releases/download/{version}/argocd-{goos}-{goarch}",
-        "digest": "6b7551e83e8296a7b0ee265400429e81185fc49f012b537016ded6ef17c178f0",
+        "digest": "b93c312956880c9597a246a7d1e705fbb7ee7f19c5229affdec99b26d5663e09",
         "verify": ["argocd", "version", "--client"],
     },
     {

--- a/test/scripts/bootstrap-linux
+++ b/test/scripts/bootstrap-linux
@@ -108,9 +108,9 @@ TOOLS = [
     },
     {
         "name": "helm",
-        "version": "v4.2.0",
+        "version": "v4.2.2",
         "url": "https://get.helm.sh/helm-{version}-{goos}-{goarch}.tar.gz",
-        "digest": "97dbeb971be4ac4b27e3839976d9564c0fb35c6f3b1da89dd1e292d236af4096",
+        "digest": "9adafecab4d406853bba163a70e9f104f47dbbf65ce24b7653bae7e36150bcb6",
         "member": "{goos}-{goarch}/helm",
         "verify": ["helm", "version"],
     },


### PR DESCRIPTION

**Update argocd and helm to latest stable versions**
Changes

- Update argocd from v2.11.3 to v3.4.4 (latest stable as of 2026-06-18)
- Switch kustomization.yaml from floating release-2.11 branch ref to pinned v3.4.4 tag for reproducibility
- Update helm from v4.2.0 to v4.2.2 (latest stable as of 2026-06-17)

**Validation
ArgoCD v3.4.4**

Deployed argocd on drenv and verified all deployments are running the updated image:
```
# oc get deploy -n argocd -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.template.spec.containers[0].image}{"\n"}{end}'
argocd-applicationset-controller	quay.io/argoproj/argocd:v3.4.4
argocd-dex-server	ghcr.io/dexidp/dex:v2.45.0
argocd-notifications-controller	quay.io/argoproj/argocd:v3.4.4
argocd-redis	public.ecr.aws/docker/library/redis:8.2.3-alpine
argocd-repo-server	quay.io/argoproj/argocd:v3.4.4
argocd-server	quay.io/argoproj/argocd:v3.4.4

# oc exec -n argocd deploy/argocd-server -- argocd version 2>/dev/null
argocd: v3.4.4
  BuildDate: 2026-06-18T08:48:48Z
  GitCommit: 443415b5527ac55366e0760c93ef0e1abd0cf273
  GitTreeState: clean
  GitTag: v3.4.4
  GoVersion: go1.26.0
  Platform: linux/amd64
```
**Helm v4.2.2**

Verified helm works correctly for the drenv volsync addon use case:
```
# helm version
version.BuildInfo{Version:"v4.2.2", GitCommit:"b05881cf967a5a09e19866799d0edfd40675803a", GitTreeState:"clean", GoVersion:"go1.26.4"}

# helm repo add --force-update backube https://backube.github.io/helm-charts/
"backube" has been added to your repositories

# helm search repo backube/volsync
NAME              CHART VERSION   APP VERSION   DESCRIPTION
backube/volsync   0.16.0          0.16.0        Asynchronous data replication for Kubernetes
```