### PR TITLE
Strip DR owner refs from PVCs during disable DR disown

### DIFF
--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -3264,13 +3264,22 @@ func (v *VSHandler) checkLastSnapshotSyncStatus(lrs *volsyncv1alpha1.Replication
 	return !completed
 }
 
+func isDRManagedOwnerReference(ref metav1.OwnerReference) bool {
+	switch ref.Kind {
+	case "VolumeReplicationGroup", "ReplicationSource", "ReplicationDestination":
+		return true
+	default:
+		return false
+	}
+}
+
 func (v *VSHandler) DisownVolSyncManagedPVC(pvc *corev1.PersistentVolumeClaim) error {
-	// Remove only the VRG ownerReference, keeping VolSync resource (RS/RD) ownership
-	// This allows Kubernetes garbage collection to properly clean up PVCs when VolSync resources are deleted
+	// Called only when do-not-delete-pvc is set (disable DR). Strip DR-managed owners
+	// (VRG, RS, RD) so the application PVC survives VolSync resource teardown.
 	newRefs := []metav1.OwnerReference{}
 
 	for _, ref := range pvc.OwnerReferences {
-		if ref.Kind != "VolumeReplicationGroup" {
+		if !isDRManagedOwnerReference(ref) {
 			newRefs = append(newRefs, ref)
 		}
 	}


### PR DESCRIPTION
## Summary

During disable DR (`do-not-delete-pvc`), `DisownVolSyncManagedPVC` now removes all DR-managed owner references (VRG, ReplicationSource, ReplicationDestination) from application PVCs, not only VRG.

`DisownVolSyncManagedPVC` is only called from `disownPVCs()` when the annotation is set. On disable, the app PVC should not keep RS/RD owners - otherwise Kubernetes GC marks it for deletion when cleanup removes ReplicationSource (seen in DR disable testing in 2638).

Related: 2638 (skip-flag / cleanup disown)

## TODO

- [ ] Test