### PR TITLE
e2e: opt in to fork PR checkout in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,10 +3,31 @@
 
 # yamllint disable rule:line-length
 ---
-# IMPORTANT: pull_request_target ensures this workflow file always comes
-# from the base branch (main) and cannot be modified by a PR. Do NOT
-# change this to pull_request, which would allow a fork PR to remove
-# the authorization check and run arbitrary code on self-hosted runners.
+# Security of pull_request_target with forked PR checkout
+#
+# This workflow uses pull_request_target to ensure the workflow file always
+# comes from the base branch (main) and cannot be modified by a PR author.
+# This is required to enforce the authorization check - using pull_request
+# would allow a fork PR to remove the check and run arbitrary code on
+# self-hosted runners.
+#
+# The test job checks out and executes PR code (allow-unsafe-pr-checkout)
+# in the pull_request_target security context. This is considered safe
+# because of the following controls and restrictions:
+#
+#   Risk              | Mitigation
+#   ------------------+--------------------------------------------------
+#   Unauthorized PRs  | The auth job verifies the PR author is listed in
+#                     | the OWNERS file (from the base branch) before
+#                     | the test job runs any PR code.
+#   GITHUB_TOKEN      | Scoped to read-only (permissions: contents: read).
+#                     | For fork PRs, pull_request also enforces read-only,
+#                     | so there is no additional exposure.
+#   Repo secrets      | Not used by this workflow. Do NOT add secrets
+#                     | without reviewing the security implications.
+#   Actions cache     | Not used by this workflow. Do NOT add actions/cache
+#                     | since pull_request_target can write to the default
+#                     | branch cache, enabling cache poisoning attacks.
 name: e2e
 
 on:
@@ -60,6 +81,7 @@ jobs:
       uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        allow-unsafe-pr-checkout: true  # See security section above
 
     - name: Build ramen-operator container
       run: make docker-build


### PR DESCRIPTION
actions/checkout@v6 now refuses to check out fork PR code in pull_request_target workflows to prevent "pwn request" vulnerabilities. Add allow-unsafe-pr-checkout to opt in.

This workflow must use pull_request_target so the workflow file always comes from the base branch and the authorization check cannot be bypassed by a PR author. The test job then checks out the PR code to run the actual tests.

This is safe because:

- The auth job verifies the PR author is in the OWNERS file (from the base branch) before the test job runs any PR code.
- The GITHUB_TOKEN is scoped to read-only (permissions: contents: read), matching the automatic restriction GitHub enforces for fork PRs using the pull_request trigger.
- The workflow does not use repo secrets or actions/cache, which are the main additional risks with pull_request_target.
- The repo default GITHUB_TOKEN permission is read-only, so even removing the permissions block would not grant write access.

Alternatives considered:

- GitHub Environments with required reviewers: enforced by GitHub infrastructure, but requires a manual approval click for every PR push, even for trusted contributors. Not practical for the team's workflow.
- Splitting into pull_request_target (auth) + pull_request (test): not viable because the pull_request workflow file comes from the PR branch and any authorization check in it can be removed by the contributor.
- Chaining via workflow_run: the triggered workflow is not linked to the PR as a status check, making it unusable.
- Moving test execution entirely off GitHub Actions (external CI): eliminates the need for pull_request_target but requires building and maintaining custom CI infrastructure.

Add a security analysis comment documenting the risks and mitigations.

Assisted-by: Cursor/Claude Opus 4.6