### PR TITLE
global-vgr: Gate secondary transition on cross-VRG PVC readiness

### DIFF
--- a/docs/design/global-vgr-design-doc.md
+++ b/docs/design/global-vgr-design-doc.md
@@ -179,14 +179,75 @@ must then again acknowledge the new VGR by setting `status.state=Secondary`
 before the recreating VRG can proceed to delete it. Keeping the VGR alive avoids
 this race.
 
-### 4.4 VGR Watcher
+### 4.4 Secondary Transition Gating
+
+Multiple VRGs share the same global VGR and their workload cleanup may complete
+at different times. Without coordination, the first VRG to finish cleanup would
+flip the shared VGR to secondary while other VRGs' workloads are still active on
+the same cluster.
+
+To prevent this, each VRG gates the VGR transition by advertising its own PVC
+readiness through a `GlobalSecondary` condition:
+
+- True / PVCsNotInUse: PVCs are not in use (or no PVCs to process).
+- False / PVCsInUse: PVCs are still in use by workloads.
+- True / Unused: not applicable (VRG is Primary).
+
+Before updating the global VGR to secondary, each VRG:
+
+1. Checks `isPVCReadyForSecondary` for its own PVCs and sets its
+   `GlobalSecondary` condition accordingly.
+1. Lists all sibling VRGs with the same `global-vgr` label.
+1. Verifies every sibling has `GlobalSecondary = True` with reason
+   `PVCsNotInUse`.
+1. Only when all siblings are ready does the VRG proceed to update the VGR.
+
+If any sibling is not ready, the VRG requeues and logs which siblings are
+pending.
+
+The readiness check differs by action:
+
+- **Failover**: PVC must not be in use by any pod (deployment deleted).
+- **Relocate**: PVC must be marked for deletion and not in use by any pod
+  (deployment and PVC deleted).
+
+Example (VRG-A ready, VRG-B still has workloads running):
+
+```yaml
+# VRG-A
+- type: GlobalSecondary
+  status: "True"
+  reason: PVCsNotInUse
+  message: PVCs are not in use
+
+# VRG-B
+- type: GlobalSecondary
+  status: "False"
+  reason: PVCsInUse
+  message: PVCs are still in use
+```
+
+Example (VRG is Primary, condition reset):
+
+```yaml
+- type: GlobalSecondary
+  status: "True"
+  reason: Unused
+  message: Not applicable when Primary
+```
+
+On steady-state secondary (destination cluster where no PVCs match the VRG
+selector), the condition is set to `True / PVCsNotInUse` so siblings do not wait
+on this VRG.
+
+### 4.5 VGR Watcher
 
 When the global VGR status changes (e.g., state transition by the external
 controller), all VRGs sharing that VGR need to react immediately. If a VGR
 change is detected in the operator namespace, all VRGs with the matching
 `global-vgr` label are enqueued for reconciliation.
 
-### 4.5 Status Handling
+### 4.6 Status Handling
 
 Some external storage providers manage replication at the LUN level and use
 `schedulingInterval: 0m` in the VolumeGroupReplicationClass. This signals that
