### PR TITLE
fix: preserve ClusterDataProtected status during kube-objects capture kube-objects capture in-progress

### DIFF
--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -244,6 +244,11 @@ func (v *VRGInstance) kubeObjectsCaptureStartOrResume(
 
 		result.Requeue = true
 
+		if v.instance.Status.KubeObjectProtection.CaptureToRecoverFrom != nil &&
+			time.Since(v.instance.Status.KubeObjectProtection.CaptureToRecoverFrom.StartTime.Time) <= 2*interval {
+			v.kubeObjectsCaptureStatusTrue(VRGConditionReasonUploading, "Kube objects capture in-progress")
+		}
+
 		return
 	}
 


### PR DESCRIPTION
When a kube-objects capture cycle starts, the VRG unconditionally resets kubeObjectsProtected to False. During the DELAY path (within interval), it gets overwritten to True before any API write. But during START/RESUME (capture in progress), the False was written to the VRG status, causing ClusterDataProtected to oscillate True→False→True every capture cycle. This propagated to DRPC Protected condition as Progressing.

Preserve True (with reason Uploading) during capture-in-progress when a valid previous capture exists, so the reset's False no longer leaks to the API. The reset itself is kept for freshness signaling on first capture and genuine failures.