### PR TITLE
drenv: Added bash/zsh tab completion using argcomplete

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -354,6 +354,49 @@ drenv cleanup
 
 This should not be needed.
 
+## Shell completion for `drenv`
+
+`drenv` supports shell completion, making it easier to complete subcommands,
+options, and environment file paths while typing.
+
+After activating the project's virtual environment, enable completion by running
+the following command. This works with the default shells on Linux (Bash) and
+macOS (Zsh):
+
+```sh
+source <(register-python-argcomplete drenv)
+```
+
+If you are using Zsh and shell completion is not already enabled in your
+environment, enable it once by running:
+
+```sh
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+```
+
+Open a new shell (or reload your shell configuration), activate the virtual
+environment, and run the completion command above.
+
+To verify the feature, try:
+
+```sh
+% drenv st[TAB]
+start        -- start an environment
+stop         -- stop an environment
+stress-test  -- run drenv stress test
+
+% drenv start --[TAB]
+--help            -- show this help message and exit
+--logfile         -- path to logfile (default 'drenv.log')
+--name-prefix     -- prefix profile names
+--skip-tests      -- Do not run addons 'test' hooks
+--skip-addons     -- Do not run addons 'start' hooks
+```
+
+`drenv` uses the Python `argcomplete` package, which integrates with `argparse`
+to keep shell completions synchronized with the command-line interface
+automatically.
+
 ## Configuring drenv
 
 drenv can be configured using an optional configuration file at

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import argcomplete
 import argparse
 import concurrent.futures
 import json
@@ -10,6 +11,7 @@ import shutil
 import signal
 import sys
 import time
+
 
 from functools import partial
 
@@ -156,6 +158,7 @@ def parse_args():
     add_registry_cache_command(sp)
     add_stress_test_command(sp)
 
+    argcomplete.autocomplete(parser)
     return parser.parse_args()
 
 
@@ -259,7 +262,8 @@ def add_command(sp, name, func, help=None, envfile=True):
             metavar="PREFIX",
             help="prefix profile names",
         )
-        parser.add_argument("envfile", help="path to environment file")
+        arg = parser.add_argument("envfile", help="path to environment file")
+        arg.completer = argcomplete.completers.FilesCompleter(["*.yaml"])
     return parser
 
 

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -12,7 +12,6 @@ import signal
 import sys
 import time
 
-
 from functools import partial
 
 import drenv

--- a/test/setup.py
+++ b/test/setup.py
@@ -30,6 +30,7 @@ setuptools.setup(
         "toml",
         "packaging",
         "matplotlib",
+        "argcomplete",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Problem

`drenv` currently has no shell completion support for its subcommands
and flags. Users have to remember exact subcommand names, nested
subcommands, and flag names (e.g. `start`, `stop`, `registry-cache
start/stop/stats`, `--skip-tests`, `--skip-addons`, `--max-workers`),
which slows down day-to-day usage compared to tools like `kubectl` or
`cobra`-based CLIs that support tab completion out of the box.

## Solution

Add shell completion using [argcomplete](https://github.com/kislyuk/argcomplete),
a third-party package that integrates directly with `argparse` and
stays automatically in sync with the parser (no manual completion
spec to maintain).

This was chosen over hand-rolled shell completion scripts because it
requires minimal code changes, supports bash/zsh/fish, and updates
automatically whenever the `argparse` definitions change — so
completions never drift out of sync with the actual CLI.

### Changes

- Added `argcomplete` to the venv requirements.
- Added the following to `test/drenv/__main__.py`, after the parser
  is built and before `parse_args()`:
```python
  import argcomplete
  argcomplete.autocomplete(parser)
```

### What this enables

- Subcommand completion: `drenv st<TAB>` → `start`, `stop`
- Flag completion: `drenv start --<TAB>` → `--skip-tests`,
  `--skip-addons`, `--max-workers`, ...
- Nested subcommand completion: `drenv registry-cache <TAB>` →
  `start`, `stop`, `stats`
- File argument completion for envfile arguments
- Works in bash, zsh, and fish

### Testing

Tested on macOS with Zsh.

Steps
- Create and activate the Python virtual environment.
- Install project dependencies (including argcomplete).
- Initialize Zsh completion using below commands:
      1. autoload -Uz compinit
      2. compinit
- Enable completion for the current shell using below command:
     eval "$(register-python-argcomplete drenv)"
- Verify shell completion by pressing Tab after typing partial commands .

Examples:
write drenv and press TAB, you will get the suggestions for all the subcommands  like below 

<img width="402" height="230" alt="image" src="https://github.com/user-attachments/assets/63fdc099-429a-4a42-a015-f0d1c20d5c65" />


## Trade-offs

This adds a third-party runtime dependency (`argcomplete`) to the
venv. Given the functionality gained and how widely-used/maintained
the package is, this was considered an acceptable trade-off over
maintaining hand-written completion scripts per shell.

Fixes #2609