@@ -260,14 +321,19 @@ status:
       message: Consensus reached for state secondary
 ```
 
-### 4.6 SchedulingInterval 0m
+For global VGR, the consensus gate (4.1) can delay PVC processing after a VRG
+generation change. If a per-PVC `DataReady` condition has an
+`ObservedGeneration` older than the current VRG generation, it is treated as
+Progressing to prevent stale conditions from being aggregated as Ready.
+
+### 4.7 SchedulingInterval 0m
 
 If the storage provider uses `schedulingInterval: 0m` in the
 VolumeGroupReplicationClass and the corresponding DRPolicy, this indicates that
 replication is managed entirely by the external storage provider and Ramen does
 not drive RPO-based scheduling. It has the following implications:
 
-1. **VGR status validation**: The simplified status path described in 4.5 only
+1. **VGR status validation**: The simplified status path described in 4.6 only
    applies when `schedulingInterval` is `0m`. For non-zero intervals, the normal
    `Completed`/`Degraded`/`Resyncing` validation path is used.
 
@@ -350,6 +416,8 @@ reconciliation, ensuring instant notification.
 - **Conditions**: `GlobalAction` (DRPC), whether all peer DRPCs agree on action
   and target cluster. `GlobalState` (VRG), whether all peer VRGs agree on
   replication state (checked on both primary and secondary paths).
+  `GlobalSecondary` (VRG), whether this VRG's PVCs are not in use, allowing the
+  shared VGR to transition to secondary.
 - **Progression**: `WaitOnGlobalAction`, set on DRPC when consensus is blocked.
   Apps remain running.
 - **Prometheus metric**: `ramen_global_action_consensus_status` gauge, 1 =
@@ -411,10 +479,13 @@ Scenario: cluster-1 is down, failover to cluster-2.
    Both VRGs see the state match, mark their PVCs as DataReady and
    DataProtected.
 1. **Cleanup on cluster-1** (if accessible): Both VRGs transition to Secondary.
-   The existing global VGR is updated to `replicationState=Secondary`. The
-   external storage provider transitions VGR `.status.state` accordingly. This
-   ensures cluster-1 is properly configured as a secondary and ready to serve as
-   a failover target in the future.
+   Each VRG checks `isPVCReadyForSecondary` for its own PVCs and sets its
+   `GlobalSecondary` condition. The VGR is only updated to
+   `replicationState=Secondary` once **all** VRGs on the cluster report
+   `GlobalSecondary = True / PVCsNotInUse` (see 4.4). The external storage
+   provider transitions VGR `.status.state` accordingly. This ensures cluster-1
+   is properly configured as a secondary and ready to serve as a failover target
+   in the future.
 
 **Result**:
 
@@ -433,11 +504,14 @@ Scenario: relocate from cluster-1 (current primary) to cluster-2.
    peers instantly.
 1. **Both clusters become Secondary**: Ramen first ensures all VRGs on both
    clusters are secondary. On cluster-1 (source), both VRGs transition to
-   Secondary. GlobalState consensus is checked — the VGR is only updated to
-   secondary once all VRGs on the cluster agree on the secondary state. Global
-   VGR on cluster-1 is updated to `replicationState=Secondary`. The external
-   storage provider transitions VGR `.status.state` accordingly. cluster-2 VRGs
-   are already secondary.
+   Secondary. GlobalState consensus is checked — all VRGs must agree on the
+   secondary state. Each VRG then checks `isPVCReadyForSecondary` for its own
+   PVCs (PVC must be marked for deletion and not in use) and sets its
+   `GlobalSecondary` condition. The global VGR is only updated to
+   `replicationState=Secondary` once **all** VRGs report
+   `GlobalSecondary = True / PVCsNotInUse` (see 4.4). The external storage
+   provider transitions VGR `.status.state` accordingly. cluster-2 VRGs are
+   already secondary.
 1. **cluster-2 promoted to Primary**: Once both clusters are confirmed
    secondary, Ramen promotes cluster-2. Both VRGs on cluster-2 transition to
    Primary. VRG-level consensus confirms both agree. If no VGR exists on

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -60,6 +60,10 @@ const (
 	// reached the desired replication state.
 	VRGConditionTypeGlobalState = "GlobalState"
 
+	// Indicates whether this VRG's PVCs are not in use, allowing the shared
+	// global VGR to transition to secondary. Only applicable for global VGR VRGs.
+	VRGConditionTypeGlobalSecondary = "GlobalSecondary"
+
 	// Indicates the status of hook execution in recipes.
 	// This condition helps identify hook failures separately from other kube object protection issues.
 	VRGConditionTypeHooksReady = "HooksReady"
@@ -107,8 +111,13 @@ const (
 	VRGConditionReasonAutoCleanupNotFeasible = "NotFeasible"
 	VRGConditionReasonAutoCleanupCompleted   = "Completed"
 
+	// Global consensus reasons for GlobalState condition.
 	ConditionReasonConsensusReached    = "ConsensusReached"
 	ConditionReasonConsensusNotReached = "ConsensusNotReached"
+
+	// Global secondary transition reasons for GlobalSecondary condition.
+	VRGConditionReasonPVCsNotInUse = "PVCsNotInUse"
+	VRGConditionReasonPVCsInUse    = "PVCsInUse"
 
 	// Hook-specific condition reasons for better visibility of hook failures
 	VRGConditionReasonHookExecuted = "HookExecuted"

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1483,6 +1483,12 @@ func (v *VRGInstance) processAsPrimary() ctrl.Result {
 
 	defer v.log.Info("Exiting processing VolumeReplicationGroup")
 
+	// Reset global VGR secondary readiness condition; only meaningful when Secondary.
+	if v.hasGlobalVGRLabel() {
+		v.setGlobalSecondaryCondition(metav1.ConditionTrue,
+			VRGConditionReasonUnused, "Not applicable when Primary")
+	}
+
 	v.resetKubeObjectsCaptureStatusIfRequired()
 
 	if v.shouldRestoreClusterData() {

--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -111,10 +111,21 @@ func (v *VRGInstance) reconcileVolGroupRepsAsPrimary(groupPVCs map[types.Namespa
 func (v *VRGInstance) reconcileVolGroupRepsAsSecondary(requeue *bool,
 	groupPVCs map[types.NamespacedName][]*corev1.PersistentVolumeClaim,
 ) {
-	if v.hasGlobalVGRLabel() && !v.isGlobalStateInConsensus() {
-		*requeue = true
+	if v.hasGlobalVGRLabel() {
+		// On steady-state secondary, no PVCs match the VRG selector.
+		// Signal readiness so siblings don't wait on this VRG.
+		if len(groupPVCs) == 0 {
+			v.setGlobalSecondaryCondition(metav1.ConditionTrue,
+				VRGConditionReasonPVCsNotInUse, "PVCs are not in use")
 
-		return
+			return
+		}
+
+		if !v.isGlobalStateInConsensus() {
+			*requeue = true
+
+			return
+		}
 	}
 
 	for vgrNamespacedName, pvcs := range groupPVCs {
@@ -152,8 +163,24 @@ func (v *VRGInstance) reconcileVGRAsSecondary(vrNamespacedName types.NamespacedN
 		skip    bool = true
 	)
 
+	isGlobal := v.hasGlobalVGRLabel()
+
 	for idx := range pvcs {
 		if !v.isPVCReadyForSecondary(pvcs[idx], log) {
+			if isGlobal {
+				v.setGlobalSecondaryCondition(metav1.ConditionFalse,
+					VRGConditionReasonPVCsInUse, "PVCs are still in use")
+			}
+
+			return requeue, false, skip
+		}
+	}
+
+	if isGlobal {
+		v.setGlobalSecondaryCondition(metav1.ConditionTrue,
+			VRGConditionReasonPVCsNotInUse, "PVCs are not in use")
+
+		if !v.areSiblingVRGsReadyForGlobalSecondary(log) {
 			return requeue, false, skip
 		}
 	}

--- a/internal/controller/vrg_volgrouprep_global.go
+++ b/internal/controller/vrg_volgrouprep_global.go
@@ -154,6 +154,60 @@ func (v *VRGInstance) isGlobalStateInConsensus() bool {
 	return true
 }
 
+// areSiblingVRGsReadyForGlobalSecondary checks that all sibling VRGs sharing
+// the same global VGR label have signaled their PVCs are ready for the global
+// VGR to transition to secondary. This prevents one VRG from flipping the shared
+// VGR while another VRG's workloads are still active.
+func (v *VRGInstance) areSiblingVRGsReadyForGlobalSecondary(log logr.Logger) bool {
+	vgrLabel := v.globalVGRLabel()
+
+	var vrgs ramendrv1alpha1.VolumeReplicationGroupList
+	if err := v.reconciler.List(v.ctx, &vrgs,
+		client.MatchingLabels{GlobalVGRLabel: vgrLabel},
+	); err != nil {
+		log.Error(err, "Failed to list sibling VRGs for global VGR secondary readiness")
+
+		return false
+	}
+
+	var pending []string
+
+	for idx := range vrgs.Items {
+		sibling := &vrgs.Items[idx]
+		if sibling.Name == v.instance.Name && sibling.Namespace == v.instance.Namespace {
+			continue
+		}
+
+		if rmnutil.ResourceIsDeleted(sibling) {
+			continue // Sibling is being torn down; don't gate on it.
+		}
+
+		if !v.isSiblingReadyForGlobalSecondary(sibling) {
+			pending = append(pending, sibling.Namespace+"/"+sibling.Name)
+		}
+	}
+
+	if len(pending) > 0 {
+		log.Info("Waiting for sibling VRGs to release PVCs before flipping global VGR",
+			"pending", strings.Join(pending, ", "))
+
+		return false
+	}
+
+	log.Info("All sibling VRGs ready for global VGR secondary transition")
+
+	return true
+}
+
+func (v *VRGInstance) isSiblingReadyForGlobalSecondary(sibling *ramendrv1alpha1.VolumeReplicationGroup) bool {
+	cond := rmnutil.FindCondition(sibling.Status.Conditions, VRGConditionTypeGlobalSecondary)
+
+	return cond != nil &&
+		cond.Status == metav1.ConditionTrue &&
+		cond.Reason != VRGConditionReasonUnused &&
+		cond.ObservedGeneration == sibling.Generation
+}
+
 // isGlobalDeleteInConsensus checks that all VRGs sharing the same global VGR label
 // have a deletion timestamp. The global VGR is only deleted when all its VRGs are removed.
 func (v *VRGInstance) isGlobalDeleteInConsensus(log logr.Logger) bool {
@@ -203,6 +257,18 @@ func (v *VRGInstance) deleteGlobalVGR() bool {
 func (v *VRGInstance) setGlobalStateCondition(status metav1.ConditionStatus, reason, message string) {
 	rmnutil.SetStatusCondition(&v.instance.Status.Conditions, metav1.Condition{
 		Type:               VRGConditionTypeGlobalState,
+		Status:             status,
+		ObservedGeneration: v.instance.Generation,
+		Reason:             reason,
+		Message:            message,
+	})
+}
+
+// setGlobalSecondaryCondition updates the condition indicating whether
+// this VRG's PVCs are not in use, allowing the shared global VGR to transition to secondary.
+func (v *VRGInstance) setGlobalSecondaryCondition(status metav1.ConditionStatus, reason, message string) {
+	rmnutil.SetStatusCondition(&v.instance.Status.Conditions, metav1.Condition{
+		Type:               VRGConditionTypeGlobalSecondary,
 		Status:             status,
 		ObservedGeneration: v.instance.Generation,
 		Reason:             reason,

--- a/internal/controller/vrg_volgrouprep_global_test.go
+++ b/internal/controller/vrg_volgrouprep_global_test.go
@@ -120,23 +120,7 @@ var _ = Describe("GlobalVGR deletion consensus", Ordered, func() {
 
 	BeforeAll(func() {
 		g = newGlobalVGRTest()
-		createGlobalSC(g.scName, g.replicationID)
-		createGlobalVGRC(g.vgrcName, g.replicationID)
-		g.peerClass = buildGlobalPeerClass(g.replicationID, g.scName)
-
-		namespaceCreate(g.vrgA.namespace)
-		createBoundPVCAndPV(g.vrgA.namespace, g.scName, g.vrgA.vrgName)
-		createGlobalVRG(g.vrgA.vrgName, g.vrgA.namespace, []ramendrv1alpha1.PeerClass{g.peerClass})
-
-		namespaceCreate(g.vrgB.namespace)
-		createBoundPVCAndPV(g.vrgB.namespace, g.scName, g.vrgB.vrgName)
-		createGlobalVRG(g.vrgB.vrgName, g.vrgB.namespace, []ramendrv1alpha1.PeerClass{g.peerClass})
-
-		g.waitForGlobalVGRLabel(g.vrgA)
-		g.waitForGlobalVGRLabel(g.vrgB)
-		g.updateGlobalVGRStatus(volrep.PrimaryState)
-		g.verifyVRGCondition(g.vrgA, vrgController.VRGConditionTypeDataReady, metav1.ConditionTrue, "")
-		g.verifyVRGCondition(g.vrgB, vrgController.VRGConditionTypeDataReady, metav1.ConditionTrue, "")
+		g.setupTwoVRGsAsPrimary()
 	})
 
 	It("keeps VGR when only one VRG is deleted", func() {
@@ -212,7 +196,120 @@ var _ = Describe("GlobalVGR mixed GroupReplicationID", Ordered, func() {
 	AfterAll(func() { g.cleanupAll() })
 })
 
+var _ = Describe("GlobalVGR secondary transition gating", Ordered, func() {
+	var g *globalVGRTest
+
+	var pod *corev1.Pod
+
+	BeforeAll(func() {
+		g = newGlobalVGRTest()
+		g.setupTwoVRGsAsPrimary()
+	})
+
+	It("sets GlobalSecondary to Unused when VRGs are Primary", func() {
+		g.verifyVRGCondition(g.vrgA, vrgController.VRGConditionTypeGlobalSecondary,
+			metav1.ConditionTrue, vrgController.VRGConditionReasonUnused)
+		g.verifyVRGCondition(g.vrgB, vrgController.VRGConditionTypeGlobalSecondary,
+			metav1.ConditionTrue, vrgController.VRGConditionReasonUnused)
+	})
+
+	It("blocks VGR flip when VRG-B PVC is in use by a pod", func() {
+		pvcName := fmt.Sprintf("pvc-%s", g.vrgB.vrgName)
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-blocking-pod-",
+				Namespace:    g.vrgB.namespace,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "c1", Image: "busybox"},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "vol1",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: pvcName,
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(context.TODO(), pod)).To(Succeed())
+
+		// Ensure pod is visible in the cache
+		Eventually(func() error {
+			return k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(pod), pod)
+		}, vrgtimeout, vrginterval).Should(Succeed())
+
+		g.updateVRGSpecWithAction(g.vrgA, ramendrv1alpha1.Secondary, ramendrv1alpha1.VRGActionFailover)
+		g.updateVRGSpecWithAction(g.vrgB, ramendrv1alpha1.Secondary, ramendrv1alpha1.VRGActionFailover)
+
+		// VRG-A PVCs are not in use
+		g.verifyVRGCondition(g.vrgA, vrgController.VRGConditionTypeGlobalSecondary,
+			metav1.ConditionTrue, vrgController.VRGConditionReasonPVCsNotInUse)
+
+		// VRG-B PVCs are in use by pod
+		g.verifyVRGCondition(g.vrgB, vrgController.VRGConditionTypeGlobalSecondary,
+			metav1.ConditionFalse, vrgController.VRGConditionReasonPVCsInUse)
+
+		// VGR should NOT have flipped to secondary
+		g.verifyGlobalVGRReplicationState(volrep.Primary)
+	})
+
+	It("allows VGR flip after pod is deleted", func() {
+		Expect(k8sClient.Delete(context.TODO(), pod)).To(Succeed())
+
+		// Wait for pod to disappear from cache
+		Eventually(func() bool {
+			err := k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(pod), &corev1.Pod{})
+
+			return errors.IsNotFound(err)
+		}, vrgtimeout, vrginterval).Should(BeTrue())
+
+		// VRG-B should now report PVCsNotInUse
+		g.verifyVRGCondition(g.vrgB, vrgController.VRGConditionTypeGlobalSecondary,
+			metav1.ConditionTrue, vrgController.VRGConditionReasonPVCsNotInUse)
+
+		// VGR should transition to secondary
+		g.verifyGlobalVGRReplicationState(volrep.Secondary)
+	})
+
+	AfterAll(func() {
+		if pod != nil {
+			deleteIgnoreNotFound(pod)
+		}
+
+		g.deleteVRG(g.vrgA)
+		g.deleteVRG(g.vrgB)
+		g.verifyVRGDeleted(g.vrgA)
+		g.verifyVRGDeleted(g.vrgB)
+		g.cleanupAll()
+	})
+})
+
 // --- Test helpers ---
+
+func (g *globalVGRTest) setupTwoVRGsAsPrimary() {
+	createGlobalSC(g.scName, g.replicationID)
+	createGlobalVGRC(g.vgrcName, g.replicationID)
+	g.peerClass = buildGlobalPeerClass(g.replicationID, g.scName)
+
+	namespaceCreate(g.vrgA.namespace)
+	createBoundPVCAndPV(g.vrgA.namespace, g.scName, g.vrgA.vrgName)
+	createGlobalVRG(g.vrgA.vrgName, g.vrgA.namespace, []ramendrv1alpha1.PeerClass{g.peerClass})
+
+	namespaceCreate(g.vrgB.namespace)
+	createBoundPVCAndPV(g.vrgB.namespace, g.scName, g.vrgB.vrgName)
+	createGlobalVRG(g.vrgB.vrgName, g.vrgB.namespace, []ramendrv1alpha1.PeerClass{g.peerClass})
+
+	g.waitForGlobalVGRLabel(g.vrgA)
+	g.waitForGlobalVGRLabel(g.vrgB)
+	g.updateGlobalVGRStatus(volrep.PrimaryState)
+	g.verifyVRGCondition(g.vrgA, vrgController.VRGConditionTypeDataReady, metav1.ConditionTrue, "")
+	g.verifyVRGCondition(g.vrgB, vrgController.VRGConditionTypeDataReady, metav1.ConditionTrue, "")
+}
 
 func (g *globalVGRTest) globalVGRKey() types.NamespacedName {
 	return types.NamespacedName{
@@ -361,29 +458,28 @@ func (g *globalVGRTest) verifyVRGCondition(
 ) {
 	vrgKey := types.NamespacedName{Name: inst.vrgName, Namespace: inst.namespace}
 
-	Eventually(func() metav1.ConditionStatus {
+	Eventually(func() bool {
 		vrg := &ramendrv1alpha1.VolumeReplicationGroup{}
 		if err := apiReader.Get(context.TODO(), vrgKey, vrg); err != nil {
-			return metav1.ConditionUnknown
+			return false
 		}
 
 		cond := meta.FindStatusCondition(vrg.Status.Conditions, condType)
 		if cond == nil {
-			return metav1.ConditionUnknown
+			return false
 		}
 
-		return cond.Status
-	}, vrgtimeout, vrginterval).Should(Equal(expectedStatus),
-		"waiting for VRG %s condition %s=%s", vrgKey, condType, expectedStatus)
+		if cond.Status != expectedStatus {
+			return false
+		}
 
-	if expectedReason != "" {
-		vrg := &ramendrv1alpha1.VolumeReplicationGroup{}
-		Expect(apiReader.Get(context.TODO(), vrgKey, vrg)).To(Succeed())
+		if expectedReason != "" && cond.Reason != expectedReason {
+			return false
+		}
 
-		cond := meta.FindStatusCondition(vrg.Status.Conditions, condType)
-		Expect(cond).NotTo(BeNil())
-		Expect(cond.Reason).To(Equal(expectedReason))
-	}
+		return true
+	}, vrgtimeout, vrginterval).Should(BeTrue(),
+		"waiting for VRG %s condition %s=%s reason=%s", vrgKey, condType, expectedStatus, expectedReason)
 }
 
 func (g *globalVGRTest) verifyVRGDeleted(inst *globalVRGInstance) {
@@ -507,4 +603,22 @@ func (g *globalVGRTest) cleanupAll() {
 	}
 
 	deleteIgnoreNotFound(&volrep.VolumeGroupReplicationClass{ObjectMeta: metav1.ObjectMeta{Name: g.vgrcName}})
+}
+
+func (g *globalVGRTest) updateVRGSpecWithAction(
+	inst *globalVRGInstance, state ramendrv1alpha1.ReplicationState, action ramendrv1alpha1.VRGAction,
+) {
+	vrgKey := types.NamespacedName{Name: inst.vrgName, Namespace: inst.namespace}
+
+	Expect(retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		vrg := &ramendrv1alpha1.VolumeReplicationGroup{}
+		if err := k8sClient.Get(context.TODO(), vrgKey, vrg); err != nil {
+			return err
+		}
+
+		vrg.Spec.ReplicationState = state
+		vrg.Spec.Action = action
+
+		return k8sClient.Update(context.TODO(), vrg)
+	})).To(Succeed())
 }


### PR DESCRIPTION
## Summary
When multiple VRGs share a global VGR, the VGR transition to secondary must
wait until all VRGs confirm their PVCs are no longer in use. Without this,
a VRG that completes cleanup faster can flip the shared VGR while other
VRGs' workloads are still active on the same cluster.

This PR adds:
- A `GlobalSecondary` condition on VRG status that each VRG sets based on
  its own PVC readiness (`PVCsNotInUse` / `PVCsInUse` / `Unused`).
- A sibling readiness check before `processVGRAsSecondary` — the VGR is
  only updated once all sibling VRGs report `True / PVCsNotInUse`.
- Updated unit test and doc with examples

## Testing:
- [x] Ran 5-iteration failover/relocate loop with no premature flips(using mock)
```
[2026-08-07 17:54:12] [INFO] ═══════════════════════════════════════════════════════════
[2026-08-07 17:54:12] [INFO]   FINAL RESULTS
[2026-08-07 17:54:12] [INFO] ═══════════════════════════════════════════════════════════
[2026-08-07 17:54:12] [INFO] Iterations completed: 5 / 5
[2026-08-07 17:54:12] [INFO] Failures: 0
[2026-08-07 17:54:12] [INFO] Log directory: test_fix_logs/run_20260807_170719
[2026-08-07 17:54:12] [INFO] Main log: test_fix_logs/run_20260807_170719/test.log
[2026-08-07 17:54:13] [INFO] State captured: test_fix_logs/run_20260807_170719/state_175413_final.txt
[2026-08-07 17:54:13] [PASS] ALL 5 ITERATIONS PASSED
```
- [x] failover(dr1->dr2) with mixed apps VGR stays primary until all apps
  cleaned up, then transitions
```
DRPCs:
NAMESPACE                     NAME                     PREFERREDCLUSTER   FAILOVERCLUSTER   DESIREDSTATE   CURRENTSTATE   PROGRESSION           PEER READY
argocd                        appset-deploy-standard   dr1                dr2               Failover       FailedOver     Cleaning Up           False
ramen-ops                     disapp-deploy-standard   dr1                dr2               Failover       FailedOver     WaitOnUserToCleanUp   False
test-subscr-deploy-standard   subscr-deploy-standard   dr1                dr2               Failover       FailedOver     Cleaning Up           False

