### PR TITLE
drpc: capture actionStartTime when deletion begins

### DIFF
--- a/docs/drpc-crd.md
+++ b/docs/drpc-crd.md
@@ -244,11 +244,12 @@ The generation of the DRPC spec that was last processed.
 
 ### `actionStartTime` (metav1.Time)
 
-When the current DR action started.
+When the current DR action started (Deploy, Failover, Relocate, or Deletion).
 
 ### `actionDuration` (metav1.Duration)
 
-How long the current action has been running.
+How long the current action took to complete (set when the action finishes,
+cleared when a new action, including deletion, starts).
 
 ### `progression` (ProgressionStatus)
 

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -190,11 +190,6 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 		if err != nil {
 			logger.Info(fmt.Sprintf("Error in deleting DRPC: (%v)", err))
 
-			statusErr := r.setDeletionStatusAndUpdate(ctx, drpc)
-			if statusErr != nil {
-				err = fmt.Errorf("drpc deletion failed: %w and status update failed: %w", err, statusErr)
-			}
-
 			return ctrl.Result{}, err
 		}
 
@@ -265,11 +260,13 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 func (r *DRPlacementControlReconciler) setDeletionStatusAndUpdate(
 	ctx context.Context, drpc *rmn.DRPlacementControl,
 ) error {
-	updated := updateDRPCProgression(drpc, rmn.ProgressionDeleting, r.Log)
+	progressionUpdated := updateDRPCProgression(drpc, rmn.ProgressionDeleting, r.Log)
+	phaseUpdated := drpc.Status.Phase != rmn.Deleting
+
 	drpc.Status.Phase = rmn.Deleting
 	drpc.Status.ObservedGeneration = drpc.Generation
 
-	if updated {
+	if progressionUpdated || phaseUpdated {
 		if err := r.Status().Update(ctx, drpc); err != nil {
 			return fmt.Errorf("failed to update DRPC status: (%w)", err)
 		}
@@ -787,6 +784,11 @@ func (r *DRPlacementControlReconciler) processDeletion(ctx context.Context,
 
 	if !controllerutil.ContainsFinalizer(drpc, DRPCFinalizer) {
 		return nil
+	}
+
+	// Set Deleting status when cleanup starts, not only after a cleanup failure.
+	if err := r.setDeletionStatusAndUpdate(ctx, drpc); err != nil {
+		return err
 	}
 
 	// Run finalization logic for dprc.

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -263,6 +263,13 @@ func (r *DRPlacementControlReconciler) setDeletionStatusAndUpdate(
 	progressionUpdated := updateDRPCProgression(drpc, rmn.ProgressionDeleting, r.Log)
 	phaseUpdated := drpc.Status.Phase != rmn.Deleting
 
+	if progressionUpdated {
+		// Reset action timing on first transition into Deleting so START TIME reflects
+		// when deletion began.
+		drpc.Status.ActionStartTime = &metav1.Time{Time: time.Now()}
+		drpc.Status.ActionDuration = nil
+	}
+
 	drpc.Status.Phase = rmn.Deleting
 	drpc.Status.ObservedGeneration = drpc.Generation
 

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -186,14 +186,14 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 	if isBeingDeleted(drpc, placementObj) {
 		// DPRC depends on User PlacementRule/Placement. If DRPC or/and the User PlacementRule is deleted,
 		// then the DRPC should be deleted as well. The least we should do here is to clean up DPRC.
+		// Capture deletion start time before cleanup so START TIME reflects when deletion began
+		if statusErr := r.setDeletionStatusAndUpdate(ctx, drpc); statusErr != nil {
+			logger.Info(fmt.Sprintf("Failed to update DRPC deletion status: (%v)", statusErr))
+		}
+
 		err := r.processDeletion(ctx, drpc, placementObj, logger)
 		if err != nil {
 			logger.Info(fmt.Sprintf("Error in deleting DRPC: (%v)", err))
-
-			statusErr := r.setDeletionStatusAndUpdate(ctx, drpc)
-			if statusErr != nil {
-				err = fmt.Errorf("drpc deletion failed: %w and status update failed: %w", err, statusErr)
-			}
 
 			return ctrl.Result{}, err
 		}
@@ -266,6 +266,13 @@ func (r *DRPlacementControlReconciler) setDeletionStatusAndUpdate(
 	ctx context.Context, drpc *rmn.DRPlacementControl,
 ) error {
 	updated := updateDRPCProgression(drpc, rmn.ProgressionDeleting, r.Log)
+	if updated {
+		// Reset action timing on first transition into Deleting for Deploy/Failover/Relocate
+		// so START TIME reflects when deletion began
+		drpc.Status.ActionStartTime = &metav1.Time{Time: time.Now()}
+		drpc.Status.ActionDuration = nil
+	}
+
 	drpc.Status.Phase = rmn.Deleting
 	drpc.Status.ObservedGeneration = drpc.Generation
 

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -1972,6 +1972,47 @@ var _ = Describe("DRPlacementControl Reconciler Errors", func() {
 			}
 		}, SpecTimeout(time.Second*10))
 	})
+
+	When("a Deployed DRPC is deleted", func() {
+		AfterEach(func() {
+			err := forceCleanupClusterAfterAErrorTest()
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("Should reset actionStartTime and clear actionDuration for deletion", func(ctx SpecContext) {
+			_, _ = InitialDeploymentAsync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster,
+				UsePlacementRule)
+
+			waitForCompletion(string(rmn.Deployed))
+			waitForDRPCPhaseAndProgression(DefaultDRPCNamespace, rmn.Deployed)
+
+			previousStartTime := metav1.NewTime(time.Now().Add(-time.Hour))
+			previousDuration := metav1.Duration{Duration: time.Minute}
+
+			err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				drpc := getLatestDRPC(DefaultDRPCNamespace)
+				drpc.Status.ActionStartTime = previousStartTime.DeepCopy()
+				drpc.Status.ActionDuration = &previousDuration
+
+				return k8sClient.Status().Update(context.TODO(), drpc)
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			err = retry.RetryOnConflict(retry.DefaultBackoff, deleteAllDRClusters)
+			Expect(err).ToNot(HaveOccurred())
+
+			deleteDRPC()
+
+			_, err = drpcReconcile(DRPCCommonName, DefaultDRPCNamespace)
+			Expect(err).To(HaveOccurred())
+
+			deletingDRPC := getLatestDRPC(DefaultDRPCNamespace)
+			Expect(deletingDRPC.Status.Phase).To(Equal(rmn.Deleting))
+			Expect(deletingDRPC.Status.Progression).To(Equal(rmn.ProgressionDeleting))
+			Expect(deletingDRPC.Status.ActionStartTime).NotTo(BeNil())
+			Expect(deletingDRPC.Status.ActionStartTime.Time.After(previousStartTime.Time)).To(BeTrue())
+			Expect(deletingDRPC.Status.ActionDuration).To(BeNil())
+		}, SpecTimeout(time.Second*10))
+	})
 })
 
 // +kubebuilder:docs-gen:collapse=Imports


### PR DESCRIPTION
## Summary

When a DRPC is deleting, kubectl's START TIME column still showed the previous Deploy/Failover/Relocate start time even after CURRENTSTATE/PROGRESSION became Deleting. That makes it hard to tell when deletion began from the wide output (`status.actionStartTime`). `metadata.deletionTimestamp` only records when delete was requested, not what the START TIME column displays.

This change:
- Resets `status.actionStartTime` and clears `status.actionDuration` on the first transition to Deleting
- Calls `setDeletionStatusAndUpdate` at the start of `processDeletion` so timing is captured when cleanup begins, not only after a cleanup failure
- Adds a unit test for the timing reset

## Test plan
- [x] Deploy a workload to Completed and note START TIME / DURATION. Stall DRPC deletion by scaling down Ramen on one of the managed clusters, then delete the workload. While CURRENTSTATE/PROGRESSION show Deleting, confirm START TIME is updated and DURATION is cleared.

Manual test **passed**. Deletion START TIME is captured correctly.

### Result
| | Deployed | While Deleting |
|--|---------------------|----------------|
| Phase / Progression | Deployed / Completed | Deleting / Deleting |
| START TIME | `2026-08-18T21:10:22Z` | `2026-08-18T21:11:58Z` (newer) |
| DURATION | `5.33s` | empty |

START refreshed on delete, DURATION cleared, phase/progression stayed `Deleting` while Ramen was scaled down.