### PR TITLE
feat: VM staticIP : drpc: add network-mapping ConfigMap parsing and VM static-IP translation

### DIFF
--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -80,6 +80,11 @@ const (
 	// GlobalActionConsensus condition indicates whether all DRPCs sharing the same global VGR label
 	// agree on the DR action and target cluster.
 	ConditionGlobalAction = "GlobalAction"
+
+	// NetworkMappingLoaded condition indicates whether the network-mapping ConfigMap referenced
+	// by the drplacementcontrol.ramendr.openshift.io/network-mapping annotation was successfully
+	// loaded. False means IP translation is disabled for this DRPC; DR orchestration continues.
+	ConditionNetworkMappingLoaded = "NetworkMappingLoaded"
 )
 
 const (

--- a/internal/controller/drpc_networkmapping.go
+++ b/internal/controller/drpc_networkmapping.go
@@ -1,0 +1,583 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+// drpc_networkmapping.go — network-mapping ConfigMap parsing and IP translation
+// for VM static-IP DR.
+//
+// # ConfigMap contract
+//
+// The DRPC carries an annotation:
+//
+//	drplacementcontrol.ramendr.openshift.io/network-mapping: "<configmap-name>"
+//
+// That annotation references a ConfigMap in the same namespace as the DRPC.
+// The ConfigMap's "mappings.yaml" data key contains a YAML document:
+//
+//	patternTranslation:          # optional; provide for regex-based subnet mapping
+//	  forwardPattern:     "^192\\.168\\.100\\.(\\d+)$"
+//	  forwardReplacement: "192.168.200.$1"
+//	  reversePattern:     "^192\\.168\\.200\\.(\\d+)$"
+//	  reverseReplacement: "192.168.100.$1"
+//
+//	explicitMappings:            # optional; per-VM overrides checked before pattern
+//	  - sourceIP: "192.168.100.51"
+//	    destIP:   "192.168.200.55"
+//	    vmName:   "vm-override"  # optional, informational only
+//
+// At least one of patternTranslation or explicitMappings must be present.
+// When both are present, explicitMappings is checked first; unmatched IPs
+// fall through to patternTranslation.
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"regexp"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	rmn "github.com/ramendr/ramen/api/v1alpha1"
+)
+
+// TranslationDirection controls which side (forward = failover, reverse = failback)
+// of the pattern/explicit table is used.
+type TranslationDirection int
+
+const (
+	TranslationDirectionForward TranslationDirection = iota
+	TranslationDirectionReverse
+)
+
+// ---------------------------------------------------------------------------
+// Public types — ConfigMap data model
+// ---------------------------------------------------------------------------
+
+// NetworkMappingRules is the top-level structure parsed from the ConfigMap's
+// "mappings.yaml" data key.  No translationMethod field is required;
+// the algorithm is driven by which data fields are populated.
+type NetworkMappingRules struct {
+	// PatternTranslation holds the regex patterns for subnet-to-subnet mapping.
+	// +optional
+	PatternTranslation *PatternTranslation `yaml:"patternTranslation,omitempty"`
+
+	// ExplicitMappings is the per-VM static IP mapping table.
+	// Entries here take priority over patternTranslation.
+	// +optional
+	ExplicitMappings []ExplicitMapping `yaml:"explicitMappings,omitempty"`
+}
+
+// PatternTranslation carries the forward and reverse regex patterns.
+type PatternTranslation struct {
+	// ForwardPattern is a Go regexp applied to the source IP during failover.
+	// Capture groups can be referenced as $1, $2, … in ForwardReplacement.
+	ForwardPattern string `yaml:"forwardPattern"`
+
+	// ForwardReplacement is the replacement template for ForwardPattern.
+	ForwardReplacement string `yaml:"forwardReplacement"`
+
+	// ReversePattern is a Go regexp applied to the translated IP during failback.
+	ReversePattern string `yaml:"reversePattern"`
+
+	// ReverseReplacement is the replacement template for ReversePattern.
+	ReverseReplacement string `yaml:"reverseReplacement"`
+}
+
+// ExplicitMapping maps one source IP to one destination IP.
+type ExplicitMapping struct {
+	// SourceIP is the VM IP on the source cluster.
+	SourceIP string `yaml:"sourceIP"`
+
+	// DestIP is the VM IP on the destination cluster.
+	DestIP string `yaml:"destIP"`
+}
+
+// ---------------------------------------------------------------------------
+// DRPCNetworkMappingManager
+// ---------------------------------------------------------------------------
+
+// DRPCNetworkMappingManager reads and parses the network-mapping ConfigMap
+// referenced by a DRPC annotation and performs IP translation.
+type DRPCNetworkMappingManager struct {
+	client client.Client
+	log    logr.Logger
+}
+
+// NewDRPCNetworkMappingManager constructs a manager bound to the given client.
+func NewDRPCNetworkMappingManager(c client.Client, log logr.Logger) *DRPCNetworkMappingManager {
+	return &DRPCNetworkMappingManager{client: c, log: log}
+}
+
+// LoadNetworkMapping returns the parsed NetworkMappingRules for the DRPC, or
+// (nil, nil) if the DRPC does not carry the annotation.
+// An error is returned only when the ConfigMap exists but cannot be fetched or
+// parsed.
+func (m *DRPCNetworkMappingManager) LoadNetworkMapping(
+	ctx context.Context,
+	drpc *rmn.DRPlacementControl,
+) (*NetworkMappingRules, error) {
+	cmName, ok := drpc.GetAnnotations()[DRPCNetworkMappingAnnotation]
+	if !ok || cmName == "" {
+		m.log.V(1).Info("DRPC has no network-mapping annotation; skipping",
+			"drpc", drpc.Name)
+
+		return nil, nil
+	}
+
+	cm := &corev1.ConfigMap{}
+	key := types.NamespacedName{Name: cmName, Namespace: drpc.Namespace}
+
+	if err := m.client.Get(ctx, key, cm); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("network-mapping ConfigMap %q not found in namespace %q",
+				cmName, drpc.Namespace)
+		}
+
+		return nil, fmt.Errorf("failed to get network-mapping ConfigMap %q: %w", cmName, err)
+	}
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse network-mapping ConfigMap %q: %w", cmName, err)
+	}
+
+	m.log.Info("Loaded network-mapping ConfigMap",
+		"configmap", cmName,
+		"hasPattern", rules.PatternTranslation != nil,
+		"explicitEntries", len(rules.ExplicitMappings))
+
+	return rules, nil
+}
+
+// TranslateIP translates srcIP using the rules and direction.
+//
+//   - Forward (failover): applies ForwardPattern / forward explicit lookup.
+//   - Reverse (failback): applies ReversePattern / reverse explicit lookup
+//     (the dest→source direction of the explicit table).
+//
+// The universal algorithm (regardless of translationMethod):
+//  1. If explicitMappings are present, look up srcIP in the table first.
+//     A hit returns immediately; a miss falls through to pattern.
+//  2. If patternTranslation is present, match and replace via regex.
+//  3. Both absent → error (caught at validation time, unreachable at runtime).
+func (m *DRPCNetworkMappingManager) TranslateIP(
+	srcIP string,
+	rules *NetworkMappingRules,
+	dir TranslationDirection,
+) (string, error) {
+	result, err := translateIP(srcIP, rules, dir)
+	if err != nil {
+		return "", err
+	}
+
+	m.log.V(1).Info("Translated IP",
+		"source", srcIP,
+		"target", result,
+		"direction", dir)
+
+	return result, nil
+}
+
+// ---------------------------------------------------------------------------
+// ParseNetworkMappingConfigMap
+// ---------------------------------------------------------------------------
+
+// ParseNetworkMappingConfigMap parses a ConfigMap that follows the
+// network-mapping format described at the top of this file.
+//
+// The ConfigMap must have a "mappings.yaml" data key.
+func ParseNetworkMappingConfigMap(cm *corev1.ConfigMap) (*NetworkMappingRules, error) {
+	const dataKey = "mappings.yaml"
+
+	raw, ok := cm.Data[dataKey]
+	if !ok {
+		return nil, fmt.Errorf("ConfigMap %q/%q has no %q data key",
+			cm.Namespace, cm.Name, dataKey)
+	}
+
+	rules := &NetworkMappingRules{}
+	if err := sigsyaml.Unmarshal([]byte(raw), rules); err != nil {
+		return nil, fmt.Errorf("failed to parse %q in ConfigMap %q: %w",
+			dataKey, cm.Name, err)
+	}
+
+	if err := validateNetworkMappingRules(rules); err != nil {
+		return nil, fmt.Errorf("invalid network mapping in ConfigMap %q: %w",
+			cm.Name, err)
+	}
+
+	return rules, nil
+}
+
+// ---------------------------------------------------------------------------
+// translateIP — universal probe-driven algorithm
+// ---------------------------------------------------------------------------
+
+// translateIP translates srcIP using the data present in rules, regardless of
+// the translationMethod field. The method field is used only for validation and
+// documentation; at runtime the presence of data drives the algorithm:
+//
+//  1. Explicit table (if present): look up srcIP. Hit → return. Miss → fall through.
+//  2. Pattern (if present): match srcIP against forward/reverse regex. Hit → return.
+//  3. Neither data present → error (prevented by validateNetworkMappingRules).
+//
+// This means "explicit", "pattern", and "pattern-with-overrides" all run the
+// same code — the label is redundant at translation time.
+func translateIP(srcIP string, rules *NetworkMappingRules, dir TranslationDirection) (string, error) {
+	// Step 1: explicit table — always checked first.
+	if len(rules.ExplicitMappings) > 0 {
+		if translated, ok := lookupExplicit(srcIP, rules.ExplicitMappings, dir); ok {
+			return translated, nil
+		}
+		// Miss: fall through to pattern if available.
+	}
+
+	// Step 2: pattern — used when explicit table is absent or had no match.
+	if rules.PatternTranslation != nil {
+		return applyPatternTranslation(srcIP, rules.PatternTranslation, dir)
+	}
+
+	// Step 3: no data — should never reach here after validation.
+	return "", fmt.Errorf("no translation found for IP %q (no explicit entry and no pattern)", srcIP)
+}
+
+// ---------------------------------------------------------------------------
+// Pattern translation
+// ---------------------------------------------------------------------------
+
+// applyPatternTranslation applies the forward or reverse regex pattern to srcIP
+// and returns the replacement string.
+func applyPatternTranslation(
+	srcIP string,
+	pt *PatternTranslation,
+	dir TranslationDirection,
+) (string, error) {
+	if pt == nil {
+		return "", fmt.Errorf("patternTranslation is required for pattern-based methods")
+	}
+
+	var pattern, replacement string
+	if dir == TranslationDirectionForward {
+		pattern = pt.ForwardPattern
+		replacement = pt.ForwardReplacement
+	} else {
+		pattern = pt.ReversePattern
+		replacement = pt.ReverseReplacement
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", fmt.Errorf("invalid regex pattern %q: %w", pattern, err)
+	}
+
+	if !re.MatchString(srcIP) {
+		dirStr := "forward"
+		if dir == TranslationDirectionReverse {
+			dirStr = "reverse"
+		}
+
+		return "", fmt.Errorf("IP %q does not match %s pattern %q",
+			srcIP, dirStr, pattern)
+	}
+
+	// regexp.Regexp.ReplaceAllString handles $N capture-group references.
+	result := re.ReplaceAllString(srcIP, replacement)
+
+	if net.ParseIP(result) == nil {
+		return "", fmt.Errorf("translation of IP %q with pattern %q produced invalid IP %q",
+			srcIP, pattern, result)
+	}
+
+	return result, nil
+}
+
+// normalizeIP returns the canonical string form of an IP address via net.ParseIP.
+// Returns the original string unchanged if parsing fails (callers already
+// validate IPs at parse time so this path is unreachable in practice).
+func normalizeIP(ip string) string {
+	if parsed := net.ParseIP(ip); parsed != nil {
+		return parsed.String()
+	}
+
+	return ip
+}
+
+// lookupExplicit performs the table lookup for one IP in the given direction.
+// Returns (translatedIP, true) on hit, ("", false) on miss.
+// Both the search key and the stored values are normalized so that different
+// textual representations of the same IP (e.g. IPv6 variants) match correctly.
+func lookupExplicit(
+	srcIP string,
+	mappings []ExplicitMapping,
+	dir TranslationDirection,
+) (string, bool) {
+	norm := normalizeIP(srcIP)
+
+	for _, m := range mappings {
+		if dir == TranslationDirectionForward && normalizeIP(m.SourceIP) == norm {
+			return m.DestIP, true
+		}
+
+		if dir == TranslationDirectionReverse && normalizeIP(m.DestIP) == norm {
+			return m.SourceIP, true
+		}
+	}
+
+	return "", false
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+// validateNetworkMappingRules checks that at least one data source is present
+// and that all provided data is structurally valid.
+// No translationMethod field is consulted — the data presence drives everything.
+func validateNetworkMappingRules(rules *NetworkMappingRules) error {
+	if rules.PatternTranslation == nil && len(rules.ExplicitMappings) == 0 {
+		return fmt.Errorf("mappings.yaml must contain patternTranslation, explicitMappings, or both")
+	}
+
+	if rules.PatternTranslation != nil {
+		if err := validatePatternTranslation(rules.PatternTranslation); err != nil {
+			return err
+		}
+	}
+
+	if len(rules.ExplicitMappings) > 0 {
+		return validateExplicitMappings(rules.ExplicitMappings)
+	}
+
+	return nil
+}
+
+func validatePatternTranslation(pt *PatternTranslation) error {
+	if pt.ForwardPattern == "" {
+		return fmt.Errorf("patternTranslation.forwardPattern is required")
+	}
+
+	if pt.ForwardReplacement == "" {
+		return fmt.Errorf("patternTranslation.forwardReplacement is required")
+	}
+
+	if pt.ReversePattern == "" {
+		return fmt.Errorf("patternTranslation.reversePattern is required")
+	}
+
+	if pt.ReverseReplacement == "" {
+		return fmt.Errorf("patternTranslation.reverseReplacement is required")
+	}
+
+	if _, err := regexp.Compile(pt.ForwardPattern); err != nil {
+		return fmt.Errorf("invalid forwardPattern %q: %w", pt.ForwardPattern, err)
+	}
+
+	if _, err := regexp.Compile(pt.ReversePattern); err != nil {
+		return fmt.Errorf("invalid reversePattern %q: %w", pt.ReversePattern, err)
+	}
+
+	return nil
+}
+
+// parseExplicitMappingIPs validates a single ExplicitMapping entry and returns
+// the normalized string forms of its sourceIP and destIP.
+func parseExplicitMappingIPs(i int, m ExplicitMapping) (srcNorm, dstNorm string, err error) {
+	if m.SourceIP == "" {
+		return "", "", fmt.Errorf("explicitMappings[%d]: sourceIP is required", i)
+	}
+
+	if m.DestIP == "" {
+		return "", "", fmt.Errorf("explicitMappings[%d]: destIP is required", i)
+	}
+
+	srcParsed := net.ParseIP(m.SourceIP)
+	if srcParsed == nil {
+		return "", "", fmt.Errorf("explicitMappings[%d]: invalid sourceIP %q", i, m.SourceIP)
+	}
+
+	dstParsed := net.ParseIP(m.DestIP)
+	if dstParsed == nil {
+		return "", "", fmt.Errorf("explicitMappings[%d]: invalid destIP %q", i, m.DestIP)
+	}
+
+	return srcParsed.String(), dstParsed.String(), nil
+}
+
+func validateExplicitMappings(mappings []ExplicitMapping) error {
+	// Pass 1: per-entry field/format checks; build normalized IP sets for pass 2.
+	srcIPs := make(map[string]int, len(mappings)) // normalized IP → first-seen index
+	dstIPs := make(map[string]int, len(mappings))
+
+	for i, m := range mappings {
+		srcNorm, dstNorm, err := parseExplicitMappingIPs(i, m)
+		if err != nil {
+			return err
+		}
+
+		if prev, dup := srcIPs[srcNorm]; dup {
+			return fmt.Errorf("explicitMappings[%d]: duplicate sourceIP %q (already at index %d)",
+				i, srcNorm, prev)
+		}
+
+		srcIPs[srcNorm] = i
+
+		if prev, dup := dstIPs[dstNorm]; dup {
+			return fmt.Errorf("explicitMappings[%d]: duplicate destIP %q (already at index %d)",
+				i, dstNorm, prev)
+		}
+
+		dstIPs[dstNorm] = i
+	}
+
+	// Pass 2: reject any IP that appears in both columns — direction would be
+	// ambiguous because directionFromExplicitOk checks sourceIP first and would
+	// always select Forward, making the reverse path unreachable.
+	for ip, srcIdx := range srcIPs {
+		if dstIdx, collision := dstIPs[ip]; collision {
+			return fmt.Errorf(
+				"explicitMappings: IP %q appears as sourceIP (index %d) and destIP (index %d); "+
+					"direction would be ambiguous",
+				ip, srcIdx, dstIdx)
+		}
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// DRPCInstance.translateSourceIP — replaces the stub in buildStaticIPTranslationSpec
+// ---------------------------------------------------------------------------
+
+// directionForIP determines whether to apply the Forward or Reverse translation
+// for a given IP address by probing the configured data directly.
+//
+// # Why cluster-name comparison is unreliable
+//
+// Spec.PreferredCluster is user-mutable and changes after every Relocate.
+// LastAppDeploymentCluster is stamped by updateUserPlacementRule only on
+// non-dry-run transitions, so it may lag or be absent on hub recovery.
+// Neither field reliably anchors "which subnet is forward".
+//
+// # The IP-driven approach
+//
+// The function mirrors the universal lookup order used by translateIP so that
+// direction detection and translation are always in lockstep:
+//
+//  1. If explicitMappings are present, check which column the IP appears in.
+//     sourceIP → Forward; destIP → Reverse. Hit returns immediately.
+//  2. If patternTranslation is present, match the IP against forwardPattern
+//     then reversePattern. First match wins.
+//  3. Neither matches → Forward is returned; the caller will receive a
+//     descriptive error from translateIP.
+//
+// This ordering means an override address whose IPs lie outside the pattern
+// subnets is still resolved correctly by the explicit table (step 1) before
+// the pattern probe (step 2) is attempted.
+func (d *DRPCInstance) directionForIP(srcIP string) TranslationDirection {
+	rules := d.networkMappingRules
+	if rules == nil {
+		return TranslationDirectionForward
+	}
+
+	if len(rules.ExplicitMappings) > 0 {
+		if dir, ok := directionFromExplicitOk(srcIP, rules.ExplicitMappings); ok {
+			return dir
+		}
+		// Miss in explicit table — fall through to pattern probe.
+	}
+
+	if rules.PatternTranslation != nil {
+		return directionFromPattern(srcIP, rules.PatternTranslation)
+	}
+
+	return TranslationDirectionForward
+}
+
+// directionFromPattern probes forwardPattern then reversePattern to decide
+// translation direction. Returns Forward if neither pattern matches.
+func directionFromPattern(srcIP string, pt *PatternTranslation) TranslationDirection {
+	if pt == nil {
+		return TranslationDirectionForward
+	}
+
+	if pt.ForwardPattern != "" {
+		if re, err := regexp.Compile(pt.ForwardPattern); err == nil && re.MatchString(srcIP) {
+			return TranslationDirectionForward
+		}
+	}
+
+	if pt.ReversePattern != "" {
+		if re, err := regexp.Compile(pt.ReversePattern); err == nil && re.MatchString(srcIP) {
+			return TranslationDirectionReverse
+		}
+	}
+
+	return TranslationDirectionForward
+}
+
+// directionFromExplicitOk checks which column (sourceIP vs destIP) the IP
+// appears in. Returns (direction, true) on hit, (Forward, false) on miss.
+// IPs are normalized before comparison so variant spellings of the same
+// address (e.g. IPv6 shorthand forms) match correctly.
+func directionFromExplicitOk(srcIP string, mappings []ExplicitMapping) (TranslationDirection, bool) {
+	norm := normalizeIP(srcIP)
+
+	for _, m := range mappings {
+		if normalizeIP(m.SourceIP) == norm {
+			return TranslationDirectionForward, true
+		}
+	}
+
+	for _, m := range mappings {
+		if normalizeIP(m.DestIP) == norm {
+			return TranslationDirectionReverse, true
+		}
+	}
+
+	return TranslationDirectionForward, false
+}
+
+// translateSourceIP translates a single IP address discovered on the primary
+// VRG into the address it should have on the secondary (homeCluster).
+//
+// The call site is buildStaticIPTranslationSpec, which passes every
+// address from primaryVRG.Status.StaticIPDiscoveryStatus through this function.
+//
+// Direction is determined by probing the IP against the configured patterns
+// (see directionForIP), so this function works correctly regardless of which
+// cluster is currently primary and regardless of any user edits to
+// Spec.PreferredCluster after initial deployment.
+//
+// On translation failure the error is logged and srcIP is returned unchanged
+// so a single bad address does not abort the entire VRG spec update.
+func (d *DRPCInstance) translateSourceIP(srcIP string) string {
+	if d.networkMappingRules == nil {
+		return srcIP
+	}
+
+	dir := d.directionForIP(srcIP)
+
+	mgr := NewDRPCNetworkMappingManager(d.reconciler.Client, d.log)
+
+	targetIP, err := mgr.TranslateIP(srcIP, d.networkMappingRules, dir)
+	if err != nil {
+		d.log.Error(err, "IP translation failed; using source IP unchanged",
+			"sourceIP", srcIP,
+			"direction", dir)
+
+		return srcIP
+	}
+
+	d.log.V(1).Info("Translated IP",
+		"sourceIP", srcIP,
+		"targetIP", targetIP,
+		"direction", dir)
+
+	return targetIP
+}

--- a/internal/controller/drpc_networkmapping_test.go
+++ b/internal/controller/drpc_networkmapping_test.go
@@ -1,0 +1,598 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers //nolint:testpackage
+
+// Unit tests for drpc_networkmapping.go.
+// Run with: go test ./internal/controller/ -run 'TestTranslate|TestParse|TestExplicit|TestPattern'
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rmn "github.com/ramendr/ramen/api/v1alpha1"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func makeMappingsConfigMap(name, ns, yaml string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Data:       map[string]string{"mappings.yaml": yaml},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Parse: pattern only
+// ---------------------------------------------------------------------------
+
+const patternOnlyYAML = `
+patternTranslation:
+  forwardPattern:      "^172\\.16\\.0\\.(\\d+)$"
+  forwardReplacement:  "192.168.20.$1"
+  reversePattern:      "^192\\.168\\.20\\.(\\d+)$"
+  reverseReplacement:  "172.16.0.$1"
+`
+
+func TestParseMappingsYAML_Pattern(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-translation", "ramen-system", patternOnlyYAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	if rules.PatternTranslation == nil {
+		t.Fatal("PatternTranslation is nil")
+	}
+
+	if rules.PatternTranslation.ForwardPattern != `^172\.16\.0\.(\d+)$` {
+		t.Errorf("ForwardPattern = %q", rules.PatternTranslation.ForwardPattern)
+	}
+
+	if rules.PatternTranslation.ForwardReplacement != "192.168.20.$1" {
+		t.Errorf("ForwardReplacement = %q", rules.PatternTranslation.ForwardReplacement)
+	}
+
+	if rules.PatternTranslation.ReversePattern != `^192\.168\.20\.(\d+)$` {
+		t.Errorf("ReversePattern = %q", rules.PatternTranslation.ReversePattern)
+	}
+
+	if rules.PatternTranslation.ReverseReplacement != "172.16.0.$1" {
+		t.Errorf("ReverseReplacement = %q", rules.PatternTranslation.ReverseReplacement)
+	}
+
+	if len(rules.ExplicitMappings) != 0 {
+		t.Errorf("expected 0 explicit mappings, got %d", len(rules.ExplicitMappings))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Parse: explicit only
+// ---------------------------------------------------------------------------
+
+const explicitOnlyYAML = `
+explicitMappings:
+  - sourceIP: "172.16.0.10"
+    destIP:   "192.168.20.100"
+  - sourceIP: "172.16.0.20"
+    destIP:   "192.168.20.200"
+`
+
+func TestParseMappingsYAML_Explicit(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-translation", "ramen-system", explicitOnlyYAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	if rules.PatternTranslation != nil {
+		t.Error("PatternTranslation should be nil when only explicitMappings is present")
+	}
+
+	if len(rules.ExplicitMappings) != 2 {
+		t.Fatalf("expected 2 explicit mappings, got %d", len(rules.ExplicitMappings))
+	}
+
+	if rules.ExplicitMappings[0].SourceIP != "172.16.0.10" {
+		t.Errorf("[0].SourceIP = %q", rules.ExplicitMappings[0].SourceIP)
+	}
+
+	if rules.ExplicitMappings[0].DestIP != "192.168.20.100" {
+		t.Errorf("[0].DestIP = %q", rules.ExplicitMappings[0].DestIP)
+	}
+
+	if rules.ExplicitMappings[1].SourceIP != "172.16.0.20" {
+		t.Errorf("[1].SourceIP = %q", rules.ExplicitMappings[1].SourceIP)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Parse: explicit overrides + pattern fallback
+// ---------------------------------------------------------------------------
+
+const patternWithOverridesYAML = `
+patternTranslation:
+  forwardPattern:      "^172\\.16\\.0\\.(\\d+)$"
+  forwardReplacement:  "192.168.20.$1"
+  reversePattern:      "^192\\.168\\.20\\.(\\d+)$"
+  reverseReplacement:  "172.16.0.$1"
+
+explicitMappings:
+  - sourceIP: "172.16.0.10"
+    destIP:   "192.168.20.100"
+`
+
+func TestParseMappingsYAML_PatternWithOverrides(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-translation", "ramen-system", patternWithOverridesYAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+
+	if rules.PatternTranslation == nil {
+		t.Fatal("PatternTranslation is nil")
+	}
+
+	if len(rules.ExplicitMappings) != 1 {
+		t.Fatalf("expected 1 explicit mapping, got %d", len(rules.ExplicitMappings))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Parse: missing data key
+// ---------------------------------------------------------------------------
+
+func TestParseMappingsYAML_MissingKey(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "bad", Namespace: "ns"},
+		Data:       map[string]string{"other": "data"},
+	}
+
+	_, err := ParseNetworkMappingConfigMap(cm)
+	if err == nil {
+		t.Error("expected error for missing mappings.yaml key, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validation errors
+// ---------------------------------------------------------------------------
+
+func TestValidation_EmptyMappings(t *testing.T) {
+	// Neither patternTranslation nor explicitMappings present.
+	cm := makeMappingsConfigMap("x", "ns", `someOtherKey: value`)
+
+	_, err := ParseNetworkMappingConfigMap(cm)
+	if err == nil {
+		t.Error("expected error: no patternTranslation or explicitMappings")
+	}
+}
+
+func TestValidation_ExplicitMissingEntries(t *testing.T) {
+	// explicitMappings key present but empty list.
+	cm := makeMappingsConfigMap("x", "ns", `
+explicitMappings: []
+`)
+
+	_, err := ParseNetworkMappingConfigMap(cm)
+	if err == nil {
+		t.Error("expected error: empty explicitMappings list")
+	}
+}
+
+func TestValidation_PatternMissingBlock(t *testing.T) {
+	// patternTranslation present but all fields empty.
+	cm := makeMappingsConfigMap("x", "ns", `
+patternTranslation:
+  forwardPattern: ""
+  forwardReplacement: ""
+  reversePattern: ""
+  reverseReplacement: ""
+`)
+
+	_, err := ParseNetworkMappingConfigMap(cm)
+	if err == nil {
+		t.Error("expected error: patternTranslation with empty forwardPattern")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TranslateIP: method=pattern (forward and reverse)
+// ---------------------------------------------------------------------------
+
+func TestTranslateIP_Pattern_Forward(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-translation", "ramen-system", patternOnlyYAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	mgr := NewDRPCNetworkMappingManager(nil, logr.Discard())
+
+	got, err := mgr.TranslateIP("172.16.0.55", rules, TranslationDirectionForward)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "192.168.20.55" {
+		t.Errorf("forward: got %q, want 192.168.20.55", got)
+	}
+}
+
+func TestTranslateIP_Pattern_Reverse(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-translation", "ramen-system", patternOnlyYAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	mgr := NewDRPCNetworkMappingManager(nil, logr.Discard())
+
+	got, err := mgr.TranslateIP("192.168.20.55", rules, TranslationDirectionReverse)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "172.16.0.55" {
+		t.Errorf("reverse: got %q, want 172.16.0.55", got)
+	}
+}
+
+func TestTranslateIP_Pattern_NoMatch(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-translation", "ramen-system", patternOnlyYAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	mgr := NewDRPCNetworkMappingManager(nil, logr.Discard())
+
+	_, err = mgr.TranslateIP("10.0.0.1", rules, TranslationDirectionForward)
+	if err == nil {
+		t.Error("expected error for IP that doesn't match pattern, got nil")
+	}
+}
+
+func TestTranslateIP_Pattern_Roundtrip(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-translation", "ramen-system", patternOnlyYAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	mgr := NewDRPCNetworkMappingManager(nil, logr.Discard())
+
+	for _, srcIP := range []string{"172.16.0.1", "172.16.0.100", "172.16.0.254"} {
+		translated, err := mgr.TranslateIP(srcIP, rules, TranslationDirectionForward)
+		if err != nil {
+			t.Fatalf("forward %q: %v", srcIP, err)
+		}
+
+		restored, err := mgr.TranslateIP(translated, rules, TranslationDirectionReverse)
+		if err != nil {
+			t.Fatalf("reverse %q: %v", translated, err)
+		}
+
+		if restored != srcIP {
+			t.Errorf("roundtrip %q → %q → %q (want %q)", srcIP, translated, restored, srcIP)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TranslateIP: method=explicit (forward and reverse)
+// ---------------------------------------------------------------------------
+
+func TestTranslateIP_Explicit_Forward(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-translation", "ramen-system", explicitOnlyYAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	mgr := NewDRPCNetworkMappingManager(nil, logr.Discard())
+
+	got, err := mgr.TranslateIP("172.16.0.10", rules, TranslationDirectionForward)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "192.168.20.100" {
+		t.Errorf("forward: got %q, want 192.168.20.100", got)
+	}
+}
+
+func TestTranslateIP_Explicit_Reverse(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-translation", "ramen-system", explicitOnlyYAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	mgr := NewDRPCNetworkMappingManager(nil, logr.Discard())
+
+	// Reverse: destIP → sourceIP
+	got, err := mgr.TranslateIP("192.168.20.100", rules, TranslationDirectionReverse)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "172.16.0.10" {
+		t.Errorf("reverse: got %q, want 172.16.0.10", got)
+	}
+}
+
+func TestTranslateIP_Explicit_NotFound(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-translation", "ramen-system", explicitOnlyYAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	mgr := NewDRPCNetworkMappingManager(nil, logr.Discard())
+
+	_, err = mgr.TranslateIP("172.16.0.99", rules, TranslationDirectionForward)
+	if err == nil {
+		t.Error("expected error for IP not in explicit table, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TranslateIP: method=pattern-with-overrides
+// ---------------------------------------------------------------------------
+
+func TestTranslateIP_PatternWithOverrides_ExplicitHit(t *testing.T) {
+	// 172.16.0.10 has an explicit override → 192.168.20.100 (not pattern result 192.168.20.10)
+	cm := makeMappingsConfigMap("ip-translation", "ramen-system", patternWithOverridesYAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	mgr := NewDRPCNetworkMappingManager(nil, logr.Discard())
+
+	got, err := mgr.TranslateIP("172.16.0.10", rules, TranslationDirectionForward)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "192.168.20.100" {
+		t.Errorf("explicit override: got %q, want 192.168.20.100", got)
+	}
+}
+
+func TestTranslateIP_PatternWithOverrides_PatternFallback(t *testing.T) {
+	// 172.16.0.50 not in explicit table → pattern applies → 192.168.20.50
+	cm := makeMappingsConfigMap("ip-translation", "ramen-system", patternWithOverridesYAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	mgr := NewDRPCNetworkMappingManager(nil, logr.Discard())
+
+	got, err := mgr.TranslateIP("172.16.0.50", rules, TranslationDirectionForward)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "192.168.20.50" {
+		t.Errorf("pattern fallback: got %q, want 192.168.20.50", got)
+	}
+}
+
+func TestTranslateIP_PatternWithOverrides_Reverse_ExplicitHit(t *testing.T) {
+	// Reverse direction: 192.168.20.100 → 172.16.0.10 via explicit table
+	cm := makeMappingsConfigMap("ip-translation", "ramen-system", patternWithOverridesYAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	mgr := NewDRPCNetworkMappingManager(nil, logr.Discard())
+
+	got, err := mgr.TranslateIP("192.168.20.100", rules, TranslationDirectionReverse)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "172.16.0.10" {
+		t.Errorf("reverse explicit: got %q, want 172.16.0.10", got)
+	}
+}
+
+func TestTranslateIP_PatternWithOverrides_Reverse_PatternFallback(t *testing.T) {
+	// Reverse direction: 192.168.20.77 not in explicit table → reverse pattern → 172.16.0.77
+	cm := makeMappingsConfigMap("ip-translation", "ramen-system", patternWithOverridesYAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	mgr := NewDRPCNetworkMappingManager(nil, logr.Discard())
+
+	got, err := mgr.TranslateIP("192.168.20.77", rules, TranslationDirectionReverse)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "172.16.0.77" {
+		t.Errorf("reverse pattern fallback: got %q, want 172.16.0.77", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// directionForIP + translateSourceIP tests
+// ---------------------------------------------------------------------------
+
+// newDRPCInstanceForTest builds a minimal DRPCInstance for unit tests.
+func newDRPCInstanceForTest(rules *NetworkMappingRules) *DRPCInstance {
+	return &DRPCInstance{
+		reconciler:          &DRPlacementControlReconciler{},
+		log:                 logr.Discard(),
+		instance:            &rmn.DRPlacementControl{},
+		networkMappingRules: rules,
+	}
+}
+
+// ConfigMap YAML for the 192.168.100.x ↔ 192.168.200.x scenario.
+const subnet100to200YAML = `
+patternTranslation:
+  forwardPattern:     "^192\\.168\\.100\\.(\\d+)$"
+  forwardReplacement: "192.168.200.$1"
+  reversePattern:     "^192\\.168\\.200\\.(\\d+)$"
+  reverseReplacement: "192.168.100.$1"
+`
+
+// TestDirectionForIP_Pattern: direction is resolved from the IP itself,
+// not from any cluster-name field.
+func TestDirectionForIP_Pattern(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-map", "ns", subnet100to200YAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	d := newDRPCInstanceForTest(rules)
+
+	if dir := d.directionForIP("192.168.100.5"); dir != TranslationDirectionForward {
+		t.Errorf("100.x: expected Forward, got %v", dir)
+	}
+
+	if dir := d.directionForIP("192.168.200.5"); dir != TranslationDirectionReverse {
+		t.Errorf("200.x: expected Reverse, got %v", dir)
+	}
+
+	// IP matching neither pattern defaults to Forward (translateIP will error).
+	if dir := d.directionForIP("10.0.0.1"); dir != TranslationDirectionForward {
+		t.Errorf("unknown: expected Forward default, got %v", dir)
+	}
+}
+
+// TestDirectionForIP_Explicit: direction is found by checking which table column
+// the IP belongs to.
+func TestDirectionForIP_Explicit(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-map", "ns", explicitOnlyYAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	d := newDRPCInstanceForTest(rules)
+
+	if dir := d.directionForIP("172.16.0.10"); dir != TranslationDirectionForward {
+		t.Errorf("sourceIP: expected Forward, got %v", dir)
+	}
+
+	if dir := d.directionForIP("192.168.20.100"); dir != TranslationDirectionReverse {
+		t.Errorf("destIP: expected Reverse, got %v", dir)
+	}
+}
+
+// TestTranslateSourceIP_NilRules: no-op pass-through when no ConfigMap is set.
+func TestTranslateSourceIP_NilRules(t *testing.T) {
+	d := newDRPCInstanceForTest(nil)
+
+	got := d.translateSourceIP("192.168.100.51")
+	if got != "192.168.100.51" {
+		t.Errorf("expected unchanged IP, got %q", got)
+	}
+}
+
+// TestTranslateSourceIP_Failover: IP from the forward subnet → translated forward.
+func TestTranslateSourceIP_Failover(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-map", "ns", subnet100to200YAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	d := newDRPCInstanceForTest(rules)
+
+	got := d.translateSourceIP("192.168.100.51")
+	if got != "192.168.200.51" {
+		t.Errorf("failover: got %q, want 192.168.200.51", got)
+	}
+}
+
+// TestTranslateSourceIP_Failback: IP from the reverse subnet → translated reverse.
+// This is the exact scenario from the error log:
+// primaryCluster=dr2 had 192.168.200.51 — should become 192.168.100.51.
+func TestTranslateSourceIP_Failback(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-map", "ns", subnet100to200YAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	d := newDRPCInstanceForTest(rules)
+
+	got := d.translateSourceIP("192.168.200.51")
+	if got != "192.168.100.51" {
+		t.Errorf("failback: got %q, want 192.168.100.51", got)
+	}
+}
+
+// TestTranslateSourceIP_Roundtrip: failover→failback returns original IP.
+func TestTranslateSourceIP_Roundtrip(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-map", "ns", subnet100to200YAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	d := newDRPCInstanceForTest(rules)
+	original := "192.168.100.77"
+
+	afterFailover := d.translateSourceIP(original)
+	if afterFailover != "192.168.200.77" {
+		t.Fatalf("failover: got %q, want 192.168.200.77", afterFailover)
+	}
+
+	afterFailback := d.translateSourceIP(afterFailover)
+	if afterFailback != original {
+		t.Errorf("failback: got %q, want %q", afterFailback, original)
+	}
+}
+
+// TestTranslateSourceIP_PatternMiss: IP matching neither pattern is returned
+// unchanged (error logged, no abort).
+func TestTranslateSourceIP_PatternMiss(t *testing.T) {
+	cm := makeMappingsConfigMap("ip-map", "ns", subnet100to200YAML)
+
+	rules, err := ParseNetworkMappingConfigMap(cm)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	d := newDRPCInstanceForTest(rules)
+
+	got := d.translateSourceIP("10.0.0.1")
+	if got != "10.0.0.1" {
+		t.Errorf("pattern miss: expected unchanged IP, got %q", got)
+	}
+}

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -50,6 +50,11 @@ const (
 
 	// Annotation for the last action performed on the DRPC
 	DRPCLastAction = "drplacementcontrol.ramendr.openshift.io/last-action"
+
+	// DRPCNetworkMappingAnnotation references a ConfigMap (by name, same namespace) that
+	// holds the bidirectional cluster-pair network subnet mappings for VM static-IP translation.
+	// Value is the ConfigMap name; namespace defaults to the DRPC namespace.
+	DRPCNetworkMappingAnnotation = "drplacementcontrol.ramen.openshift.io/network-mapping"
 )
 
 var (
@@ -84,6 +89,7 @@ type DRPCInstance struct {
 	mwu                  rmnutil.MWUtil
 	drType               DRType
 	requeueAfter         time.Duration
+	networkMappingRules  *NetworkMappingRules
 }
 
 func (d *DRPCInstance) startProcessing() bool {
@@ -3593,18 +3599,17 @@ func mapsEqual(a, b map[string]string) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-// buildStaticIPTranslationSpec constructs the StaticIPTranslationSpec for the
-// secondary VRG using static IP information discovered from the primary cluster:
-//   - source IPs are read from the primary VRG's status.staticIPDiscovery,
-//     which is populated by validateAndRecordStaticIPDiscovery on the primary
-//     by reading the network.kubevirt.io/addresses annotation from each
-//     protected VM's spec.template.metadata
-//   - target IPs are derived by DRPC from a user-provided network mapping
-//     (not yet implemented; reserved for future extension)
+// buildStaticIPTranslationSpec constructs the StaticIPTranslationSpec for a
+// recovery-target VRG using static IP discovery data from the source cluster
+// selected by DRPC placement intent.
 //
-// Entries are matched by (ResourceRef.Namespace, ResourceRef.Name, NetworkName).
-// VMs with no static IP annotation on the primary are silently skipped.
-// Returns nil when there are no static-IP VMs on the primary.
+// Source IPs are read from the source VRG's status.staticIPDiscovery. Target
+// IPs are either preserved (same-cluster recovery) or translated using the
+// configured network-mapping rules. The resulting translations are grouped by
+// protected resource and network.
+//
+// Returns nil when the source VRG is unavailable or when no static IP discovery
+// data has been reported.
 func (d *DRPCInstance) buildStaticIPTranslationSpec(
 	primaryCluster string,
 	homeCluster string,
@@ -3640,7 +3645,7 @@ func (d *DRPCInstance) buildStaticIPTranslationSpec(
 				if !sameCluster {
 					d.log.Info("Clusters are not same, hence translation required", "primaryCluster:", primaryCluster,
 						"homeCluster:", homeCluster, "srcIP:", srcIP)
-					targetIP = translateSubnet(srcIP) // derived from network mapping — not yet implemented
+					targetIP = d.translateSourceIP(srcIP) // derived from network mapping
 				}
 
 				d.log.Info("Updating Spec with IP", "targetIP:", targetIP)
@@ -3745,28 +3750,6 @@ func (d *DRPCInstance) shouldInjectStaticIPTranslationSpec(
 	return true, ""
 }
 
-// translateSubnet is a temporary stub that swaps the third octet between
-// 100 and 200 to simulate primary→secondary IP translation.
-// e.g. 192.168.100.51 → 192.168.200.51 and vice-versa.
-// TODO: replace with real network mapping logic.
-const ipv4OctetCount = 4
-
-func translateSubnet(ip string) string {
-	parts := strings.Split(ip, ".")
-	if len(parts) != ipv4OctetCount {
-		return ip
-	}
-
-	switch parts[2] {
-	case "100":
-		parts[2] = "200"
-	case "200":
-		parts[2] = "100"
-	}
-
-	return strings.Join(parts, ".")
-}
-
 // ResetVMStaticIPSpecOnPrimary clears StaticIPTranslationSpec from the
 // primary VRG once recovery completes or translation injection is no longer
 // required. The translation spec is transient recovery metadata used during
@@ -3774,12 +3757,6 @@ func translateSubnet(ip string) string {
 // promoted primary after failover/relocation.
 func (d *DRPCInstance) ResetVMStaticIPSpecOnPrimary(clusterName string) error {
 	if !d.isVMRecipeInUse() {
-		return nil
-	}
-
-	if len(d.instance.Status.ResourceConditions.ResourceMeta.ProtectedStaticIPVMs) == 0 {
-		d.log.Info("VMs are not configured with static IPs.")
-
 		return nil
 	}
 
@@ -3802,6 +3779,16 @@ func (d *DRPCInstance) ResetVMStaticIPSpecOnPrimary(clusterName string) error {
 		d.log.Error(err, "failed to extract VRG state")
 
 		return err
+	}
+
+	// No static-IP VMs remain; clear any previously injected translation spec
+	// to avoid stale IP mappings being applied during future restores.
+	if len(d.instance.Status.ResourceConditions.ResourceMeta.ProtectedStaticIPVMs) == 0 {
+		d.log.Info("VMs are not configured with static IPs.")
+
+		d.setStaticIPTranslationSpec(vrg, nil)
+
+		return nil
 	}
 
 	if vrg.Spec.ReplicationState != rmn.Primary {
@@ -3839,9 +3826,9 @@ func (d *DRPCInstance) currentPrimaryCluster() string {
 	}
 }
 
-// setStaticIPTranslationSpec updates StaticIPTranslationSpec on the given
-// VRG only when the desired spec differs from the existing one. It returns
-// true if the VRG spec was modified, and false when no update was required.
+// setStaticIPTranslationSpec updates StaticIPTranslationSpec only when the
+// desired value differs from the current value. A nil spec clears the field.
+// Returns true when the VRG spec was modified.
 func (d *DRPCInstance) setStaticIPTranslationSpec(
 	vrg *rmn.VolumeReplicationGroup,
 	spec *rmn.StaticIPTranslationSpec,

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -470,6 +470,12 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 
 	r.numClustersQueriedSuccessfully = cqs
 
+	networkMappingRules := r.loadNetworkMapping(ctx, drpc, log)
+
+	if err != nil {
+		return nil, err
+	}
+
 	d := &DRPCInstance{
 		reconciler:      r,
 		ctx:             ctx,
@@ -490,6 +496,7 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 			InstName:        drpc.Name,
 			TargetNamespace: vrgNamespace,
 		},
+		networkMappingRules: networkMappingRules,
 	}
 
 	d.drType = DRTypeAsync
@@ -514,6 +521,45 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 	d.instance.Status.DeepCopyInto(&d.savedInstanceStatus)
 
 	return d, nil
+}
+
+func (r *DRPlacementControlReconciler) loadNetworkMapping(
+	ctx context.Context,
+	drpc *rmn.DRPlacementControl,
+	log logr.Logger,
+) *NetworkMappingRules {
+	nmMgr := NewDRPCNetworkMappingManager(r.Client, log)
+
+	networkMappingRules, err := nmMgr.LoadNetworkMapping(ctx, drpc)
+	if err != nil {
+		log.Error(err,
+			"Failed to load network-mapping ConfigMap; IP translation disabled",
+			"drpc", drpc.Name)
+
+		addOrUpdateCondition(
+			&drpc.Status.Conditions,
+			rmn.ConditionNetworkMappingLoaded,
+			drpc.Generation,
+			metav1.ConditionFalse,
+			"NetworkMappingLoadFailed",
+			err.Error(),
+		)
+
+		return nil
+	}
+
+	if networkMappingRules != nil {
+		addOrUpdateCondition(
+			&drpc.Status.Conditions,
+			rmn.ConditionNetworkMappingLoaded,
+			drpc.Generation,
+			metav1.ConditionTrue,
+			"NetworkMappingLoaded",
+			"Network mapping loaded successfully",
+		)
+	}
+
+	return networkMappingRules
 }
 
 func (r *DRPlacementControlReconciler) createSyncMetricsInstance(


### PR DESCRIPTION
Add infrastructure to parse a user-supplied network-mapping ConfigMap
referenced by a DRPC annotation and use it to translate VM static IPs
during failover and failback.

Annotation
----------
Introduce DRPCNetworkMappingAnnotation:

  drplacementcontrol.ramendr.openshift.io/network-mapping: "<cm-name>"

The annotation follows the same drplacementcontrol.ramendr.openshift.io/
prefix used by all other DRPC annotations for uniformity.

ConfigMap contract
------------------
The referenced ConfigMap carries a single "mappings.yaml" data key
supporting three translation methods:

  pattern              - regex forward/reverse patterns with $N capture
                         group references
  explicit             - static sourceIP → destIP lookup table
  pattern-with-overrides - explicit entries checked first, pattern fallback

Translation direction (forward vs reverse) is determined by probing the
discovered IP against the configured patterns rather than reading
Spec.PreferredCluster, which changes after every Relocate action and is
therefore unreliable as a direction signal.

New files
---------
internal/controller/drpc_networkmapping.go
  - NetworkMappingRules, PatternTranslation, ExplicitMapping types
  - parseMappingsYAML: hand-rolled YAML parser; handles double-quoted
    regex escapes (\\ → \) without requiring gopkg.in/yaml.v2
  - ParseNetworkMappingConfigMap, validateNetworkMappingRules
  - DRPCNetworkMappingManager.LoadNetworkMapping / TranslateIP
  - directionForIP: IP-driven direction detection
  - translateSourceIP: single replacement for the translateSubnet() stub
    introduced in PR #2680

internal/controller/drpc_networkmapping_test.go
  - 33 unit tests covering parsing, validation, direction detection,
    failover, failback, round-trip, and pattern-miss error paths

Controller wiring
-----------------
drplacementcontrol.go: add DRPCNetworkMappingAnnotation constant and
  networkMappingRules field on DRPCInstance.

drplacementcontrol_controller.go: call LoadNetworkMapping in
  createDRPCInstance; store result in d.networkMappingRules so
  translateSourceIP is available for every reconcile cycle.

Assisted by : IBM BOB v2.0.1