### PR TITLE
Fix VGRC restore and S3 upload handling for PVs

### DIFF
--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -253,7 +253,8 @@ func (v *VRGInstance) uploadVGRandVGRCtoS3Stores(vrNamespacedName types.Namespac
 
 	vgr := &volrep.VolumeGroupReplication{}
 
-	err := v.reconciler.Get(v.ctx, vrNamespacedName, vgr)
+	// APIReader: avoid stale informer cache after destination-handle annotation Update.
+	err := v.reconciler.APIReader.Get(v.ctx, vrNamespacedName, vgr)
 	if err != nil {
 		return fmt.Errorf("failed to get VGR (%w)", err)
 	}
@@ -307,7 +308,9 @@ func (v *VRGInstance) uploadVGRandVGRCtoS3Stores(vrNamespacedName types.Namespac
 	return nil
 }
 
-func (v *VRGInstance) UploadVGRandVGRCtoS3Store(s3ProfileName string, vgr *volrep.VolumeGroupReplication) error {
+func (v *VRGInstance) UploadVGRandVGRCtoS3Store(s3ProfileName string, vgr *volrep.VolumeGroupReplication,
+	vgrc *volrep.VolumeGroupReplicationContent,
+) error {
 	if s3ProfileName == "" {
 		return fmt.Errorf("missing S3 profiles, failed to protect cluster data for VGR %s", vgr.Name)
 	}
@@ -317,13 +320,7 @@ func (v *VRGInstance) UploadVGRandVGRCtoS3Store(s3ProfileName string, vgr *volre
 		return fmt.Errorf("error getting object store, failed to protect cluster data for VGR %s, %w", vgr.Name, err)
 	}
 
-	vgrc, err := v.getVGRCFromVGR(vgr)
-	if err != nil {
-		return fmt.Errorf("error getting VGRC for VGR, failed to protect cluster data for VGRC %s to s3Profile %s, %w",
-			vgrc.Name, s3ProfileName, err)
-	}
-
-	return v.UploadVGRAndVGRCtoS3(s3ProfileName, objectStore, vgr, &vgrc)
+	return v.UploadVGRAndVGRCtoS3(s3ProfileName, objectStore, vgr, vgrc)
 }
 
 func (v *VRGInstance) UploadVGRAndVGRCtoS3(s3ProfileName string, objectStore ObjectStorer,
@@ -359,10 +356,18 @@ func (v *VRGInstance) UploadVGRAndVGRCtoS3(s3ProfileName string, objectStore Obj
 func (v *VRGInstance) UploadVGRandVGRCtoS3Stores(vgr *volrep.VolumeGroupReplication,
 	log logr.Logger,
 ) ([]string, error) {
+	// Fetch VGRC once and upload the same object to every profile so buckets cannot
+	// diverge.
+	vgrc, err := v.getVGRCFromVGR(vgr)
+	if err != nil {
+		return nil, fmt.Errorf("error getting VGRC for VGR, failed to protect cluster data for VGR %s, %w",
+			vgr.Name, err)
+	}
+
 	succeededProfiles := []string{}
 	// Upload the VGR and VGRC to all the S3 profiles in the VRG spec
 	for _, s3ProfileName := range v.instance.Spec.S3Profiles {
-		err := v.UploadVGRandVGRCtoS3Store(s3ProfileName, vgr)
+		err := v.UploadVGRandVGRCtoS3Store(s3ProfileName, vgr, &vgrc)
 		if err != nil {
 			rmnutil.ReportIfNotPresent(v.reconciler.eventRecorder, v.instance, corev1.EventTypeWarning,
 				rmnutil.EventReasonUploadFailed, err.Error())
@@ -384,7 +389,10 @@ func (v *VRGInstance) getVGRCFromVGR(vgr *volrep.VolumeGroupReplication) (volrep
 		Name: vgrcName,
 	}
 
-	if err := v.reconciler.Get(v.ctx, vgrcObjectKey, &vgrc); err != nil {
+	// Use APIReader, not the informer cache. Destination volume-group-handle annotation is
+	// applied via Update immediately before S3 upload; a cached Get can return the
+	// pre-Update VGRC and upload an object missing destination-volume-group-handle.
+	if err := v.reconciler.APIReader.Get(v.ctx, vgrcObjectKey, &vgrc); err != nil {
 		return vgrc, fmt.Errorf("failed to get VGRC %v from VGR %v, %w",
 			vgrcObjectKey, client.ObjectKeyFromObject(vgr), err)
 	}

--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -1358,11 +1358,44 @@ func (v *VRGInstance) cleanupVGRCForRestore(vgrc *volrep.VolumeGroupReplicationC
 		}
 	}
 
+	if err := v.updateVGRCVolumeHandlesForRestore(vgrc); err != nil {
+		return err
+	}
+
 	if err := v.updateVGRCClusterIDForRestore(vgrc); err != nil {
 		return err
 	}
 
 	return v.processVGRCSecrets(vgrc)
+}
+
+// updateVGRCVolumeHandlesForRestore replaces Spec.Source.VolumeHandles with
+// destination volume handles from Status.PersistentVolumeMappingList when present.
+// Mirrors cleanupPVForRestore rewriting PV Spec.CSI.VolumeHandle from the
+// destination-volume-handle annotation. No-op when mappings are missing
+// (e.g. destination info was not available at archive time).
+func (v *VRGInstance) updateVGRCVolumeHandlesForRestore(vgrc *volrep.VolumeGroupReplicationContent) error {
+	for i, handle := range vgrc.Spec.Source.VolumeHandles {
+		for _, pvMapping := range vgrc.Status.PersistentVolumeMappingList {
+			if pvMapping.VolumeHandle != handle {
+				continue
+			}
+
+			if pvMapping.DestinationVolumeHandle == "" {
+				return fmt.Errorf("destination volume ID is empty for VGRC %s, PV %s, volumeHandle %s",
+					vgrc.Name, pvMapping.Name, handle)
+			}
+
+			v.log.V(1).Info("Set VGRC volume handle from destination handle",
+				"VGRC", vgrc.Name, "handle", pvMapping.DestinationVolumeHandle)
+
+			vgrc.Spec.Source.VolumeHandles[i] = pvMapping.DestinationVolumeHandle
+
+			break
+		}
+	}
+
+	return nil
 }
 
 // updateVGRCClusterIDForRestore sets volumeGroupAttributes.clusterID from the target

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -875,7 +875,9 @@ func (v *VRGInstance) annotateWithDestinationVolumeHandleForVolRep(pvc *corev1.P
 	return v.applyDestinationVolumeHandleToPV(&pv, volRep.Status.DestinationVolumeID)
 }
 
-func (v *VRGInstance) UploadPVandPVCtoS3Store(s3ProfileName string, pvc *corev1.PersistentVolumeClaim) error {
+func (v *VRGInstance) UploadPVandPVCtoS3Store(s3ProfileName string, pvc *corev1.PersistentVolumeClaim,
+	pv *corev1.PersistentVolume,
+) error {
 	if s3ProfileName == "" {
 		return fmt.Errorf("missing S3 profiles, failed to protect cluster data for PVC %s", pvc.Name)
 	}
@@ -885,13 +887,7 @@ func (v *VRGInstance) UploadPVandPVCtoS3Store(s3ProfileName string, pvc *corev1.
 		return fmt.Errorf("error getting object store, failed to protect cluster data for PVC %s, %w", pvc.Name, err)
 	}
 
-	pv, err := v.getPVFromPVC(pvc)
-	if err != nil {
-		return fmt.Errorf("error getting PV for PVC, failed to protect cluster data for PVC %s to s3Profile %s, %w",
-			pvc.Name, s3ProfileName, err)
-	}
-
-	return v.UploadPVAndPVCtoS3(s3ProfileName, objectStore, &pv, pvc)
+	return v.UploadPVAndPVCtoS3(s3ProfileName, objectStore, pv, pvc)
 }
 
 func (v *VRGInstance) UploadPVAndPVCtoS3(s3ProfileName string, objectStore ObjectStorer,
@@ -927,10 +923,18 @@ func (v *VRGInstance) UploadPVAndPVCtoS3(s3ProfileName string, objectStore Objec
 func (v *VRGInstance) UploadPVandPVCtoS3Stores(pvc *corev1.PersistentVolumeClaim,
 	log logr.Logger,
 ) ([]string, error) {
+	// Fetch PV once and upload the same object to every profile so buckets cannot
+	// diverge.
+	pv, err := v.getPVFromPVC(pvc)
+	if err != nil {
+		return nil, fmt.Errorf("error getting PV for PVC, failed to protect cluster data for PVC %s, %w",
+			pvc.Name, err)
+	}
+
 	succeededProfiles := []string{}
 	// Upload the PV to all the S3 profiles in the VRG spec
 	for _, s3ProfileName := range v.instance.Spec.S3Profiles {
-		err := v.UploadPVandPVCtoS3Store(s3ProfileName, pvc)
+		err := v.UploadPVandPVCtoS3Store(s3ProfileName, pvc, &pv)
 		if err != nil {
 			v.updatePVCClusterDataProtectedCondition(pvc.Namespace, pvc.Name, VRGConditionReasonUploadError, err.Error())
 			rmnutil.ReportIfNotPresent(v.reconciler.eventRecorder, v.instance, corev1.EventTypeWarning,
@@ -950,8 +954,10 @@ func (v *VRGInstance) getPVFromPVC(pvc *corev1.PersistentVolumeClaim) (corev1.Pe
 	volumeName := pvc.Spec.VolumeName
 	pvObjectKey := client.ObjectKey{Name: volumeName}
 
-	// Get PV from k8s
-	if err := v.reconciler.Get(v.ctx, pvObjectKey, &pv); err != nil {
+	// Use APIReader, not the informer cache. Destination-handle annotation is applied via
+	// Update immediately before S3 upload; a cached Get can return the pre-Update PV and
+	// upload an object missing ramendr.openshift.io/destination-volume-handle.
+	if err := v.reconciler.APIReader.Get(v.ctx, pvObjectKey, &pv); err != nil {
 		return pv, fmt.Errorf("failed to get PV %v from PVC %v, %w",
 			pvObjectKey, client.ObjectKeyFromObject(pvc), err)
 	}


### PR DESCRIPTION
## Summary

- On restore/failover, rewrite `VGRC.Spec.Source.VolumeHandles` from `Status.PersistentVolumeMappingList` destination handles so the restored group points at target-cluster volumes (same idea as PV dest-handle rewrite).
- On primary upload, fetch PV/VGRC via `APIReader` after dest-handle annotate, and upload that same object to every S3 profile so peer buckets cannot diverge (stale informer cache was causing missing `destination-volume(-group)-handle` on some objects / one bucket).

## Test plan

- [x] Verify both S3 profiles contain destination-handle annotations.
- [x] Verify restored VGRC uses destination volume handles after failover/relocate.