### PR TITLE
controller: add DR telemetry metric definitions

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -214,6 +214,10 @@ func setupReconcilersCluster(mgr ctrl.Manager, ramenConfig *ramendrv1alpha1.Rame
 }
 
 func setupReconcilersHub(mgr ctrl.Manager, ramenConfig *ramendrv1alpha1.RamenConfig) {
+	// Initialize all DR telemetry series to 0, so that a present-but-zero
+	// series distinguishes an idle hub from an absent operator
+	controllers.InitDRTelemetryMetrics()
+
 	if err := (&controllers.DRPolicyReconciler{
 		Client:    mgr.GetClient(),
 		APIReader: mgr.GetAPIReader(),

--- a/config/prometheus/alerts.yaml
+++ b/config/prometheus/alerts.yaml
@@ -14,6 +14,20 @@ spec:
           expr: (time() - (ramen_last_sync_timestamp_seconds{job='ramen-hub-operator-metrics-service'}))
         - record: ramen_rpo_difference
           expr: ramen_sync_duration_seconds / on(policyname) group_left() (ramen_policy_schedule_interval_seconds{job="ramen-hub-operator-metrics-service"})
+    # Pre-aggregated series for Red Hat Telemetry. Aggregation drops the
+    # per-target labels (pod, instance, job, ...) so telemetry receives a
+    # small, stable set of series, and max dedupes overlapping scrapes of
+    # multiple operator pods (rolling update, stale former leader). These
+    # recorded names, not the raw ramen_dr_* names, belong in the
+    # cluster-monitoring-operator telemetry allowlist.
+    - name: dr_telemetry.rules
+      rules:
+        - record: ramen:dr_policy_type:max
+          expr: max by (dr_type) (ramen_dr_policy_type{job="ramen-hub-operator-metrics-service"})
+        - record: ramen:dr_protected_apps:max
+          expr: max by (management_method) (ramen_dr_protected_apps{job="ramen-hub-operator-metrics-service"})
+        - record: ramen:dr_actions:max
+          expr: max by (action) (ramen_dr_actions{job="ramen-hub-operator-metrics-service"})
     - name: alerts
       rules:
         - alert: VolumeSynchronizationDelay

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect

--- a/internal/controller/dr_telemetry_metrics.go
+++ b/internal/controller/dr_telemetry_metrics.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	rmn "github.com/ramendr/ramen/api/v1alpha1"
+)
+
+// drPolicyDRType classifies a DRPolicy as DRTypeMetro, DRTypeRegional or
+// DRTypeUnknown for the ramen_dr_policy_type telemetry metric. It reuses
+// dRPolicySupportsMetro so that the classification matches Ramen's
+// operational Metro detection: status peerClasses when present, with a
+// fallback to spec.schedulingInterval for policies without peerClasses.
+func drPolicyDRType(drpolicy *rmn.DRPolicy) string {
+	metro, _, err := dRPolicySupportsMetro(drpolicy, nil)
+	if err != nil {
+		return DRTypeUnknown
+	}
+
+	if metro {
+		return DRTypeMetro
+	}
+
+	return DRTypeRegional
+}

--- a/internal/controller/dr_telemetry_metrics.go
+++ b/internal/controller/dr_telemetry_metrics.go
@@ -4,7 +4,11 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
 	rmnutil "github.com/ramendr/ramen/internal/controller/util"
@@ -88,6 +92,78 @@ func drpcActionCounts(drpc *rmn.DRPlacementControl) (float64, float64) {
 	counts := parseDRActionCount(drpc)
 
 	return float64(counts.Failover), float64(counts.Relocate)
+}
+
+// UpdateDRTelemetryMetrics recomputes all DR telemetry metrics from the
+// DRPolicy and DRPC resources in the cluster. Every series is Set on every
+// call, so deletions and classification changes are reflected without any
+// per-resource increment/decrement bookkeeping.
+func UpdateDRTelemetryMetrics(ctx context.Context, c client.Client) error {
+	if err := updateDRPolicyTypeMetrics(ctx, c); err != nil {
+		return err
+	}
+
+	return updateDRPCTelemetryMetrics(ctx, c)
+}
+
+func updateDRPolicyTypeMetrics(ctx context.Context, c client.Client) error {
+	drpolicies := &rmn.DRPolicyList{}
+	if err := c.List(ctx, drpolicies); err != nil {
+		return fmt.Errorf("failed to list DRPolicy resources for telemetry metrics: %w", err)
+	}
+
+	policyCounts := map[string]float64{
+		DRTypeMetro:    0,
+		DRTypeRegional: 0,
+		DRTypeUnknown:  0,
+	}
+
+	for idx := range drpolicies.Items {
+		policyCounts[drPolicyDRType(&drpolicies.Items[idx])]++
+	}
+
+	for drType, count := range policyCounts {
+		SetDRPolicyTypeMetric(drType, count)
+	}
+
+	return nil
+}
+
+func updateDRPCTelemetryMetrics(ctx context.Context, c client.Client) error {
+	drpcs := &rmn.DRPlacementControlList{}
+	if err := c.List(ctx, drpcs); err != nil {
+		return fmt.Errorf("failed to list DRPC resources for telemetry metrics: %w", err)
+	}
+
+	appCounts := map[string]float64{
+		ManagementMethodDiscovered: 0,
+		ManagementMethodManaged:    0,
+	}
+
+	var failoverTotal, relocateTotal float64
+
+	for idx := range drpcs.Items {
+		drpc := &drpcs.Items[idx]
+
+		if isDiscoveredApp(drpc) {
+			appCounts[ManagementMethodDiscovered]++
+		} else {
+			appCounts[ManagementMethodManaged]++
+		}
+
+		failover, relocate := drpcActionCounts(drpc)
+		failoverTotal += failover
+		relocateTotal += relocate
+	}
+
+	for method, count := range appCounts {
+		SetDRProtectedAppsMetric(method, count)
+	}
+
+	SetDRActionsMetric(ActionFailover, failoverTotal)
+	SetDRActionsMetric(ActionRelocate, relocateTotal)
+
+	return nil
 }
 
 // drPolicyDRType classifies a DRPolicy as DRTypeMetro, DRTypeRegional or

--- a/internal/controller/dr_telemetry_metrics.go
+++ b/internal/controller/dr_telemetry_metrics.go
@@ -4,8 +4,91 @@
 package controllers
 
 import (
+	"encoding/json"
+
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
+	rmnutil "github.com/ramendr/ramen/internal/controller/util"
 )
+
+// DRActionCountAnnotation persists the cumulative failover and relocate
+// action counts on a DRPC, so that the counts survive operator restarts and
+// hub recovery. lastPhase records the last accounted status.phase, ensuring
+// each initiated action is counted exactly once across retried reconciles.
+const DRActionCountAnnotation = "drplacementcontrol.ramendr.openshift.io/dr-action-count"
+
+type drActionCount struct {
+	Failover  uint64      `json:"failover"`
+	Relocate  uint64      `json:"relocate"`
+	LastPhase rmn.DRState `json:"lastPhase"`
+}
+
+func parseDRActionCount(drpc *rmn.DRPlacementControl) drActionCount {
+	counts := drActionCount{}
+
+	value, ok := drpc.GetAnnotations()[DRActionCountAnnotation]
+	if !ok {
+		return counts
+	}
+
+	if err := json.Unmarshal([]byte(value), &counts); err != nil {
+		// Self-heal from a malformed annotation by restarting the counts
+		return drActionCount{}
+	}
+
+	return counts
+}
+
+// syncDRActionCountAnnotation updates the DRActionCountAnnotation on the DRPC
+// in memory from its status.phase, and returns whether the annotation changed
+// and needs to be persisted.
+//
+// A new DR action always starts by transitioning into Initiating (see
+// setStatusInitiating), so an action is counted exactly when Initiating
+// transitions into FailingOver or Relocating. Direct re-entries into an
+// action phase (e.g. Relocated -> Relocating while post-action cleanup is in
+// progress) are phase flapping, not new actions, and are ignored. DRPCs that
+// never initiate an action never gain the annotation.
+func syncDRActionCountAnnotation(drpc *rmn.DRPlacementControl) bool {
+	phase := drpc.Status.Phase
+	counts := parseDRActionCount(drpc)
+
+	if counts.LastPhase == phase {
+		return false
+	}
+
+	// Only transitions into or out of Initiating are recorded
+	if counts.LastPhase != rmn.Initiating && phase != rmn.Initiating {
+		return false
+	}
+
+	if counts.LastPhase == rmn.Initiating {
+		// Initiating into any other phase only disarms
+		//nolint:exhaustive
+		switch phase {
+		case rmn.FailingOver:
+			counts.Failover++
+		case rmn.Relocating:
+			counts.Relocate++
+		}
+	}
+
+	counts.LastPhase = phase
+
+	value, err := json.Marshal(counts)
+	if err != nil {
+		return false
+	}
+
+	return rmnutil.AddAnnotation(drpc, DRActionCountAnnotation, string(value))
+}
+
+// drpcActionCounts returns the cumulative failover and relocate action counts
+// persisted on a DRPC
+func drpcActionCounts(drpc *rmn.DRPlacementControl) (float64, float64) {
+	counts := parseDRActionCount(drpc)
+
+	return float64(counts.Failover), float64(counts.Relocate)
+}
 
 // drPolicyDRType classifies a DRPolicy as DRTypeMetro, DRTypeRegional or
 // DRTypeUnknown for the ramen_dr_policy_type telemetry metric. It reuses

--- a/internal/controller/dr_telemetry_metrics_internal_test.go
+++ b/internal/controller/dr_telemetry_metrics_internal_test.go
@@ -4,9 +4,15 @@
 package controllers
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
 )
@@ -149,6 +155,87 @@ var _ = Describe("DRTelemetryMetrics syncDRActionCountAnnotation", func() {
 		failover, relocate := drpcActionCounts(drpcWithPhase(rmn.Deployed, nil))
 		Expect(failover).To(BeZero())
 		Expect(relocate).To(BeZero())
+	})
+})
+
+var _ = Describe("DRTelemetryMetrics UpdateDRTelemetryMetrics", func() {
+	newFakeClient := func(objects ...client.Object) client.Client {
+		scheme := runtime.NewScheme()
+		Expect(rmn.AddToScheme(scheme)).To(Succeed())
+
+		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	}
+
+	namedPolicy := func(name string, drpolicy *rmn.DRPolicy) *rmn.DRPolicy {
+		drpolicy.ObjectMeta = metav1.ObjectMeta{Name: name}
+
+		return drpolicy
+	}
+
+	newDRPC := func(name string, protectedNamespaces *[]string, annotations map[string]string) *rmn.DRPlacementControl {
+		return &rmn.DRPlacementControl{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Namespace:   "test-ns",
+				Annotations: annotations,
+			},
+			Spec: rmn.DRPlacementControlSpec{ProtectedNamespaces: protectedNamespaces},
+		}
+	}
+
+	It("resets all series to zero when no resources exist", func() {
+		SetDRPolicyTypeMetric(DRTypeMetro, 4)
+		SetDRProtectedAppsMetric(ManagementMethodManaged, 4)
+		SetDRActionsMetric(ActionFailover, 4)
+
+		Expect(UpdateDRTelemetryMetrics(context.TODO(), newFakeClient())).To(Succeed())
+
+		for _, drType := range []string{DRTypeMetro, DRTypeRegional, DRTypeUnknown} {
+			Expect(testutil.ToFloat64(drPolicyType.WithLabelValues(drType))).To(BeZero())
+		}
+
+		for _, method := range []string{ManagementMethodDiscovered, ManagementMethodManaged} {
+			Expect(testutil.ToFloat64(drProtectedApps.WithLabelValues(method))).To(BeZero())
+		}
+
+		for _, action := range []string{ActionFailover, ActionRelocate} {
+			Expect(testutil.ToFloat64(drActions.WithLabelValues(action))).To(BeZero())
+		}
+	})
+
+	It("counts DRPolicy resources by DR type", func() {
+		peers := []rmn.PeerClass{{StorageID: []string{"storage-id-1"}}}
+		c := newFakeClient(
+			namedPolicy("metro-by-peers", drPolicyWithPeerClasses(peers, nil)),
+			namedPolicy("metro-by-interval", drPolicyWithInterval("")),
+			namedPolicy("regional", drPolicyWithInterval("5m")),
+			namedPolicy("unknown", drPolicyWithInterval("5x")),
+		)
+
+		Expect(UpdateDRTelemetryMetrics(context.TODO(), c)).To(Succeed())
+
+		Expect(testutil.ToFloat64(drPolicyType.WithLabelValues(DRTypeMetro))).To(Equal(2.0))
+		Expect(testutil.ToFloat64(drPolicyType.WithLabelValues(DRTypeRegional))).To(Equal(1.0))
+		Expect(testutil.ToFloat64(drPolicyType.WithLabelValues(DRTypeUnknown))).To(Equal(1.0))
+	})
+
+	It("counts DRPC resources by management method and sums action counts", func() {
+		c := newFakeClient(
+			newDRPC("discovered", &[]string{"app-ns"}, map[string]string{
+				DRActionCountAnnotation: `{"failover":2,"relocate":1,"lastPhase":"FailedOver"}`,
+			}),
+			newDRPC("managed-1", nil, map[string]string{
+				DRActionCountAnnotation: `{"failover":1,"relocate":0,"lastPhase":"FailingOver"}`,
+			}),
+			newDRPC("managed-2", &[]string{}, nil),
+		)
+
+		Expect(UpdateDRTelemetryMetrics(context.TODO(), c)).To(Succeed())
+
+		Expect(testutil.ToFloat64(drProtectedApps.WithLabelValues(ManagementMethodDiscovered))).To(Equal(1.0))
+		Expect(testutil.ToFloat64(drProtectedApps.WithLabelValues(ManagementMethodManaged))).To(Equal(2.0))
+		Expect(testutil.ToFloat64(drActions.WithLabelValues(ActionFailover))).To(Equal(3.0))
+		Expect(testutil.ToFloat64(drActions.WithLabelValues(ActionRelocate))).To(Equal(1.0))
 	})
 })
 

