### PR TITLE
vrg: Prevent stale DataReady condition for global VGR apps

### DIFF
--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -2926,7 +2926,7 @@ func cleanupPVCForRestore(pvc *corev1.PersistentVolumeClaim) error {
 //	VRG.conditions.Available.Status = false
 //	VRG.conditions.Available.Reason = Progressing
 //
-//nolint:funlen
+//nolint:funlen,gocognit,cyclop
 func (v *VRGInstance) aggregateVolRepDataReadyCondition() *metav1.Condition {
 	if len(v.volRepPVCs) == 0 {
 		return v.vrgReadyStatus(VRGConditionReasonUnused)
@@ -2950,6 +2950,18 @@ func (v *VRGInstance) aggregateVolRepDataReadyCondition() *metav1.Condition {
 			// why treat it as an error instead of progressing?
 			v.log.Info(fmt.Sprintf("Failed to find condition %s for vrg %s/%s", VRGConditionTypeDataReady,
 				v.instance.Name, v.instance.Namespace))
+
+			break
+		}
+
+		if v.hasGlobalVGRLabel() && condition.ObservedGeneration != v.instance.Generation {
+			vrgReady = false
+			vrgProgressing = true
+
+			v.log.Info("Stale DataReady condition detected for PVC, treating as progressing",
+				"protectedPVC", protectedPVC.Name,
+				"conditionGeneration", condition.ObservedGeneration,
+				"vrgGeneration", v.instance.Generation)
 
 			break
 		}


### PR DESCRIPTION
## Problem

During failover/relocate for global VGR (offloaded storage) apps, DRPC
progression can prematurely reach `Completed` while workloads are still
running on the source cluster.

cause: when consensus gate blocks VRG reconciliation after a spec
change (e.g., primary→secondary), per-PVC `DataReady` conditions retain
their old `observedGeneration`. `aggregateVolRepDataReadyCondition()`
promotes these stale conditions to the VRG-level `DataReady` with the
current generation, causing the VRG to falsely report `Secondary` state.
DRPC then sets `PeerReady=True` and marks the action `Completed`.

## Fix

Add a generation check in `aggregateVolRepDataReadyCondition()`: for
global VGR apps, if a per-PVC `DataReady` condition's
`observedGeneration` does not match the current VRG generation, treat it
as progressing rather than ready. This blocks the stale condition from
being laundered into the VRG-level status.
Scoped to `hasGlobalVGRLabel()` to avoid regressions for standard
(non-offloaded) replication paths.

## Testing
- Was able to reproduce the issue 100% of the time without the fix by adding sleep between multiple app action initiation.
- 10 iterations of failover + relocate with 3  apps (AppSet, Subscription, Discovered) sharing a global VGR
```
[2026-08-05 19:33:07] [INFO] ═══════════════════════════════════════════════════════════
[2026-08-05 19:33:07] [INFO]   FINAL RESULTS
[2026-08-05 19:33:07] [INFO] ═══════════════════════════════════════════════════════════
[2026-08-05 19:33:07] [INFO] Iterations completed: 10 / 10
[2026-08-05 19:33:07] [INFO] Failures: 0
[2026-08-05 19:33:07] [INFO] Stale conditions caught by fix: 68
[2026-08-05 19:33:07] [INFO] Log directory: test_fix_logs/run_20260805_175753
```
- 0 premature flips detected
-  correctly blocking stale conditions
```
2026-08-05T13:56:14.046Z	INFO	vrg	controller/vrg_volrep.go:2961	Stale DataReady condition detected for PVC, treating as progressing	{"vrg": {"name":"subscr-deploy-standard","namespace":"test-subscr-deploy-standard"}, "rid": "e4b487b5", "State": "primary", "protectedPVC": "busybox-pvc", "conditionGeneration": 53, "vrgGeneration": 54}
2026-08-05T13:56:14.046Z	INFO	vrg	controller/vrg_volrep.go:2961	Stale DataReady condition detected for PVC, treating as progressing	{"vrg": {"name":"appset-deploy-standard","namespace":"test-appset-deploy-standard"}, "rid": "3d0491a2", "State": "primary", "protectedPVC": "busybox-pvc", "conditionGeneration": 53, "vrgGeneration": 54}
2026-08-05T13:56:14.149Z	INFO	vrg	controller/vrg_volrep.go:2961	Stale DataReady condition detected for PVC, treating as progressing	{"vrg": {"name":"disapp-deploy-standard","namespace":"ramen-ops"}, "rid": "35d0789a", "State": "primary", "protectedPVC": "busybox-pvc", "conditionGeneration": 53, "vrgGeneration": 54}
```

Fixes: DFBUGS-9002 and DFBUGS-9176