### PR TITLE
volsync: preserve PVC ownerReferences when adding RD/RS as owners

### DIFF
--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -292,13 +292,28 @@ func AddOwnerReference(obj, owner metav1.Object, scheme *runtime.Scheme) (bool, 
 func RemoveOwnerReference(obj, owner metav1.Object, scheme *runtime.Scheme) (bool, error) {
 	currentOwnerRefs := obj.GetOwnerReferences()
 
-	length := len(currentOwnerRefs)
-	if length < 1 {
+	if len(currentOwnerRefs) < 1 {
 		return false, nil // No owner references to remove
 	}
 
-	// TODO: Remove just the owner's Reference instead of blindly removing all ownerreferences.
-	obj.SetOwnerReferences(nil)
+	ownerObj, ok := owner.(client.Object)
+	if !ok {
+		return false, fmt.Errorf("%T is not a client.Object, cannot call RemoveOwnerReference", owner)
+	}
+
+	// If the owner reference is not present, treat it as a no-op rather than an error.
+	found, err := controllerutil.HasOwnerReference(currentOwnerRefs, ownerObj, scheme)
+	if err != nil {
+		return false, err
+	}
+
+	if !found {
+		return false, nil
+	}
+
+	if err := controllerutil.RemoveOwnerReference(owner, obj, scheme); err != nil {
+		return false, err
+	}
 
 	return true, nil
 }

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -298,25 +298,56 @@ func (v *VSHandler) setRDAndRSAsOwnerOfPVC(
 	obj client.Object,
 	pvc *corev1.PersistentVolumeClaim,
 ) error {
-	// Only set OwnerReference if RD and PVC are in the same namespace
+	// Only set OwnerReference if RD/RS and PVC are in the same namespace
 	if obj.GetNamespace() != pvc.Namespace {
 		return nil
 	}
-
-	// Work on a deep copy to avoid mutating caller's object
-	updated := pvc.DeepCopy()
 
 	kind, err := getKindRSorRD(obj)
 	if err != nil {
 		return err
 	}
 
-	// Create a new controller reference
-	ref := metav1.NewControllerRef(
-		obj,
-		volsyncv1alpha1.GroupVersion.WithKind(kind))
-	// Overwrite OwnerReferences with the new one
-	updated.SetOwnerReferences([]metav1.OwnerReference{*ref})
+	gvk := volsyncv1alpha1.GroupVersion.WithKind(kind)
+
+	// Neither RD nor RS is the controller of the PVC; they are non-controlling owners.
+	ref := metav1.OwnerReference{
+		APIVersion:         gvk.GroupVersion().String(),
+		Kind:               gvk.Kind,
+		Name:               obj.GetName(),
+		UID:                obj.GetUID(),
+		Controller:         ptr.To(false),
+		BlockOwnerDeletion: ptr.To(false),
+	}
+
+	// Work on a deep copy to avoid mutating caller's object
+	updated := pvc.DeepCopy()
+
+	needsAppend := true
+
+	for i, existing := range updated.GetOwnerReferences() {
+		if existing.UID != ref.UID {
+			continue
+		}
+
+		// Owner reference already exists. If its Controller field is true,
+		// downgrade it to false — RS/RD must never be the controller of the PVC.
+		if ptr.Deref(existing.Controller, false) {
+			updated.OwnerReferences[i].Controller = ptr.To(false)
+		} else {
+			// Already present with Controller=false; nothing to do.
+			return nil
+		}
+
+		needsAppend = false
+
+		break
+	}
+
+	if needsAppend {
+		newRefs := append(updated.GetOwnerReferences(), ref)
+		updated.SetOwnerReferences(newRefs)
+	}
 
 	// Update the PVC
 	if err := v.client.Update(v.ctx, updated); err != nil {
@@ -939,6 +970,7 @@ func (v *VSHandler) createTmpPVCForFinalSync(pvcNamespacedName types.NamespacedN
 		}
 
 		tmpPVC = pvc.DeepCopy()
+		tmpPVC.SetOwnerReferences(nil)
 		tmpPVC.Name = util.GetTmpPVCNameForFinalSync(pvc.Name)
 		tmpPVC.ResourceVersion = ""
 		tmpPVC.UID = ""
@@ -2033,21 +2065,7 @@ func (v *VSHandler) EnsurePVCforDirectCopy(ctx context.Context,
 		return fmt.Errorf("capacity must be provided %v", rdSpec.ProtectedPVC)
 	}
 
-	pvc, err := v.getPVC(util.ProtectedPVCNamespacedName(rdSpec.ProtectedPVC))
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-
-	if pvc != nil {
-		// This PVC is used by the RD. We don't need have the finalizer.
-		ctrlutil.RemoveFinalizer(pvc, PVCFinalizerProtected)
-
-		if err := v.removeOCMAnnotationsAndUpdate(pvc); err != nil {
-			return err
-		}
-	}
-
-	pvc = &corev1.PersistentVolumeClaim{
+	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      rdSpec.ProtectedPVC.Name,
 			Namespace: rdSpec.ProtectedPVC.Namespace,
@@ -2062,6 +2080,17 @@ func (v *VSHandler) EnsurePVCforDirectCopy(ctx context.Context,
 		}
 
 		pvc.Spec.Resources.Requests = rdSpec.ProtectedPVC.Resources.Requests
+
+		// Remove the VolSync protection finalizer and OCM annotations inside the
+		// mutate func so they are handled in the same single write as the rest of
+		// the PVC mutations. Previously these were applied via a separate
+		// client.Update on a stale copy of the PVC fetched at function entry,
+		// which raced with the StatefulSet controller adding its ownerReference
+		// (persistentVolumeClaimRetentionPolicy.whenDeleted: Delete). That race
+		// caused the StatefulSet ownerRef to be silently stripped, preventing
+		// Kubernetes GC from deleting the PVC when the StatefulSet was removed.
+		ctrlutil.RemoveFinalizer(pvc, PVCFinalizerProtected)
+		removeOCMAnnotations(pvc)
 
 		util.SyncPVCLabels(pvc, rdSpec.ProtectedPVC.Labels)
 		util.SyncPVCAnnotations(pvc, rdSpec.ProtectedPVC.Annotations)
@@ -3298,7 +3327,9 @@ func (v *VSHandler) addBackOCMAnnotationsAndUpdate(obj client.Object, annotation
 	return v.client.Update(v.ctx, obj)
 }
 
-func (v *VSHandler) removeOCMAnnotationsAndUpdate(obj client.Object) error {
+// removeOCMAnnotations removes all ACM appsub annotations from obj in-place without
+// performing any API write.
+func removeOCMAnnotations(obj client.Object) {
 	updatedAnnotations := map[string]string{}
 
 	for key, val := range obj.GetAnnotations() {
@@ -3308,8 +3339,6 @@ func (v *VSHandler) removeOCMAnnotationsAndUpdate(obj client.Object) error {
 	}
 
 	obj.SetAnnotations(updatedAnnotations)
-
-	return v.client.Update(v.ctx, obj)
 }
 
 func (v *VSHandler) IsActiveJobPresent(name, namespace string) (bool, error) {
@@ -3363,7 +3392,7 @@ func (v *VSHandler) UnprotectVolSyncPVC(pvc *corev1.PersistentVolumeClaim, skipP
 	}
 
 	// Remove the VolSync labels and annotations from the PVC
-	return util.NewResourceUpdater(pvc).
+	updater := util.NewResourceUpdater(pvc).
 		DeleteLabel(util.VRGOwnerNameLabel).
 		DeleteLabel(util.VRGOwnerNamespaceLabel).
 		DeleteLabel(VolSyncDoNotDeleteLabel).
@@ -3371,9 +3400,16 @@ func (v *VSHandler) UnprotectVolSyncPVC(pvc *corev1.PersistentVolumeClaim, skipP
 		DeleteLabel(util.LabelOwnerNamespaceName).
 		DeleteLabel(util.ConsistencyGroupLabel).
 		DeleteLabel(util.CreatedByRamenLabel).
-		RemoveFinalizer(PVCFinalizerProtected).
-		RemoveOwner(v.owner, v.client.Scheme()).
-		Update(v.ctx, v.client)
+		RemoveFinalizer(PVCFinalizerProtected)
+
+	// Skip removing the VRG owner reference when the VRG itself is being deleted:
+	// Kubernetes GC will cascade-delete the PVC via the existing owner reference,
+	// so stripping it here would orphan the PVC instead of letting GC clean it up.
+	if !skipPVCDisownership {
+		updater = updater.RemoveOwner(v.owner, v.client.Scheme())
+	}
+
+	return updater.Update(v.ctx, v.client)
 }
 
 func updateClaimRef(pv *corev1.PersistentVolume, name, namespace string) {

--- a/internal/controller/volsync/vshandler_test.go
+++ b/internal/controller/volsync/vshandler_test.go
@@ -710,7 +710,7 @@ var _ = Describe("VolSync_Handler", func() {
 					// RD should NOT have VRG owner
 					Expect(ownerMatches(rd, owner.GetName(), "ConfigMap", true)).To(BeFalse())
 
-					// 4) PVC should have RD as controller owner (re-fetch PVC)
+					// 4) PVC should have RD as non-controlling owner (re-fetch PVC)
 					Eventually(func() bool {
 						pvcCheck := &corev1.PersistentVolumeClaim{}
 						if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pvc), pvcCheck); err != nil {
@@ -718,7 +718,7 @@ var _ = Describe("VolSync_Handler", func() {
 						}
 
 						// fmt.Printf("PVC ownerRefs after RD creation: %+v\n", pvcCheck.GetOwnerReferences())
-						return ownerMatches(pvcCheck, rd.GetName(), "ReplicationDestination", true)
+						return ownerMatches(pvcCheck, rd.GetName(), "ReplicationDestination", false)
 					}, maxWait, interval).Should(BeTrue())
 
 					// PVC should still have VRG labels
@@ -742,7 +742,7 @@ var _ = Describe("VolSync_Handler", func() {
 						Namespace: testNamespace.GetName(),
 					}, pvcCheck)).To(Succeed())
 					// fmt.Printf("PVC ownerRefs after RD deletion: %+v\n", pvcCheck.GetOwnerReferences())
-					Expect(ownerMatches(pvcCheck, rd.GetName(), "ReplicationDestination", true)).To(BeTrue())
+					Expect(ownerMatches(pvcCheck, rd.GetName(), "ReplicationDestination", false)).To(BeTrue())
 				})
 			})
 		})


### PR DESCRIPTION
Previously, setRDAndRSAsOwnerOfPVC called SetOwnerReferences with a single-element slice, silently wiping any pre-existing owner references on the PVC whenever protection was applied.

Fix three issues in that function:

- Append the new owner reference instead of overwriting the whole slice, so existing owner references (e.g. set by the application or another controller) are preserved.

- Set Controller: false for both ReplicationDestination and ReplicationSource. Neither owns the lifecycle of the PVC; they are non-controlling dependents, and marking them as controllers was incorrect.

- Skip the API update when the owner reference is already present (match by UID), avoiding unnecessary writes on every reconcile.

Update the two vshandler_test.go assertions that expected Controller: true for ReplicationDestination to reflect the corrected behaviour.

Assisted by IBM Bob