### PR TITLE
drenv: remove startTime value in cephblockpool setup

### DIFF
--- a/test/drenv/addons/rook/pool/replica-pool.yaml
+++ b/test/drenv/addons/rook/pool/replica-pool.yaml
@@ -16,4 +16,3 @@ spec:
     mode: image
     snapshotSchedules:
       - interval: 2m
-        startTime: 14:00:00-05:00


### PR DESCRIPTION
We already define a very short interval of 2m, so having a `startTime` for such short interval doesn't make sense.