### PR TITLE
Improve drenv CLI help with descriptions and examples

### DIFF
--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -20,6 +20,7 @@ from . import cluster
 from . import commands
 from . import envfile
 from . import kubectl
+from . import options
 from . import providers
 from . import ramen
 from . import registry
@@ -32,6 +33,7 @@ ADDONS_DIR = "addons"
 LOGFILE = "drenv.log"
 
 executors = []
+width = options.terminal_width()
 
 
 def main():
@@ -60,7 +62,23 @@ def parse_args():
 
     # Environment commands.
 
-    p = add_command(sp, "start", do_start, help="start an environment")
+    p = add_command(
+        sp,
+        "start",
+        do_start,
+        help="start an environment",
+        description=options.dedent("""
+            Start the DR environment defined in the envfile. Creates the
+            clusters if needed, deploys all addons, and runs addon tests.
+            The command is idempotent - rerunning it on an already-running
+            environment is safe. Run "drenv setup" once before the first
+            start to prepare the host.
+
+            Examples:
+              # Start the regional-dr environment
+              drenv start envs/regional-dr.yaml
+            """),
+    )
     p.add_argument(
         "--skip-tests",
         dest="run_tests",
@@ -105,7 +123,21 @@ def parse_args():
         ),
     )
 
-    p = add_command(sp, "stop", do_stop, help="stop an environment")
+    p = add_command(
+        sp,
+        "stop",
+        do_stop,
+        help="stop an environment",
+        description=options.dedent("""
+            Stop the DR environment defined in the envfile. Stops all
+            clusters for the environment profiles. Cluster data
+            is preserved and can be resumed later with "drenv start".
+
+            Examples:
+              # Stop the regional-dr environment
+              drenv stop envs/regional-dr.yaml
+            """),
+    )
     p.add_argument(
         "--skip-addons",
         dest="run_addons",
@@ -113,7 +145,22 @@ def parse_args():
         help="Do not run addons 'stop' hooks",
     )
 
-    p = add_command(sp, "cache", do_cache, help="cache environment resources")
+    p = add_command(
+        sp,
+        "cache",
+        do_cache,
+        help="cache environment resources",
+        description=options.dedent("""
+            Pre-fetch and cache addon resources for the envfile. Runs each
+            addon's "cache" hook to prepare resources needed by the
+            environment. This improves stability when running with
+            bad network connectivity.
+
+            Examples:
+              # Cache resources for the regional-dr environment
+              drenv cache envs/regional-dr.yaml
+            """),
+    )
     p.add_argument(
         "--max-workers",
         type=int,
@@ -121,7 +168,21 @@ def parse_args():
         help="maximum number of workers per profile",
     )
 
-    p = add_command(sp, "gather", do_gather, help="gather environment data")
+    p = add_command(
+        sp,
+        "gather",
+        do_gather,
+        help="gather environment data",
+        description=options.dedent("""
+            Gather diagnostic data from a running environment. Collects
+            logs and resource dumps from every cluster defined in the
+            envfile, useful for debugging.
+
+            Examples:
+              # Gather data from all namespaces into the default directory
+              drenv gather --directory rdr.gather envs/regional-dr.yaml
+            """),
+    )
     p.add_argument(
         "-d",
         "--directory",
@@ -134,23 +195,141 @@ def parse_args():
         help="if specified, comma separated list of namespaces to gather data from",
     )
 
-    p = add_command(sp, "load", do_load, help="load an image into the cluster")
+    p = add_command(
+        sp,
+        "load",
+        do_load,
+        help="load an image into the cluster",
+        description=options.dedent("""
+            Load a container image into every cluster in the envfile.
+            Useful for testing local image builds without pushing them to a
+            registry first. Use "podman save -o myimage.tar myimage" to
+            create the image tarball.
+
+            Examples:
+              # Load a local image tarball into all profiles
+              drenv load --image myimage.tar envs/regional-dr.yaml
+            """),
+    )
     p.add_argument(
         "--image",
         required=True,
         help="image to load into the cluster in tar format",
     )
 
