### PR TITLE
submariner: Use "devel" for consuming upstream fix

### DIFF
--- a/test/drenv/addons/submariner/start.py
+++ b/test/drenv/addons/submariner/start.py
@@ -9,7 +9,7 @@ from drenv import cluster as drenv_cluster
 from drenv import kubectl
 from drenv import subctl
 
-VERSION = "0.24.0"
+VERSION = "devel"
 
 NAMESPACE = "submariner-operator"
 


### PR DESCRIPTION
The submariner fix[1] was merged, using the special "devel" version to test the fix before the next release.

This uses the "devel" tag for all images:

    % subctl show versions --context dr1
     ✓ Showing versions
    COMPONENT                       REPOSITORY           CONFIGURED   RUNNING              ARCH
    submariner-gateway              quay.io/submariner   devel        devel-a5d2aba37b1d   arm64
    submariner-routeagent           quay.io/submariner   devel        devel-a5d2aba37b1d   arm64
    submariner-globalnet            quay.io/submariner   devel        devel-a5d2aba37b1d   arm64
    submariner-metrics-proxy        quay.io/submariner   devel        devel-dc2b634fb6bb   arm64
    submariner-operator             quay.io/submariner   devel        devel-8bef08878f9c   arm64
    submariner-lighthouse-agent     quay.io/submariner   devel        devel-b1b4669a6542   arm64
    submariner-lighthouse-coredns   quay.io/submariner   devel        devel-b1b4669a6542   arm64

[1] https://github.com/submariner-io/submariner/pull/4123