### PR TITLE
e2e: Upload uncompressed tar so GitHub zip compresses it.

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -158,15 +158,15 @@ jobs:
         drenv gather --directory gather.rdr envs/regional-dr.yaml
 
     # Tar manually to work around github limitations with special characters (:)
-    # in file names, and getting much smaller archives compared with zip (6m vs
-    # 12m). This is also useful to collect all files in one archive.
+    # in file names, and to collect all files in one archive. Leave the tar
+    # uncompressed so upload-artifact's zip can compress the stream (similar
+    # size to gzip, better macOS Finder extract than nested zip+tar.gz).
     # https://github.com/actions/upload-artifact/issues/546
     - name: Archive artifacts
       if: always()
       run: |
         tar --create \
-            --gzip \
-            --file e2e.${{ env.BUILD_ID }}.tar.gz \
+            --file e2e.${{ env.BUILD_ID }}.tar \
             --transform "s|^|e2e.${{ env.BUILD_ID }}/|" \
             --files-from artifacts.txt
 
@@ -175,8 +175,8 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: e2e.${{ env.BUILD_ID }}
-        path: e2e.${{ env.BUILD_ID }}.tar.gz
-        compression-level: 0
+        path: e2e.${{ env.BUILD_ID }}.tar
+        compression-level: 9
         retention-days: 15
 
     - name: Delete clusters

--- a/test/drenv/providers/minikube/__init__.py
+++ b/test/drenv/providers/minikube/__init__.py
@@ -33,7 +33,14 @@ EXTRA_CONFIG = [
     # < 1.9 or an Aufs storage backend.
     # https://github.com/kubernetes/kubernetes/issues/10959
     # Speeds up regional-dr start by 20%.
-    "kubelet.serialize-image-pulls=false"
+    "kubelet.serialize-image-pulls=false",
+    # Keep ~30 minutes of container logs available via kubectl logs / gather.
+    # Default max size (10Mi) rotates away hub Ramen operator logs before a
+    # typical e2e run finishes, so failure diagnosis loses the protect window.
+    # Keep only 2 files (kubelet minimum) to limit minikube VM disk use; gather
+    # only collects the active file anyway.
+    "kubelet.container-log-max-size=20Mi",
+    "kubelet.container-log-max-files=2",
 ]
 
 LOCAL_REGISTRY = "host.minikube.internal:5050"


### PR DESCRIPTION
Nested zip(tar.gz) broke macOS Finder extraction in recent Archive
Utility versions: double-clicking the downloaded zip often fails with
an unsupported-format error and leaves a .tar that needs a second
extract. Uploading a plain .tar lets upload-artifact's zip (level 9)
compress one contiguous stream—same deflate family as gzip(tar), so
size should stay in the same ballpark as the old .tar.gz—while Finder
can extract zip → .tar more reliably.
