### PR TITLE
test: use server-side apply by default

### DIFF
--- a/ramendev/ramendev/config.py
+++ b/ramendev/ramendev/config.py
@@ -78,7 +78,13 @@ def generate_config_map(controller, env, args):
 
 def create_ramen_config_map(cluster, yaml):
     command.info("Updating ramen config map in cluster '%s'", cluster)
-    kubectl.apply("--filename=-", input=yaml, context=cluster, log=command.debug)
+    kubectl.apply(
+        "--filename=-",
+        "--force-conflicts",
+        input=yaml,
+        context=cluster,
+        log=command.debug,
+    )
 
 
 def create_ramen_ops_binding(cluster):

--- a/ramendev/ramendev/config.py
+++ b/ramendev/ramendev/config.py
@@ -80,7 +80,7 @@ def create_ramen_config_map(cluster, yaml):
     command.info("Updating ramen config map in cluster '%s'", cluster)
     kubectl.apply(
         "--filename=-",
-        "--force-conflicts",
+        force_conflicts=True,
         input=yaml,
         context=cluster,
         log=command.debug,

--- a/ramendev/ramendev/resources/configmap.yaml
+++ b/ramendev/ramendev/resources/configmap.yaml
@@ -4,8 +4,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  labels:
-    cluster.open-cluster-management.io/backup: resource
   name: $name
   namespace: $namespace
 data:

--- a/test/drenv/addons/argocd/start.py
+++ b/test/drenv/addons/argocd/start.py
@@ -29,15 +29,11 @@ def wait_for_clusters(clusters):
 def deploy_argocd(cluster):
     print("Deploying argocd")
     path = _cache.get(str(PACKAGE_DIR / "start-data"), CACHE_KEY)
-    # Using Server-side Apply to avoid this failure:
-    #   The CustomResourceDefinition "applicationsets.argoproj.io" is invalid:
-    #   metadata.annotations: Too long: may not be more than 262144 bytes
     kubectl.apply(
         "--filename",
         path,
         "--namespace",
         "argocd",
-        "--server-side=true",
         context=cluster,
     )
 

--- a/test/drenv/addons/olm/start.py
+++ b/test/drenv/addons/olm/start.py
@@ -17,12 +17,8 @@ def start(cluster):
 def deploy(cluster):
     print("Deploying olm crds")
 
-    # Using Server-side Apply to avoid this failure:
-    #   The CustomResourceDefinition "clusterserviceversions.operators.coreos.com"
-    #   is invalid: metadata.annotations: Too long: must have at most 262144 bytes
-    # See https://medium.com/pareture/kubectl-install-crd-failed-annotations-too-long-2ebc91b40c7d
     path = _cache.get(str(PACKAGE_DIR / "start-data" / "crds"), CRDS_CACHE_KEY)
-    kubectl.apply("--filename", path, "--server-side=true", context=cluster)
+    kubectl.apply("--filename", path, context=cluster)
 
     print("Waiting until cdrs are established")
     kubectl.wait(

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -76,10 +76,19 @@ def exec(*args, context=None):
     return _run("exec", *args, context=context)
 
 
-def apply(*args, input=None, context=None, log=print):
+def apply(*args, server_side=True, input=None, context=None, log=print):
     """
     Run kubectl apply ... logging progress messages.
+
+    Server-side apply is enabled by default to avoid the large
+    last-applied-configuration annotation created by client-side apply.
     """
+    args = list(args)
+    for arg in args:
+        if arg == "--server-side" or arg.startswith("--server-side="):
+            raise ValueError("use server_side argument instead of --server-side flag")
+    if server_side:
+        args.append("--server-side=true")
     _watch("apply", *args, input=input, context=context, log=log)
 
 

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -16,6 +16,21 @@ JSONPATH_NEWLINE = '{"\\n"}'
 # distinguishable for rollout() (only "status" supports --timeout).
 _DEFAULT_TIMEOUT = sentinel.Duration(300)
 
+_APPLY_FLAGS_WITH_VALUE = frozenset(
+    ("-f", "--filename", "-k", "--kustomize", "--template")
+)
+
+
+def _apply_flags(args):
+    """Yield flags while skipping values consumed by preceding options."""
+    previous = None
+    for arg in args:
+        if previous in _APPLY_FLAGS_WITH_VALUE:
+            previous = None
+            continue
+        previous = arg
+        yield arg
+
 
 def version(context=None, output=None):
     """
@@ -76,10 +91,19 @@ def exec(*args, context=None):
     return _run("exec", *args, context=context)
 
 
-def apply(*args, input=None, context=None, log=print):
+def apply(*args, server_side=True, input=None, context=None, log=print):
     """
     Run kubectl apply ... logging progress messages.
+
+    Server-side apply is enabled by default to avoid the large
+    last-applied-configuration annotation created by client-side apply.
     """
+    args = list(args)
+    for flag in _apply_flags(args):
+        if flag == "--server-side" or flag.startswith("--server-side="):
+            raise ValueError("use server_side argument instead of --server-side flag")
+    if server_side:
+        args.append("--server-side=true")
     _watch("apply", *args, input=input, context=context, log=log)
 
 

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -16,6 +16,21 @@ JSONPATH_NEWLINE = '{"\\n"}'
 # distinguishable for rollout() (only "status" supports --timeout).
 _DEFAULT_TIMEOUT = sentinel.Duration(300)
 
+_APPLY_FLAGS_WITH_VALUE = frozenset(
+    ("-f", "--filename", "-k", "--kustomize", "--template")
+)
+
+
+def _apply_flags(args):
+    """Yield flags while skipping values consumed by preceding options."""
+    previous = None
+    for arg in args:
+        if previous in _APPLY_FLAGS_WITH_VALUE:
+            previous = None
+            continue
+        previous = arg
+        yield arg
+
 
 def version(context=None, output=None):
     """
@@ -84,8 +99,8 @@ def apply(*args, server_side=True, input=None, context=None, log=print):
     last-applied-configuration annotation created by client-side apply.
     """
     args = list(args)
-    for arg in args:
-        if arg == "--server-side" or arg.startswith("--server-side="):
+    for flag in _apply_flags(args):
+        if flag == "--server-side" or flag.startswith("--server-side="):
             raise ValueError("use server_side argument instead of --server-side flag")
     if server_side:
         args.append("--server-side=true")

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -91,7 +91,14 @@ def exec(*args, context=None):
     return _run("exec", *args, context=context)
 
 
-def apply(*args, server_side=True, input=None, context=None, log=print):
+def apply(
+    *args,
+    server_side=True,
+    force_conflicts=False,
+    input=None,
+    context=None,
+    log=print,
+):
     """
     Run kubectl apply ... logging progress messages.
 
@@ -102,8 +109,14 @@ def apply(*args, server_side=True, input=None, context=None, log=print):
     for flag in _apply_flags(args):
         if flag == "--server-side" or flag.startswith("--server-side="):
             raise ValueError("use server_side argument instead of --server-side flag")
+        if flag == "--force-conflicts" or flag.startswith("--force-conflicts="):
+            raise ValueError(
+                "use force_conflicts argument instead of --force-conflicts flag"
+            )
     if server_side:
         args.append("--server-side=true")
+    if force_conflicts:
+        args.append("--force-conflicts")
     _watch("apply", *args, input=input, context=context, log=log)
 
 

--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -17,9 +17,8 @@ from drenv.addons import example
 # Avoid random timeouts in github.
 TIMEOUT = 30
 
-pytestmark = pytest.mark.cluster
 
-
+@pytest.mark.cluster
 def test_version(tmpenv):
     out = kubectl.version(output="json", context=tmpenv.profile)
     info = json.loads(out)
@@ -28,16 +27,19 @@ def test_version(tmpenv):
     assert "clientVersion" in info
 
 
+@pytest.mark.cluster
 def test_get(tmpenv):
     out = kubectl.get("deploy", "--output=name", context=tmpenv.profile)
     assert out.strip() == "deployment.apps/example-deployment"
 
 
+@pytest.mark.cluster
 def test_config(tmpenv):
     out = kubectl.config("view", "--output=json")
     json.loads(out)
 
 
+@pytest.mark.cluster
 def test_exec(tmpenv):
     out = kubectl.exec(
         "deploy/example-deployment",
@@ -48,12 +50,70 @@ def test_exec(tmpenv):
     assert out.startswith("example-deployment-")
 
 
+@pytest.mark.cluster
 def test_apply(tmpenv, capsys):
     kubectl.apply(f"--filename={example.DEPLOYMENT}", context=tmpenv.profile)
     out, err = capsys.readouterr()
-    assert out.strip() == "deployment.apps/example-deployment unchanged"
+    assert out.strip() == "deployment.apps/example-deployment serverside-applied"
 
 
+@pytest.mark.cluster
+@pytest.mark.parametrize(
+    ("server_side", "has_last_applied"),
+    [(None, False), (True, False), (False, True)],
+)
+def test_apply_mode(tmpenv, tmp_path, server_side, has_last_applied):
+    name = f"test-apply-{secrets.token_hex(4)}"
+    resource = f"configmap/{name}"
+    manifest = tmp_path / "configmap.yaml"
+    manifest.write_text(
+        f"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {name}\n",
+        encoding="utf-8",
+    )
+
+    try:
+        kwargs = {} if server_side is None else {"server_side": server_side}
+        kubectl.apply(
+            f"--filename={manifest}",
+            **kwargs,
+            context=tmpenv.profile,
+        )
+        out = kubectl.get(resource, "--output=json", context=tmpenv.profile)
+        metadata = json.loads(out)["metadata"]
+        annotations = metadata.get("annotations", {})
+        assert (
+            "kubectl.kubernetes.io/last-applied-configuration" in annotations
+        ) is has_last_applied
+    finally:
+        kubectl.delete(
+            resource,
+            "--ignore-not-found=true",
+            context=tmpenv.profile,
+        )
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("--server-side", "true"),
+        ("--server-side", "false"),
+        ("--server-side=true",),
+        ("--server-side=false",),
+    ],
+)
+def test_apply_rejects_raw_server_side_flags(args):
+    with pytest.raises(
+        ValueError,
+        match="use server_side argument instead of --server-side flag",
+    ):
+        kubectl.apply(
+            "--filename=resource.yaml",
+            *args,
+            context="non-existing",
+        )
+
+
+@pytest.mark.cluster
 def test_rollout_status(tmpenv, capsys):
     kubectl.rollout(
         "status",
@@ -65,6 +125,7 @@ def test_rollout_status(tmpenv, capsys):
     assert out.strip() == 'deployment "example-deployment" successfully rolled out'
 
 
+@pytest.mark.cluster
 def test_rollout_status_default_timeout(tmpenv, capsys):
     kubectl.rollout(
         "status",
@@ -75,6 +136,7 @@ def test_rollout_status_default_timeout(tmpenv, capsys):
     assert out.strip() == 'deployment "example-deployment" successfully rolled out'
 
 
+@pytest.mark.cluster
 def test_rollout_restart(tmpenv, capsys):
     kubectl.rollout(
         "restart",
@@ -104,6 +166,7 @@ def test_rollout_restart_unsupported_timeout():
         )
 
 
+@pytest.mark.cluster
 def test_wait(tmpenv, capsys):
     kubectl.wait(
         "deploy/example-deployment",
@@ -115,6 +178,7 @@ def test_wait(tmpenv, capsys):
     assert out.strip() == "deployment.apps/example-deployment condition met"
 
 
+@pytest.mark.cluster
 def test_wait_for_create(tmpenv):
     """Wait for a resource that does not exist yet."""
     name = f"test-wait-create-{secrets.token_hex(4)}"
@@ -143,6 +207,7 @@ def test_wait_for_create(tmpenv):
         kubectl.delete(resource, context=tmpenv.profile, log=logging.debug)
 
 
+@pytest.mark.cluster
 def test_wait_for_jsonpath_value(tmpenv):
     """Wait for a jsonpath field that does not exist yet."""
     name = f"test-wait-jsonpath-{secrets.token_hex(4)}"
@@ -179,6 +244,7 @@ def test_wait_for_jsonpath_value(tmpenv):
         kubectl.delete(resource, context=tmpenv.profile, log=logging.debug)
 
 
+@pytest.mark.cluster
 def test_wait_for_jsonpath_any_value(tmpenv):
     """Wait for a jsonpath field to have any non-empty value."""
     name = f"test-wait-any-{secrets.token_hex(4)}"
@@ -215,6 +281,7 @@ def test_wait_for_jsonpath_any_value(tmpenv):
         kubectl.delete(resource, context=tmpenv.profile, log=logging.debug)
 
 
+@pytest.mark.cluster
 def test_patch(tmpenv, capsys):
     pod = _current_pod(tmpenv.profile)
     kubectl.patch(
@@ -227,6 +294,7 @@ def test_patch(tmpenv, capsys):
     assert out.strip() == f"{pod} patched"
 
 
+@pytest.mark.cluster
 def test_label(tmpenv, capsys):
     pod = _current_pod(tmpenv.profile)
     name = f"test-{secrets.token_hex(8)}"
@@ -240,6 +308,7 @@ def test_label(tmpenv, capsys):
     assert out.strip() == f"{pod} labeled"
 
 
+@pytest.mark.cluster
 def test_annotate(tmpenv, capsys):
     pod = _current_pod(tmpenv.profile)
     annotation = f"test-{secrets.token_hex(8)}"
@@ -262,6 +331,7 @@ def test_annotate(tmpenv, capsys):
     assert annotation not in _get_annotations(pod, tmpenv.profile)
 
 
+@pytest.mark.cluster
 def test_delete(tmpenv, capsys):
     pod = _current_pod(tmpenv.profile)
     kubectl.delete(pod, context=tmpenv.profile)
@@ -270,6 +340,7 @@ def test_delete(tmpenv, capsys):
     assert out.strip().startswith(f'pod "{name}" deleted')
 
 
+@pytest.mark.cluster
 def test_watch(tmpenv):
     pod_name = kubectl.get(
         "pod",
@@ -286,6 +357,7 @@ def test_watch(tmpenv):
     assert pod["metadata"]["name"] == pod_name
 
 
+@pytest.mark.cluster
 def test_watch_leaf(tmpenv):
     pod_name = kubectl.get(
         "pod",
@@ -305,6 +377,7 @@ def test_watch_leaf(tmpenv):
     assert line == pod_name
 
 
+@pytest.mark.cluster
 def test_watch_jsonpath(tmpenv):
     pod_name = kubectl.get(
         "pod",
@@ -331,6 +404,7 @@ def test_watch_jsonpath(tmpenv):
     assert container["name"] == container_name
 
 
+@pytest.mark.cluster
 def test_watch_events(tmpenv):
     deploy = "deploy/example-deployment"
     label = f"test-{secrets.token_hex(8)}"
@@ -364,6 +438,7 @@ def test_watch_events(tmpenv):
             raise RuntimeError("Timeout waiting for event")
 
 
+@pytest.mark.cluster
 def test_watch_timeout(tmpenv):
     output = []
     with pytest.raises(commands.Timeout):

--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -17,9 +17,10 @@ from drenv.addons import example
 # Avoid random timeouts in github.
 TIMEOUT = 30
 
-pytestmark = pytest.mark.cluster
+LAST_APPLIED_CONFIGURATION = "kubectl.kubernetes.io/last-applied-configuration"
 
 
+@pytest.mark.cluster
 def test_version(tmpenv):
     out = kubectl.version(output="json", context=tmpenv.profile)
     info = json.loads(out)
@@ -28,16 +29,19 @@ def test_version(tmpenv):
     assert "clientVersion" in info
 
 
+@pytest.mark.cluster
 def test_get(tmpenv):
     out = kubectl.get("deploy", "--output=name", context=tmpenv.profile)
     assert out.strip() == "deployment.apps/example-deployment"
 
 
+@pytest.mark.cluster
 def test_config(tmpenv):
     out = kubectl.config("view", "--output=json")
     json.loads(out)
 
 
+@pytest.mark.cluster
 def test_exec(tmpenv):
     out = kubectl.exec(
         "deploy/example-deployment",
@@ -48,12 +52,93 @@ def test_exec(tmpenv):
     assert out.startswith("example-deployment-")
 
 
+@pytest.mark.cluster
 def test_apply(tmpenv, capsys):
     kubectl.apply(f"--filename={example.DEPLOYMENT}", context=tmpenv.profile)
     out, err = capsys.readouterr()
-    assert out.strip() == "deployment.apps/example-deployment unchanged"
+    assert out.strip() == "deployment.apps/example-deployment serverside-applied"
 
 
+@pytest.mark.cluster
+@pytest.mark.parametrize("server_side", [None, True])
+def test_apply_server_side(tmpenv, tmp_path, server_side):
+    name = f"test-apply-server-side-{server_side}".lower()
+    resource = f"configmap/{name}"
+    manifest = tmp_path / "configmap.yaml"
+    manifest.write_text(f"""\
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {name}
+""")
+
+    kwargs = {} if server_side is None else {"server_side": server_side}
+    kubectl.apply(f"--filename={manifest}", **kwargs, context=tmpenv.profile)
+    try:
+        annotations = _get_annotations(resource, tmpenv.profile)
+        assert LAST_APPLIED_CONFIGURATION not in annotations
+    finally:
+        kubectl.delete(resource, context=tmpenv.profile)
+
+
+@pytest.mark.cluster
+def test_apply_client_side(tmpenv, tmp_path):
+    name = "test-apply-client-side"
+    resource = f"configmap/{name}"
+    manifest = tmp_path / "configmap.yaml"
+    manifest.write_text(f"""\
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {name}
+""")
+
+    kubectl.apply(f"--filename={manifest}", server_side=False, context=tmpenv.profile)
+    try:
+        annotations = _get_annotations(resource, tmpenv.profile)
+        assert LAST_APPLIED_CONFIGURATION in annotations
+    finally:
+        kubectl.delete(resource, context=tmpenv.profile)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("--server-side", "true"),
+        ("--server-side", "false"),
+        ("--server-side=true",),
+        ("--server-side=false",),
+    ],
+)
+def test_apply_rejects_raw_server_side_flags(args):
+    with pytest.raises(
+        ValueError,
+        match="use server_side argument instead of --server-side flag",
+    ):
+        kubectl.apply(
+            "--filename=resource.yaml",
+            *args,
+            context="non-existing",
+        )
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        (["--filename", "VALUE", "--all"], ["--filename", "--all"]),
+        (["-f", "VALUE", "--all"], ["-f", "--all"]),
+        (["-k", "VALUE", "--prune"], ["-k", "--prune"]),
+        (["--kustomize", "VALUE", "--prune"], ["--kustomize", "--prune"]),
+        (["--template", "VALUE", "--all"], ["--template", "--all"]),
+        (["--filename=VALUE", "--all"], ["--filename=VALUE", "--all"]),
+        (["--all", "--filename", "VALUE"], ["--all", "--filename"]),
+    ],
+)
+def test_apply_flags(args, expected):
+    assert list(kubectl._apply_flags(args)) == expected
+
+
+@pytest.mark.cluster
 def test_rollout_status(tmpenv, capsys):
     kubectl.rollout(
         "status",
@@ -65,6 +150,7 @@ def test_rollout_status(tmpenv, capsys):
     assert out.strip() == 'deployment "example-deployment" successfully rolled out'
 
 
+@pytest.mark.cluster
 def test_rollout_status_default_timeout(tmpenv, capsys):
     kubectl.rollout(
         "status",
@@ -75,6 +161,7 @@ def test_rollout_status_default_timeout(tmpenv, capsys):
     assert out.strip() == 'deployment "example-deployment" successfully rolled out'
 
 
+@pytest.mark.cluster
 def test_rollout_restart(tmpenv, capsys):
     kubectl.rollout(
         "restart",
@@ -104,6 +191,7 @@ def test_rollout_restart_unsupported_timeout():
         )
 
 
+@pytest.mark.cluster
 def test_wait(tmpenv, capsys):
     kubectl.wait(
         "deploy/example-deployment",
@@ -115,6 +203,7 @@ def test_wait(tmpenv, capsys):
     assert out.strip() == "deployment.apps/example-deployment condition met"
 
 
+@pytest.mark.cluster
 def test_wait_for_create(tmpenv):
     """Wait for a resource that does not exist yet."""
     name = f"test-wait-create-{secrets.token_hex(4)}"
@@ -143,6 +232,7 @@ def test_wait_for_create(tmpenv):
         kubectl.delete(resource, context=tmpenv.profile, log=logging.debug)
 
 
+@pytest.mark.cluster
 def test_wait_for_jsonpath_value(tmpenv):
     """Wait for a jsonpath field that does not exist yet."""
     name = f"test-wait-jsonpath-{secrets.token_hex(4)}"
@@ -179,6 +269,7 @@ def test_wait_for_jsonpath_value(tmpenv):
         kubectl.delete(resource, context=tmpenv.profile, log=logging.debug)
 
 
+@pytest.mark.cluster
 def test_wait_for_jsonpath_any_value(tmpenv):
     """Wait for a jsonpath field to have any non-empty value."""
     name = f"test-wait-any-{secrets.token_hex(4)}"
@@ -215,6 +306,7 @@ def test_wait_for_jsonpath_any_value(tmpenv):
         kubectl.delete(resource, context=tmpenv.profile, log=logging.debug)
 
 
+@pytest.mark.cluster
 def test_patch(tmpenv, capsys):
     pod = _current_pod(tmpenv.profile)
     kubectl.patch(
@@ -227,6 +319,7 @@ def test_patch(tmpenv, capsys):
     assert out.strip() == f"{pod} patched"
 
 
+@pytest.mark.cluster
 def test_label(tmpenv, capsys):
     pod = _current_pod(tmpenv.profile)
     name = f"test-{secrets.token_hex(8)}"
@@ -240,6 +333,7 @@ def test_label(tmpenv, capsys):
     assert out.strip() == f"{pod} labeled"
 
 
+@pytest.mark.cluster
 def test_annotate(tmpenv, capsys):
     pod = _current_pod(tmpenv.profile)
     annotation = f"test-{secrets.token_hex(8)}"
@@ -262,6 +356,7 @@ def test_annotate(tmpenv, capsys):
     assert annotation not in _get_annotations(pod, tmpenv.profile)
 
 
+@pytest.mark.cluster
 def test_delete(tmpenv, capsys):
     pod = _current_pod(tmpenv.profile)
     kubectl.delete(pod, context=tmpenv.profile)
@@ -270,6 +365,7 @@ def test_delete(tmpenv, capsys):
     assert out.strip().startswith(f'pod "{name}" deleted')
 
 
+@pytest.mark.cluster
 def test_watch(tmpenv):
     pod_name = kubectl.get(
         "pod",
@@ -286,6 +382,7 @@ def test_watch(tmpenv):
     assert pod["metadata"]["name"] == pod_name
 
 
+@pytest.mark.cluster
 def test_watch_leaf(tmpenv):
     pod_name = kubectl.get(
         "pod",
@@ -305,6 +402,7 @@ def test_watch_leaf(tmpenv):
     assert line == pod_name
 
 
+@pytest.mark.cluster
 def test_watch_jsonpath(tmpenv):
     pod_name = kubectl.get(
         "pod",
@@ -331,6 +429,7 @@ def test_watch_jsonpath(tmpenv):
     assert container["name"] == container_name
 
 
+@pytest.mark.cluster
 def test_watch_events(tmpenv):
     deploy = "deploy/example-deployment"
     label = f"test-{secrets.token_hex(8)}"
@@ -364,6 +463,7 @@ def test_watch_events(tmpenv):
             raise RuntimeError("Timeout waiting for event")
 
 
+@pytest.mark.cluster
 def test_watch_timeout(tmpenv):
     output = []
     with pytest.raises(commands.Timeout):

--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -17,6 +17,8 @@ from drenv.addons import example
 # Avoid random timeouts in github.
 TIMEOUT = 30
 
+LAST_APPLIED_CONFIGURATION = "kubectl.kubernetes.io/last-applied-configuration"
+
 
 @pytest.mark.cluster
 def test_version(tmpenv):
@@ -58,38 +60,45 @@ def test_apply(tmpenv, capsys):
 
 
 @pytest.mark.cluster
-@pytest.mark.parametrize(
-    ("server_side", "has_last_applied"),
-    [(None, False), (True, False), (False, True)],
-)
-def test_apply_mode(tmpenv, tmp_path, server_side, has_last_applied):
-    name = f"test-apply-{secrets.token_hex(4)}"
+@pytest.mark.parametrize("server_side", [None, True])
+def test_apply_server_side(tmpenv, tmp_path, server_side):
+    name = f"test-apply-server-side-{server_side}".lower()
     resource = f"configmap/{name}"
     manifest = tmp_path / "configmap.yaml"
-    manifest.write_text(
-        f"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: {name}\n",
-        encoding="utf-8",
-    )
+    manifest.write_text(f"""\
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {name}
+""")
 
+    kwargs = {} if server_side is None else {"server_side": server_side}
+    kubectl.apply(f"--filename={manifest}", **kwargs, context=tmpenv.profile)
     try:
-        kwargs = {} if server_side is None else {"server_side": server_side}
-        kubectl.apply(
-            f"--filename={manifest}",
-            **kwargs,
-            context=tmpenv.profile,
-        )
-        out = kubectl.get(resource, "--output=json", context=tmpenv.profile)
-        metadata = json.loads(out)["metadata"]
-        annotations = metadata.get("annotations", {})
-        assert (
-            "kubectl.kubernetes.io/last-applied-configuration" in annotations
-        ) is has_last_applied
+        annotations = _get_annotations(resource, tmpenv.profile)
+        assert LAST_APPLIED_CONFIGURATION not in annotations
     finally:
-        kubectl.delete(
-            resource,
-            "--ignore-not-found=true",
-            context=tmpenv.profile,
-        )
+        kubectl.delete(resource, context=tmpenv.profile)
+
+
+@pytest.mark.cluster
+def test_apply_client_side(tmpenv, tmp_path):
+    name = "test-apply-client-side"
+    resource = f"configmap/{name}"
+    manifest = tmp_path / "configmap.yaml"
+    manifest.write_text(f"""\
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {name}
+""")
+
+    kubectl.apply(f"--filename={manifest}", server_side=False, context=tmpenv.profile)
+    try:
+        annotations = _get_annotations(resource, tmpenv.profile)
+        assert LAST_APPLIED_CONFIGURATION in annotations
+    finally:
+        kubectl.delete(resource, context=tmpenv.profile)
 
 
 @pytest.mark.parametrize(
@@ -111,6 +120,22 @@ def test_apply_rejects_raw_server_side_flags(args):
             *args,
             context="non-existing",
         )
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        (["--filename", "VALUE", "--all"], ["--filename", "--all"]),
+        (["-f", "VALUE", "--all"], ["-f", "--all"]),
+        (["-k", "VALUE", "--prune"], ["-k", "--prune"]),
+        (["--kustomize", "VALUE", "--prune"], ["--kustomize", "--prune"]),
+        (["--template", "VALUE", "--all"], ["--template", "--all"]),
+        (["--filename=VALUE", "--all"], ["--filename=VALUE", "--all"]),
+        (["--all", "--filename", "VALUE"], ["--all", "--filename"]),
+    ],
+)
+def test_apply_flags(args, expected):
+    assert list(kubectl._apply_flags(args)) == expected
 
 
 @pytest.mark.cluster

--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -123,6 +123,22 @@ def test_apply_rejects_raw_server_side_flags(args):
 
 
 @pytest.mark.parametrize(
+    "flag",
+    ["--force-conflicts", "--force-conflicts=true", "--force-conflicts=false"],
+)
+def test_apply_rejects_raw_force_conflicts_flags(flag):
+    with pytest.raises(
+        ValueError,
+        match="use force_conflicts argument instead of --force-conflicts flag",
+    ):
+        kubectl.apply(
+            "--filename=resource.yaml",
+            flag,
+            context="non-existing",
+        )
+
+
+@pytest.mark.parametrize(
     "args,expected",
     [
         (["--filename", "VALUE", "--all"], ["--filename", "--all"]),


### PR DESCRIPTION
## Summary

- default `drenv.kubectl.apply()` to server-side apply
- allow callers to opt out with `server_side=False`
- reject raw `--server-side` flags and remove the existing ad-hoc flags
- add focused unit coverage for the default, opt-out, and validation paths

## Validation

- `make unit-test` — 124 passed, 3 skipped, 33 deselected
- `make flake8`
- `make pylint`
- `make black`
- focused `kubectl_unit_test.py` — 4 passed
- `git diff --check`

The cluster-backed e2e path was not run locally; upstream's e2e workflow requires an authorized self-hosted runner.

Fixes #2648
