### PR TITLE
Improve drenv CLI help with descriptions and examples

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -354,6 +354,49 @@ drenv cleanup
 
 This should not be needed.
 
+## Shell completion for `drenv`
+
+`drenv` supports shell completion, making it easier to complete subcommands,
+options, and environment file paths while typing.
+
+After activating the project's virtual environment, enable completion by running
+the following command. This works with the default shells on Linux (Bash) and
+macOS (Zsh):
+
+```sh
+source <(register-python-argcomplete drenv)
+```
+
+If you are using Zsh and shell completion is not already enabled in your
+environment, enable it once by running:
+
+```sh
+echo "autoload -U compinit; compinit" >> ~/.zshrc
+```
+
+Open a new shell (or reload your shell configuration), activate the virtual
+environment, and run the completion command above.
+
+To verify the feature, try:
+
+```sh
+% drenv st[TAB]
+start        -- start an environment
+stop         -- stop an environment
+stress-test  -- run drenv stress test
+
+% drenv start --[TAB]
+--help            -- show this help message and exit
+--logfile         -- path to logfile (default 'drenv.log')
+--name-prefix     -- prefix profile names
+--skip-tests      -- Do not run addons 'test' hooks
+--skip-addons     -- Do not run addons 'start' hooks
+```
+
+`drenv` uses the Python `argcomplete` package, which integrates with `argparse`
+to keep shell completions synchronized with the command-line interface
+automatically.
+
 ## Configuring drenv
 
 drenv can be configured using an optional configuration file at

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+import argcomplete
 import argparse
 import concurrent.futures
 import json
@@ -10,6 +11,7 @@ import shutil
 import signal
 import sys
 import time
+
 
 from functools import partial
 
@@ -156,6 +158,7 @@ def parse_args():
     add_registry_cache_command(sp)
     add_stress_test_command(sp)
 
+    argcomplete.autocomplete(parser)
     return parser.parse_args()
 
 
@@ -259,7 +262,8 @@ def add_command(sp, name, func, help=None, envfile=True):
             metavar="PREFIX",
             help="prefix profile names",
         )
-        parser.add_argument("envfile", help="path to environment file")
+        arg = parser.add_argument("envfile", help="path to environment file")
+        arg.completer = argcomplete.completers.FilesCompleter(["*.yaml"])
     return parser
 
 

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -12,7 +12,6 @@ import signal
 import sys
 import time
 
-
 from functools import partial
 
 import drenv

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -141,7 +141,23 @@ def parse_args():
         help="image to load into the cluster in tar format",
     )
 
