### PR TITLE
drpc: Fix namespace MCV deletion for discovered apps

### DIFF
--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -970,10 +970,9 @@ func (r *DRPlacementControlReconciler) deleteAllManagedClusterViews(
 			return fmt.Errorf("failed to delete VRG MCV %w", err)
 		}
 
-		// Delete MCV for Namespace
-		err = r.MCVGetter.DeleteNamespaceManagedClusterView(drpc.Name, drpc.Namespace, drClusterName, rmnutil.MWTypeNS)
-		if err != nil {
-			return fmt.Errorf("failed to delete namespace MCV %w", err)
+		// Delete MCVs for protected namespaces
+		if err := r.deleteProtectedNamespaceMCVs(drpc, drClusterName); err != nil {
+			return err
 		}
 
 		// Delete MCV for Recipe
@@ -986,6 +985,25 @@ func (r *DRPlacementControlReconciler) deleteAllManagedClusterViews(
 			if err != nil {
 				return fmt.Errorf("failed to delete recipe MCV %w", err)
 			}
+		}
+	}
+
+	return nil
+}
+
+// deleteProtectedNamespaceMCVs deletes MCVs for protected namespaces. These MCVs are created by
+// createOrUpdateNSForDiscoveredApps via GetNSFromManagedCluster, named "{namespace}-ns-mcv" (e.g.,
+// "test-multi-1-ns-mcv"). Does nothing for non-discovered apps.
+func (r *DRPlacementControlReconciler) deleteProtectedNamespaceMCVs(
+	drpc *rmn.DRPlacementControl, clusterName string,
+) error {
+	if !isDiscoveredApp(drpc) {
+		return nil
+	}
+
+	for _, ns := range *drpc.Spec.ProtectedNamespaces {
+		if err := r.MCVGetter.DeleteNamespaceManagedClusterView(ns, "", clusterName, rmnutil.MWTypeNS); err != nil {
+			return fmt.Errorf("failed to delete namespace MCV for %q: %w", ns, err)
 		}
 	}
 


### PR DESCRIPTION
When deleting a DRPC for a discovered app, deleteAllManagedClusterViews used the DRPC name and namespace to build the MCV name (e.g., "busybox-ramen-ns-mcv"). However, namespace MCVs are created by GetNSFromManagedCluster using the protected namespace name with an empty resourceNamespace (e.g., "test-multi-1-ns-mcv"). The names never matched, so the deletion was always a no-op. The bug was hidden because DeleteManagedClusterView returns nil for NotFound errors.

For discovered apps, iterate over ProtectedNamespaces and delete each namespace MCV using the namespace name, matching how GetNSFromManagedCluster creates them. Non-discovered apps do not create namespace MCVs, so no deletion is needed.

Fixes: #2653
Assisted-by: Cursor/Claude Opus 4