--- a/internal/controller/dr_telemetry_metrics_internal_test.go
+++ b/internal/controller/dr_telemetry_metrics_internal_test.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+var _ = Describe("DRTelemetryMetrics", func() {
+	BeforeEach(func() {
+		InitDRTelemetryMetrics()
+	})
+
+	Describe("InitDRTelemetryMetrics", func() {
+		It("initializes every label combination to zero", func() {
+			Expect(testutil.CollectAndCount(drPolicyType)).To(Equal(3))
+			Expect(testutil.CollectAndCount(drProtectedApps)).To(Equal(2))
+			Expect(testutil.CollectAndCount(drActions)).To(Equal(2))
+
+			for _, drType := range []string{DRTypeMetro, DRTypeRegional, DRTypeUnknown} {
+				Expect(testutil.ToFloat64(drPolicyType.WithLabelValues(drType))).To(BeZero())
+			}
+
+			for _, method := range []string{ManagementMethodDiscovered, ManagementMethodManaged} {
+				Expect(testutil.ToFloat64(drProtectedApps.WithLabelValues(method))).To(BeZero())
+			}
+
+			for _, action := range []string{ActionFailover, ActionRelocate} {
+				Expect(testutil.ToFloat64(drActions.WithLabelValues(action))).To(BeZero())
+			}
+		})
+
+		It("resets previously set values to zero", func() {
+			SetDRPolicyTypeMetric(DRTypeMetro, 4)
+			InitDRTelemetryMetrics()
+
+			Expect(testutil.ToFloat64(drPolicyType.WithLabelValues(DRTypeMetro))).To(BeZero())
+		})
+	})
+
+	Describe("Set helpers", func() {
+		It("sets the policy type gauge for the given dr_type", func() {
+			SetDRPolicyTypeMetric(DRTypeMetro, 2)
+			SetDRPolicyTypeMetric(DRTypeRegional, 3)
+
+			Expect(testutil.ToFloat64(drPolicyType.WithLabelValues(DRTypeMetro))).To(Equal(2.0))
+			Expect(testutil.ToFloat64(drPolicyType.WithLabelValues(DRTypeRegional))).To(Equal(3.0))
+			Expect(testutil.ToFloat64(drPolicyType.WithLabelValues(DRTypeUnknown))).To(BeZero())
+		})
+
+		It("sets the protected apps gauge for the given management_method", func() {
+			SetDRProtectedAppsMetric(ManagementMethodDiscovered, 5)
+
+			Expect(testutil.ToFloat64(drProtectedApps.WithLabelValues(ManagementMethodDiscovered))).To(Equal(5.0))
+			Expect(testutil.ToFloat64(drProtectedApps.WithLabelValues(ManagementMethodManaged))).To(BeZero())
+		})
+
+		It("sets the actions gauge for the given action", func() {
+			SetDRActionsMetric(ActionFailover, 7)
+			SetDRActionsMetric(ActionRelocate, 1)
+
+			Expect(testutil.ToFloat64(drActions.WithLabelValues(ActionFailover))).To(Equal(7.0))
+			Expect(testutil.ToFloat64(drActions.WithLabelValues(ActionRelocate))).To(Equal(1.0))
+		})
+	})
+})