-    add_command(sp, "delete", do_delete, help="delete an environment")
+    add_command(
+        sp,
+        "delete",
+        do_delete,
+        help="delete an environment",
+        description="Delete a DR environment.",
+        epilog=(
+            "Deletes all clusters and resources created from the specified\n"
+            "environment definition. This includes Minikube profiles,\n"
+            "temporary files, and resources managed by drenv.\n\n"
+            "Examples:\n"
+            "  drenv delete envs/regional-dr.yaml\n"
+            "  drenv delete envs/metro-dr.yaml\n"
+            "  drenv delete --name-prefix test- envs/regional-dr.yaml"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     add_command(sp, "suspend", do_suspend, help="suspend virtual machines")
     add_command(sp, "resume", do_resume, help="resume virtual machines")
     add_command(sp, "dump", do_dump, help="dump an environment yaml")
@@ -162,7 +178,18 @@ def parse_args():
 
 
 def add_registry_cache_command(sp):
-    p = sp.add_parser("registry-cache", help="manage registry cache")
+    p = sp.add_parser(
+        "registry-cache",
+        help="manage registry cache",
+        description="Manage the drenv registry cache.",
+        epilog=(
+            "Inspect or remove cached registry containers used by drenv.\n\n"
+            "Examples:\n"
+            "  drenv registry-cache stats\n"
+            "  drenv registry-cache remove"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     sp = p.add_subparsers(dest="command", required=True)
 
     p = add_command(
@@ -171,6 +198,12 @@ def add_registry_cache_command(sp):
         registry.show_stats,
         help="show cache statistics",
         envfile=False,
+        description="Show registry cache statistics.",
+        epilog=(
+            "Display the current contents and usage statistics for the cached\n"
+            "registry containers managed by drenv."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument(
         "-o",
@@ -185,11 +218,28 @@ def add_registry_cache_command(sp):
         registry.remove_containers,
         help="remove cache containers",
         envfile=False,
+        description="Remove cached registry containers.",
+        epilog=(
+            "Remove the cached registry containers managed by drenv."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
 
 def add_stress_test_command(sp):
-    p = sp.add_parser("stress-test", help="run drenv stress test")
+    p = sp.add_parser(
+        "stress-test",
+        help="run drenv stress test",
+        description="Run drenv stress tests.",
+        epilog=(
+            "Execute repeated stress-test runs and collect results for later\n"
+            "comparison and reporting.\n\n"
+            "Examples:\n"
+            "  drenv stress-test run\n"
+            "  drenv stress-test report out"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     sp = p.add_subparsers(dest="command", required=True)
 
     p = add_command(
@@ -197,6 +247,12 @@ def add_stress_test_command(sp):
         "run",
         stress.run,
         help="run stress test",
+        description="Run a stress test.",
+        epilog=(
+            "Execute one or more stress-test runs and write the results to the\n"
+            "specified output directory."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument(
         "-r",
@@ -224,6 +280,12 @@ def add_stress_test_command(sp):
         stress.report,
         help="generate markdown report from stress test results",
         envfile=False,
+        description="Generate a markdown report from stress test results.",
+        epilog=(
+            "Generate a human-readable markdown report from the JSON results\n"
+            "produced by a stress-test run."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument(
         "directory",
@@ -236,6 +298,12 @@ def add_stress_test_command(sp):
         stress.compare,
         help="compare 2 stress tests",
         envfile=False,
+        description="Compare two stress test runs.",
+        epilog=(
+            "Compare the results of two stress-test output directories and\n"
+            "summarize the differences."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument(
         "before",
@@ -247,8 +315,23 @@ def add_stress_test_command(sp):
     )
 
 
-def add_command(sp, name, func, help=None, envfile=True):
-    parser = sp.add_parser(name, help=help)
+def add_command(
+    sp,
+    name,
+    func,
+    help=None,
+    envfile=True,
+    description=None,
+    epilog=None,
+    formatter_class=argparse.HelpFormatter,
+):
+    parser = sp.add_parser(
+        name,
+        help=help,
+        description=description,
+        epilog=epilog,
+        formatter_class=formatter_class,
+    )
     parser.add_argument(
         "--logfile",
         default=LOGFILE,

--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -219,9 +219,7 @@ def add_registry_cache_command(sp):
         help="remove cache containers",
         envfile=False,
         description="Remove cached registry containers.",
-        epilog=(
-            "Remove the cached registry containers managed by drenv."
-        ),
+        epilog=("Remove the cached registry containers managed by drenv."),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 

--- a/test/setup.py
+++ b/test/setup.py
@@ -30,6 +30,7 @@ setuptools.setup(
         "toml",
         "packaging",
         "matplotlib",
+        "argcomplete",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
## Summary

Improve the `drenv` CLI help output by adding descriptive text and
usage examples to make commands easier to understand and use.

## Changes

- Added a short description for commands to clearly explain their purpose.
- Added detailed help text describing each command's behavior.
- Included common usage examples in the help output.
- Improved the overall readability and discoverability of the CLI help.


## Why

The previous help output primarily displayed the command syntax and
available options, requiring users to refer to external documentation
to understand a command's purpose and usage. This change makes the
built-in help more informative and aligns it more closely with the
user experience provided by mature CLIs such as `kubectl`.

## Example
<img width="547" height="300" alt="image" src="https://github.com/user-attachments/assets/534e9f34-252c-43e7-9145-7cb95539d255" />