-    add_command(sp, "delete", do_delete, help="delete an environment")
-    add_command(sp, "suspend", do_suspend, help="suspend virtual machines")
-    add_command(sp, "resume", do_resume, help="resume virtual machines")
-    add_command(sp, "dump", do_dump, help="dump an environment yaml")
+    add_command(
+        sp,
+        "delete",
+        do_delete,
+        help="delete an environment",
+        description=options.dedent("""
+            Delete a DR environment. Deletes all clusters and
+            temporary files under `~/.config/drenv` for the
+            profiles and environment.
+
+            Examples:
+              # Delete the regional-dr environment
+              drenv delete envs/regional-dr.yaml
+            """),
+    )
+    add_command(
+        sp,
+        "suspend",
+        do_suspend,
+        help="suspend virtual machines",
+        description=options.dedent("""
+            Suspend the virtual machines for the envfile. Pauses the
+            underlying virtual machines for every profile without deleting
+            them, freeing up host resources temporarily. Resume them later
+            with "drenv resume". Supported on Linux only.
+
+            Examples:
+              # Suspend the regional-dr environment
+              drenv suspend envs/regional-dr.yaml
+            """),
+    )
+    add_command(
+        sp,
+        "resume",
+        do_resume,
+        help="resume virtual machines",
+        description=options.dedent("""
+            Resume virtual machines previously suspended for the envfile.
+            Supported on Linux only.
+
+            Examples:
+              # Resume the regional-dr environment
+              drenv resume envs/regional-dr.yaml
+            """),
+    )
+    add_command(
+        sp,
+        "dump",
+        do_dump,
+        help="dump an environment yaml",
+        description=options.dedent("""
+            Dump the resolved environment as yaml. Prints the fully
+            resolved environment configuration (after applying defaults and
+            the name prefix) to stdout. Useful for debugging envfile
+            definitions.
+
+            Examples:
+              # Dump the resolved regional-dr environment
+              drenv dump envs/regional-dr.yaml
+            """),
+    )
 
     # Host commands.
 
-    add_command(sp, "clear", do_clear, help="cleared cached resources", envfile=False)
-    add_command(sp, "setup", do_setup, help="setup host for drenv")
-    add_command(sp, "cleanup", do_cleanup, help="cleanup host")
+    add_command(
+        sp,
+        "clear",
+        do_clear,
+        help="clear cached resources",
+        envfile=False,
+        description=options.dedent("""
+            Clear all cached resources. Removes resources cached by
+            "drenv cache", freeing up disk space. This affects all
+            environments, not just one.
+
+            Examples:
+              # Clear all cached resources
+              drenv clear
+            """),
+    )
+    add_command(
+        sp,
+        "setup",
+        do_setup,
+        help="setup host for drenv",
+        description=options.dedent("""
+            Prepare the host for the DR environment defined in the envfile.
+            Configures the host-level dependencies required by the environment.
+            This command does not create or start any clusters. Run it once
+            before the first "drenv start", and again after every reboot since
+            registry cache containers started by setup do not survive a reboot.
+
+            Examples:
+              # Prepare the host for the regional-dr environment
+              drenv setup envs/regional-dr.yaml
+            """),
+    )
+    add_command(
+        sp,
+        "cleanup",
+        do_cleanup,
+        help="cleanup host",
+        description=options.dedent("""
+            Clean up host-level dependencies installed by "drenv setup".
+            Reverses the changes made by "drenv setup" for the given
+            envfile, removing host-level dependencies that are no longer
+            needed.
+
+            Examples:
+              # Clean up host dependencies for the regional-dr environment
+              drenv cleanup envs/regional-dr.yaml
+            """),
+    )
 
     # Sub commands.
 
@@ -162,7 +341,18 @@ def parse_args():
 
 
 def add_registry_cache_command(sp):
-    p = sp.add_parser("registry-cache", help="manage registry cache")
+    p = sp.add_parser(
+        "registry-cache",
+        help="manage registry cache",
+        description=options.wrap_description(
+            options.dedent("""
+            Manage the drenv registry cache. Inspect or remove cached
+            registry containers used by drenv.
+            """),
+            width,
+        ),
+        formatter_class=options.formatter_class(width),
+    )
     sp = p.add_subparsers(dest="command", required=True)
 
     p = add_command(
@@ -171,6 +361,14 @@ def add_registry_cache_command(sp):
         registry.show_stats,
         help="show cache statistics",
         envfile=False,
+        description=options.dedent("""
+            Display the current contents and usage statistics for the
+            cached registry containers managed by drenv.
+
+            Examples:
+              # Show cache statistics in JSON format
+              drenv registry-cache stats
+            """),
     )
     p.add_argument(
         "-o",
@@ -185,11 +383,29 @@ def add_registry_cache_command(sp):
         registry.remove_containers,
         help="remove cache containers",
         envfile=False,
+        description=options.dedent("""
+            Remove the cached registry containers managed by drenv.
+
+            Examples:
+              # Remove all cached registry containers
+              drenv registry-cache remove
+            """),
     )
 
 
 def add_stress_test_command(sp):
