### PR TITLE
Update submariner to v0.24.0

### DIFF
--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -168,7 +168,7 @@ clusters. *Ramen* makes this easy using minikube, but you need enough resources:
 
    For more info see
    [Submariner subctl installation](https://submariner.io/operations/deployment/subctl/).
-   Tested with version v0.22.0. Version v0.21.2 or later is required.
+   Version v0.24.0 or later is required.
 
 1. Install the `velero` tool
 

--- a/test/README.md
+++ b/test/README.md
@@ -76,7 +76,7 @@ environment.
 
    For more info see
    [Submariner subctl installation](https://submariner.io/operations/deployment/subctl/).
-   Tested with version v0.22.0. Version v0.21.2 or later is required.
+   Version v0.24.0 or later is required.
 
 1. Install the `velero` tool
 
@@ -223,7 +223,7 @@ environment.
 
    For more info see
    [Submariner subctl installation](https://submariner.io/operations/deployment/subctl/).
-   Tested with version v0.22.0. Version v0.21.2 or later is required.
+   Version v0.24.0 or later is required.
 
 1. Install the `kubectl-gather` plugin
 

--- a/test/drenv/addons/submariner/start.py
+++ b/test/drenv/addons/submariner/start.py
@@ -35,6 +35,12 @@ def start(broker, *clusters):
     for cluster in clusters:
         wait_for_cluster(cluster)
 
+    for cluster in clusters:
+        restart_coredns(cluster)
+
+    for cluster in clusters:
+        wait_for_coredns(cluster)
+
 
 def deploy_broker(broker):
     print(f"Waiting until broker '{broker}' is ready")
@@ -104,6 +110,33 @@ def annotate_nodes(cluster):
 def wait_for_cluster(cluster):
     print(f"Waiting for submariner deployuments in cluster '{cluster}'")
     wait_for_deployments(cluster, CLUSTER_DEPLOYMENTS, NAMESPACE)
+
+
+def restart_coredns(cluster):
+    """
+    Reload cluster CoreDNS after lighthouse has patched the Corefile.
+
+    CoreDNS reload defaults to ~30s; until then clusterset.local queries miss
+    the lighthouse forward and NXDOMAIN is cached.
+    """
+    print(f"Restarting CoreDNS on cluster '{cluster}'")
+    kubectl.rollout(
+        "restart",
+        "deployment/coredns",
+        "--namespace=kube-system",
+        context=cluster,
+    )
+
+
+def wait_for_coredns(cluster):
+    print(f"Waiting for CoreDNS on cluster '{cluster}'")
+    kubectl.rollout(
+        "status",
+        "deployment/coredns",
+        "--namespace=kube-system",
+        timeout=60,
+        context=cluster,
+    )
 
 
 def wait_for_deployments(cluster, names, namespace):

--- a/test/drenv/addons/submariner/start.py
+++ b/test/drenv/addons/submariner/start.py
@@ -9,8 +9,7 @@ from drenv import cluster as drenv_cluster
 from drenv import kubectl
 from drenv import subctl
 
-# 0.22.0 is broken in minikube.
-VERSION = "0.21.2"
+VERSION = "0.24.0"
 
 NAMESPACE = "submariner-operator"
 
@@ -31,6 +30,9 @@ def start(broker, *clusters):
 
     for cluster in clusters:
         join_cluster(cluster, broker_info)
+
+    for cluster in clusters:
+        configure_submariner(cluster)
 
     for cluster in clusters:
         wait_for_cluster(cluster)
@@ -76,6 +78,26 @@ def join_cluster(cluster, broker_info):
         cable_driver="vxlan",
         version=VERSION,
     )
+
+
+def configure_submariner(cluster):
+    """
+    Configure submariner for minikube kernel.
+
+    TODO: Remove when minikube supports knftables:
+    https://github.com/kubernetes/minikube/issues/23450
+    """
+    print(f"Configuring submariner on cluster '{cluster}'")
+    configmap = """
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: submariner-global
+  namespace: submariner-operator
+data:
+  use-nftables: "false"
+"""
+    kubectl.apply("--filename=-", input=configmap, context=cluster)
 
 
 def annotate_nodes(cluster):

--- a/test/drenv/addons/submariner/start.py
+++ b/test/drenv/addons/submariner/start.py
@@ -9,8 +9,7 @@ from drenv import cluster as drenv_cluster
 from drenv import kubectl
 from drenv import subctl
 
-# 0.22.0 is broken in minikube.
-VERSION = "0.21.2"
+VERSION = "0.24.0"
 
 NAMESPACE = "submariner-operator"
 
@@ -31,6 +30,9 @@ def start(broker, *clusters):
 
     for cluster in clusters:
         join_cluster(cluster, broker_info)
+
+    for cluster in clusters:
+        configure_submariner(cluster)
 
     for cluster in clusters:
         wait_for_cluster(cluster)
@@ -82,6 +84,26 @@ def join_cluster(cluster, broker_info):
         cable_driver="vxlan",
         version=VERSION,
     )
+
+
+def configure_submariner(cluster):
+    """
+    Configure submariner for minikube kernel.
+
+    TODO: Remove when minikube supports knftables:
+    https://github.com/kubernetes/minikube/issues/23450
+    """
+    print(f"Configuring submariner on cluster '{cluster}'")
+    configmap = """
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: submariner-global
+  namespace: submariner-operator
+data:
+  use-nftables: "false"
+"""
+    kubectl.apply("--filename=-", input=configmap, context=cluster)
 
 
 def annotate_nodes(cluster):

--- a/test/drenv/addons/submariner/start.py
+++ b/test/drenv/addons/submariner/start.py
@@ -37,6 +37,12 @@ def start(broker, *clusters):
     for cluster in clusters:
         wait_for_cluster(cluster)
 
+    for cluster in clusters:
+        restart_coredns(cluster)
+
+    for cluster in clusters:
+        wait_for_coredns(cluster)
+
 
 def deploy_broker(broker):
     print(f"Waiting until broker '{broker}' is ready")
@@ -126,6 +132,33 @@ def annotate_nodes(cluster):
 def wait_for_cluster(cluster):
     print(f"Waiting for submariner deployuments in cluster '{cluster}'")
     wait_for_deployments(cluster, CLUSTER_DEPLOYMENTS, NAMESPACE)
+
+
+def restart_coredns(cluster):
+    """
+    Reload cluster CoreDNS after lighthouse has patched the Corefile.
+
+    CoreDNS reload defaults to ~30s; until then clusterset.local queries miss
+    the lighthouse forward and NXDOMAIN is cached.
+    """
+    print(f"Restarting CoreDNS on cluster '{cluster}'")
+    kubectl.rollout(
+        "restart",
+        "deployment/coredns",
+        "--namespace=kube-system",
+        context=cluster,
+    )
+
+
+def wait_for_coredns(cluster):
+    print(f"Waiting for CoreDNS on cluster '{cluster}'")
+    kubectl.rollout(
+        "status",
+        "deployment/coredns",
+        "--namespace=kube-system",
+        timeout=60,
+        context=cluster,
+    )
 
 
 def wait_for_deployments(cluster, names, namespace):

--- a/test/drenv/addons/submariner/test.py
+++ b/test/drenv/addons/submariner/test.py
@@ -206,7 +206,8 @@ def wait_for_service_import(cluster, namespace):
 
 
 def service_address(namespace):
-    return f"{SERVICE}.{namespace}.svc.clusterset.local"
+    # Trailing dot: absolute name so the resolver skips search domains (ndots).
+    return f"{SERVICE}.{namespace}.svc.clusterset.local."
 
 
 def test_connectivity(cluster, namespace, timeout=300):

--- a/test/drenv/addons/submariner/test.py
+++ b/test/drenv/addons/submariner/test.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-import platform
 import time
 from pathlib import Path
 
@@ -43,11 +42,8 @@ def test(broker, *clusters):
     wait_for_service_export(clusters[1], NS2)
     wait_for_service_import(clusters[0], NS2)
 
-    if platform.system() == "Darwin":
-        print("Skipping connectivity test: broken with lima provider")
-    else:
-        test_connectivity(clusters[1], NS1)
-        test_connectivity(clusters[0], NS2)
+    test_connectivity(clusters[1], NS1)
+    test_connectivity(clusters[0], NS2)
 
     unexport_service(clusters[0], NS1)
     unexport_service(clusters[1], NS2)


### PR DESCRIPTION
Submariner 0.22+ defaults to knftables, which crashes globalnet on the current minikube ISO. Separately, first-run connectivity after `drenv start` spent ~54s waiting on DNS until CoreDNS picked up the lighthouse Corefile change. With these fixes, connectivity completes in ~0.1s.

Changes:

- Upgrade drenv Submariner from 0.21.2 to 0.24.0
- Enable the cross-cluster connectivity test on darwin - leftover from lima
- Work around minikube ISO lacking nftables (`CONFIG_NF_TABLES`): set `use-nftables=false` via `submariner-global` after join ([kubernetes/minikube#23450](https://github.com/kubernetes/minikube/issues/23450)).
- After lighthouse patches cluster CoreDNS, restart CoreDNS immediately so the `clusterset.local` forward is active (CoreDNS `reload` defaults to ~30s; early NXDOMAIN was cached and delayed the first run).
- Use an absolute clusterset DNS name (trailing dot) in the connectivity check.

Notes:
- This reveals the random failures cephfs e2e failures with latest submariner. Before this change we used an old version (v0.21.2) so we could not report this bug. (#2699)

Issues:
- Need to update submariner install to require 0.24.0

Fixes #2364