### PR TITLE
Prevent RGS/RGD reconciliation while the associated VRG is being deleted.

### DIFF
--- a/internal/controller/replicationgroupdestination_controller.go
+++ b/internal/controller/replicationgroupdestination_controller.go
@@ -74,6 +74,15 @@ func (r *ReplicationGroupDestinationReconciler) Reconcile(ctx context.Context, r
 		return ctrl.Result{}, err
 	}
 
+	if util.ResourceIsDeleted(vrg) {
+		logger.Info("VRG is deleted, skipping RGD reconciliation", "vrg", types.NamespacedName{
+			Name:      vrg.GetName(),
+			Namespace: vrg.GetNamespace(),
+		})
+
+		return ctrl.Result{}, nil
+	}
+
 	logger.Info("Get ramen config from configmap")
 
 	_, ramenConfig, err := ConfigMapGet(ctx, r.Client)

--- a/internal/controller/replicationgroupdestination_controller.go
+++ b/internal/controller/replicationgroupdestination_controller.go
@@ -47,31 +47,52 @@ func (r *ReplicationGroupDestinationReconciler) Reconcile(ctx context.Context, r
 
 	defer logger.Info("Exiting reconcile loop")
 
+	rgd, vrg, ramenConfig, done, err := r.getRGDConfig(ctx, req, logger)
+	if done {
+		return ctrl.Result{}, err
+	}
+
+	return r.runRGDReconcile(ctx, logger, rgd, vrg, ramenConfig)
+}
+
+// getRGDConfig fetches the RGD object, the owning VRG, and ramen config.
+// done=true means the caller should return ctrl.Result{}, err immediately.
+func (r *ReplicationGroupDestinationReconciler) getRGDConfig(
+	ctx context.Context,
+	req ctrl.Request,
+	logger logr.Logger,
+) (
+	rgd *ramendrv1alpha1.ReplicationGroupDestination,
+	vrg *ramendrv1alpha1.VolumeReplicationGroup,
+	ramenConfig *ramendrv1alpha1.RamenConfig,
+	done bool,
+	err error,
+) {
 	logger.Info("Get ReplicationGroupDestination")
 
-	rgd := &ramendrv1alpha1.ReplicationGroupDestination{}
-	if err := r.Client.Get(ctx, req.NamespacedName, rgd); err != nil {
+	rgd = &ramendrv1alpha1.ReplicationGroupDestination{}
+	if err = r.Client.Get(ctx, req.NamespacedName, rgd); err != nil {
 		if !k8serrors.IsNotFound(err) {
 			logger.Error(err, "Failed to get ReplicationGroupDestination")
 		}
 
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		return nil, nil, nil, true, client.IgnoreNotFound(err)
 	}
 
 	if rgd.Spec.Paused {
 		logger.Info("ReplicationGroupDestination is paused, skipping reconciliation")
 
-		return ctrl.Result{}, nil
+		return nil, nil, nil, true, nil
 	}
 
 	logger.Info("Get vrg from ReplicationGroupDestination")
 
-	vrg := &ramendrv1alpha1.VolumeReplicationGroup{}
-	if err := r.Client.Get(ctx, types.NamespacedName{
+	vrg = &ramendrv1alpha1.VolumeReplicationGroup{}
+	if err = r.Client.Get(ctx, types.NamespacedName{
 		Name:      rgd.GetLabels()[util.VRGOwnerNameLabel],
 		Namespace: rgd.GetLabels()[util.VRGOwnerNamespaceLabel],
 	}, vrg); err != nil {
-		return ctrl.Result{}, err
+		return nil, nil, nil, true, err
 	}
 
 	if util.ResourceIsDeleted(vrg) {
@@ -80,22 +101,34 @@ func (r *ReplicationGroupDestinationReconciler) Reconcile(ctx context.Context, r
 			Namespace: vrg.GetNamespace(),
 		})
 
-		return ctrl.Result{}, nil
+		return nil, nil, nil, true, nil
 	}
 
 	logger.Info("Get ramen config from configmap")
 
-	_, ramenConfig, err := ConfigMapGet(ctx, r.Client)
+	_, ramenConfig, err = ConfigMapGet(ctx, r.Client)
 	if err != nil {
 		logger.Error(err, "Failed to get ramen config")
 
-		return ctrl.Result{}, err
+		return nil, nil, nil, true, err
 	}
 
+	return rgd, vrg, ramenConfig, false, nil
+}
+
+// runRGDReconcile drives the RGD state machine and updates status.
+func (r *ReplicationGroupDestinationReconciler) runRGDReconcile(
+	ctx context.Context,
+	logger logr.Logger,
+	rgd *ramendrv1alpha1.ReplicationGroupDestination,
+	vrg *ramendrv1alpha1.VolumeReplicationGroup,
+	ramenConfig *ramendrv1alpha1.RamenConfig,
+) (ctrl.Result, error) {
 	adminNamespaceVRG := vrgInAdminNamespace(vrg, ramenConfig)
 	defaultCephFSCSIDriverName := cephFSCSIDriverNameOrDefault(ramenConfig)
 
 	logger.Info("Run ReplicationGroupDestination state machine", "DefaultCephFSCSIDriverName", defaultCephFSCSIDriverName)
+
 	result, err := statemachine.Run(
 		ctx,
 		cephfscg.NewRGDMachine(r.Client, rgd,

--- a/internal/controller/replicationgroupsource_controller.go
+++ b/internal/controller/replicationgroupsource_controller.go
@@ -72,7 +72,6 @@ type ReplicationGroupSourceReconciler struct {
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get
 
-//nolint:funlen
 func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("rgs", req.NamespacedName, "rid", util.GetRID())
 	logger.Info("Entering reconcile loop")
@@ -81,40 +80,63 @@ func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ct
 
 	logger.Info("Get ReplicationGroupSource")
 
+	rgs, vrg, ramenConfig, done, err := r.getRGSConfig(ctx, req, logger)
+	if done {
+		return ctrl.Result{}, err
+	}
+
+	vsHandler, vgsHandler := r.buildVGSHandler(ctx, logger, rgs, vrg, ramenConfig)
+
+	return r.runRGSReconcile(ctx, logger, rgs, vrg, vsHandler, vgsHandler, ramenConfig)
+}
+
+// getRGSConfig fetches the RGS object, ramen config, and the owning VRG.
+// done=true means the caller should return result/err immediately.
+func (r *ReplicationGroupSourceReconciler) getRGSConfig(
+	ctx context.Context,
+	req ctrl.Request,
+	logger logr.Logger,
+) (
+	rgs *ramendrv1alpha1.ReplicationGroupSource,
+	vrg *ramendrv1alpha1.VolumeReplicationGroup,
+	ramenConfig *ramendrv1alpha1.RamenConfig,
+	done bool,
+	err error,
+) {
 	if !r.volumeGroupSnapshotCRsAreWatched {
-		return ctrl.Result{},
+		return nil, nil, nil, true,
 			fmt.Errorf("ReplicationGroupSource {%s/%s} doesn't work if VolumeGroupSnapshot CRD is not installed. "+
 				"Please install VolumeGroupSnapshot CRD and restart the operator", req.Namespace, req.Name)
 	}
 
-	rgs := &ramendrv1alpha1.ReplicationGroupSource{}
-	if err := r.Client.Get(ctx, req.NamespacedName, rgs); err != nil {
+	logger.Info("Get ReplicationGroupSource")
+
+	rgs = &ramendrv1alpha1.ReplicationGroupSource{}
+	if err = r.Client.Get(ctx, req.NamespacedName, rgs); err != nil {
 		if !k8serrors.IsNotFound(err) {
 			logger.Error(err, "Failed to get ReplicationGroupSource")
 		}
 
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		return nil, nil, nil, true, client.IgnoreNotFound(err)
 	}
 
 	logger.Info("Get ramen config from configmap")
 
-	_, ramenConfig, err := ConfigMapGet(ctx, r.Client)
+	_, ramenConfig, err = ConfigMapGet(ctx, r.Client)
 	if err != nil {
 		logger.Error(err, "Failed to get ramen config")
 
-		return ctrl.Result{}, err
+		return nil, nil, nil, true, err
 	}
-
-	defaultCephFSCSIDriverName := cephFSCSIDriverNameOrDefault(ramenConfig)
 
 	logger.Info("Get vrg from ReplicationGroupSource")
 
-	vrg := &ramendrv1alpha1.VolumeReplicationGroup{}
-	if err := r.Client.Get(ctx, types.NamespacedName{
+	vrg = &ramendrv1alpha1.VolumeReplicationGroup{}
+	if err = r.Client.Get(ctx, types.NamespacedName{
 		Name:      rgs.GetLabels()[util.VRGOwnerNameLabel],
 		Namespace: rgs.GetLabels()[util.VRGOwnerNamespaceLabel],
 	}, vrg); err != nil {
-		return ctrl.Result{}, err
+		return nil, nil, nil, true, err
 	}
 
 	if util.ResourceIsDeleted(vrg) {
@@ -123,9 +145,21 @@ func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ct
 			Namespace: vrg.GetNamespace(),
 		})
 
-		return ctrl.Result{}, nil
+		return nil, nil, nil, true, nil
 	}
 
+	return rgs, vrg, ramenConfig, false, nil
+}
+
+// buildVGSHandler constructs the VSHandler and VolumeGroupSource handler appropriate for this RGS.
+func (r *ReplicationGroupSourceReconciler) buildVGSHandler(
+	ctx context.Context,
+	logger logr.Logger,
+	rgs *ramendrv1alpha1.ReplicationGroupSource,
+	vrg *ramendrv1alpha1.VolumeReplicationGroup,
+	ramenConfig *ramendrv1alpha1.RamenConfig,
+) (*volsync.VSHandler, cephfscg.VolumeGroupSourceHandler) {
+	defaultCephFSCSIDriverName := cephFSCSIDriverNameOrDefault(ramenConfig)
 	adminNamespaceVRG := vrgInAdminNamespace(vrg, ramenConfig)
 
 	vsHandler := volsync.NewVSHandler(ctx, r.Client, logger, vrg,
@@ -133,24 +167,36 @@ func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ct
 		volSyncDestinationCopyMethodOrDefault(ramenConfig), adminNamespaceVRG,
 	)
 
-	var vgsHandler cephfscg.VolumeGroupSourceHandler
 	if util.IsDiffSyncEnabled(rgs.GetAnnotations()) {
-		vgsHandler = cephfscg.NewDiffVolumeGroupSourceHandler(r.Client, rgs, defaultCephFSCSIDriverName, vsHandler, logger)
-	} else {
-		vgsHandler = cephfscg.NewVolumeGroupSourceHandler(r.Client, rgs, defaultCephFSCSIDriverName, vsHandler, logger)
+		return vsHandler,
+			cephfscg.NewDiffVolumeGroupSourceHandler(r.Client, rgs, defaultCephFSCSIDriverName, vsHandler, logger)
 	}
 
+	return vsHandler, cephfscg.NewVolumeGroupSourceHandler(r.Client, rgs, defaultCephFSCSIDriverName, vsHandler, logger)
+}
+
+// runRGSReconcile drives the RGS state machine (or the final-sync cleanup path) and updates status.
+func (r *ReplicationGroupSourceReconciler) runRGSReconcile(
+	ctx context.Context,
+	logger logr.Logger,
+	rgs *ramendrv1alpha1.ReplicationGroupSource,
+	vrg *ramendrv1alpha1.VolumeReplicationGroup,
+	vsHandler *volsync.VSHandler,
+	vgsHandler cephfscg.VolumeGroupSourceHandler,
+	ramenConfig *ramendrv1alpha1.RamenConfig,
+) (ctrl.Result, error) {
 	if cephfscg.IsPrepareForFinalSyncTriggered(rgs) {
 		logger.Info("Detected request for final sync preparation, waiting for confirmation to continue")
 
-		err := vgsHandler.CleanVolumeGroupSnapshot(ctx)
-
 		const retryDelay = 5 * time.Second
 
-		return ctrl.Result{RequeueAfter: retryDelay}, err
+		return ctrl.Result{RequeueAfter: retryDelay}, vgsHandler.CleanVolumeGroupSnapshot(ctx)
 	}
 
+	defaultCephFSCSIDriverName := cephFSCSIDriverNameOrDefault(ramenConfig)
+
 	logger.Info("Run ReplicationGroupSource state machine", "DefaultCephFSCSIDriverName", defaultCephFSCSIDriverName)
+
 	result, err := statemachine.Run(
 		ctx,
 		cephfscg.NewRGSMachine(r.Client, rgs, vrg, vsHandler, vgsHandler, logger),

--- a/internal/controller/replicationgroupsource_controller.go
+++ b/internal/controller/replicationgroupsource_controller.go
@@ -117,6 +117,15 @@ func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ct
 		return ctrl.Result{}, err
 	}
 
+	if util.ResourceIsDeleted(vrg) {
+		logger.Info("VRG is deleted, skipping RGSreconciliation", "vrg", types.NamespacedName{
+			Name:      vrg.GetName(),
+			Namespace: vrg.GetNamespace(),
+		})
+
+		return ctrl.Result{}, nil
+	}
+
 	adminNamespaceVRG := vrgInAdminNamespace(vrg, ramenConfig)
 
 	vsHandler := volsync.NewVSHandler(ctx, r.Client, logger, vrg,

--- a/internal/controller/replicationgroupsource_controller.go
+++ b/internal/controller/replicationgroupsource_controller.go
@@ -78,16 +78,15 @@ func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ct
 
 	defer logger.Info("Exiting reconcile loop")
 
-	logger.Info("Get ReplicationGroupSource")
-
 	rgs, vrg, ramenConfig, done, err := r.getRGSConfig(ctx, req, logger)
 	if done {
 		return ctrl.Result{}, err
 	}
 
-	vsHandler, vgsHandler := r.buildVGSHandler(ctx, logger, rgs, vrg, ramenConfig)
+	defaultCephFSCSIDriverName := cephFSCSIDriverNameOrDefault(ramenConfig)
+	vsHandler, vgsHandler := r.buildVGSHandler(ctx, logger, rgs, vrg, ramenConfig, defaultCephFSCSIDriverName)
 
-	return r.runRGSReconcile(ctx, logger, rgs, vrg, vsHandler, vgsHandler, ramenConfig)
+	return r.runRGSReconcile(ctx, logger, rgs, vrg, vsHandler, vgsHandler, defaultCephFSCSIDriverName)
 }
 
 // getRGSConfig fetches the RGS object, ramen config, and the owning VRG.
@@ -158,8 +157,8 @@ func (r *ReplicationGroupSourceReconciler) buildVGSHandler(
 	rgs *ramendrv1alpha1.ReplicationGroupSource,
 	vrg *ramendrv1alpha1.VolumeReplicationGroup,
 	ramenConfig *ramendrv1alpha1.RamenConfig,
+	defaultCephFSCSIDriverName string,
 ) (*volsync.VSHandler, cephfscg.VolumeGroupSourceHandler) {
-	defaultCephFSCSIDriverName := cephFSCSIDriverNameOrDefault(ramenConfig)
 	adminNamespaceVRG := vrgInAdminNamespace(vrg, ramenConfig)
 
 	vsHandler := volsync.NewVSHandler(ctx, r.Client, logger, vrg,
@@ -183,7 +182,7 @@ func (r *ReplicationGroupSourceReconciler) runRGSReconcile(
 	vrg *ramendrv1alpha1.VolumeReplicationGroup,
 	vsHandler *volsync.VSHandler,
 	vgsHandler cephfscg.VolumeGroupSourceHandler,
-	ramenConfig *ramendrv1alpha1.RamenConfig,
+	defaultCephFSCSIDriverName string,
 ) (ctrl.Result, error) {
 	if cephfscg.IsPrepareForFinalSyncTriggered(rgs) {
 		logger.Info("Detected request for final sync preparation, waiting for confirmation to continue")
@@ -192,8 +191,6 @@ func (r *ReplicationGroupSourceReconciler) runRGSReconcile(
 
 		return ctrl.Result{RequeueAfter: retryDelay}, vgsHandler.CleanVolumeGroupSnapshot(ctx)
 	}
-
-	defaultCephFSCSIDriverName := cephFSCSIDriverNameOrDefault(ramenConfig)
 
 	logger.Info("Run ReplicationGroupSource state machine", "DefaultCephFSCSIDriverName", defaultCephFSCSIDriverName)
 


### PR DESCRIPTION
## Problem

A race condition can occasionally occur on the secondary cluster during application deletion. Ramen controllers operate independently, so the VRG controller may be processing VRG deletion while the RGD controller is simultaneously reconciling resources and restoring PVCs.

In this scenario, a PVC can be deleted as part of VRG cleanup and then immediately recreated by the parallel RGD reconciliation, leaving stale resources behind.

## Solution

In this change, we prevent RGS/RGD reconciliation when the associated VRG is in the process of being deleted. By blocking reconciliation during VRG deletion, cleanup and restore operations can no longer run concurrently, eliminating the race condition that allows PVCs to be recreated after cleanup has started.

## Testing

* Verified that RGS/RGD reconciliation is skipped while the associated VRG is being deleted.
* Verified that PVCs are no longer recreated during VRG cleanup on the secondary cluster.

Fixes: [DFBUGS-8800](https://redhat.atlassian.net/browse/DFBUGS-8800)