-    p = sp.add_parser("stress-test", help="run drenv stress test")
+    p = sp.add_parser(
+        "stress-test",
+        help="run drenv stress test",
+        description=options.wrap_description(
+            options.dedent("""
+            Run drenv stress tests. Execute repeated stress-test runs
+            and collect results for later comparison and reporting.
+            """),
+            width,
+        ),
+        formatter_class=options.formatter_class(width),
+    )
     sp = p.add_subparsers(dest="command", required=True)
 
     p = add_command(
@@ -197,6 +413,14 @@ def add_stress_test_command(sp):
         "run",
         stress.run,
         help="run stress test",
+        description=options.dedent("""
+            Execute one or more stress-test runs and write the results to
+            the specified output directory.
+
+            Examples:
+              # Run a single stress test for the regional-dr environment
+              drenv stress-test run -o out/test envs/regional-dr.yaml
+            """),
     )
     p.add_argument(
         "-r",
@@ -224,6 +448,14 @@ def add_stress_test_command(sp):
         stress.report,
         help="generate markdown report from stress test results",
         envfile=False,
+        description=options.dedent("""
+            Generate a human-readable markdown report from the JSON
+            results produced by a stress-test run.
+
+            Examples:
+              # Generate a report from stress test results
+              drenv stress-test report out/test
+            """),
     )
     p.add_argument(
         "directory",
@@ -236,6 +468,14 @@ def add_stress_test_command(sp):
         stress.compare,
         help="compare 2 stress tests",
         envfile=False,
+        description=options.dedent("""
+            Compare the results of two stress-test output directories and
+            summarize the differences.
+
+            Examples:
+              # Compare two stress test results
+              drenv stress-test compare out/before out/after
+            """),
     )
     p.add_argument(
         "before",
@@ -247,8 +487,15 @@ def add_stress_test_command(sp):
     )
 
 