VRGs DR1:
NAMESPACE                     NAME                     DESIREDSTATE   CURRENTSTATE
ramen-ops                     disapp-deploy-standard   secondary      Unknown
test-appset-deploy-standard   appset-deploy-standard   secondary      Unknown
test-subscr-deploy-standard   subscr-deploy-standard   secondary      Unknown

VGR DR1:
NS             NAME                              SPEC        STATE
ramen-system global-mock-replication-group-1 primary Primary

GlobalSecondary conditions (DR1):
```yaml
# appset-deploy-standard
- type: GlobalSecondary
  status: "False"
  reason: PVCsInUse
  message: PVCs are still in use
# disapp-deploy-standard
- type: GlobalSecondary
  status: "False"
  reason: PVCsInUse
  message: PVCs are still in use
# subscr-deploy-standard
- type: GlobalSecondary
  status: "True"
  reason: PVCsNotInUse
  message: PVCs are not in use

After cleanup VGR flipped

VGR DR1:
NS             NAME                              SPEC        STATE
ramen-system global-mock-replication-group-1 Secondary Secondary
```
- [x] relocate(dr2->dr1) with mixed apps VGR stays primary until discovered
  app PVC deleted, then transitions
```
During transition, VGR blocked
DRPCs:

NAMESPACE                     NAME                     DESIREDSTATE   CURRENTSTATE   PROGRESSION                   PEER READY
argocd                        appset-deploy-standard   Relocate       Relocating     EnsuringVolumesAreSecondary   False
ramen-ops                     disapp-deploy-standard   Relocate       Relocating     WaitOnUserToCleanUp           False
test-subscr-deploy-standard   subscr-deploy-standard   Relocate       Relocating     EnsuringVolumesAreSecondary   False

VRGs DR2:

NAMESPACE                     NAME                     DESIREDSTATE   CURRENTSTATE
ramen-ops                     disapp-deploy-standard   secondary      Unknown
test-appset-deploy-standard   appset-deploy-standard   secondary      Unknown
test-subscr-deploy-standard   subscr-deploy-standard   secondary      Unknown

VGR DR2:

NS             NAME                              SPEC      STATE
ramen-system   global-mock-replication-group-1   primary   Primary

GlobalSecondary conditions (DR2):

# appset-deploy-standard
- type: GlobalSecondary
  status: "True"
  reason: PVCsNotInUse
  message: PVCs are not in use
# disapp-deploy-standard
- type: GlobalSecondary
  status: "False"
  reason: PVCsInUse
  message: PVCs are still in use
# subscr-deploy-standard
- type: GlobalSecondary
  status: "True"
  reason: PVCsNotInUse
  message: PVCs are not in use
After cleanup — VGR flipped
DRPCs:

NAMESPACE                     NAME                     DESIREDSTATE   CURRENTSTATE   PROGRESSION   PEER READY
argocd                        appset-deploy-standard   Relocate       Relocated      Completed     True
ramen-ops                     disapp-deploy-standard   Relocate       Relocated      Completed     True
test-subscr-deploy-standard   subscr-deploy-standard   Relocate       Relocated      Completed     True
VGR DR2:

NS             NAME                              SPEC        STATE
ramen-system   global-mock-replication-group-1   secondary   Secondary
```