### PR TITLE
feat:VM Static IP: Verify if VM uses static IP before restore.

### DIFF
--- a/internal/controller/util/vm_util.go
+++ b/internal/controller/util/vm_util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -18,7 +19,26 @@ import (
 const (
 	KindVirtualMachine = "VirtualMachine"
 	KubeVirtAPIVersion = "kubevirt.io/v1"
+	// VMStaticIPAnnotation is the annotation placed on spec.template.metadata
+	// to pre-reserve a specific IP from an OVN-K8s, used by DR to identify the
+	// static IP configured VM
+	VMStaticIPAnnotation = "network.kubevirt.io/addresses"
 )
+
+// VMStaticIPInfo holds per-VM static IP detection results.
+// HasStaticIP=false is not an error — it means the VM uses DHCP or pod
+// network and requires no IP translation during DR.
+type VMStaticIPInfo struct {
+	VMName    string
+	Namespace string
+	// HasStaticIP is true when the VM carries the network.kubevirt.io/addresses
+	// annotation on spec.template.metadata, indicating a UDN/CUDN static IP
+	// reservation that must be translated on failover/relocate.
+	HasStaticIP bool
+	// PrimaryAddresses holds the interface→IPs parsed directly from the
+	// annotation on the primary cluster. This is the source for translation.
+	PrimaryAddresses map[string][]string
+}
 
 func ListVMsByLabelSelector(
 	ctx context.Context,
@@ -235,4 +255,17 @@ func fetchPartialMeta(
 
 func gvkString(o metav1.OwnerReference) string {
 	return o.APIVersion + "/" + o.Kind
+}
+
+// ParseVMInterfaceAddresses parses the network.kubevirt.io/addresses annotation.
+// Value format: '{"primary-udn": ["192.168.0.100"]'
+// Returns the full interface→IPs mapping, or nil on parse failure.
+// Callers that only need interface names can iterate the map keys.
+func ParseVMInterfaceAddresses(raw string) map[string][]string {
+	var mapping map[string][]string
+	if err := json.Unmarshal([]byte(raw), &mapping); err != nil {
+		return nil
+	}
+
+	return mapping
 }

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -2666,6 +2666,13 @@ func (v *VRGInstance) CheckForVMConflictOnPrimary() error {
 			"label selector, potentially affecting failover or recovery")
 	}
 
+	// Label-selector agreement is proven. Now populate static IP discovery status.
+	if err := v.validateAndRecordStaticIPDiscovery(vmList, vmNamespace); err != nil {
+		v.log.Error(err, "Failed to validate and record static IP discovery")
+
+		return err
+	}
+
 	return nil
 }
 
@@ -2947,4 +2954,96 @@ func (v *VRGInstance) aggregateVRGAutoCleanupCondition() *metav1.Condition {
 
 func (v *VRGInstance) isDiscoveredApp() bool {
 	return v.instance.Spec.ProtectedNamespaces != nil && len(*v.instance.Spec.ProtectedNamespaces) > 0
+}
+
+// validateAndRecordStaticIPDiscovery validates static IP annotations and populates
+// v.instance.Status.StaticIPDiscoveryStatus using the already-fetched VM list.
+// This is called from CheckForVMConflictOnPrimary after label-selector validation.
+func (v *VRGInstance) validateAndRecordStaticIPDiscovery(vmList []string, vmNamespace []string) error {
+	infos, err := v.ValidateStaticIPNetworkMapping(vmList, vmNamespace)
+	if err != nil {
+		return fmt.Errorf("static IP validation failed: %w", err)
+	}
+
+	if infos != nil {
+		v.log.Info("Static IP discovery complete")
+	}
+
+	return nil
+}
+
+// ValidateStaticIPNetworkMapping inspects every protected VM in the VRG and
+// classifies each one as requiring static IP translation or not.
+//
+// This is intentionally per-VM: a single DRPC/VRG may protect a mixed group
+// where some VMs use a static IP via UDN/CUDN and others use plain pod
+// network with DHCP. Only VMs carrying the network.kubevirt.io/addresses
+// annotation need IP translation; the rest are left untouched.
+//
+// Returns (nil, nil) when no protected VM list is configured. Returns an error
+// if the protected VMs cannot be listed or if a static IP annotation is present
+// but malformed.
+
+func (v *VRGInstance) ValidateStaticIPNetworkMapping(
+	vmList []string, vmNamespaceList []string,
+) ([]util.VMStaticIPInfo, error) {
+	if len(vmList) == 0 {
+		v.log.V(1).Info("No VM list found; no VMs to classify for static IP")
+
+		return nil, nil
+	}
+
+	vms, err := util.ListVMsByVMNamespace(v.ctx, v.reconciler.Client, v.log, vmNamespaceList, vmList)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list protected VMs for static IP validation: %w", err)
+	}
+
+	v.log.Info("Classifying protected VMs for static IP translation", "count", len(vms))
+
+	results := make([]util.VMStaticIPInfo, 0, len(vms))
+
+	for i := range vms {
+		vm := &vms[i]
+
+		info := util.VMStaticIPInfo{
+			VMName:    vm.Name,
+			Namespace: vm.Namespace,
+			// HasStaticIP defaults to false — correct for DHCP VMs
+		}
+
+		// spec.template.metadata.annotations is where OVN-K8s
+		// places the static IP reservation - distinct from the VM object's own annotations.
+		// Template is a pointer in the KubeVirt API; guard before dereferencing.
+		if vm.Spec.Template != nil {
+			raw, ok := vm.Spec.Template.ObjectMeta.Annotations[util.VMStaticIPAnnotation]
+			if ok {
+				info.HasStaticIP = true
+				info.PrimaryAddresses = util.ParseVMInterfaceAddresses(raw)
+
+				if info.PrimaryAddresses == nil {
+					return results, fmt.Errorf(
+						"VM %s/%s has malformed static IP annotation %q (invalid JSON format); "+
+							"expected format: {\"interface-name\": [\"ip-address\"]}. "+
+							"Fix the annotation value to allow IP translation",
+						vm.Namespace, vm.Name, raw,
+					)
+				}
+
+				v.log.Info("VM has static IP reservation",
+					"vm", vm.Name,
+					"namespace", vm.Namespace,
+					"interfaces", info.PrimaryAddresses,
+				)
+			}
+		} else {
+			v.log.V(1).Info("VM has no static IP annotation, skipping",
+				"vm", vm.Name,
+				"namespace", vm.Namespace,
+			)
+		}
+
+		results = append(results, info)
+	}
+
+	return results, nil
 }


### PR DESCRIPTION
Verify if VM uses static IP before restore.
vrg: Detect VM static IP annotation before kube objects restore

Discovered apps using the vm-recipe protection scheme may include VMs
that have a static IP reserved via an OVN-K8s UDN/CUDN annotation
(network.kubevirt.io/addresses on spec.template.metadata). During DR
failover these VMs require IP translation resource modifiers to be
injected into the Velero restore; VMs without the annotation (DHCP or
plain pod network) require no translation.

Add ValidateStaticIPNetworkMapping that iterates every protected VM in
the VRG and classifies each one:
- HasStaticIP=true + Interfaces list  → annotation present and parseable
- HasStaticIP=true + Interfaces nil   → annotation present but malformed;
  returns an error and sets KubeObjectsReady=False via
  setVRGKubeObjectsErrorCondition, blocking kube objects restore until
  the annotation is fixed
- HasStaticIP=false                   → no annotation; DHCP/pod network,
  no translation needed

Add ParseStaticIPInterfaces in vm_util.go to unmarshal the JSON map
{"<iface>": ["<ip>", …], …} and return the map of interface name and IP.

Add VMStaticIPAnnotation constant ("network.kubevirt.io/addresses").

Call ValidateStaticIPNetworkMapping after VM CheckForVMConflictOnPrimary
on Primary VRG so that a malformed annotation is caught early and
surfaced as a KubeObjectsReady=False condition rather than silently
proceeding with an incomplete IP translation set.