-def add_command(sp, name, func, help=None, envfile=True):
-    parser = sp.add_parser(name, help=help)
+def add_command(sp, name, func, help=None, envfile=True, description=None):
+    parser = sp.add_parser(
+        name,
+        help=help,
+        description=(
+            options.wrap_description(description, width) if description else None
+        ),
+        formatter_class=options.formatter_class(width),
+    )
     parser.add_argument(
         "--logfile",
         default=LOGFILE,

--- a/test/drenv/options.py
+++ b/test/drenv/options.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import functools
+import shutil
+import textwrap
+
+
+def terminal_width():
+    """
+    Return the terminal width, or default to 80 if not attached to a terminal.
+    """
+    return shutil.get_terminal_size(fallback=(80, 24)).columns
+
+
+def formatter_class(width):
+    """
+    Formatter factory for argparse's `formatter_class=`.
+
+    Works together with wrap_description(): that pre-wraps the
+    description to the terminal width, and this gives the same width
+    to RawDescriptionHelpFormatter so the rest of the help output
+    (usage line, argument columns) wraps to match.
+    """
+    return functools.partial(argparse.RawDescriptionHelpFormatter, width=width)
+
+
+def dedent(s):
+    """
+    Dedent and strip a multi-line string.
+    """
+    return textwrap.dedent(s).strip()
+
+
+def wrap_description(text, width):
+    """
+    Wrap description/help text to the given width, filling normal paragraphs
+    but preserving blank lines and indented blocks (e.g. an "Examples:"
+    section) as-is.
+
+    width must always be supplied explicitly — call terminal_width() once at
+    startup and pass the result here so every description is wrapped at the
+    same width and terminal_width() is never called more than once per run.
+
+    Works together with formatter_class():
+    - Here we pre-wrap the description so it matches the terminal width.
+    - There we override width= when creating
+      argparse.RawDescriptionHelpFormatter, so the rest of the help output
+      (usage line, argument help columns) wraps to the same width.
+    """
+    paragraphs = text.split("\n\n")
+    filled = []
+    for paragraph in paragraphs:
+        lines = paragraph.splitlines()
+        has_indent = any(line[:1].isspace() for line in lines if line.strip())
+        if has_indent:
+            # Contains an indented block (e.g. example commands under an
+            # "Examples:" header) - keep as is.
+            filled.append(paragraph)
+        else:
+            filled.append(textwrap.fill(paragraph, width))
+    return "\n\n".join(filled)

--- a/test/drenv/options_test.py
+++ b/test/drenv/options_test.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+from drenv import options
+
+# wrap_description
+
+
+def test_wrap_description_width_shorter_than_input():
+    # Real registry-cache description, terminal narrower than the text.
+    text = "Manage the drenv registry cache. Inspect or remove cached registry containers used by drenv."
+    result = options.wrap_description(text, width=40)
+    assert result == """\
+Manage the drenv registry cache. Inspect
+or remove cached registry containers
+used by drenv."""
+
+
+def test_wrap_description_width_longer_than_input():
+    # Real registry-cache description, terminal wider than the text — no wrapping.
+    text = "Manage the drenv registry cache. Inspect or remove cached registry containers used by drenv."
+    result = options.wrap_description(text, width=120)
+    assert result == text
+
+
+def test_wrap_description_normal_paragraph_before_indented_block():
+    # Real stats command description, terminal narrower than the paragraph — paragraph wrapped, Examples block unchanged.
+    text = """\
+Display the current contents and usage statistics for the cached registry containers managed by drenv.
+
+Examples:
+  # Show cache statistics in JSON format
+  drenv registry-cache stats"""
+    result = options.wrap_description(text, width=60)
+    expected = """\
+Display the current contents and usage statistics for the
+cached registry containers managed by drenv.
+
+Examples:
+  # Show cache statistics in JSON format
+  drenv registry-cache stats"""
+    assert result == expected
+
+
+def test_wrap_description_empty_string():
+    assert options.wrap_description("", width=80) == ""


### PR DESCRIPTION
## Summary

Improve the `drenv` CLI help output by adding descriptive text and
usage examples to make commands easier to understand and use.

## Changes

- Added detailed help text describing each command's behavior.
- Included common usage examples in the CLI help output.
- Improved the overall readability and discoverability of the CLI options.
- Description/example text and option help wrap dynamically to the
  actual terminal width, instead of a fixed line length.
- Added tests to verify help text wrapping across different terminal widths and formatting scenarios.

## Why

The previous help output primarily displayed the command syntax and
available options, requiring users to refer to external documentation
to understand a command's purpose and usage. This change makes the
built-in help more informative and aligns it more closely with the
user experience provided by mature CLIs such as `kubectl`.

## Example

```console
% drenv start -h
usage: drenv start [-h] [--logfile LOGFILE] [--name-prefix PREFIX] [--skip-tests] [--skip-addons]
                   [--max-workers N] [--timeout TIMEOUT] [--local-registry] [--dns-mode {auto,static,host}]
                   envfile

Start the DR environment defined in the envfile. Creates minikube clusters for each profile (if they don't
already exist), deploys all addons, and runs addon tests. The command is idempotent — rerunning it on an          
already-running environment is safe. Run drenv setup once before the first start to prepare the host.

Examples:
  # Start the regional-dr.yaml environemnt
  drenv start test/envs/regional-dr.yaml

positional arguments:
  envfile               path to environment file

options:
  -h, --help            show this help message and exit
  --logfile LOGFILE     path to logfile (default 'drenv.log')
  --name-prefix PREFIX  prefix profile names
  --skip-tests          Do not run addons 'test' hooks
  --skip-addons         Do not run addons 'start' hooks
  --max-workers N       maximum number of workers per profile
  --timeout TIMEOUT     time in seconds to wait until clsuter is started
  --local-registry      Use local registry. For lima provider the local registry must have the k8s images for
                        kubeadm. See registry/README.md for more info.
  --dns-mode {auto,static,host}
                        DNS configuration mode. 'auto' detects managed Macs and uses 'static' if needed.
                        'static' configures public DNS servers (8.8.8.8, 1.1.1.1). 'host' uses the host resolver
                        (default for minikube, may not work on managed Macs).
```




Fixes #2715 