--- a/internal/controller/dr_telemetry_metrics_internal_test.go
+++ b/internal/controller/dr_telemetry_metrics_internal_test.go
@@ -43,6 +43,115 @@ var _ = Describe("DRTelemetryMetrics drPolicyDRType", func() {
 	)
 })
 
+var _ = Describe("DRTelemetryMetrics syncDRActionCountAnnotation", func() {
+	drpcWithPhase := func(phase rmn.DRState, annotations map[string]string) *rmn.DRPlacementControl {
+		drpc := &rmn.DRPlacementControl{}
+		drpc.SetAnnotations(annotations)
+		drpc.Status.Phase = phase
+
+		return drpc
+	}
+
+	syncThroughPhases := func(drpc *rmn.DRPlacementControl, phases ...rmn.DRState) {
+		for _, phase := range phases {
+			drpc.Status.Phase = phase
+			syncDRActionCountAnnotation(drpc)
+		}
+	}
+
+	It("does nothing for a DRPC that has not initiated an action", func() {
+		drpc := drpcWithPhase("", nil)
+		Expect(syncDRActionCountAnnotation(drpc)).To(BeFalse())
+		Expect(drpc.GetAnnotations()).To(BeEmpty())
+
+		drpc = drpcWithPhase(rmn.Deployed, nil)
+		Expect(syncDRActionCountAnnotation(drpc)).To(BeFalse())
+		Expect(drpc.GetAnnotations()).To(BeEmpty())
+	})
+
+	It("counts a failover when Initiating transitions into FailingOver", func() {
+		drpc := drpcWithPhase(rmn.Initiating, nil)
+		Expect(syncDRActionCountAnnotation(drpc)).To(BeTrue())
+
+		failover, relocate := drpcActionCounts(drpc)
+		Expect(failover).To(BeZero())
+		Expect(relocate).To(BeZero())
+
+		drpc.Status.Phase = rmn.FailingOver
+		Expect(syncDRActionCountAnnotation(drpc)).To(BeTrue())
+
+		failover, relocate = drpcActionCounts(drpc)
+		Expect(failover).To(Equal(1.0))
+		Expect(relocate).To(BeZero())
+	})
+
+	It("counts a relocate when Initiating transitions into Relocating", func() {
+		drpc := drpcWithPhase("", nil)
+		syncThroughPhases(drpc, rmn.Initiating, rmn.Relocating)
+
+		failover, relocate := drpcActionCounts(drpc)
+		Expect(failover).To(BeZero())
+		Expect(relocate).To(Equal(1.0))
+	})
+
+	It("does not double count while the phase is unchanged", func() {
+		drpc := drpcWithPhase("", nil)
+		syncThroughPhases(drpc, rmn.Initiating, rmn.FailingOver)
+
+		Expect(syncDRActionCountAnnotation(drpc)).To(BeFalse())
+
+		failover, _ := drpcActionCounts(drpc)
+		Expect(failover).To(Equal(1.0))
+	})
+
+	It("does not count action phase re-entry without a new initiation", func() {
+		drpc := drpcWithPhase("", nil)
+		// Post-action cleanup can flap between the action phase and its
+		// completed phase; such re-entries are not new actions
+		syncThroughPhases(drpc, rmn.Initiating, rmn.Relocating, rmn.Relocated, rmn.Relocating, rmn.Relocated)
+
+		_, relocate := drpcActionCounts(drpc)
+		Expect(relocate).To(Equal(1.0))
+	})
+
+	It("counts each newly initiated action", func() {
+		drpc := drpcWithPhase("", nil)
+		syncThroughPhases(drpc, rmn.Initiating, rmn.FailingOver, rmn.FailedOver,
+			rmn.Initiating, rmn.Relocating, rmn.Relocated,
+			rmn.Initiating, rmn.FailingOver)
+
+		failover, relocate := drpcActionCounts(drpc)
+		Expect(failover).To(Equal(2.0))
+		Expect(relocate).To(Equal(1.0))
+	})
+
+	It("disarms when Initiating leads to a non-action phase and rearms on the next initiation", func() {
+		drpc := drpcWithPhase("", nil)
+		syncThroughPhases(drpc, rmn.Initiating, rmn.WaitForUser, rmn.Initiating, rmn.Relocating)
+
+		failover, relocate := drpcActionCounts(drpc)
+		Expect(failover).To(BeZero())
+		Expect(relocate).To(Equal(1.0))
+	})
+
+	It("recovers from a malformed annotation", func() {
+		drpc := drpcWithPhase("", map[string]string{
+			DRActionCountAnnotation: "not-json",
+		})
+		syncThroughPhases(drpc, rmn.Initiating, rmn.FailingOver)
+
+		failover, relocate := drpcActionCounts(drpc)
+		Expect(failover).To(Equal(1.0))
+		Expect(relocate).To(BeZero())
+	})
+
+	It("reports zero counts for a DRPC without the annotation", func() {
+		failover, relocate := drpcActionCounts(drpcWithPhase(rmn.Deployed, nil))
+		Expect(failover).To(BeZero())
+		Expect(relocate).To(BeZero())
+	})
+})
+
 var _ = Describe("DRTelemetryMetrics", func() {
 	BeforeEach(func() {
 		InitDRTelemetryMetrics()

--- a/internal/controller/dr_telemetry_metrics_internal_test.go
+++ b/internal/controller/dr_telemetry_metrics_internal_test.go
@@ -7,7 +7,41 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	rmn "github.com/ramendr/ramen/api/v1alpha1"
 )
+
+func drPolicyWithPeerClasses(syncPeers, asyncPeers []rmn.PeerClass) *rmn.DRPolicy {
+	return &rmn.DRPolicy{
+		Status: rmn.DRPolicyStatus{
+			Sync:  rmn.Sync{PeerClasses: syncPeers},
+			Async: rmn.Async{PeerClasses: asyncPeers},
+		},
+	}
+}
+
+func drPolicyWithInterval(schedulingInterval string) *rmn.DRPolicy {
+	return &rmn.DRPolicy{
+		Spec: rmn.DRPolicySpec{SchedulingInterval: schedulingInterval},
+	}
+}
+
+var _ = Describe("DRTelemetryMetrics drPolicyDRType", func() {
+	peers := []rmn.PeerClass{{StorageID: []string{"storage-id-1"}}}
+
+	DescribeTable("classifies a DRPolicy",
+		func(drpolicy *rmn.DRPolicy, expected string) {
+			Expect(drPolicyDRType(drpolicy)).To(Equal(expected))
+		},
+		Entry("sync peerClasses populated", drPolicyWithPeerClasses(peers, nil), DRTypeMetro),
+		Entry("async peerClasses populated", drPolicyWithPeerClasses(nil, peers), DRTypeRegional),
+		Entry("both sync and async peerClasses populated", drPolicyWithPeerClasses(peers, peers), DRTypeMetro),
+		Entry("no peerClasses, no scheduling interval", drPolicyWithInterval(""), DRTypeMetro),
+		Entry("no peerClasses, zero scheduling interval", drPolicyWithInterval("0m"), DRTypeMetro),
+		Entry("no peerClasses, non-zero scheduling interval", drPolicyWithInterval("5m"), DRTypeRegional),
+		Entry("no peerClasses, malformed scheduling interval", drPolicyWithInterval("5x"), DRTypeUnknown),
+	)
+})
 
 var _ = Describe("DRTelemetryMetrics", func() {
 	BeforeEach(func() {

--- a/internal/controller/dr_telemetry_wiring_test.go
+++ b/internal/controller/dr_telemetry_wiring_test.go
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	rmn "github.com/ramendr/ramen/api/v1alpha1"
+	controllers "github.com/ramendr/ramen/internal/controller"
+)
+
+// drTelemetryGaugeValue reads a DR telemetry gauge from the controller
+// metrics registry; a series that is not present reads as 0
+func drTelemetryGaugeValue(metricName, labelName, labelValue string) float64 {
+	metricFamilies, err := metrics.Registry.Gather()
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, metricFamily := range metricFamilies {
+		if metricFamily.GetName() != metricName {
+			continue
+		}
+
+		for _, metric := range metricFamily.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == labelName && label.GetValue() == labelValue {
+					return metric.GetGauge().GetValue()
+				}
+			}
+		}
+	}
+
+	return 0
+}
+
+var _ = Describe("DRTelemetryWiring", func() {
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 100
+	)
+
+	Describe("DRPolicy reconciler", func() {
+		It("reflects DRPolicy creation and deletion in ramen_dr_policy_type", func() {
+			baseline := drTelemetryGaugeValue("ramen_dr_policy_type", controllers.DRTypeLabel, controllers.DRTypeRegional)
+
+			drpolicy := &rmn.DRPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "telemetry-wiring-regional"},
+				Spec: rmn.DRPolicySpec{
+					SchedulingInterval: "99m",
+					DRClusters:         []string{"telemetry-absent-c1", "telemetry-absent-c2"},
+				},
+			}
+			Expect(k8sClient.Create(context.TODO(), drpolicy)).To(Succeed())
+
+			Eventually(func() float64 {
+				return drTelemetryGaugeValue("ramen_dr_policy_type", controllers.DRTypeLabel, controllers.DRTypeRegional)
+			}, timeout, interval).Should(Equal(baseline + 1))
+
+			Expect(k8sClient.Delete(context.TODO(), drpolicy)).To(Succeed())
+
+			Eventually(func() float64 {
+				return drTelemetryGaugeValue("ramen_dr_policy_type", controllers.DRTypeLabel, controllers.DRTypeRegional)
+			}, timeout, interval).Should(Equal(baseline))
+		})
+	})
+
+	Describe("DRPC reconciler", func() {
+		It("reflects DRPC creation and deletion in ramen_dr_protected_apps", func() {
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "telemetry-wiring-ns"},
+			}
+			Expect(k8sClient.Create(context.TODO(), namespace)).To(Succeed())
+
+			baseline := drTelemetryGaugeValue(
+				"ramen_dr_protected_apps", controllers.ManagementMethodLabel, controllers.ManagementMethodManaged)
+
+			drpc := &rmn.DRPlacementControl{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "telemetry-wiring-drpc",
+					Namespace: namespace.Name,
+				},
+				Spec: rmn.DRPlacementControlSpec{
+					PlacementRef: corev1.ObjectReference{
+						Kind: "Placement", Name: "telemetry-absent-placement", Namespace: namespace.Name,
+					},
+					DRPolicyRef: corev1.ObjectReference{Name: "telemetry-absent-policy"},
+					PVCSelector: metav1.LabelSelector{},
+				},
+			}
+			Expect(k8sClient.Create(context.TODO(), drpc)).To(Succeed())
+
+			Eventually(func() float64 {
+				return drTelemetryGaugeValue(
+					"ramen_dr_protected_apps", controllers.ManagementMethodLabel, controllers.ManagementMethodManaged)
+			}, timeout, interval).Should(Equal(baseline + 1))
+
+			Expect(k8sClient.Delete(context.TODO(), drpc)).To(Succeed())
+
+			Eventually(func() float64 {
+				return drTelemetryGaugeValue(
+					"ramen_dr_protected_apps", controllers.ManagementMethodLabel, controllers.ManagementMethodManaged)
+			}, timeout, interval).Should(Equal(baseline))
+		})
+	})
+})

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -2982,6 +2982,13 @@ func (d *DRPCInstance) setDRState(nextState rmn.DRState) {
 
 		d.instance.Status.Phase = nextState
 		d.instance.Status.ObservedGeneration = d.instance.Generation
+
+		// Account the transition at the moment it happens, so that a
+		// multi-phase transition within a single reconcile cannot skip
+		// over an action phase unaccounted. Persisted by the reconciler
+		// along with the status update.
+		syncDRActionCountAnnotation(d.instance)
+
 		d.reportEvent(nextState)
 	}
 }

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -87,6 +87,7 @@ type DRPlacementControlReconciler struct {
 	Callback                       ProgressCallback
 	eventRecorder                  *rmnutil.EventReporter
 	savedInstanceStatus            rmn.DRPlacementControlStatus
+	savedDRActionCount             string
 	ObjStoreGetter                 ObjectStoreGetter
 	RateLimiter                    *workqueue.TypedRateLimiter[reconcile.Request]
 	numClustersQueriedSuccessfully int
@@ -153,6 +154,7 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	// Save a copy of the instance status to be used for the VRG status update comparison
 	drpc.Status.DeepCopyInto(&r.savedInstanceStatus)
+	r.savedDRActionCount = drpc.GetAnnotations()[DRActionCountAnnotation]
 
 	ensureDRPCConditionsInited(&drpc.Status.Conditions, drpc.Generation, "Initialization")
 
@@ -1487,6 +1489,24 @@ func (r *DRPlacementControlReconciler) updateDRPCStatus(
 	userPlacement client.Object, log logr.Logger, vrgs map[string]*rmn.VolumeReplicationGroup,
 ) error {
 	log.Info("Updating DRPC status")
+
+	// Account any DR action phase transition and persist the action count
+	// annotation before the status update, so that a failed status update
+	// cannot lose an already observed transition
+	syncDRActionCountAnnotation(drpc)
+
+	if annotation := drpc.GetAnnotations()[DRActionCountAnnotation]; annotation != r.savedDRActionCount {
+		// Update refreshes drpc from the API response, which would discard
+		// the in-memory status updates that are not persisted yet
+		status := *drpc.Status.DeepCopy()
+
+		if err := r.Update(ctx, drpc); err != nil {
+			return fmt.Errorf("failed to update DRPC dr-action-count annotation: %w", err)
+		}
+
+		drpc.Status = status
+		r.savedDRActionCount = annotation
+	}
 
 	r.updateResourceCondition(ctx, drpc, userPlacement, log, vrgs)
 

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -139,6 +139,14 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 	logger.Info("Entering reconcile loop")
 	defer logger.Info("Exiting reconcile loop")
 
+	// Recompute on every reconcile, including the not-found path after a
+	// DRPC deletion, so the metrics track the cluster state
+	defer func() {
+		if err := UpdateDRTelemetryMetrics(ctx, r.Client); err != nil {
+			logger.Info("Failed to update DR telemetry metrics", "error", err)
+		}
+	}()
+
 	drpc := &rmn.DRPlacementControl{}
 
 	err := r.APIReader.Get(ctx, req.NamespacedName, drpc)

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -5,6 +5,7 @@ package controllers_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"runtime"
 	"strings"
@@ -1367,10 +1368,42 @@ func getDRPCCondition(status *rmn.DRPlacementControlStatus, conditionType string
 	return -1, nil
 }
 
+type drActionCounts struct {
+	Failover  float64     `json:"failover"`
+	Relocate  float64     `json:"relocate"`
+	LastPhase rmn.DRState `json:"lastPhase"`
+}
+
+// getDRActionCounts returns the failover and relocate counts and the last
+// accounted phase persisted in the dr-action-count annotation of the DRPC in
+// the given namespace
+func getDRActionCounts(namespace string) drActionCounts {
+	drpc := getLatestDRPC(namespace)
+
+	counts := drActionCounts{}
+
+	value, ok := drpc.GetAnnotations()[controllers.DRActionCountAnnotation]
+	if !ok {
+		return counts
+	}
+
+	Expect(json.Unmarshal([]byte(value), &counts)).To(Succeed())
+
+	return counts
+}
+
 //nolint:unparam
 func runFailoverAction(placementObj client.Object, fromCluster, toCluster string, isSyncDR bool,
 	manualFence bool,
 ) {
+	countsBefore := getDRActionCounts(placementObj.GetNamespace())
+
+	expectedFailoverCount := countsBefore.Failover + 1
+	if countsBefore.LastPhase == rmn.FailingOver {
+		// The failover was already initiated, and counted, by an earlier step
+		expectedFailoverCount = countsBefore.Failover
+	}
+
 	if isSyncDR {
 		fenceCluster(fromCluster, manualFence)
 	}
@@ -1402,12 +1435,23 @@ func runFailoverAction(placementObj client.Object, fromCluster, toCluster string
 	Expect(condition.Reason).To(Equal(string(rmn.FailedOver)))
 	Expect(drpc.Status.ActionStartTime).ShouldNot(BeNil())
 
+	Expect(getDRActionCounts(placementObj.GetNamespace()).Failover).To(Equal(expectedFailoverCount),
+		"dr-action-count annotation should count the failover")
+
 	decision := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
 	Expect(decision.ClusterName).To(Equal(toCluster))
 }
 
 func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR bool, manualUnfence bool) {
 	toCluster1 := "east1-cluster"
+
+	countsBefore := getDRActionCounts(placementObj.GetNamespace())
+
+	expectedRelocateCount := countsBefore.Relocate + 1
+	if countsBefore.LastPhase == rmn.Relocating {
+		// The relocate was already initiated, and counted, by an earlier step
+		expectedRelocateCount = countsBefore.Relocate
+	}
 
 	if isSyncDR {
 		unfenceCluster(toCluster1, manualUnfence)
@@ -1453,6 +1497,9 @@ func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR 
 	Expect(len(drpc.Status.Conditions)).To(Equal(3))
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
 	Expect(condition.Reason).To(Equal(string(rmn.Relocated)))
+
+	Expect(getDRActionCounts(placementObj.GetNamespace()).Relocate).To(Equal(expectedRelocateCount),
+		"dr-action-count annotation should count the relocate")
 
 	decision := getLatestUserPlacementDecision(placementObj.GetName(), placementObj.GetNamespace())
 	Expect(decision.ClusterName).To(Equal(toCluster1))

--- a/internal/controller/drpolicy_controller.go
+++ b/internal/controller/drpolicy_controller.go
@@ -89,6 +89,14 @@ func (r *DRPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	defer log.Info("Exiting reconcile loop")
 
+	// Recompute on every reconcile, including the not-found path after a
+	// DRPolicy deletion, so the metrics track the cluster state
+	defer func() {
+		if err := UpdateDRTelemetryMetrics(ctx, r.Client); err != nil {
+			log.Info("Failed to update DR telemetry metrics", "error", err)
+		}
+	}()
+
 	drpolicy := &ramen.DRPolicy{}
 	if err := r.Client.Get(ctx, req.NamespacedName, drpolicy); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("get: %w", err))

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -33,6 +33,33 @@ const (
 	InvalidCIDRsDetected = "invalid_cidrs_detected"
 )
 
+// DR telemetry metrics, forwarded to Red Hat Telemetry via the
+// cluster-monitoring-operator allowlist. Label cardinality is bounded
+// (3 + 2 + 2 = 7 series) as required by telemetry.
+const (
+	DRPolicyTypeName    = "dr_policy_type"
+	DRProtectedAppsName = "dr_protected_apps"
+	DRActionsName       = "dr_actions"
+)
+
+const (
+	DRTypeLabel           = "dr_type"
+	ManagementMethodLabel = "management_method"
+	ActionLabel           = "action"
+)
+
+const (
+	DRTypeMetro    = "metro"
+	DRTypeRegional = "regional"
+	DRTypeUnknown  = "unknown"
+
+	ManagementMethodDiscovered = "discovered"
+	ManagementMethodManaged    = "managed"
+
+	ActionFailover = "failover"
+	ActionRelocate = "relocate"
+)
+
 type SyncTimeMetrics struct {
 	LastSyncTime prometheus.Gauge
 }
@@ -222,6 +249,33 @@ var (
 		},
 		drProgressionStateMetricsLabels,
 	)
+
+	drPolicyType = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      DRPolicyTypeName,
+			Namespace: metricNamespace,
+			Help:      "Count of DRPolicy resources by DR type",
+		},
+		[]string{DRTypeLabel},
+	)
+
+	drProtectedApps = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      DRProtectedAppsName,
+			Namespace: metricNamespace,
+			Help:      "Count of DR protected applications (DRPC resources) by management method",
+		},
+		[]string{ManagementMethodLabel},
+	)
+
+	drActions = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      DRActionsName,
+			Namespace: metricNamespace,
+			Help:      "Cumulative count of DR actions initiated by existing DRPC resources",
+		},
+		[]string{ActionLabel},
+	)
 )
 
 // lastSyncTime metrics reports value from lastGrpupSyncTime taken from DRPC status
