### PR TITLE
feat: VM staticIP: add network-mapping ConfigMap parsing and IP translation for VM static-IP DR

### DIFF
--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -80,6 +80,11 @@ const (
 	// GlobalActionConsensus condition indicates whether all DRPCs sharing the same global VGR label
 	// agree on the DR action and target cluster.
 	ConditionGlobalAction = "GlobalAction"
+
+	// NetworkMappingLoaded condition indicates whether the network-mapping ConfigMap referenced
+	// by the drplacementcontrol.ramendr.openshift.io/network-mapping annotation was successfully
+	// loaded. False means IP translation is disabled for this DRPC; DR orchestration continues.
+	ConditionNetworkMappingLoaded = "NetworkMappingLoaded"
 )
 
 const (

--- a/internal/controller/drpc_networkmapping.go
+++ b/internal/controller/drpc_networkmapping.go
@@ -1,0 +1,1158 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+// drpc_networkmapping.go — network-mapping ConfigMap parsing and IP translation
+// for VM static-IP DR.
+//
+// # ConfigMap contract
+//
+// The DRPC carries an annotation:
+//
+//	drplacementcontrol.ramendr.openshift.io/network-mapping: "<configmap-name>"
+//
+// That annotation references a ConfigMap in the same namespace as the DRPC.
+// The ConfigMap's "mappings.yaml" data key contains a YAML document.
+// Cluster names (dr1/dr2) come from drpolicy.spec.drClusters[0] and [1].
+//
+// # Schema — each block maps one NAD and may carry any combination of rules
+//
+//  version: "v1"    # required; must be "v1" for this release
+//	networkMappings:
+//
+//	  - networkRef:
+//	      nadNamespace: default
+//	      nadName:      backup
+//
+//	    # CIDR translation — bidirectional subnet-offset mapping.
+//	    # Presence is detected from dr1/dr2 keys.
+//	    cidr:
+//	      dr1: 192.168.100.0/24
+//	      dr2: 192.168.110.0/24
+//
+//	    # Explicit per-VM overrides — checked before CIDR.
+//	    explicitMappings:
+//	      - dr1: 192.168.100.10
+//	        dr2: 192.168.110.10
+//	      - dr1: 192.168.100.51
+//	        dr2: 192.168.110.58
+//
+//	    # Regex fallback — direction is required because patterns are not
+//	    # inherently reversible.
+//	    regexMappings:
+//	      dr1-to-dr2:
+//	        - pattern:     "^172\\.16\\.100\\.(\\d+)$"
+//	          replacement: "10.20.30.$1"
+//	      dr2-to-dr1:
+//	        - pattern:     "^10\\.20\\.30\\.(\\d+)$"
+//	          replacement: "172.16.100.$1"
+//
+// # Evaluation order (per discovered IP)
+//
+// Given (networkRef, sourceCluster, ip):
+//  1. explicitMappings — most specific; exact IP match wins immediately.
+//  2. cidr             — subnet-offset translation.
+//  3. regexMappings    — fallback regex rules; first matching pattern wins.
+//
+// At least one of the three sections must be present per block.
+//
+// # Direction model
+//
+// "dr1" = drpolicy.spec.drClusters[0], "dr2" = drpolicy.spec.drClusters[1].
+// Forward direction = dr1 → dr2 (failover).
+// Reverse direction = dr2 → dr1 (failback).
+// CIDR and explicitMappings are bidirectional (dr1/dr2 keys supply both sides).
+// regexMappings direction must be stated explicitly in the YAML keys.
+//
+// # Versioning
+//
+// The top-level "version" field allows the schema to evolve across releases
+// while keeping backward compatibility.  ParseNetworkMappingConfigMap rejects
+// any version it does not recognize so that an operator upgraded to a future
+// release can detect stale ConfigMaps rather than misparse them silently.
+//
+// Current supported version: "v1"
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"regexp"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	rmn "github.com/ramendr/ramen/api/v1alpha1"
+)
+
+// TranslationDirection controls which side (Forward = dr1→dr2, Reverse = dr2→dr1)
+// of a mapping block is used.
+type TranslationDirection int
+
+const (
+	TranslationDirectionForward TranslationDirection = iota // dr1 → dr2
+	TranslationDirectionReverse                             // dr2 → dr1
+)
+
+// RuleType identifies which rule produced a translation result (used in logs).
+type RuleType string
+
+const (
+	RuleTypeExplicit RuleType = "Explicit"
+	RuleTypeCIDR     RuleType = "CIDR"
+	RuleTypeRegex    RuleType = "Regex"
+)
+
+const MaxDRClusterCount = 2
+
+// ---------------------------------------------------------------------------
+// Version constants
+// ---------------------------------------------------------------------------
+
+// networkMappingSchemaV1 is the only version accepted by this release.
+// Future releases may add new values and handle old ones with migration logic.
+const networkMappingSchemaV1 = "v1"
+
+// ---------------------------------------------------------------------------
+// On-disk (raw) types — decoded directly from mappings.yaml
+// ---------------------------------------------------------------------------
+
+// rawNetworkMappingConfig is the top-level structure decoded from mappings.yaml.
+type rawNetworkMappingConfig struct {
+	// Version identifies the schema version of this document.  Required.
+	Version         string              `yaml:"version"`
+	NetworkMappings []rawNetworkMapping `yaml:"networkMappings"`
+}
+
+// rawNetworkMapping is one entry in the networkMappings list.
+type rawNetworkMapping struct {
+	// NetworkRef identifies the NAD this block applies to.
+	NetworkRef NetworkRef `yaml:"networkRef"`
+
+	// CIDR holds the subnet CIDRs keyed by cluster name.  Both dr1 and dr2
+	// keys must be present when this section is used.
+	// +optional
+	CIDR map[string]string `yaml:"cidr,omitempty"`
+
+	// ExplicitMappings holds per-VM static IP pairs keyed by cluster name.
+	// +optional
+	ExplicitMappings []rawClusterIPPair `yaml:"explicitMappings,omitempty"`
+
+	// RegexMappings holds ordered regex rules keyed by direction string
+	// "<dr1>-to-<dr2>" and "<dr2>-to-<dr1>".
+	// +optional
+	RegexMappings map[string][]rawRegexRule `yaml:"regexMappings,omitempty"`
+}
+
+// rawClusterIPPair holds one row of an explicit mapping keyed by cluster name.
+type rawClusterIPPair map[string]string
+
+// rawRegexRule is a single pattern/replacement pair inside regexMappings.
+type rawRegexRule struct {
+	Pattern     string `yaml:"pattern"`
+	Replacement string `yaml:"replacement"`
+}
+
+// ---------------------------------------------------------------------------
+// Runtime types — produced after cluster-name resolution and validation
+// ---------------------------------------------------------------------------
+
+// NetworkMappingRules is the normalised, direction-resolved form of the full
+// ConfigMap.
+type NetworkMappingRules struct {
+	// Version is the schema version read from the ConfigMap (e.g. "v1").
+	Version string
+	// DR1 is drpolicy.spec.drClusters[0].
+	DR1 string
+	// DR2 is drpolicy.spec.drClusters[1].
+	DR2 string
+
+	// Blocks is the ordered list of resolved per-NAD translation blocks.
+	Blocks []NetworkMappingBlock
+}
+
+// NetworkRef identifies the NAD (NetworkAttachmentDefinition) that a block
+// applies to.
+type NetworkRef struct {
+	NADNamespace string `yaml:"nadNamespace" json:"nadNamespace"`
+	NADName      string `yaml:"nadName"      json:"nadName"`
+}
+
+// NetworkMappingBlock is one resolved per-NAD translation block.
+// All three rule sets are optional individually; at least one must be present.
+// Evaluation order at runtime: ExplicitMappings → CIDRMapping → RegexRules.
+type NetworkMappingBlock struct {
+	// NetworkRef scopes this block to a specific NAD.
+	NetworkRef NetworkRef
+
+	// ExplicitMappings holds the per-VM static IP table (highest priority).
+	// Forward maps a dr1 IP to its dr2 IP; Reverse is the inverse.
+	// Both maps are nil when explicitMappings is not configured.
+	ExplicitMappings *ExplicitMappings
+
+	// CIDRMapping is the subnet-offset translation (second priority).
+	// nil when not configured.
+	CIDRMapping *CIDRMapping
+
+	// RegexRules is the directional regex fallback (lowest priority).
+	// nil when not configured.
+	RegexRules *RegexRules
+}
+
+// ExplicitMappings holds the forward and reverse lookup maps built from the
+// explicitMappings YAML list.  Both maps are populated together at parse time
+// so lookup is O(1) in both directions.
+//
+// Forward: dr1IP → dr2IP (failover, dr1→dr2)
+// Reverse: dr2IP → dr1IP (failback, dr2→dr1)
+type ExplicitMappings struct {
+	Forward map[string]string // dr1IP → dr2IP
+	Reverse map[string]string // dr2IP → dr1IP
+}
+
+// CIDRMapping carries the two subnets for subnet-offset translation.
+// Both subnets must have the same prefix length.
+type CIDRMapping struct {
+	// DR1CIDR is the subnet on cluster dr1.
+	DR1CIDR string
+	// DR2CIDR is the subnet on cluster dr2.
+	DR2CIDR string
+
+	// pre-parsed networks (set at validation time to avoid repeated parsing).
+	dr1Net *net.IPNet
+	dr2Net *net.IPNet
+}
+
+// RegexRules holds the two ordered direction lists for regex-based translation.
+type RegexRules struct {
+	// Forward rules applied during dr1→dr2.
+	Forward []CompiledRegexRule
+	// Reverse rules applied during dr2→dr1.
+	Reverse []CompiledRegexRule
+}
+
+// CompiledRegexRule is a single pre-compiled regex-replacement rule.
+type CompiledRegexRule struct {
+	compiled    *regexp.Regexp
+	Pattern     string // original pattern string, kept for error messages
+	Replacement string
+}
+
+// ---------------------------------------------------------------------------
+// DRPCNetworkMappingManager
+// ---------------------------------------------------------------------------
+
+// DRPCNetworkMappingManager reads and parses the network-mapping ConfigMap
+// referenced by a DRPC annotation and performs IP translation.
+type DRPCNetworkMappingManager struct {
+	client client.Client
+	log    logr.Logger
+}
+
+// NewDRPCNetworkMappingManager constructs a manager bound to the given client.
+func NewDRPCNetworkMappingManager(c client.Client, log logr.Logger) *DRPCNetworkMappingManager {
+	return &DRPCNetworkMappingManager{client: c, log: log}
+}
+
+// LoadNetworkMapping returns the parsed NetworkMappingRules for the DRPC, or
+// (nil, nil) if the DRPC does not carry the annotation.
+//
+// drPolicy is required to resolve cluster names from drpolicy.spec.drClusters.
+func (m *DRPCNetworkMappingManager) LoadNetworkMapping(
+	ctx context.Context,
+	drpc *rmn.DRPlacementControl,
+	drPolicy *rmn.DRPolicy,
+) (*NetworkMappingRules, error) {
+	cmName, ok := drpc.GetAnnotations()[DRPCNetworkMappingAnnotation]
+	if !ok || cmName == "" {
+		m.log.V(1).Info("DRPC has no network-mapping annotation; skipping",
+			"drpc", drpc.Name)
+
+		return nil, nil
+	}
+
+	cm := &corev1.ConfigMap{}
+	key := types.NamespacedName{Name: cmName, Namespace: drpc.Namespace}
+
+	if err := m.client.Get(ctx, key, cm); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("network-mapping ConfigMap %q not found in namespace %q",
+				cmName, drpc.Namespace)
+		}
+
+		return nil, fmt.Errorf("failed to get network-mapping ConfigMap %q: %w", cmName, err)
+	}
+
+	if len(drPolicy.Spec.DRClusters) != MaxDRClusterCount {
+		return nil, fmt.Errorf("DRPolicy %q must have exactly 2 drClusters, got %d",
+			drPolicy.Name, len(drPolicy.Spec.DRClusters))
+	}
+
+	dr1, dr2 := drPolicy.Spec.DRClusters[0], drPolicy.Spec.DRClusters[1]
+
+	rules, err := ParseNetworkMappingConfigMap(cm, dr1, dr2)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse network-mapping ConfigMap %q: %w", cmName, err)
+	}
+
+	m.log.Info("Loaded network-mapping ConfigMap",
+		"configmap", cmName,
+		"dr1", dr1,
+		"dr2", dr2,
+		"blocks", len(rules.Blocks))
+
+	return rules, nil
+}
+
+// ---------------------------------------------------------------------------
+// ParseNetworkMappingConfigMap
+// ---------------------------------------------------------------------------
+
+// ParseNetworkMappingConfigMap parses a ConfigMap that follows the
+// network-mapping format described at the top of this file.
+//
+// dr1 = drpolicy.spec.drClusters[0], dr2 = drpolicy.spec.drClusters[1].
+func ParseNetworkMappingConfigMap(cm *corev1.ConfigMap, dr1, dr2 string) (*NetworkMappingRules, error) {
+	const dataKey = "mappings.yaml"
+
+	raw, ok := cm.Data[dataKey]
+	if !ok {
+		return nil, fmt.Errorf("ConfigMap %q/%q has no %q data key",
+			cm.Namespace, cm.Name, dataKey)
+	}
+
+	if dr1 == "" || dr2 == "" {
+		return nil, fmt.Errorf("dr1 and dr2 cluster names must be non-empty")
+	}
+
+	if dr1 == dr2 {
+		return nil, fmt.Errorf("dr1 and dr2 cluster names must be distinct, got %q", dr1)
+	}
+
+	rawCfg := &rawNetworkMappingConfig{}
+	if err := sigsyaml.Unmarshal([]byte(raw), rawCfg); err != nil {
+		return nil, fmt.Errorf("failed to parse %q in ConfigMap %q: %w",
+			dataKey, cm.Name, err)
+	}
+
+	if rawCfg.Version == "" {
+		return nil, fmt.Errorf("ConfigMap %q: %q is missing required field \"version\" (expected %q)",
+			cm.Name, dataKey, networkMappingSchemaV1)
+	}
+
+	if rawCfg.Version != networkMappingSchemaV1 {
+		return nil, fmt.Errorf("ConfigMap %q: unsupported network-mapping schema version %q (supported: %q)",
+			cm.Name, rawCfg.Version, networkMappingSchemaV1)
+	}
+
+	rules, err := resolveAndValidate(rawCfg, dr1, dr2)
+	if err != nil {
+		return nil, fmt.Errorf("invalid network mapping in ConfigMap %q: %w", cm.Name, err)
+	}
+
+	return rules, nil
+}
+
+// ---------------------------------------------------------------------------
+// resolveAndValidate — raw → runtime with full validation
+// ---------------------------------------------------------------------------
+
+func resolveAndValidate(rawCfg *rawNetworkMappingConfig, dr1, dr2 string) (*NetworkMappingRules, error) {
+	if len(rawCfg.NetworkMappings) == 0 {
+		return nil, fmt.Errorf("networkMappings list must not be empty")
+	}
+
+	fwdKey := dr1 + "-to-" + dr2
+	revKey := dr2 + "-to-" + dr1
+
+	rules := &NetworkMappingRules{
+		Version: rawCfg.Version,
+		DR1:     dr1,
+		DR2:     dr2,
+		Blocks:  make([]NetworkMappingBlock, 0, len(rawCfg.NetworkMappings)),
+	}
+
+	seen := make(map[string]int, len(rawCfg.NetworkMappings))
+
+	for i, raw := range rawCfg.NetworkMappings {
+		if raw.NetworkRef.NADNamespace == "" {
+			return nil, fmt.Errorf("networkMappings[%d]: networkRef.nadNamespace is required", i)
+		}
+
+		if raw.NetworkRef.NADName == "" {
+			return nil, fmt.Errorf("networkMappings[%d]: networkRef.nadName is required", i)
+		}
+
+		nadKey := raw.NetworkRef.NADNamespace + "/" + raw.NetworkRef.NADName
+		if prev, dup := seen[nadKey]; dup {
+			return nil, fmt.Errorf("networkMappings[%d]: duplicate networkRef %s (already at index %d)",
+				i, nadKey, prev)
+		}
+
+		seen[nadKey] = i
+
+		block, err := resolveBlock(i, raw, dr1, dr2, fwdKey, revKey)
+		if err != nil {
+			return nil, err
+		}
+
+		rules.Blocks = append(rules.Blocks, block)
+	}
+
+	return rules, nil
+}
+
+// resolveBlock resolves and validates a single rawNetworkMapping into a
+// NetworkMappingBlock.
+func resolveBlock(
+	blockIdx int,
+	raw rawNetworkMapping,
+	dr1, dr2, fwdKey, revKey string,
+) (NetworkMappingBlock, error) {
+	block := NetworkMappingBlock{NetworkRef: raw.NetworkRef}
+
+	// --- explicitMappings ---
+	if len(raw.ExplicitMappings) > 0 {
+		em, err := resolveExplicitMappings(blockIdx, raw.ExplicitMappings, dr1, dr2)
+		if err != nil {
+			return block, err
+		}
+
+		block.ExplicitMappings = em // *ExplicitMappings
+	}
+
+	// --- cidr ---
+	if len(raw.CIDR) > 0 {
+		cm, err := resolveCIDR(blockIdx, raw.CIDR, dr1, dr2)
+		if err != nil {
+			return block, err
+		}
+
+		block.CIDRMapping = cm
+	}
+
+	// --- regexMappings ---
+	if len(raw.RegexMappings) > 0 {
+		rr, err := resolveRegexMappings(blockIdx, raw.RegexMappings, fwdKey, revKey)
+		if err != nil {
+			return block, err
+		}
+
+		block.RegexRules = rr
+	}
+
+	// At least one rule set must be present.
+	if block.ExplicitMappings == nil && block.CIDRMapping == nil && block.RegexRules == nil {
+		return block, fmt.Errorf(
+			"networkMappings[%d] (%s/%s): at least one of cidr, explicitMappings, or regexMappings is required",
+			blockIdx, raw.NetworkRef.NADNamespace, raw.NetworkRef.NADName)
+	}
+
+	return block, nil
+}
+
+// ---------------------------------------------------------------------------
+// explicitMappings resolver
+// ---------------------------------------------------------------------------
+
+func resolveExplicitMappings(
+	blockIdx int,
+	rawPairs []rawClusterIPPair,
+	dr1, dr2 string,
+) (*ExplicitMappings, error) {
+	fwd := make(map[string]string, len(rawPairs))
+	rev := make(map[string]string, len(rawPairs))
+
+	for j, pair := range rawPairs {
+		dr1IP, dr2IP, err := extractClusterIPs(
+			blockIdx, j, pair, dr1, dr2,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		dr1Norm, dr2Norm, err := normalizeExplicitIPs(
+			blockIdx, j, dr1, dr2, dr1IP, dr2IP,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := validateExplicitMappingCollision(
+			blockIdx, j,
+			dr1Norm, dr2Norm,
+			dr1, dr2,
+			fwd, rev,
+		); err != nil {
+			return nil, err
+		}
+
+		fwd[dr1Norm] = dr2Norm
+		rev[dr2Norm] = dr1Norm
+	}
+
+	return &ExplicitMappings{
+		Forward: fwd,
+		Reverse: rev,
+	}, nil
+}
+
+// ---------------------------------------------------------------------------
+// CIDR resolver
+// ---------------------------------------------------------------------------
+
+func resolveCIDR(
+	blockIdx int,
+	rawCIDR map[string]string,
+	dr1, dr2 string,
+) (*CIDRMapping, error) {
+	dr1CIDR, dr2CIDR, err := validateCIDRKeys(blockIdx, rawCIDR, dr1, dr2)
+	if err != nil {
+		return nil, err
+	}
+
+	dr1Net, dr2Net, err := parseAndValidateCIDRs(
+		blockIdx,
+		dr1, dr2,
+		dr1CIDR, dr2CIDR,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CIDRMapping{
+		DR1CIDR: dr1CIDR,
+		DR2CIDR: dr2CIDR,
+		dr1Net:  dr1Net,
+		dr2Net:  dr2Net,
+	}, nil
+}
+
+func validateCIDRKeys(
+	blockIdx int,
+	rawCIDR map[string]string,
+	dr1, dr2 string,
+) (string, string, error) {
+	dr1CIDR, hasDR1 := rawCIDR[dr1]
+	if !hasDR1 {
+		return "", "", fmt.Errorf("networkMappings[%d]: cidr: missing cluster key %q", blockIdx, dr1)
+	}
+
+	dr2CIDR, hasDR2 := rawCIDR[dr2]
+	if !hasDR2 {
+		return "", "", fmt.Errorf("networkMappings[%d]: cidr: missing cluster key %q", blockIdx, dr2)
+	}
+
+	for k := range rawCIDR {
+		if k != dr1 && k != dr2 {
+			return "", "", fmt.Errorf("networkMappings[%d]: cidr: unrecognized key %q (expected %q or %q)",
+				blockIdx, k, dr1, dr2)
+		}
+	}
+
+	return dr1CIDR, dr2CIDR, nil
+}
+
+func parseAndValidateCIDRs(
+	blockIdx int,
+	dr1, dr2 string,
+	dr1CIDR, dr2CIDR string,
+) (*net.IPNet, *net.IPNet, error) {
+	_, dr1Net, err := net.ParseCIDR(dr1CIDR)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"networkMappings[%d]: cidr.%s: invalid CIDR %q: %w",
+			blockIdx, dr1, dr1CIDR, err,
+		)
+	}
+
+	_, dr2Net, err := net.ParseCIDR(dr2CIDR)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"networkMappings[%d]: cidr.%s: invalid CIDR %q: %w",
+			blockIdx, dr2, dr2CIDR, err,
+		)
+	}
+
+	if err := validateCIDRNetworks(
+		blockIdx,
+		dr1, dr2,
+		dr1CIDR, dr2CIDR,
+		dr1Net, dr2Net,
+	); err != nil {
+		return nil, nil, err
+	}
+
+	return dr1Net, dr2Net, nil
+}
+
+func validateCIDRNetworks(
+	blockIdx int,
+	dr1, dr2 string,
+	dr1CIDR, dr2CIDR string,
+	dr1Net, dr2Net *net.IPNet,
+) error {
+	dr1Ones, dr1Bits := dr1Net.Mask.Size()
+	dr2Ones, dr2Bits := dr2Net.Mask.Size()
+
+	if dr1Bits != dr2Bits {
+		return fmt.Errorf(
+			"networkMappings[%d]: cidr: %s and %s CIDRs have different address families",
+			blockIdx, dr1, dr2,
+		)
+	}
+
+	if dr1Ones != dr2Ones {
+		return fmt.Errorf(
+			"networkMappings[%d]: cidr: %s (/%d) and %s (/%d) have different prefix lengths; equal prefix lengths are required",
+			blockIdx, dr1, dr1Ones, dr2, dr2Ones,
+		)
+	}
+
+	if dr1Net.IP.To4() == nil || dr2Net.IP.To4() == nil {
+		return fmt.Errorf(
+			"networkMappings[%d]: cidr: only IPv4 CIDRs are supported (%s=%q, %s=%q)",
+			blockIdx, dr1, dr1CIDR, dr2, dr2CIDR,
+		)
+	}
+
+	if dr1Net.IP.Equal(dr2Net.IP) {
+		return fmt.Errorf(
+			"networkMappings[%d]: cidr: %s and %s are the same network (%s); source and destination subnets must differ",
+			blockIdx, dr1, dr2, dr1Net.String(),
+		)
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// regexMappings resolver
+// ---------------------------------------------------------------------------
+
+func resolveRegexMappings(
+	blockIdx int,
+	rawRegex map[string][]rawRegexRule,
+	fwdKey, revKey string,
+) (*RegexRules, error) {
+	for k := range rawRegex {
+		if k != fwdKey && k != revKey {
+			return nil, fmt.Errorf(
+				"networkMappings[%d]: regexMappings: unrecognized direction key %q (expected %q or %q)",
+				blockIdx, k, fwdKey, revKey)
+		}
+	}
+
+	fwdRaw, hasFwd := rawRegex[fwdKey]
+	revRaw, hasRev := rawRegex[revKey]
+
+	if !hasFwd || len(fwdRaw) == 0 {
+		return nil, fmt.Errorf(
+			"networkMappings[%d]: regexMappings[%q] is required and must have at least one rule",
+			blockIdx, fwdKey)
+	}
+
+	if !hasRev || len(revRaw) == 0 {
+		return nil, fmt.Errorf(
+			"networkMappings[%d]: regexMappings[%q] is required and must have at least one rule",
+			blockIdx, revKey)
+	}
+
+	fwd, err := compileRegexRules(blockIdx, fwdKey, fwdRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	rev, err := compileRegexRules(blockIdx, revKey, revRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RegexRules{Forward: fwd, Reverse: rev}, nil
+}
+
+func compileRegexRules(blockIdx int, dirKey string, raw []rawRegexRule) ([]CompiledRegexRule, error) {
+	rules := make([]CompiledRegexRule, 0, len(raw))
+
+	for j, r := range raw {
+		if r.Pattern == "" {
+			return nil, fmt.Errorf("networkMappings[%d]: regexMappings[%q][%d]: pattern is required",
+				blockIdx, dirKey, j)
+		}
+
+		if r.Replacement == "" {
+			return nil, fmt.Errorf("networkMappings[%d]: regexMappings[%q][%d]: replacement is required",
+				blockIdx, dirKey, j)
+		}
+
+		re, err := regexp.Compile(r.Pattern)
+		if err != nil {
+			return nil, fmt.Errorf("networkMappings[%d]: regexMappings[%q][%d]: invalid pattern %q: %w",
+				blockIdx, dirKey, j, r.Pattern, err)
+		}
+
+		rules = append(rules, CompiledRegexRule{compiled: re, Pattern: r.Pattern, Replacement: r.Replacement})
+	}
+
+	return rules, nil
+}
+
+// ---------------------------------------------------------------------------
+// Runtime lookup
+// ---------------------------------------------------------------------------
+
+// findBlock returns the NetworkMappingBlock for the given NAD, or nil.
+func findBlock(rules *NetworkMappingRules, nadRef NetworkRef) *NetworkMappingBlock {
+	for i := range rules.Blocks {
+		b := &rules.Blocks[i]
+		if b.NetworkRef.NADNamespace == nadRef.NADNamespace &&
+			b.NetworkRef.NADName == nadRef.NADName {
+			return b
+		}
+	}
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// translateIP — ordered dispatch: explicit → CIDR → regex
+// ---------------------------------------------------------------------------
+
+// translateIP translates srcIP for the NAD identified by nadRef.
+// Returns the translated IP and the RuleType that produced the result.
+func translateIP(
+	srcIP string,
+	rules *NetworkMappingRules,
+	dir TranslationDirection,
+	nadRef NetworkRef,
+) (string, RuleType, error) {
+	block := findBlock(rules, nadRef)
+	if block == nil {
+		return "", "", fmt.Errorf("no networkMapping block found for NAD %s/%s",
+			nadRef.NADNamespace, nadRef.NADName)
+	}
+
+	// Step 1: explicit mappings — most specific.
+	if block.ExplicitMappings != nil {
+		if result, ok := lookupExplicit(srcIP, block.ExplicitMappings, dir); ok {
+			return result, RuleTypeExplicit, nil
+		}
+	}
+
+	// Step 2: CIDR subnet-offset.
+	if block.CIDRMapping != nil {
+		if result, ok := applyCIDR(srcIP, block.CIDRMapping, dir); ok {
+			return result, RuleTypeCIDR, nil
+		}
+	}
+
+	// Step 3: regex fallback.
+	if block.RegexRules != nil {
+		result, err := applyRegexRules(srcIP, block.RegexRules, dir, rules.DR1, rules.DR2)
+		if err != nil {
+			return "", "", err
+		}
+
+		return result, RuleTypeRegex, nil
+	}
+
+	// No rule matched.
+	dirStr := rules.DR1 + "-to-" + rules.DR2
+	if dir == TranslationDirectionReverse {
+		dirStr = rules.DR2 + "-to-" + rules.DR1
+	}
+
+	return "", "", fmt.Errorf(
+		"no translation found for IP %q (NAD %s/%s, direction %s): "+
+			"no explicit match, not in CIDR range, no regex match",
+		srcIP, nadRef.NADNamespace, nadRef.NADName, dirStr)
+}
+
+// ---------------------------------------------------------------------------
+// Explicit lookup
+// ---------------------------------------------------------------------------
+
+// lookupExplicit performs an O(1) map lookup.
+// Forward: dr1IP → dr2IP.  Reverse: dr2IP → dr1IP.
+// Returns ("", false) on miss.
+func lookupExplicit(srcIP string, em *ExplicitMappings, dir TranslationDirection) (string, bool) {
+	norm := normalizeIP(srcIP)
+
+	if dir == TranslationDirectionForward {
+		result, ok := em.Forward[norm]
+
+		return result, ok
+	}
+
+	result, ok := em.Reverse[norm]
+
+	return result, ok
+}
+
+// ---------------------------------------------------------------------------
+// CIDR translation
+// ---------------------------------------------------------------------------
+
+// applyCIDR applies subnet-offset translation.
+// Forward: translates srcIP from dr1Net to dr2Net.
+// Reverse: translates srcIP from dr2Net to dr1Net.
+// Returns ("", false) when the IP is not in the relevant subnet.
+func applyCIDR(srcIP string, cm *CIDRMapping, dir TranslationDirection) (string, bool) {
+	ip := net.ParseIP(srcIP)
+	if ip == nil {
+		return "", false
+	}
+
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return "", false
+	}
+
+	var srcNet, dstNet *net.IPNet
+
+	if dir == TranslationDirectionForward {
+		srcNet, dstNet = cm.dr1Net, cm.dr2Net
+	} else {
+		srcNet, dstNet = cm.dr2Net, cm.dr1Net
+	}
+
+	if !srcNet.Contains(ip4) {
+		return "", false
+	}
+
+	srcNetAddr := ipToUint32(srcNet.IP.To4())
+	dstNetAddr := ipToUint32(dstNet.IP.To4())
+	hostOffset := ipToUint32(ip4) - srcNetAddr
+	dstIPAddr := dstNetAddr + hostOffset
+
+	result := uint32ToIP(dstIPAddr)
+
+	if !dstNet.Contains(result) {
+		// Host offset exceeds destination subnet — treat as miss.
+		return "", false
+	}
+
+	return result.String(), true
+}
+
+// ---------------------------------------------------------------------------
+// Regex translation
+// ---------------------------------------------------------------------------
+
+// applyRegexRules applies the ordered list of rules for the given direction.
+// The first matching rule wins.  Returns an error if no rule matches.
+func applyRegexRules(srcIP string, rr *RegexRules, dir TranslationDirection, dr1, dr2 string) (string, error) {
+	rules := rr.Forward
+	dirStr := dr1 + "-to-" + dr2
+
+	if dir == TranslationDirectionReverse {
+		rules = rr.Reverse
+		dirStr = dr2 + "-to-" + dr1
+	}
+
+	for _, rule := range rules {
+		if !rule.compiled.MatchString(srcIP) {
+			continue
+		}
+
+		result := rule.compiled.ReplaceAllString(srcIP, rule.Replacement)
+
+		if net.ParseIP(result) == nil {
+			return "", fmt.Errorf("regex pattern %q applied to IP %q produced invalid IP %q",
+				rule.Pattern, srcIP, result)
+		}
+
+		return result, nil
+	}
+
+	return "", fmt.Errorf("no %s regex rule matched IP %q", dirStr, srcIP)
+}
+
+// ---------------------------------------------------------------------------
+// IP normalization
+// ---------------------------------------------------------------------------
+
+// normalizeIP returns the canonical dotted-decimal form of an IPv4 address.
+// Returns the original string unchanged if parsing or To4 conversion fails.
+func normalizeIP(ip string) string {
+	if parsed := net.ParseIP(ip); parsed != nil {
+		if v4 := parsed.To4(); v4 != nil {
+			return v4.String()
+		}
+	}
+
+	return ip
+}
+
+// directionFromCluster converts a source cluster name to a TranslationDirection.
+// Forward = sourceCluster is dr1 (failover: dr1→dr2).
+// Reverse = sourceCluster is dr2 (failback: dr2→dr1).
+// Returns an error if sourceCluster matches neither.
+func directionFromCluster(sourceCluster, dr1, dr2 string) (TranslationDirection, error) {
+	switch sourceCluster {
+	case dr1:
+		return TranslationDirectionForward, nil
+	case dr2:
+		return TranslationDirectionReverse, nil
+	default:
+		return TranslationDirectionForward, fmt.Errorf(
+			"sourceCluster %q is not a member of this DRPolicy (dr1=%q, dr2=%q)",
+			sourceCluster, dr1, dr2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DRPCInstance methods
+// ---------------------------------------------------------------------------
+
+// translateSourceIP translates srcIP using the source cluster name to
+// determine direction (Forward = sourceCluster is dr1; Reverse = dr2).
+//
+// nadRef identifies which NetworkMapping block to use.
+// On any failure the error is logged and srcIP is returned unchanged so
+// that DR orchestration is never blocked by mapping errors.
+func (d *DRPCInstance) translateSourceIP(srcIP, sourceCluster string, nadRef NetworkRef) string {
+	if d.networkMappingRules == nil {
+		return srcIP
+	}
+
+	dir, err := directionFromCluster(sourceCluster, d.networkMappingRules.DR1, d.networkMappingRules.DR2)
+	if err != nil {
+		d.log.Error(err, "IP translation failed; using source IP unchanged",
+			"sourceIP", srcIP,
+			"nad", nadRef.NADNamespace+"/"+nadRef.NADName)
+
+		return srcIP
+	}
+
+	targetIP, ruleType, err := translateIP(srcIP, d.networkMappingRules, dir, nadRef)
+	if err != nil {
+		d.log.Error(err, "IP translation failed; using source IP unchanged",
+			"sourceIP", srcIP,
+			"nad", nadRef.NADNamespace+"/"+nadRef.NADName)
+
+		return srcIP
+	}
+
+	d.log.V(1).Info("Translated IP",
+		"network", nadRef.NADNamespace+"/"+nadRef.NADName,
+		"sourceCluster", sourceCluster,
+		"inputIP", srcIP,
+		"ruleType", ruleType,
+		"outputIP", targetIP)
+
+	return targetIP
+}
+
+// ---------------------------------------------------------------------------
+// translateSubnet — arithmetic helper (used by tests)
+// ---------------------------------------------------------------------------
+
+// translateSubnet translates srcIP from srcCIDR into the equivalent address in
+// dstCIDR by preserving the host offset within the source subnet.
+//
+// Both CIDRs must have equal prefix lengths.
+// When preserveHostPart is false the first usable host in dstCIDR is returned.
+func translateSubnet(srcIP, srcCIDR, dstCIDR string, preserveHostPart bool) (string, error) {
+	ip := net.ParseIP(srcIP)
+	if ip == nil {
+		return "", fmt.Errorf("invalid source IP %q", srcIP)
+	}
+
+	ip = ip.To4()
+	if ip == nil {
+		return "", fmt.Errorf("only IPv4 is supported (got %q)", srcIP)
+	}
+
+	_, srcNet, err := net.ParseCIDR(srcCIDR)
+	if err != nil {
+		return "", fmt.Errorf("invalid source CIDR %q: %w", srcCIDR, err)
+	}
+
+	_, dstNet, err := net.ParseCIDR(dstCIDR)
+	if err != nil {
+		return "", fmt.Errorf("invalid destination CIDR %q: %w", dstCIDR, err)
+	}
+
+	if !srcNet.Contains(ip) {
+		return "", fmt.Errorf("source IP %q is not within source CIDR %q", srcIP, srcCIDR)
+	}
+
+	srcOnes, srcBits := srcNet.Mask.Size()
+	dstOnes, dstBits := dstNet.Mask.Size()
+
+	if srcBits != dstBits {
+		return "", fmt.Errorf("source and destination CIDRs have different address families")
+	}
+
+	if srcOnes != dstOnes {
+		return "", fmt.Errorf(
+			"source CIDR /%d and destination CIDR /%d have different prefix lengths; "+
+				"equal prefix lengths are required for subnet-based host-offset translation",
+			srcOnes, dstOnes)
+	}
+
+	if !preserveHostPart {
+		dstAddr := ipToUint32(dstNet.IP.To4())
+
+		return uint32ToIP(dstAddr + 1).String(), nil
+	}
+
+	srcNetAddr := ipToUint32(srcNet.IP.To4())
+	srcIPAddr := ipToUint32(ip)
+	hostOffset := srcIPAddr - srcNetAddr
+
+	dstNetAddr := ipToUint32(dstNet.IP.To4())
+	dstIPAddr := dstNetAddr + hostOffset
+
+	result := uint32ToIP(dstIPAddr)
+	if !dstNet.Contains(result) {
+		return "", fmt.Errorf(
+			"translated IP %s (offset %d) is outside destination CIDR %q",
+			result, hostOffset, dstCIDR)
+	}
+
+	return result.String(), nil
+}
+
+// ---------------------------------------------------------------------------
+// Internal arithmetic helpers
+// ---------------------------------------------------------------------------
+
+func ipToUint32(ip net.IP) uint32 {
+	return binary.BigEndian.Uint32(ip)
+}
+
+const ipv4Len = 4
+
+func uint32ToIP(n uint32) net.IP {
+	b := make([]byte, ipv4Len)
+	binary.BigEndian.PutUint32(b, n)
+
+	return net.IP(b)
+}
+
+func extractClusterIPs(
+	blockIdx, rowIdx int,
+	pair rawClusterIPPair,
+	dr1, dr2 string,
+) (string, string, error) {
+	dr1IP, hasDR1 := pair[dr1]
+	if !hasDR1 {
+		return "", "", fmt.Errorf(
+			"networkMappings[%d]: explicitMappings[%d]: missing cluster key %q",
+			blockIdx, rowIdx, dr1,
+		)
+	}
+
+	dr2IP, hasDR2 := pair[dr2]
+	if !hasDR2 {
+		return "", "", fmt.Errorf(
+			"networkMappings[%d]: explicitMappings[%d]: missing cluster key %q",
+			blockIdx, rowIdx, dr2,
+		)
+	}
+
+	for k := range pair {
+		if k != dr1 && k != dr2 {
+			return "", "", fmt.Errorf(
+				"networkMappings[%d]: explicitMappings[%d]: unrecognized key %q (expected %q or %q)",
+				blockIdx, rowIdx, k, dr1, dr2,
+			)
+		}
+	}
+
+	return dr1IP, dr2IP, nil
+}
+
+func normalizeExplicitIPs(
+	blockIdx, rowIdx int,
+	dr1, dr2 string,
+	dr1IP, dr2IP string,
+) (string, string, error) {
+	dr1IP4 := net.ParseIP(dr1IP).To4()
+	if dr1IP4 == nil {
+		return "", "", fmt.Errorf(
+			"networkMappings[%d]: explicitMappings[%d]: invalid or non-IPv4 %s address %q",
+			blockIdx, rowIdx, dr1, dr1IP,
+		)
+	}
+
+	dr2IP4 := net.ParseIP(dr2IP).To4()
+	if dr2IP4 == nil {
+		return "", "", fmt.Errorf(
+			"networkMappings[%d]: explicitMappings[%d]: invalid or non-IPv4 %s address %q",
+			blockIdx, rowIdx, dr2, dr2IP,
+		)
+	}
+
+	dr1Norm := dr1IP4.String()
+	dr2Norm := dr2IP4.String()
+
+	if dr1Norm == dr2Norm {
+		return "", "", fmt.Errorf(
+			"networkMappings[%d]: explicitMappings[%d]: %s and %s IP are the same (%q); direction ambiguous",
+			blockIdx, rowIdx,
+			dr1, dr2,
+			dr1Norm,
+		)
+	}
+
+	return dr1Norm, dr2Norm, nil
+}
+
+func validateExplicitMappingCollision(
+	blockIdx, rowIdx int,
+	dr1Norm, dr2Norm string,
+	dr1, dr2 string,
+	fwd, rev map[string]string,
+) error {
+	if prev, dup := fwd[dr1Norm]; dup {
+		return fmt.Errorf(
+			"networkMappings[%d]: explicitMappings[%d]: duplicate %s IP %q (already maps to %q)",
+			blockIdx, rowIdx,
+			dr1,
+			dr1Norm,
+			prev,
+		)
+	}
+
+	if prev, dup := rev[dr2Norm]; dup {
+		return fmt.Errorf(
+			"networkMappings[%d]: explicitMappings[%d]: duplicate %s IP %q (already maps to %q)",
+			blockIdx, rowIdx,
+			dr2,
+			dr2Norm,
+			prev,
+		)
+	}
+
+	if _, collision := rev[dr1Norm]; collision {
+		return fmt.Errorf(
+			"networkMappings[%d]: explicitMappings[%d]: IP %q appears as both a %s IP and a %s IP; direction would be ambiguous",
+			blockIdx,
+			rowIdx,
+			dr1Norm,
+			dr1,
+			dr2,
+		)
+	}
+
+	if _, collision := fwd[dr2Norm]; collision {
+		return fmt.Errorf(
+			"networkMappings[%d]: explicitMappings[%d]: IP %q appears as both a %s IP and a %s IP; direction would be ambiguous",
+			blockIdx,
+			rowIdx,
+			dr2Norm,
+			dr2,
+			dr1,
+		)
+	}
+
+	return nil
+}

--- a/internal/controller/drpc_networkmapping_test.go
+++ b/internal/controller/drpc_networkmapping_test.go
@@ -1,0 +1,1513 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers //nolint:testpackage
+
+// Unit tests for drpc_networkmapping.go (schema v1).
+//
+// Rule types tested:
+//   explicitMappings — per-VM exact IP overrides, O(1) map lookup
+//   cidr             — subnet-offset translation (bidirectional)
+//   regexMappings    — directional regex fallback (lowest priority)
+//
+// Direction is always derived from the source cluster name, never inferred
+// from the IP value.
+//
+// Run with: go test ./internal/controller/ -run 'TestNM|TestTranslate'
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	rmn "github.com/ramendr/ramen/api/v1alpha1"
+)
+
+// ---------------------------------------------------------------------------
+// Shared constants
+// ---------------------------------------------------------------------------
+
+const (
+	testDR1 = "east-cluster"
+	testDR2 = "west-cluster"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func makeCM(yaml string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "nm", Namespace: "ns"},
+		Data:       map[string]string{"mappings.yaml": yaml},
+	}
+}
+
+// mustParse parses yaml with testDR1/testDR2 and fails the test on error.
+func mustParse(t *testing.T, yaml string) *NetworkMappingRules {
+	t.Helper()
+
+	rules, err := ParseNetworkMappingConfigMap(makeCM(yaml), testDR1, testDR2)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	return rules
+}
+
+// mustParseErr parses yaml and returns the error (nil means parse succeeded).
+func mustParseErr(t *testing.T, yaml string) error {
+	t.Helper()
+
+	_, err := ParseNetworkMappingConfigMap(makeCM(yaml), testDR1, testDR2)
+
+	return err
+}
+
+func nadRef(name string) NetworkRef {
+	return NetworkRef{NADNamespace: "default", NADName: name}
+}
+
+// newDRPCInstanceForTest builds the minimal DRPCInstance needed for
+// translateSourceIP tests.
+func newDRPCInstanceForTest(rules *NetworkMappingRules) *DRPCInstance {
+	return &DRPCInstance{
+		reconciler:          &DRPlacementControlReconciler{},
+		log:                 logr.Discard(),
+		instance:            &rmn.DRPlacementControl{},
+		networkMappingRules: rules,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// translateSubnet helper — unchanged across schema versions
+// ---------------------------------------------------------------------------
+
+func TestTranslateSubnet_PreserveHostPart(t *testing.T) {
+	tests := []struct {
+		name     string
+		srcIP    string
+		srcCIDR  string
+		dstCIDR  string
+		preserve bool
+		want     string
+		wantErr  bool
+	}{
+		{"/24 offset", "192.168.10.25", "192.168.10.0/24", "10.40.0.0/24", true, "10.40.0.25", false},
+		{"/16 offset", "10.100.1.200", "10.100.0.0/16", "10.200.0.0/16", true, "10.200.1.200", false},
+		{"gateway", "192.168.10.1", "192.168.10.0/24", "10.40.0.0/24", true, "10.40.0.1", false},
+		{"no preserve", "192.168.10.25", "192.168.10.0/24", "10.40.0.0/24", false, "10.40.0.1", false},
+		{"bad ip", "not-an-ip", "192.168.10.0/24", "10.40.0.0/24", true, "", true},
+		{"out of cidr", "192.168.20.5", "192.168.10.0/24", "10.40.0.0/24", true, "", true},
+		{"prefix mismatch", "192.168.10.1", "192.168.10.0/24", "10.0.0.0/16", true, "", true},
+		{"network addr", "192.168.10.0", "192.168.10.0/24", "10.40.0.0/24", true, "10.40.0.0", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := translateSubnet(tc.srcIP, tc.srcCIDR, tc.dstCIDR, tc.preserve)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil (result=%q)", got)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// directionFromCluster
+// ---------------------------------------------------------------------------
+
+func TestDirectionFromCluster_DR1(t *testing.T) {
+	dir, err := directionFromCluster(testDR1, testDR1, testDR2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if dir != TranslationDirectionForward {
+		t.Errorf("dr1 source → Forward, got %v", dir)
+	}
+}
+
+func TestDirectionFromCluster_DR2(t *testing.T) {
+	dir, err := directionFromCluster(testDR2, testDR1, testDR2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if dir != TranslationDirectionReverse {
+		t.Errorf("dr2 source → Reverse, got %v", dir)
+	}
+}
+
+func TestDirectionFromCluster_Unknown(t *testing.T) {
+	_, err := directionFromCluster("other-cluster", testDR1, testDR2)
+	if err == nil {
+		t.Error("expected error for unknown source cluster")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// YAML fixtures — schema v1
+// ---------------------------------------------------------------------------
+
+// cidrOnlyYAML — single NAD with only a CIDR block.
+const cidrOnlyYAML = `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName:      storage
+    cidr:
+      east-cluster: 192.168.100.0/24
+      west-cluster: 192.168.120.0/24
+`
+
+// explicitOnlyYAML — single NAD with only explicit mappings.
+const explicitOnlyYAML = `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName:      backup
+    explicitMappings:
+      - east-cluster: "192.168.100.10"
+        west-cluster: "192.168.120.10"
+      - east-cluster: "192.168.100.20"
+        west-cluster: "192.168.120.20"
+`
+
+// regexOnlyYAML — single NAD with only regex mappings.
+const regexOnlyYAML = `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName:      mgmt
+    regexMappings:
+      east-cluster-to-west-cluster:
+        - pattern:     "^172\\.16\\.100\\.(\\d+)$"
+          replacement: "10.20.30.$1"
+      west-cluster-to-east-cluster:
+        - pattern:     "^10\\.20\\.30\\.(\\d+)$"
+          replacement: "172.16.100.$1"
+`
+
+// allThreeYAML — single NAD with all three rule types: explicit + cidr + regex.
+// 192.168.100.51 (explicit) takes priority over the CIDR range it sits in.
+const allThreeYAML = `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName:      backup
+    cidr:
+      east-cluster: 192.168.100.0/24
+      west-cluster: 192.168.110.0/24
+    explicitMappings:
+      - east-cluster: "192.168.100.10"
+        west-cluster: "192.168.110.10"
+      - east-cluster: "192.168.100.51"
+        west-cluster: "192.168.110.58"
+    regexMappings:
+      east-cluster-to-west-cluster:
+        - pattern:     "^172\\.16\\.100\\.(\\d+)$"
+          replacement: "10.20.30.$1"
+      west-cluster-to-east-cluster:
+        - pattern:     "^10\\.20\\.30\\.(\\d+)$"
+          replacement: "172.16.100.$1"
+`
+
+// twoBlockYAML — two NADs with different rule types.
+const twoBlockYAML = `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName:      storage
+    cidr:
+      east-cluster: 192.168.100.0/24
+      west-cluster: 192.168.120.0/24
+
+  - networkRef:
+      nadNamespace: default
+      nadName:      backup
+    explicitMappings:
+      - east-cluster: "10.0.0.1"
+        west-cluster: "10.0.1.1"
+`
+
+// ---------------------------------------------------------------------------
+// Parse tests — structure validation
+// ---------------------------------------------------------------------------
+
+func TestNMParse_CIDRBlock(t *testing.T) {
+	rules := mustParse(t, cidrOnlyYAML)
+
+	if len(rules.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(rules.Blocks))
+	}
+
+	b := rules.Blocks[0]
+
+	if b.NetworkRef.NADNamespace != "default" || b.NetworkRef.NADName != "storage" {
+		t.Errorf("unexpected networkRef: %+v", b.NetworkRef)
+	}
+
+	if b.CIDRMapping == nil {
+		t.Fatal("CIDRMapping is nil")
+	}
+
+	if b.CIDRMapping.DR1CIDR != "192.168.100.0/24" {
+		t.Errorf("DR1CIDR = %q", b.CIDRMapping.DR1CIDR)
+	}
+
+	if b.CIDRMapping.DR2CIDR != "192.168.120.0/24" {
+		t.Errorf("DR2CIDR = %q", b.CIDRMapping.DR2CIDR)
+	}
+
+	if b.ExplicitMappings != nil {
+		t.Error("ExplicitMappings should be nil for a cidr-only block")
+	}
+
+	if b.RegexRules != nil {
+		t.Error("RegexRules should be nil for a cidr-only block")
+	}
+}
+
+func TestNMParse_ExplicitBlock(t *testing.T) {
+	rules := mustParse(t, explicitOnlyYAML)
+
+	if len(rules.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(rules.Blocks))
+	}
+
+	b := rules.Blocks[0]
+
+	if b.NetworkRef.NADName != "backup" {
+		t.Errorf("unexpected NAD name: %q", b.NetworkRef.NADName)
+	}
+
+	if b.ExplicitMappings == nil {
+		t.Fatal("ExplicitMappings is nil")
+	}
+
+	if len(b.ExplicitMappings.Forward) != 2 {
+		t.Errorf("expected 2 forward entries, got %d", len(b.ExplicitMappings.Forward))
+	}
+
+	if b.ExplicitMappings.Forward["192.168.100.10"] != "192.168.120.10" {
+		t.Errorf("forward[192.168.100.10] = %q", b.ExplicitMappings.Forward["192.168.100.10"])
+	}
+
+	if b.ExplicitMappings.Reverse["192.168.120.10"] != "192.168.100.10" {
+		t.Errorf("reverse[192.168.120.10] = %q", b.ExplicitMappings.Reverse["192.168.120.10"])
+	}
+
+	if b.CIDRMapping != nil {
+		t.Error("CIDRMapping should be nil for an explicit-only block")
+	}
+
+	if b.RegexRules != nil {
+		t.Error("RegexRules should be nil for an explicit-only block")
+	}
+}
+
+func TestNMParse_RegexBlock(t *testing.T) {
+	rules := mustParse(t, regexOnlyYAML)
+
+	if len(rules.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(rules.Blocks))
+	}
+
+	b := rules.Blocks[0]
+
+	if b.NetworkRef.NADName != "mgmt" {
+		t.Errorf("unexpected NAD name: %q", b.NetworkRef.NADName)
+	}
+
+	if b.RegexRules == nil {
+		t.Fatal("RegexRules is nil")
+	}
+
+	if len(b.RegexRules.Forward) != 1 {
+		t.Errorf("expected 1 forward rule, got %d", len(b.RegexRules.Forward))
+	}
+
+	if len(b.RegexRules.Reverse) != 1 {
+		t.Errorf("expected 1 reverse rule, got %d", len(b.RegexRules.Reverse))
+	}
+
+	if b.RegexRules.Forward[0].Pattern != `^172\.16\.100\.(\d+)$` {
+		t.Errorf("forward pattern = %q", b.RegexRules.Forward[0].Pattern)
+	}
+
+	if b.RegexRules.Forward[0].Replacement != "10.20.30.$1" {
+		t.Errorf("forward replacement = %q", b.RegexRules.Forward[0].Replacement)
+	}
+
+	if b.CIDRMapping != nil {
+		t.Error("CIDRMapping should be nil for a regex-only block")
+	}
+
+	if b.ExplicitMappings != nil {
+		t.Error("ExplicitMappings should be nil for a regex-only block")
+	}
+}
+
+func TestNMParse_AllThreeRuleTypes(t *testing.T) {
+	rules := mustParse(t, allThreeYAML)
+
+	if len(rules.Blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(rules.Blocks))
+	}
+
+	b := rules.Blocks[0]
+
+	if b.ExplicitMappings == nil || len(b.ExplicitMappings.Forward) != 2 {
+		t.Errorf("expected 2 explicit mappings")
+	}
+
+	if b.CIDRMapping == nil {
+		t.Error("CIDRMapping should be non-nil")
+	}
+
+	if b.RegexRules == nil {
+		t.Error("RegexRules should be non-nil")
+	}
+}
+
+func TestNMParse_TwoBlocks(t *testing.T) {
+	rules := mustParse(t, twoBlockYAML)
+
+	if len(rules.Blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(rules.Blocks))
+	}
+
+	if rules.Blocks[0].NetworkRef.NADName != "storage" {
+		t.Errorf("block[0] NAD = %q", rules.Blocks[0].NetworkRef.NADName)
+	}
+
+	if rules.Blocks[1].NetworkRef.NADName != "backup" {
+		t.Errorf("block[1] NAD = %q", rules.Blocks[1].NetworkRef.NADName)
+	}
+}
+
+func TestNMParse_ClusterNamesStoredInRules(t *testing.T) {
+	rules := mustParse(t, cidrOnlyYAML)
+
+	if rules.DR1 != testDR1 {
+		t.Errorf("DR1 = %q, want %q", rules.DR1, testDR1)
+	}
+
+	if rules.DR2 != testDR2 {
+		t.Errorf("DR2 = %q, want %q", rules.DR2, testDR2)
+	}
+}
+
+func TestNMParse_VersionStoredInRules(t *testing.T) {
+	rules := mustParse(t, cidrOnlyYAML)
+
+	if rules.Version != "v1" {
+		t.Errorf("Version = %q, want \"v1\"", rules.Version)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Version validation tests
+// ---------------------------------------------------------------------------
+
+func TestNMParse_Version_Missing(t *testing.T) {
+	yaml := `
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: storage
+    cidr:
+      east-cluster: 192.168.100.0/24
+      west-cluster: 192.168.110.0/24
+`
+
+	if err := mustParseErr(t, yaml); err == nil {
+		t.Error("expected error when version field is absent")
+	}
+}
+
+func TestNMParse_Version_Empty(t *testing.T) {
+	yaml := `
+version: ""
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: storage
+    cidr:
+      east-cluster: 192.168.100.0/24
+      west-cluster: 192.168.110.0/24
+`
+
+	if err := mustParseErr(t, yaml); err == nil {
+		t.Error("expected error when version field is empty string")
+	}
+}
+
+func TestNMParse_Version_Unsupported(t *testing.T) {
+	yaml := `
+version: "v2"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: storage
+    cidr:
+      east-cluster: 192.168.100.0/24
+      west-cluster: 192.168.110.0/24
+`
+
+	if err := mustParseErr(t, yaml); err == nil {
+		t.Error("expected error for unsupported schema version")
+	}
+}
+
+func TestNMParse_Version_V1Accepted(t *testing.T) {
+	// Explicit sanity check: v1 must parse without error and version must be
+	// propagated into the returned rules.
+	rules := mustParse(t, cidrOnlyYAML)
+
+	if rules.Version != "v1" {
+		t.Errorf("expected Version \"v1\", got %q", rules.Version)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Parse error tests — missing data key and cluster name validation
+// ---------------------------------------------------------------------------
+
+func TestNMParse_MissingDataKey(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "nm", Namespace: "ns"},
+		Data:       map[string]string{"wrong-key": "x"},
+	}
+
+	_, err := ParseNetworkMappingConfigMap(cm, testDR1, testDR2)
+	if err == nil {
+		t.Error("expected error for missing mappings.yaml key")
+	}
+}
+
+func TestNMParse_EmptyClusterName(t *testing.T) {
+	_, err := ParseNetworkMappingConfigMap(makeCM(cidrOnlyYAML), "", testDR2)
+	if err == nil {
+		t.Error("expected error for empty dr1 cluster name")
+	}
+}
+
+func TestNMParse_SameClusterName(t *testing.T) {
+	_, err := ParseNetworkMappingConfigMap(makeCM(cidrOnlyYAML), "same", "same")
+	if err == nil {
+		t.Error("expected error when dr1 == dr2")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validation error tests — networkRef
+// ---------------------------------------------------------------------------
+
+func TestNMValidation_EmptyList(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings: []`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for empty networkMappings list")
+	}
+
+	if !strings.Contains(err.Error(), "networkMappings list must not be empty") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_MissingNADNamespace(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadName: backup
+    cidr:
+      east-cluster: 192.168.100.0/24
+      west-cluster: 192.168.110.0/24
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for missing nadNamespace")
+	}
+
+	if !strings.Contains(err.Error(), "nadNamespace is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_MissingNADName(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+    cidr:
+      east-cluster: 192.168.100.0/24
+      west-cluster: 192.168.110.0/24
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for missing nadName")
+	}
+
+	if !strings.Contains(err.Error(), "nadName is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_DuplicateNetworkRef(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: backup
+    cidr:
+      east-cluster: 192.168.100.0/24
+      west-cluster: 192.168.110.0/24
+  - networkRef:
+      nadNamespace: default
+      nadName: backup
+    cidr:
+      east-cluster: 10.0.0.0/24
+      west-cluster: 10.0.1.0/24
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for duplicate networkRef")
+	}
+
+	if !strings.Contains(err.Error(), "duplicate networkRef") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_NoRuleType(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: backup
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error when no cidr/explicitMappings/regexMappings present")
+	}
+
+	if !strings.Contains(err.Error(), "at least one of cidr, explicitMappings, or regexMappings is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validation error tests — cidr section
+// ---------------------------------------------------------------------------
+
+func TestNMValidation_CIDR_MissingDR1Key(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: storage
+    cidr:
+      west-cluster: 192.168.110.0/24
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for missing dr1 key in cidr")
+	}
+
+	if !strings.Contains(err.Error(), "missing cluster key") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_CIDR_MissingDR2Key(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: storage
+    cidr:
+      east-cluster: 192.168.100.0/24
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for missing dr2 key in cidr")
+	}
+
+	if !strings.Contains(err.Error(), "missing cluster key") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_CIDR_UnknownKey(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: storage
+    cidr:
+      east-cluster: 192.168.100.0/24
+      west-cluster: 192.168.110.0/24
+      unknown-cluster: 10.0.0.0/24
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for unrecognized key in cidr")
+	}
+
+	if !strings.Contains(err.Error(), "unrecognized key") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_CIDR_InvalidCIDR(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: storage
+    cidr:
+      east-cluster: not-a-cidr
+      west-cluster: 192.168.110.0/24
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for invalid CIDR")
+	}
+
+	if !strings.Contains(err.Error(), "invalid CIDR") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_CIDR_PrefixMismatch(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: storage
+    cidr:
+      east-cluster: 192.168.100.0/24
+      west-cluster: 192.168.0.0/16
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for mismatched prefix lengths")
+	}
+
+	if !strings.Contains(err.Error(), "different prefix lengths") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_CIDR_IdenticalNetworks(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: storage
+    cidr:
+      east-cluster: 192.168.100.0/24
+      west-cluster: 192.168.100.0/24
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error when dr1 and dr2 CIDR are the same network")
+	}
+
+	if !strings.Contains(err.Error(), "same network") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validation error tests — explicitMappings section
+// ---------------------------------------------------------------------------
+
+func TestNMValidation_Explicit_MissingDR1Key(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: backup
+    explicitMappings:
+      - west-cluster: "192.168.110.10"
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for missing dr1 key in explicitMappings")
+	}
+
+	if !strings.Contains(err.Error(), "missing cluster key") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_Explicit_InvalidIP(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: backup
+    explicitMappings:
+      - east-cluster: "not-an-ip"
+        west-cluster: "192.168.110.10"
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for invalid IP in explicitMappings")
+	}
+
+	if !strings.Contains(err.Error(), "non-IPv4") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_Explicit_IPv6Rejected(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: backup
+    explicitMappings:
+      - east-cluster: "2001:db8::1"
+        west-cluster: "192.168.110.10"
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for IPv6 address in explicitMappings")
+	}
+
+	if !strings.Contains(err.Error(), "non-IPv4") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_Explicit_SameIPBothColumns(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: backup
+    explicitMappings:
+      - east-cluster: "192.168.100.10"
+        west-cluster: "192.168.100.10"
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error when dr1 IP == dr2 IP (direction ambiguous)")
+	}
+
+	if !strings.Contains(err.Error(), "direction ambiguous") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_Explicit_DuplicateDR1IP(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: backup
+    explicitMappings:
+      - east-cluster: "192.168.100.10"
+        west-cluster: "192.168.110.10"
+      - east-cluster: "192.168.100.10"
+        west-cluster: "192.168.110.20"
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for duplicate dr1 IP in explicitMappings")
+	}
+
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_Explicit_DuplicateDR2IP(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: backup
+    explicitMappings:
+      - east-cluster: "192.168.100.10"
+        west-cluster: "192.168.110.10"
+      - east-cluster: "192.168.100.20"
+        west-cluster: "192.168.110.10"
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for duplicate dr2 IP in explicitMappings")
+	}
+
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_Explicit_UnknownKey(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: backup
+    explicitMappings:
+      - east-cluster: "192.168.100.10"
+        west-cluster: "192.168.110.10"
+        unknown-cluster: "10.0.0.1"
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for unrecognized key in explicitMappings row")
+	}
+
+	if !strings.Contains(err.Error(), "unrecognized key") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validation error tests — regexMappings section
+// ---------------------------------------------------------------------------
+
+func TestNMValidation_Regex_MissingForwardKey(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: mgmt
+    regexMappings:
+      west-cluster-to-east-cluster:
+        - pattern:     "^10\\.20\\.30\\.(\\d+)$"
+          replacement: "172.16.100.$1"
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for missing forward direction key in regexMappings")
+	}
+
+	if !strings.Contains(err.Error(), "is required and must have at least one rule") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_Regex_MissingReverseKey(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: mgmt
+    regexMappings:
+      east-cluster-to-west-cluster:
+        - pattern:     "^172\\.16\\.100\\.(\\d+)$"
+          replacement: "10.20.30.$1"
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for missing reverse direction key in regexMappings")
+	}
+}
+
+func TestNMValidation_Regex_UnknownDirectionKey(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: mgmt
+    regexMappings:
+      east-cluster-to-west-cluster:
+        - pattern:     "^172\\.16\\.100\\.(\\d+)$"
+          replacement: "10.20.30.$1"
+      west-cluster-to-east-cluster:
+        - pattern:     "^10\\.20\\.30\\.(\\d+)$"
+          replacement: "172.16.100.$1"
+      unknown-to-unknown:
+        - pattern:     "^1\\.2\\.3\\.(\\d+)$"
+          replacement: "4.5.6.$1"
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for unrecognized direction key in regexMappings")
+	}
+
+	if !strings.Contains(err.Error(), "unrecognized direction key") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_Regex_InvalidPattern(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: mgmt
+    regexMappings:
+      east-cluster-to-west-cluster:
+        - pattern:     "["
+          replacement: "10.20.30.$1"
+      west-cluster-to-east-cluster:
+        - pattern:     "^10\\.20\\.30\\.(\\d+)$"
+          replacement: "172.16.100.$1"
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for invalid regex pattern")
+	}
+
+	if !strings.Contains(err.Error(), "invalid pattern") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_Regex_MissingPattern(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: mgmt
+    regexMappings:
+      east-cluster-to-west-cluster:
+        - replacement: "10.20.30.$1"
+      west-cluster-to-east-cluster:
+        - pattern:     "^10\\.20\\.30\\.(\\d+)$"
+          replacement: "172.16.100.$1"
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for missing pattern field in regex rule")
+	}
+
+	if !strings.Contains(err.Error(), "pattern is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNMValidation_Regex_MissingReplacement(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: mgmt
+    regexMappings:
+      east-cluster-to-west-cluster:
+        - pattern: "^172\\.16\\.100\\.(\\d+)$"
+      west-cluster-to-east-cluster:
+        - pattern:     "^10\\.20\\.30\\.(\\d+)$"
+          replacement: "172.16.100.$1"
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for missing replacement field in regex rule")
+	}
+
+	if !strings.Contains(err.Error(), "replacement is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CIDR: IPv4-only validation
+// ---------------------------------------------------------------------------
+
+func TestNMValidation_CIDR_IPv6Rejected(t *testing.T) {
+	yaml := `
+version: "v1"
+networkMappings:
+  - networkRef:
+      nadNamespace: default
+      nadName: storage
+    cidr:
+      east-cluster: "2001:db8::/64"
+      west-cluster: "2001:db8:1::/64"
+`
+
+	err := mustParseErr(t, yaml)
+	if err == nil {
+		t.Fatal("expected error for IPv6 CIDRs")
+	}
+
+	if !strings.Contains(err.Error(), "only IPv4") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Translation: CIDR block
+// ---------------------------------------------------------------------------
+
+func TestNMTranslate_CIDR_Forward(t *testing.T) {
+	rules := mustParse(t, cidrOnlyYAML)
+	ref := nadRef("storage")
+
+	got, ruleType, err := translateIP("192.168.100.51", rules, TranslationDirectionForward, ref)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "192.168.120.51" {
+		t.Errorf("got %q, want 192.168.120.51", got)
+	}
+
+	if ruleType != RuleTypeCIDR {
+		t.Errorf("ruleType = %q, want CIDR", ruleType)
+	}
+}
+
+func TestNMTranslate_CIDR_Reverse(t *testing.T) {
+	rules := mustParse(t, cidrOnlyYAML)
+	ref := nadRef("storage")
+
+	got, ruleType, err := translateIP("192.168.120.51", rules, TranslationDirectionReverse, ref)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "192.168.100.51" {
+		t.Errorf("got %q, want 192.168.100.51", got)
+	}
+
+	if ruleType != RuleTypeCIDR {
+		t.Errorf("ruleType = %q, want CIDR", ruleType)
+	}
+}
+
+func TestNMTranslate_CIDR_IPNotInSubnet(t *testing.T) {
+	rules := mustParse(t, cidrOnlyYAML)
+	ref := nadRef("storage")
+
+	_, _, err := translateIP("10.0.0.1", rules, TranslationDirectionForward, ref)
+	if err == nil {
+		t.Error("expected error for IP outside CIDR range")
+	}
+}
+
+func TestNMTranslate_CIDR_Roundtrip(t *testing.T) {
+	rules := mustParse(t, cidrOnlyYAML)
+	ref := nadRef("storage")
+
+	for _, srcIP := range []string{"192.168.100.1", "192.168.100.100", "192.168.100.254"} {
+		translated, _, err := translateIP(srcIP, rules, TranslationDirectionForward, ref)
+		if err != nil {
+			t.Fatalf("%s forward: %v", srcIP, err)
+		}
+
+		restored, _, err := translateIP(translated, rules, TranslationDirectionReverse, ref)
+		if err != nil {
+			t.Fatalf("%s reverse: %v", translated, err)
+		}
+
+		if restored != srcIP {
+			t.Errorf("roundtrip %q → %q → %q", srcIP, translated, restored)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Translation: explicit block
+// ---------------------------------------------------------------------------
+
+func TestNMTranslate_Explicit_Forward(t *testing.T) {
+	rules := mustParse(t, explicitOnlyYAML)
+	ref := nadRef("backup")
+
+	got, ruleType, err := translateIP("192.168.100.10", rules, TranslationDirectionForward, ref)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "192.168.120.10" {
+		t.Errorf("got %q, want 192.168.120.10", got)
+	}
+
+	if ruleType != RuleTypeExplicit {
+		t.Errorf("ruleType = %q, want Explicit", ruleType)
+	}
+}
+
+func TestNMTranslate_Explicit_Reverse(t *testing.T) {
+	rules := mustParse(t, explicitOnlyYAML)
+	ref := nadRef("backup")
+
+	got, ruleType, err := translateIP("192.168.120.20", rules, TranslationDirectionReverse, ref)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "192.168.100.20" {
+		t.Errorf("got %q, want 192.168.100.20", got)
+	}
+
+	if ruleType != RuleTypeExplicit {
+		t.Errorf("ruleType = %q, want Explicit", ruleType)
+	}
+}
+
+func TestNMTranslate_Explicit_NotFound(t *testing.T) {
+	rules := mustParse(t, explicitOnlyYAML)
+	ref := nadRef("backup")
+
+	_, _, err := translateIP("192.168.100.99", rules, TranslationDirectionForward, ref)
+	if err == nil {
+		t.Error("expected error for IP not in explicit table")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Translation: regex block
+// ---------------------------------------------------------------------------
+
+func TestNMTranslate_Regex_Forward(t *testing.T) {
+	rules := mustParse(t, regexOnlyYAML)
+	ref := nadRef("mgmt")
+
+	got, ruleType, err := translateIP("172.16.100.5", rules, TranslationDirectionForward, ref)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "10.20.30.5" {
+		t.Errorf("got %q, want 10.20.30.5", got)
+	}
+
+	if ruleType != RuleTypeRegex {
+		t.Errorf("ruleType = %q, want Regex", ruleType)
+	}
+}
+
+func TestNMTranslate_Regex_Reverse(t *testing.T) {
+	rules := mustParse(t, regexOnlyYAML)
+	ref := nadRef("mgmt")
+
+	got, ruleType, err := translateIP("10.20.30.5", rules, TranslationDirectionReverse, ref)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "172.16.100.5" {
+		t.Errorf("got %q, want 172.16.100.5", got)
+	}
+
+	if ruleType != RuleTypeRegex {
+		t.Errorf("ruleType = %q, want Regex", ruleType)
+	}
+}
+
+func TestNMTranslate_Regex_NoMatch(t *testing.T) {
+	rules := mustParse(t, regexOnlyYAML)
+	ref := nadRef("mgmt")
+
+	_, _, err := translateIP("192.168.1.1", rules, TranslationDirectionForward, ref)
+	if err == nil {
+		t.Error("expected error when no regex rule matches")
+	}
+}
+
+func TestNMTranslate_Regex_Roundtrip(t *testing.T) {
+	rules := mustParse(t, regexOnlyYAML)
+	ref := nadRef("mgmt")
+	srcIP := "172.16.100.77"
+
+	translated, _, err := translateIP(srcIP, rules, TranslationDirectionForward, ref)
+	if err != nil {
+		t.Fatalf("forward: %v", err)
+	}
+
+	if translated != "10.20.30.77" {
+		t.Fatalf("forward: got %q, want 10.20.30.77", translated)
+	}
+
+	restored, _, err := translateIP(translated, rules, TranslationDirectionReverse, ref)
+	if err != nil {
+		t.Fatalf("reverse: %v", err)
+	}
+
+	if restored != srcIP {
+		t.Errorf("roundtrip %q → %q → %q", srcIP, translated, restored)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Translation: all-three priority ordering
+// ---------------------------------------------------------------------------
+
+// TestNMTranslate_Priority_ExplicitBeforeCIDR verifies that an IP listed in
+// explicitMappings uses the explicit override even though the CIDR would also
+// match (192.168.100.51 is within 192.168.100.0/24).
+func TestNMTranslate_Priority_ExplicitBeforeCIDR(t *testing.T) {
+	rules := mustParse(t, allThreeYAML)
+	ref := nadRef("backup")
+
+	got, ruleType, err := translateIP("192.168.100.51", rules, TranslationDirectionForward, ref)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "192.168.110.58" {
+		t.Errorf("got %q, want 192.168.110.58 (explicit override)", got)
+	}
+
+	if ruleType != RuleTypeExplicit {
+		t.Errorf("ruleType = %q, want Explicit", ruleType)
+	}
+}
+
+func TestNMTranslate_Priority_CIDRBeforeRegex(t *testing.T) {
+	rules := mustParse(t, allThreeYAML)
+	ref := nadRef("backup")
+
+	got, ruleType, err := translateIP("192.168.100.77", rules, TranslationDirectionForward, ref)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "192.168.110.77" {
+		t.Errorf("got %q, want 192.168.110.77 (CIDR offset)", got)
+	}
+
+	if ruleType != RuleTypeCIDR {
+		t.Errorf("ruleType = %q, want CIDR", ruleType)
+	}
+}
+
+func TestNMTranslate_Priority_RegexFallback(t *testing.T) {
+	rules := mustParse(t, allThreeYAML)
+	ref := nadRef("backup")
+
+	got, ruleType, err := translateIP("172.16.100.5", rules, TranslationDirectionForward, ref)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "10.20.30.5" {
+		t.Errorf("got %q, want 10.20.30.5 (regex fallback)", got)
+	}
+
+	if ruleType != RuleTypeRegex {
+		t.Errorf("ruleType = %q, want Regex", ruleType)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Translation: unknown NAD and two-block routing
+// ---------------------------------------------------------------------------
+
+func TestNMTranslate_UnknownNAD(t *testing.T) {
+	rules := mustParse(t, cidrOnlyYAML)
+
+	_, _, err := translateIP("192.168.100.5", rules, TranslationDirectionForward, nadRef("nonexistent"))
+	if err == nil {
+		t.Error("expected error for unknown NAD")
+	}
+}
+
+func TestNMTranslate_TwoBlocks_EachNADUsesOwnBlock(t *testing.T) {
+	rules := mustParse(t, twoBlockYAML)
+
+	got, ruleType, err := translateIP("192.168.100.10", rules, TranslationDirectionForward, nadRef("storage"))
+	if err != nil {
+		t.Fatalf("storage: %v", err)
+	}
+
+	if got != "192.168.120.10" || ruleType != RuleTypeCIDR {
+		t.Errorf("storage CIDR: got %q ruleType %q", got, ruleType)
+	}
+
+	got, ruleType, err = translateIP("10.0.0.1", rules, TranslationDirectionForward, nadRef("backup"))
+	if err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	if got != "10.0.1.1" || ruleType != RuleTypeExplicit {
+		t.Errorf("backup explicit: got %q ruleType %q", got, ruleType)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// translateSourceIP — DRPCInstance integration
+// Direction derived from sourceCluster name, not from the IP value.
+// ---------------------------------------------------------------------------
+
+func TestNMTranslateSourceIP_NilRules(t *testing.T) {
+	d := newDRPCInstanceForTest(nil)
+
+	got := d.translateSourceIP("192.168.100.51", testDR1, nadRef("storage"))
+	if got != "192.168.100.51" {
+		t.Errorf("expected unchanged IP with nil rules, got %q", got)
+	}
+}
+
+func TestNMTranslateSourceIP_UnknownSourceCluster(t *testing.T) {
+	d := newDRPCInstanceForTest(mustParse(t, cidrOnlyYAML))
+
+	// "other-cluster" is not dr1 or dr2 — must return IP unchanged.
+	got := d.translateSourceIP("192.168.100.51", "other-cluster", nadRef("storage"))
+	if got != "192.168.100.51" {
+		t.Errorf("unknown source cluster: expected unchanged, got %q", got)
+	}
+}
+
+func TestNMTranslateSourceIP_CIDR_Failover(t *testing.T) {
+	d := newDRPCInstanceForTest(mustParse(t, cidrOnlyYAML))
+
+	got := d.translateSourceIP("192.168.100.51", testDR1, nadRef("storage"))
+	if got != "192.168.120.51" {
+		t.Errorf("CIDR failover: got %q, want 192.168.120.51", got)
+	}
+}
+
+func TestNMTranslateSourceIP_CIDR_Failback(t *testing.T) {
+	d := newDRPCInstanceForTest(mustParse(t, cidrOnlyYAML))
+
+	got := d.translateSourceIP("192.168.120.51", testDR2, nadRef("storage"))
+	if got != "192.168.100.51" {
+		t.Errorf("CIDR failback: got %q, want 192.168.100.51", got)
+	}
+}
+
+func TestNMTranslateSourceIP_CIDR_Roundtrip(t *testing.T) {
+	d := newDRPCInstanceForTest(mustParse(t, cidrOnlyYAML))
+	ref := nadRef("storage")
+	original := "192.168.100.77"
+
+	after := d.translateSourceIP(original, testDR1, ref)
+	if after != "192.168.120.77" {
+		t.Fatalf("failover: got %q, want 192.168.120.77", after)
+	}
+
+	back := d.translateSourceIP(after, testDR2, ref)
+	if back != original {
+		t.Errorf("failback: got %q, want %q", back, original)
+	}
+}
+
+func TestNMTranslateSourceIP_CIDR_Miss_Unchanged(t *testing.T) {
+	d := newDRPCInstanceForTest(mustParse(t, cidrOnlyYAML))
+
+	// 10.0.0.1 is not in the dr1 CIDR — error path, returns unchanged.
+	got := d.translateSourceIP("10.0.0.1", testDR1, nadRef("storage"))
+	if got != "10.0.0.1" {
+		t.Errorf("CIDR miss: expected unchanged, got %q", got)
+	}
+}
+
+func TestNMTranslateSourceIP_Explicit_Failover(t *testing.T) {
+	d := newDRPCInstanceForTest(mustParse(t, explicitOnlyYAML))
+
+	got := d.translateSourceIP("192.168.100.10", testDR1, nadRef("backup"))
+	if got != "192.168.120.10" {
+		t.Errorf("explicit failover: got %q, want 192.168.120.10", got)
+	}
+}
+
+func TestNMTranslateSourceIP_Explicit_Failback(t *testing.T) {
+	d := newDRPCInstanceForTest(mustParse(t, explicitOnlyYAML))
+
+	got := d.translateSourceIP("192.168.120.10", testDR2, nadRef("backup"))
+	if got != "192.168.100.10" {
+		t.Errorf("explicit failback: got %q, want 192.168.100.10", got)
+	}
+}
+
+// TestNMTranslateSourceIP_AllThree_ExplicitOverride is the main integration
+// test that matches the design doc log scenario:
+//
+//	Network: default/backup  sourceCluster: east-cluster
+//	inputIP: 192.168.100.51  ruleType: Explicit  outputIP: 192.168.110.58
+func TestNMTranslateSourceIP_AllThree_ExplicitOverride(t *testing.T) {
+	d := newDRPCInstanceForTest(mustParse(t, allThreeYAML))
+
+	got := d.translateSourceIP("192.168.100.51", testDR1, nadRef("backup"))
+	if got != "192.168.110.58" {
+		t.Errorf("all-three explicit override: got %q, want 192.168.110.58", got)
+	}
+}
+
+func TestNMTranslateSourceIP_AllThree_CIDRFallthrough(t *testing.T) {
+	d := newDRPCInstanceForTest(mustParse(t, allThreeYAML))
+
+	got := d.translateSourceIP("192.168.100.77", testDR1, nadRef("backup"))
+	if got != "192.168.110.77" {
+		t.Errorf("all-three CIDR fallthrough: got %q, want 192.168.110.77", got)
+	}
+}
+
+func TestNMTranslateSourceIP_AllThree_RegexFallthrough(t *testing.T) {
+	d := newDRPCInstanceForTest(mustParse(t, allThreeYAML))
+
+	got := d.translateSourceIP("172.16.100.5", testDR1, nadRef("backup"))
+	if got != "10.20.30.5" {
+		t.Errorf("all-three regex fallthrough: got %q, want 10.20.30.5", got)
+	}
+}

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -50,6 +50,11 @@ const (
 
 	// Annotation for the last action performed on the DRPC
 	DRPCLastAction = "drplacementcontrol.ramendr.openshift.io/last-action"
+
+	// DRPCNetworkMappingAnnotation references a ConfigMap (by name, same namespace) that
+	// holds the bidirectional cluster-pair network subnet mappings for VM static-IP translation.
+	// Value is the ConfigMap name; namespace defaults to the DRPC namespace.
+	DRPCNetworkMappingAnnotation = "drplacementcontrol.ramendr.openshift.io/network-mapping"
 )
 
 var (
@@ -84,6 +89,7 @@ type DRPCInstance struct {
 	mwu                  rmnutil.MWUtil
 	drType               DRType
 	requeueAfter         time.Duration
+	networkMappingRules  *NetworkMappingRules
 }
 
 func (d *DRPCInstance) startProcessing() bool {
@@ -1409,7 +1415,8 @@ func (d *DRPCInstance) ensureCleanupAndSecondaryReplicationSetup(srcCluster stri
 
 	err = d.ResetVMStaticIPSpecOnPrimary(srcCluster)
 	if err != nil {
-		return err
+		d.log.Error(err, "Failed to reset VM static-IP configuration on primary cluster; continuing reconciliation",
+			"sourceCluster", srcCluster)
 	}
 
 	// Check if the reset has already been applied. ResetVolSyncRDOnPrimary resets the VRG
@@ -3593,18 +3600,17 @@ func mapsEqual(a, b map[string]string) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-// buildStaticIPTranslationSpec constructs the StaticIPTranslationSpec for the
-// secondary VRG using static IP information discovered from the primary cluster:
-//   - source IPs are read from the primary VRG's status.staticIPDiscovery,
-//     which is populated by validateAndRecordStaticIPDiscovery on the primary
-//     by reading the network.kubevirt.io/addresses annotation from each
-//     protected VM's spec.template.metadata
-//   - target IPs are derived by DRPC from a user-provided network mapping
-//     (not yet implemented; reserved for future extension)
+// buildStaticIPTranslationSpec constructs the StaticIPTranslationSpec for a
+// recovery-target VRG using static IP discovery data from the source cluster
+// selected by DRPC placement intent.
 //
-// Entries are matched by (ResourceRef.Namespace, ResourceRef.Name, NetworkName).
-// VMs with no static IP annotation on the primary are silently skipped.
-// Returns nil when there are no static-IP VMs on the primary.
+// Source IPs are read from the source VRG's status.staticIPDiscovery. Target
+// IPs are either preserved (same-cluster recovery) or translated using the
+// configured network-mapping rules. The resulting translations are grouped by
+// protected resource and network.
+//
+// Returns nil when the source VRG is unavailable or when no static IP discovery
+// data has been reported.
 func (d *DRPCInstance) buildStaticIPTranslationSpec(
 	primaryCluster string,
 	homeCluster string,
@@ -3633,6 +3639,7 @@ func (d *DRPCInstance) buildStaticIPTranslationSpec(
 		for _, pNet := range pRes.Networks {
 			var addrs []rmn.AddressTranslation
 
+			nadNamespace, nadName := ParseNetworkName(pNet.NetworkName, pRes.ResourceRef.Namespace)
 			for _, srcIP := range pNet.Addresses {
 				d.log.Info("Source IP for translation", "ip", srcIP)
 
@@ -3640,7 +3647,8 @@ func (d *DRPCInstance) buildStaticIPTranslationSpec(
 				if !sameCluster {
 					d.log.Info("Clusters are not same, hence translation required", "primaryCluster:", primaryCluster,
 						"homeCluster:", homeCluster, "srcIP:", srcIP)
-					targetIP = translateSubnet(srcIP) // derived from network mapping — not yet implemented
+					// derived from network mapping
+					targetIP = d.translateSourceIP(srcIP, primaryCluster, NetworkRef{nadNamespace, nadName})
 				}
 
 				d.log.Info("Updating Spec with IP", "targetIP:", targetIP)
@@ -3745,28 +3753,6 @@ func (d *DRPCInstance) shouldInjectStaticIPTranslationSpec(
 	return true, ""
 }
 
-// translateSubnet is a temporary stub that swaps the third octet between
-// 100 and 200 to simulate primary→secondary IP translation.
-// e.g. 192.168.100.51 → 192.168.200.51 and vice-versa.
-// TODO: replace with real network mapping logic.
-const ipv4OctetCount = 4
-
-func translateSubnet(ip string) string {
-	parts := strings.Split(ip, ".")
-	if len(parts) != ipv4OctetCount {
-		return ip
-	}
-
-	switch parts[2] {
-	case "100":
-		parts[2] = "200"
-	case "200":
-		parts[2] = "100"
-	}
-
-	return strings.Join(parts, ".")
-}
-
 // ResetVMStaticIPSpecOnPrimary clears StaticIPTranslationSpec from the
 // primary VRG once recovery completes or translation injection is no longer
 // required. The translation spec is transient recovery metadata used during
@@ -3774,12 +3760,6 @@ func translateSubnet(ip string) string {
 // promoted primary after failover/relocation.
 func (d *DRPCInstance) ResetVMStaticIPSpecOnPrimary(clusterName string) error {
 	if !d.isVMRecipeInUse() {
-		return nil
-	}
-
-	if len(d.instance.Status.ResourceConditions.ResourceMeta.ProtectedStaticIPVMs) == 0 {
-		d.log.Info("VMs are not configured with static IPs.")
-
 		return nil
 	}
 
@@ -3802,6 +3782,18 @@ func (d *DRPCInstance) ResetVMStaticIPSpecOnPrimary(clusterName string) error {
 		d.log.Error(err, "failed to extract VRG state")
 
 		return err
+	}
+
+	// No static-IP VMs remain; clear any previously injected translation spec
+	// to avoid stale IP mappings being applied during future restores.
+	if len(d.instance.Status.ResourceConditions.ResourceMeta.ProtectedStaticIPVMs) == 0 {
+		d.log.Info("VMs are not configured with static IPs.")
+
+		if !d.setStaticIPTranslationSpec(vrg, nil) {
+			return nil
+		}
+
+		return d.mwu.UpdateVRGManifestWork(vrg, mw)
 	}
 
 	if vrg.Spec.ReplicationState != rmn.Primary {
@@ -3839,9 +3831,9 @@ func (d *DRPCInstance) currentPrimaryCluster() string {
 	}
 }
 
-// setStaticIPTranslationSpec updates StaticIPTranslationSpec on the given
-// VRG only when the desired spec differs from the existing one. It returns
-// true if the VRG spec was modified, and false when no update was required.
+// setStaticIPTranslationSpec updates StaticIPTranslationSpec only when the
+// desired value differs from the current value. A nil spec clears the field.
+// Returns true when the VRG spec was modified.
 func (d *DRPCInstance) setStaticIPTranslationSpec(
 	vrg *rmn.VolumeReplicationGroup,
 	spec *rmn.StaticIPTranslationSpec,

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -470,6 +470,8 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 
 	r.numClustersQueriedSuccessfully = cqs
 
+	networkMappingRules := r.loadNetworkMapping(ctx, drpc, drPolicy, log)
+
 	d := &DRPCInstance{
 		reconciler:      r,
 		ctx:             ctx,
@@ -490,6 +492,7 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 			InstName:        drpc.Name,
 			TargetNamespace: vrgNamespace,
 		},
+		networkMappingRules: networkMappingRules,
 	}
 
 	d.drType = DRTypeAsync
@@ -514,6 +517,46 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 	d.instance.Status.DeepCopyInto(&d.savedInstanceStatus)
 
 	return d, nil
+}
+
+func (r *DRPlacementControlReconciler) loadNetworkMapping(
+	ctx context.Context,
+	drpc *rmn.DRPlacementControl,
+	drPolicy *rmn.DRPolicy,
+	log logr.Logger,
+) *NetworkMappingRules {
+	nmMgr := NewDRPCNetworkMappingManager(r.Client, log)
+
+	networkMappingRules, err := nmMgr.LoadNetworkMapping(ctx, drpc, drPolicy)
+	if err != nil {
+		log.Error(err,
+			"Failed to load network-mapping ConfigMap; IP translation disabled",
+			"drpc", drpc.Name)
+
+		addOrUpdateCondition(
+			&drpc.Status.Conditions,
+			rmn.ConditionNetworkMappingLoaded,
+			drpc.Generation,
+			metav1.ConditionFalse,
+			"NetworkMappingLoadFailed",
+			err.Error(),
+		)
+
+		return nil
+	}
+
+	if networkMappingRules != nil {
+		addOrUpdateCondition(
+			&drpc.Status.Conditions,
+			rmn.ConditionNetworkMappingLoaded,
+			drpc.Generation,
+			metav1.ConditionTrue,
+			"NetworkMappingLoaded",
+			"Network mapping loaded successfully",
+		)
+	}
+
+	return networkMappingRules
 }
 
 func (r *DRPlacementControlReconciler) createSyncMetricsInstance(

--- a/internal/controller/vrg_staticip.go
+++ b/internal/controller/vrg_staticip.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -96,6 +97,7 @@ func buildDiscoveredResources(infos []util.VMStaticIPInfo) []ramen.DiscoveredRes
 
 	for i := range infos {
 		info := &infos[i]
+
 		if !info.HasStaticIP {
 			continue
 		}
@@ -403,4 +405,19 @@ func (v *VRGInstance) deleteResourceModifierCM(ctx context.Context, namespace st
 	v.log.Info("ResourceModifier ConfigMap deleted", "namespace", namespace, "name", cmName)
 
 	return nil
+}
+
+func ParseNetworkName(networkName string, vmNamespace string) (nadNamespace, nadName string) {
+	parts := strings.Split(networkName, "/")
+
+	if len(parts) == 1 {
+		// namespace omitted
+		return vmNamespace, parts[0]
+	}
+
+	if len(parts) == MaxDRClusterCount {
+		return parts[0], parts[1]
+	}
+
+	return "", ""
 }


### PR DESCRIPTION
Background / Motivation
-----------------------
This work is part of the VM static-IP DR solution for UDN/CUDN-based
networking and is intended to support the KubeVirt design:

  "Requesting a Specific IP for a VM in UDN via Third-Party Integration"

When a VM fails over or fails back between clusters, statically assigned
IPs may need translation to equivalent addresses on the peer cluster.

The translation framework introduced in this PR is generic, but its
primary motivating use case is VM static IPs provisioned through
UDN/CUDN integrations.

Translation scope is NAD-based
------------------------------
The implementation scopes translation rules using:

  networkRef:
    nadNamespace:
    nadName:

rather than by IP alone.

This is intentional because:

- the same IP/subnet may legitimately exist in multiple UDNs
- translation must be network-scoped
- UDNs and CUDNs ultimately materialise as NADs consumed by VMs

The implementation therefore works for:

- NADs created directly by users
- NADs generated from UDNs
- NADs generated from CUDNs

without introducing separate schema concepts for each network type.

Supported translation mechanisms
--------------------------------
Three translation models are supported.

1. explicitMappings

  explicitMappings:
  - dr1: 192.168.100.51
    dr2: 192.168.110.58

Use case:

  one-to-one VM IP remapping

Priority:

  highest

Lookup:

  O(1)

via pre-built forward/reverse maps.

2. cidr

  cidr:
    dr1: 192.168.100.0/24
    dr2: 192.168.110.0/24

Use case:

  subnet-preserving host translation

Example:

  192.168.100.25 → 192.168.110.25

Requirements:

- same address family
- same prefix length
- source and destination networks must differ

3. regexMappings

  regexMappings:
    dr1-to-dr2:
      ...
    dr2-to-dr1:
      ...

Use case:

  arbitrary/non-symmetric translations

Direction is explicit because regex transformations are not inherently
reversible.

Deterministic direction model
-----------------------------
Direction is not inferred from the IP address.

Instead:

  TranslateIP(srcIP, sourceCluster, ...)

uses the caller-supplied source cluster name.

Benefits:

- avoids ambiguity with overlapping subnets
- avoids ambiguity with regex mappings
- keeps failover/failback behaviour deterministic

Evaluation order
----------------
Translation is applied in the following order:

  explicitMappings
      ↓
  cidr
      ↓
  regexMappings

This ensures:

- specific VM overrides win
- subnet translations act as defaults
- regex rules act as a fallback

Validation guarantees
---------------------
The parser performs strict validation before rules become active.

CIDR

Validates:

- cluster keys present
- valid CIDR syntax
- equal prefix lengths
- source network != destination network

explicitMappings

Validates:

- IPv4-only
- cluster keys present
- no duplicate source IPs
- no duplicate destination IPs
- no cross-column ambiguity
- source IP != destination IP

regexMappings

Validates:

- both directions present
- valid regex syntax
- non-empty pattern/replacement

Operational behaviour
---------------------
Configuration errors do not block DR workflows.

If:

- ConfigMap missing
- ConfigMap invalid
- Translation fails

then:

  ConditionNetworkMappingLoaded=False

is reported and:

  translateSourceIP()

returns the original IP unchanged.

This preserves DR orchestration while surfacing configuration problems.

Non-goals of this PR
--------------------
Not included:

- ConfigMap watch/reload
- DRPolicy integration for ConfigMap reference
- Discovery of VM static IPs
- Cloud-Init parsing
- UDN/CUDN network discovery

This PR is intentionally limited to:

- ConfigMap parsing
- Validation
- Translation engine
- Runtime translation APIs

Design rationale
----------------
The most important design decision is:

  Translation is scoped by network identity (NAD) rather than by IP
  address.

This avoids ambiguity in environments where:

- multiple UDNs use overlapping subnets
- the same IP may exist on different networks
- CUDN/UDN-generated NADs coexist with user-created NADs

Assisted by: IBM Bob v2.0.2