### PR TITLE
ci: Simplify tidiness check with `git diff --exit-code`

### DIFF
--- a/.github/workflows/ramen.yaml
+++ b/.github/workflows/ramen.yaml
@@ -60,8 +60,7 @@ jobs:
           go mod tidy
           (cd e2e && go mod tidy)
           (cd api && go mod tidy)
-          git --no-pager diff
-          git diff-index --quiet HEAD
+          git --no-pager diff --exit-code
 
   golangci:
     name: Golangci Lint


### PR DESCRIPTION
## Summary

The Linters tidiness step used two git commands to show a diff and fail the job. Use a single `git --no-pager diff --exit-code` instead, matching RamenDR/ramenctl#493.

Fixes #2667