### PR TITLE
drenv: Keep 20Mi of container logs for e2e diagnosis

### DIFF
--- a/test/drenv/providers/minikube/__init__.py
+++ b/test/drenv/providers/minikube/__init__.py
@@ -33,7 +33,14 @@ EXTRA_CONFIG = [
     # < 1.9 or an Aufs storage backend.
     # https://github.com/kubernetes/kubernetes/issues/10959
     # Speeds up regional-dr start by 20%.
-    "kubelet.serialize-image-pulls=false"
+    "kubelet.serialize-image-pulls=false",
+    # Keep ~30 minutes of container logs available via kubectl logs / gather.
+    # Default max size (10Mi) rotates away hub Ramen operator logs before a
+    # typical e2e run finishes, so failure diagnosis loses the protect window.
+    # Keep only 2 files (kubelet minimum) to limit minikube VM disk use; gather
+    # only collects the active file anyway.
+    "kubelet.container-log-max-size=20Mi",
+    "kubelet.container-log-max-files=2",
 ]
 
 LOCAL_REGISTRY = "host.minikube.internal:5050"


### PR DESCRIPTION
Kubelet defaults to rotating container logs at 10Mi. During a ~30m e2e run the hub Ramen operator fills that quickly, and kubectl logs / gather only see the active file, so protect-window logs are lost and failures cannot be diagnosed from gather artifacts.

Raise container-log-max-size to 20Mi by default and keep only 2 log files to limit minikube VM disk use.

## Example log sizes

In this run ramen log on the dr2 was 14 MiB. Without this change the log would rotate during single e2e run, making debugging impossible.

```
% find . -type f -name "*.log" | xargs du -m | sort -rn | head -5
14	./gather.rdr/dr2/namespaces/ramen-system/pods/ramen-dr-cluster-operator-dd5954f8-mrm8p/manager/current.log
12	./gather.rdr/dr1/namespaces/volsync-system/pods/volsync-968bcb6df-vq6gq/manager/current.log
9	./gather.rdr/hub/namespaces/ramen-system/pods/ramen-hub-operator-5db9c48f67-54jwb/manager/current.log
9	./gather.rdr/dr1/namespaces/ramen-system/pods/ramen-dr-cluster-operator-dd5954f8-mcnw5/manager/current.log
7	./gather.rdr/hub/namespaces/olm/pods/operatorhubio-catalog-kj9kk/registry-server/current.log
```

Build: https://github.com/RamenDR/ramen/actions/runs/31623924040

Fixes: #2706