### PR TITLE
Standardize entering/exiting reconcile loop logging across controllers

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -49,8 +49,14 @@ This document outlines the logging standards and best practices for Ramen.
   logged:
 
   ```go
-  logger.Info("reconcile start")
-  defer logger.Info("reconcile end", "time spent", time.Since(start))
+  logger.Info("Entering reconcile loop")
+  defer logger.Info("Exiting reconcile loop")
+  ```
+
+  Controllers may also include duration on exit when useful:
+
+  ```go
+  defer logger.Info("Exiting reconcile loop", "time spent", time.Since(start))
   ```
 
 - When logging errors, include the context of the error:
@@ -77,13 +83,13 @@ This document outlines the logging standards and best practices for Ramen.
   Example of a well-structured log message:
 
   ```go
-  s.log.Info("reconcile end", "time spent", time.Since(start))
+  s.log.Info("Exiting reconcile loop", "time spent", time.Since(start))
   ```
 
   This will log in the following format, providing clear and structured context:
 
-  ```
-  2024-01-31T14:27:12.726-0500  INFO    pvrgl   reconcile end   {"name": "protectedvrglist-0", "rid": "1e09b0fb-687b-4100-9ab1-a52ba899b37b", "rv": "322", "time spent": 6ms}
+  ```text
+  2024-01-31T14:27:12.726-0500  INFO    pvrgl   Exiting reconcile loop   {"name": "protectedvrglist-0", "rid": "1e09b0fb-687b-4100-9ab1-a52ba899b37b", "rv": "322", "time spent": 6ms}
   ```
 
 ## Debugging with Logs

--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -367,9 +367,9 @@ func (r *DRClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// TODO: Validate managedCluster name? and also ensure it is not deleted!
 	// TODO: Setup views for storage class and VRClass to read and report IDs
 	log := r.Log.WithValues("drc", req.NamespacedName.Name, "rid", util.GetRID())
-	log.Info("reconcile enter")
+	log.Info("Entering reconcile loop")
 
-	defer log.Info("reconcile exit")
+	defer log.Info("Exiting reconcile loop")
 
 	drcluster := &ramen.DRCluster{}
 	if err := r.Client.Get(ctx, req.NamespacedName, drcluster); err != nil {

--- a/internal/controller/drclusterconfig_controller.go
+++ b/internal/controller/drclusterconfig_controller.go
@@ -74,9 +74,9 @@ type DRClusterConfigReconciler struct {
 
 func (r *DRClusterConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("drcc", req.NamespacedName.Name, "rid", util.GetRID())
-	log.Info("reconcile enter")
+	log.Info("Entering reconcile loop")
 
-	defer log.Info("reconcile exit")
+	defer log.Info("Exiting reconcile loop")
 
 	drCConfig := &ramen.DRClusterConfig{}
 	if err := r.Client.Get(ctx, req.NamespacedName, drCConfig); err != nil {

--- a/internal/controller/drpolicy_controller.go
+++ b/internal/controller/drpolicy_controller.go
@@ -85,9 +85,9 @@ const AllDRPolicyAnnotation = "drpolicy.ramendr.openshift.io"
 //nolint:cyclop,funlen
 func (r *DRPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("drp", req.NamespacedName.Name, "rid", util.GetRID())
-	log.Info("reconcile enter")
+	log.Info("Entering reconcile loop")
 
-	defer log.Info("reconcile exit")
+	defer log.Info("Exiting reconcile loop")
 
 	drpolicy := &ramen.DRPolicy{}
 	if err := r.Client.Get(ctx, req.NamespacedName, drpolicy); err != nil {

--- a/internal/controller/protectedvolumereplicationgrouplist_controller.go
+++ b/internal/controller/protectedvolumereplicationgrouplist_controller.go
@@ -64,6 +64,12 @@ func (r *ProtectedVolumeReplicationGroupListReconciler) Reconcile(ctx context.Co
 		instance:   &ramendrv1alpha1.ProtectedVolumeReplicationGroupList{},
 	}
 
+	s.log.Info("Entering reconcile loop")
+
+	defer func() {
+		s.log.Info("Exiting reconcile loop", "time spent", time.Since(start))
+	}()
+
 	// get ProtectedVolumeReplicationGroupListInstance and save to s.instance
 	if err := r.Client.Get(s.ctx, req.NamespacedName, s.instance); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("get: %w", err))
@@ -72,12 +78,6 @@ func (r *ProtectedVolumeReplicationGroupListReconciler) Reconcile(ctx context.Co
 	s.log = s.log.WithValues("rid", s.instance.ObjectMeta.UID, "gen", s.instance.ObjectMeta.Generation,
 		"rv", s.instance.ObjectMeta.ResourceVersion)
 	s.ctx = ctrl.LoggerInto(ctx, s.log)
-
-	s.log.Info("reconcile start")
-
-	defer func() {
-		s.log.Info("reconcile end", "time spent", time.Since(start))
-	}()
 
 	if s.instance.Status != nil {
 		return ctrl.Result{}, nil

--- a/internal/controller/replicationgroupdestination_controller.go
+++ b/internal/controller/replicationgroupdestination_controller.go
@@ -40,8 +40,13 @@ type ReplicationGroupDestinationReconciler struct {
 //+kubebuilder:rbac:groups=volsync.backube,resources=replicationdestinations,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;list;watch;delete
 
+//nolint:funlen
 func (r *ReplicationGroupDestinationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("rgd", req.NamespacedName, "rid", util.GetRID())
+	logger.Info("Entering reconcile loop")
+
+	defer logger.Info("Exiting reconcile loop")
+
 	logger.Info("Get ReplicationGroupDestination")
 
 	rgd := &ramendrv1alpha1.ReplicationGroupDestination{}

--- a/internal/controller/replicationgroupsource_controller.go
+++ b/internal/controller/replicationgroupsource_controller.go
@@ -75,6 +75,10 @@ type ReplicationGroupSourceReconciler struct {
 //nolint:funlen
 func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("rgs", req.NamespacedName, "rid", util.GetRID())
+	logger.Info("Entering reconcile loop")
+
+	defer logger.Info("Exiting reconcile loop")
+
 	logger.Info("Get ReplicationGroupSource")
 
 	if !r.volumeGroupSnapshotCRsAreWatched {


### PR DESCRIPTION
## Summary
- Audit enter/exit reconcile logging across all controllers and align on a single message: `Entering reconcile loop` / `Exiting reconcile loop`.
- Rename inconsistent messages in DRClusterConfig, DRCluster, DRPolicy, and ProtectedVRGList; add missing enter/exit logs to RGD and RGS.
- Move ProtectedVRGList enter/exit (including existing `time spent`) before `Get` so not-found and API-error paths still emit a matched pair.
- Add `//nolint:funlen` on RGD `Reconcile` after the enter/exit lines tipped it over the limit.
- Update `docs/logging.md` to match, including a language tag on the log-output example fence (MD040).