### PR TITLE
requirements: pin black and pytest to fix CVEs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-black
+black>=26.3.1
 coverage
 flake8
 mdformat
 mdformat-gfm
 mdformat-gfm-alerts
 pylint
-pytest
+pytest>=9.0.3
 setuptools


### PR DESCRIPTION
Pin black>=26.3.1 to fix CVE-2026-31900 and CVE-2026-32274. Pin pytest>=9.0.3 to fix CVE-2025-71176.

Assisted-by: Claude Code/claude-opus-4-6