### PR TITLE
chore: add SuchiBhargav(new member) to OWNERS for E2E workflow access

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -15,3 +15,4 @@ e2e:
   - raaizik
   - raghavendra-talur
   - rakeshgm
+  - SuchiBhargav


### PR DESCRIPTION
## Summary

Add `SuchiBhargav` to the `OWNERS` file to authorize E2E GitHub Actions workflow execution.

## Reason

Fixes the authorization failure:

```text
Warning: User SuchiBhargav is not in the e2e group.
Add yourself to the OWNERS file to run the e2e workflow.
```

This change allows E2E workflow runs initiated by `SuchiBhargav` to complete successfully.
