### PR TITLE
ramendev: remove unused fields from cm template

### DIFF
--- a/ramendev/ramendev/resources/configmap.yaml
+++ b/ramendev/ramendev/resources/configmap.yaml
@@ -12,15 +12,6 @@ data:
   ramen_manager_config.yaml: |
     apiVersion: ramendr.openshift.io/v1alpha1
     kind: RamenConfig
-    health:
-      healthProbeBindAddress: :8081
-    metrics:
-      bindAddress: :8443
-    webhook:
-      port: 9443
-    leaderElection:
-      leaderElect: true
-      resourceName: hub.ramendr.openshift.io
     maxConcurrentReconciles: 50
     drClusterOperator:
       deploymentAutomationEnabled: $auto_deploy


### PR DESCRIPTION
The fields health, metrics, webhook, and leaderElection in the configmap are not read at startup since c0367077 ("Load RamenConfig from defaults; drop RamenControllerType from API usage"), which switched to building controller configuration from hardcoded defaults instead of the mounted config file. The webhook field was never in the RamenConfig Go struct.

Remove these dead fields to avoid misleading operators into thinking bindAddress or leaderElection settings have any effect.

Of the removed fields, three are read by `LoadControllerOptions()`:

| Removed field | Used in `LoadControllerOptions()` |
|---|---|
| `health.healthProbeBindAddress` | `options.HealthProbeBindAddress = ramenConfig.Health.HealthProbeBindAddress` |
| `metrics.bindAddress` | `options.Metrics.BindAddress = ramenConfig.Metrics.BindAddress` |
| `leaderElection.leaderElect` | `options.LeaderElection = *ramenConfig.LeaderElection.LeaderElect` |
| `leaderElection.resourceName` | `options.LeaderElectionID = ramenConfig.LeaderElection.ResourceName` |

`webhook.port` was never in the Go struct and is not used anywhere.

Before c0367077, the intent was: configmap → `LoadControllerConfig()` reads it → `LoadControllerOptions()` applies those values to `ctrl.Options`. After c0367077, `LoadControllerConfig()` returns `DefaultRamenConfig()` and the configmap values for these fields are ignored entirely.