@@ -395,6 +449,41 @@ func DeleteDRPCProgressionStateMetric(labels prometheus.Labels) bool {
 	return drpcProgressionState.Delete(labels)
 }
 
+// SetDRPolicyTypeMetric sets the count of DRPolicy resources for a DR type
+// (DRTypeMetro, DRTypeRegional or DRTypeUnknown)
+func SetDRPolicyTypeMetric(drType string, value float64) {
+	drPolicyType.WithLabelValues(drType).Set(value)
+}
+
+// SetDRProtectedAppsMetric sets the count of DRPC resources for a management
+// method (ManagementMethodDiscovered or ManagementMethodManaged)
+func SetDRProtectedAppsMetric(method string, value float64) {
+	drProtectedApps.WithLabelValues(method).Set(value)
+}
+
+// SetDRActionsMetric sets the cumulative count of DR actions for an action
+// (ActionFailover or ActionRelocate)
+func SetDRActionsMetric(action string, value float64) {
+	drActions.WithLabelValues(action).Set(value)
+}
+
+// InitDRTelemetryMetrics initializes all DR telemetry metric label
+// combinations to 0, so that a series being present with value 0 indicates
+// Ramen is installed with no DR resources, as opposed to an absent series
+func InitDRTelemetryMetrics() {
+	for _, drType := range []string{DRTypeMetro, DRTypeRegional, DRTypeUnknown} {
+		SetDRPolicyTypeMetric(drType, 0)
+	}
+
+	for _, method := range []string{ManagementMethodDiscovered, ManagementMethodManaged} {
+		SetDRProtectedAppsMetric(method, 0)
+	}
+
+	for _, action := range []string{ActionFailover, ActionRelocate} {
+		SetDRActionsMetric(action, 0)
+	}
+}
+
 func init() {
 	// Register custom metrics with the global prometheus registry
 	metrics.Registry.MustRegister(dRPolicySyncInterval)
@@ -406,4 +495,7 @@ func init() {
 	metrics.Registry.MustRegister(globalAction)
 	metrics.Registry.MustRegister(invalidCIDRsDetected)
 	metrics.Registry.MustRegister(drpcProgressionState)
+	metrics.Registry.MustRegister(drPolicyType)
+	metrics.Registry.MustRegister(drProtectedApps)
+	metrics.Registry.MustRegister(drActions)
 }


### PR DESCRIPTION
Add three low-cardinality metrics intended for Telemetry


- ramen_dr_policy_type: count of DRPolicy resources by DR type
  (metro, regional, unknown)
- ramen_dr_protected_apps: count of DRPC resources by management
  method (discovered, managed)
- ramen_dr_actions: cumulative count of failover and relocate actions

All label combinations are bounded (7 series total) and are
initialized to 0 so that a present-but-zero series distinguishes
"Ramen installed, DR unused" from an absent series.

Assisted-by: Claude Code/claude-fable-5
Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>