### PR TITLE
unit test for drclusterconfig discover nads based on ramen labels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7 h1:z4P744DR+PIpkjwXSEc6TvN3L6LVzmUquFgmNm8wSUc=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7/go.mod h1:CM7HAH5PNuIsqjMN0fGc1ydM74Uj+0VZFhob620nklw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/internal/controller/drcluster_controller_test.go
+++ b/internal/controller/drcluster_controller_test.go
@@ -29,6 +29,10 @@ import (
 
 var NFClassCount int // Number of NFCs to simulate (0=disabled, 1=single, 2+=multiple)
 
+// nadDataByCluster holds per-cluster DRClusterConfig for NAD validation tests.
+// Tests set entries before creating DRPolicy objects; AfterEach should reset to {}.
+var nadDataByCluster = map[string]*ramen.DRClusterConfig{}
+
 var cidrs = [][]string{
 	{"198.51.100.17/24", "198.51.100.18/24", "198.51.100.19/24"}, // valid CIDR
 	{"198.51.100.20/24", "198.51.100.21/24", "198.51.100.22/24"}, // valid CIDR
@@ -165,6 +169,10 @@ func (f FakeMCVGetter) GetDRClusterConfigFromManagedCluster(
 	resourceName string,
 	annotations map[string]string,
 ) (*ramen.DRClusterConfig, error) {
+	// NAD validation tests pre-populate nadDataByCluster; serve that first.
+	if cfg, ok := nadDataByCluster[resourceName]; ok {
+		return cfg, nil
+	}
 	// Guard against test interference: Only return populated DRClusterConfig when
 	// NFClass is being tested to maintain test isolation for other test suites.
 	if NFClassCount > 0 {

--- a/internal/controller/drclusterconfig_controller_test.go
+++ b/internal/controller/drclusterconfig_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	ramencontrollers "github.com/ramendr/ramen/internal/controller"
 	"github.com/ramendr/ramen/internal/controller/util"
@@ -44,6 +45,7 @@ type Classes struct {
 	VolumeGroupSnapshotClasses    []string
 	NetworkFenceClasses           []string
 	storageAccessDetails          []ramen.StorageAccessDetail
+	NetworkAttachments            []ramen.NetworkAttachment
 }
 
 func ensureNamespaceExists(ctx context.Context, k8sClient client.Client, namespace string) {
@@ -81,6 +83,7 @@ func ensureClassStatus(apiReader client.Reader, drCConfig *ramen.DRClusterConfig
 		g.Expect(drClusterConfig.Status.VolumeGroupSnapshotClasses).To(ConsistOf(classes.VolumeGroupSnapshotClasses))
 		g.Expect(drClusterConfig.Status.NetworkFenceClasses).To(ConsistOf(classes.NetworkFenceClasses))
 		g.Expect(drClusterConfig.Status.StorageAccessDetails).To(ConsistOf(classes.storageAccessDetails))
+		g.Expect(drClusterConfig.Status.NetworkAttachments).To(ConsistOf(classes.NetworkAttachments))
 	}, timeout, interval).Should(Succeed())
 }
 
@@ -100,6 +103,8 @@ var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 		baseVGSC, vgsc1, vgsc2            *groupsnapv1beta1.VolumeGroupSnapshotClass
 		baseNFC, nfc1, nfc2               *csiaddonsv1alpha1.NetworkFenceClass
 		baseCSIAddonsNode, csiAddonsNode1 *csiaddonsv1alpha1.CSIAddonsNode
+		baseNAD, nad1, nad2               *netattdefv1.NetworkAttachmentDefinition
+		nadNamespace                      string
 		classes                           Classes
 	)
 
@@ -289,6 +294,24 @@ var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 				Driver: csiaddonsv1alpha1.CSIAddonsNodeDriver{
 					Name: "fake.ramen.com",
 				},
+			},
+		}
+
+		By("Defining base NAD namespace and object")
+
+		nadNamespace = "nad-test-ns"
+		ensureNamespaceExists(context.TODO(), k8sClient, nadNamespace)
+
+		baseNAD = &netattdefv1.NetworkAttachmentDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "baseNAD",
+				Namespace: nadNamespace,
+				Labels: map[string]string{
+					"ramendr.openshift.io/dr-network": "true",
+				},
+			},
+			Spec: netattdefv1.NetworkAttachmentDefinitionSpec{
+				Config: `{"type":"bridge","name":"baseNAD"}`,
 			},
 		}
 	})
@@ -915,6 +938,126 @@ var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 					Equal("Configuration processed and validated"),
 					ramen.DRClusterConfigConfigurationProcessed,
 				)
+			})
+		})
+		When("there is a NetworkAttachmentDefinition with dr-enabled label", func() {
+			It("updates DRClusterConfig Status with NetworkAttachments", func() {
+				By("creating a NetworkAttachmentDefinition with dr-enabled label")
+
+				nad1 = baseNAD.DeepCopy()
+				nad1.Name = "nad1"
+				Expect(k8sClient.Create(context.TODO(), nad1)).To(Succeed())
+
+				classes.NetworkAttachments = []ramen.NetworkAttachment{
+					{Name: nad1.Name, Namespace: nadNamespace, CNIType: "bridge"},
+				}
+
+				ensureClassStatus(apiReader, drCConfig, classes)
+				objectConditionExpectEventually(
+					apiReader,
+					drCConfig,
+					metav1.ConditionTrue,
+					Equal("Succeeded"),
+					Equal("Configuration processed and validated"),
+					ramen.DRClusterConfigConfigurationProcessed,
+				)
+			})
+		})
+		When("a NetworkAttachmentDefinition with dr-enabled label is deleted", func() {
+			It("removes the NAD from DRClusterConfig Status", func() {
+				By("deleting the NetworkAttachmentDefinition")
+
+				Expect(k8sClient.Delete(context.TODO(), nad1)).To(Succeed())
+
+				classes.NetworkAttachments = []ramen.NetworkAttachment{}
+
+				ensureClassStatus(apiReader, drCConfig, classes)
+				objectConditionExpectEventually(
+					apiReader,
+					drCConfig,
+					metav1.ConditionTrue,
+					Equal("Succeeded"),
+					Equal("Configuration processed and validated"),
+					ramen.DRClusterConfigConfigurationProcessed,
+				)
+			})
+		})
+		When("there are multiple NetworkAttachmentDefinitions with dr-enabled label", func() {
+			It("updates DRClusterConfig Status with all NetworkAttachments", func() {
+				By("creating multiple NetworkAttachmentDefinitions")
+
+				nad1 = baseNAD.DeepCopy()
+				nad1.Name = "nad1"
+				Expect(k8sClient.Create(context.TODO(), nad1)).To(Succeed())
+
+				nad2 = baseNAD.DeepCopy()
+				nad2.Name = "nad2"
+				Expect(k8sClient.Create(context.TODO(), nad2)).To(Succeed())
+
+				classes.NetworkAttachments = []ramen.NetworkAttachment{
+					{Name: nad1.Name, Namespace: nadNamespace, CNIType: "bridge"},
+					{Name: nad2.Name, Namespace: nadNamespace, CNIType: "bridge"},
+				}
+
+				ensureClassStatus(apiReader, drCConfig, classes)
+				objectConditionExpectEventually(
+					apiReader,
+					drCConfig,
+					metav1.ConditionTrue,
+					Equal("Succeeded"),
+					Equal("Configuration processed and validated"),
+					ramen.DRClusterConfigConfigurationProcessed,
+				)
+			})
+		})
+		When("a NetworkAttachmentDefinition's dr-enabled label is removed", func() {
+			It("removes the NAD from DRClusterConfig Status", func() {
+				By("removing the dr-enabled label from the NetworkAttachmentDefinition")
+
+				nad1.Labels = map[string]string{}
+				Expect(k8sClient.Update(context.TODO(), nad1)).To(Succeed())
+
+				classes.NetworkAttachments = []ramen.NetworkAttachment{
+					{Name: nad2.Name, Namespace: nadNamespace, CNIType: "bridge"},
+				}
+
+				ensureClassStatus(apiReader, drCConfig, classes)
+				objectConditionExpectEventually(
+					apiReader,
+					drCConfig,
+					metav1.ConditionTrue,
+					Equal("Succeeded"),
+					Equal("Configuration processed and validated"),
+					ramen.DRClusterConfigConfigurationProcessed,
+				)
+			})
+		})
+		When("a NetworkAttachmentDefinition without dr-enabled label exists", func() {
+			It("does not include it in DRClusterConfig Status", func() {
+				By("creating a NAD without the dr-enabled label")
+
+				unlabeledNAD := baseNAD.DeepCopy()
+				unlabeledNAD.Name = "unlabeled-nad"
+				unlabeledNAD.Labels = map[string]string{}
+				Expect(k8sClient.Create(context.TODO(), unlabeledNAD)).To(Succeed())
+
+				// NetworkAttachments should still only contain nad2 (labeled)
+				classes.NetworkAttachments = []ramen.NetworkAttachment{
+					{Name: nad2.Name, Namespace: nadNamespace, CNIType: "bridge"},
+				}
+
+				ensureClassStatus(apiReader, drCConfig, classes)
+				objectConditionExpectEventually(
+					apiReader,
+					drCConfig,
+					metav1.ConditionTrue,
+					Equal("Succeeded"),
+					Equal("Configuration processed and validated"),
+					ramen.DRClusterConfigConfigurationProcessed,
+				)
+
+				// cleanup
+				Expect(k8sClient.Delete(context.TODO(), unlabeledNAD)).To(Succeed())
 			})
 		})
 	})

--- a/internal/controller/drpolicy_controller_test.go
+++ b/internal/controller/drpolicy_controller_test.go
@@ -519,3 +519,244 @@ var _ = Describe("DRPolicyController", func() {
 		})
 	})
 })
+
+var _ = Describe("DRPolicyController NAD validation", Ordered, func() {
+	const (
+		clusterA = "nad-cluster-a"
+		clusterB = "nad-cluster-b"
+	)
+
+	// nadEntry builds a NetworkAttachment suitable for DRClusterConfig status.
+	nadEntry := func(name, ns, cniType string) ramen.NetworkAttachment {
+		return ramen.NetworkAttachment{Name: name, Namespace: ns, CNIType: cniType}
+	}
+
+	// drccWith builds a minimal DRClusterConfig whose status carries the given NADs.
+	drccWith := func(cluster string, nads ...ramen.NetworkAttachment) *ramen.DRClusterConfig {
+		return &ramen.DRClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: cluster},
+			Status:     ramen.DRClusterConfigStatus{NetworkAttachments: nads},
+		}
+	}
+
+	// nadConditionExpect polls until the DRPolicy carries the expected
+	// NetworkAttachmentsValidated condition status and message.
+	nadConditionExpect := func(drp *ramen.DRPolicy, status metav1.ConditionStatus,
+		msgMatcher gomegaTypes.GomegaMatcher,
+	) {
+		Eventually(func(g Gomega) {
+			g.Expect(apiReader.Get(context.TODO(), types.NamespacedName{Name: drp.Name}, drp)).To(Succeed())
+			cond := util.FindCondition(drp.Status.Conditions, controllers.ConditionNetworkAttachmentsValidated)
+			g.Expect(cond).NotTo(BeNil())
+			g.Expect(cond.Status).To(Equal(status))
+			g.Expect(cond.Message).To(msgMatcher)
+		}, timeout, interval).Should(Succeed())
+	}
+
+	// deletePolicy deletes a DRPolicy and waits for it to disappear.
+	deletePolicy := func(drp *ramen.DRPolicy) {
+		Expect(k8sClient.Delete(context.TODO(), drp)).To(Succeed())
+		Eventually(func() bool {
+			return k8serrors.IsNotFound(apiReader.Get(context.TODO(), types.NamespacedName{Name: drp.Name}, drp))
+		}, timeout, interval).Should(BeTrue())
+	}
+
+	// newNetworkPolicy creates a DRPolicy spec referencing both NAD clusters
+	// and a NetworkMappingRef so that NAD validation is triggered.
+	newNetworkPolicy := func(name string) *ramen.DRPolicy {
+		return &ramen.DRPolicy{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: ramen.DRPolicySpec{
+				DRClusters:         []string{clusterA, clusterB},
+				SchedulingInterval: "1h",
+				NetworkMappingRef:  &corev1.LocalObjectReference{Name: "dummy-network-map"},
+			},
+		}
+	}
+
+	BeforeAll(func() {
+		By("creating ManagedClusters and DRClusters for NAD validation tests")
+
+		for _, name := range []string{clusterA, clusterB} {
+			ensureManagedCluster(k8sClient, name)
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+			_ = k8sClient.Create(context.TODO(), ns) // ignore already-exists
+
+			drc := &ramen.DRCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Spec:       ramen.DRClusterSpec{S3ProfileName: s3Profiles[0].S3ProfileName, Region: "east"},
+			}
+
+			if err := k8sClient.Create(context.TODO(), drc); err != nil && !k8serrors.IsAlreadyExists(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			updateDRClusterManifestWorkStatus(k8sClient, apiReader, name)
+			updateDRClusterConfigMWStatus(k8sClient, apiReader, name)
+			objectConditionExpectEventually(
+				apiReader,
+				drc,
+				metav1.ConditionTrue,
+				Equal("Succeeded"),
+				Ignore(),
+				ramen.DRClusterValidated,
+				!ramenConfig.DrClusterOperator.DeploymentAutomationEnabled,
+			)
+		}
+	})
+
+	AfterAll(func() {
+		By("removing DRClusters created for NAD validation tests")
+
+		for _, name := range []string{clusterA, clusterB} {
+			drc := &ramen.DRCluster{ObjectMeta: metav1.ObjectMeta{Name: name}}
+			_ = k8sClient.Delete(context.TODO(), drc)
+		}
+	})
+
+	AfterEach(func() {
+		// Reset shared NAD map so each It starts clean.
+		nadDataByCluster = map[string]*ramen.DRClusterConfig{}
+	})
+
+	When("DRPolicy has no NetworkMappingRef", func() {
+		It("does not set NetworkAttachmentsValidated condition", func() {
+			drp := &ramen.DRPolicy{
+				ObjectMeta: metav1.ObjectMeta{Name: "nad-no-mapping"},
+				Spec: ramen.DRPolicySpec{
+					DRClusters:         []string{clusterA, clusterB},
+					SchedulingInterval: "1h",
+				},
+			}
+			Expect(k8sClient.Create(context.TODO(), drp)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(apiReader.Get(context.TODO(), types.NamespacedName{Name: drp.Name}, drp)).To(Succeed())
+				cond := util.FindCondition(drp.Status.Conditions, controllers.ConditionNetworkAttachmentsValidated)
+				g.Expect(cond).To(BeNil())
+				validated := util.FindCondition(drp.Status.Conditions, ramen.DRPolicyValidated)
+				g.Expect(validated).NotTo(BeNil())
+				g.Expect(validated.Status).To(Equal(metav1.ConditionTrue))
+			}, timeout, interval).Should(Succeed())
+
+			deletePolicy(drp)
+		})
+	})
+
+	When("NADs are symmetric across both clusters", func() {
+		It("sets NetworkAttachmentsValidated=True and populates NetworkPeers", func() {
+			nad := nadEntry("macvlan-net", "vm-ns", "macvlan")
+			nadDataByCluster[clusterA] = drccWith(clusterA, nad)
+			nadDataByCluster[clusterB] = drccWith(clusterB, nad)
+
+			drp := newNetworkPolicy("nad-symmetric")
+			Expect(k8sClient.Create(context.TODO(), drp)).To(Succeed())
+
+			nadConditionExpect(drp, metav1.ConditionTrue, ContainSubstring("symmetric"))
+
+			Eventually(func(g Gomega) {
+				g.Expect(apiReader.Get(context.TODO(), types.NamespacedName{Name: drp.Name}, drp)).To(Succeed())
+				g.Expect(drp.Status.NetworkPeers).To(HaveLen(1))
+				peer := drp.Status.NetworkPeers[0]
+				g.Expect(peer.NADName).To(Equal("macvlan-net"))
+				g.Expect(peer.NADNamespace).To(Equal("vm-ns"))
+				g.Expect(peer.ClusterCNITypes).To(HaveKeyWithValue(clusterA, "macvlan"))
+				g.Expect(peer.ClusterCNITypes).To(HaveKeyWithValue(clusterB, "macvlan"))
+				validated := util.FindCondition(drp.Status.Conditions, ramen.DRPolicyValidated)
+				g.Expect(validated).NotTo(BeNil())
+				g.Expect(validated.Status).To(Equal(metav1.ConditionTrue))
+			}, timeout, interval).Should(Succeed())
+
+			deletePolicy(drp)
+		})
+	})
+
+	When("a NAD is present on clusterA but missing on clusterB", func() {
+		It("sets NetworkAttachmentsValidated=False and DRPolicyValidated=False with reason NADsMissing", func() {
+			nadDataByCluster[clusterA] = drccWith(clusterA, nadEntry("net1", "vm-ns", "macvlan"))
+			nadDataByCluster[clusterB] = drccWith(clusterB) // empty
+
+			drp := newNetworkPolicy("nad-missing-on-b")
+			Expect(k8sClient.Create(context.TODO(), drp)).To(Succeed())
+
+			nadConditionExpect(drp, metav1.ConditionFalse, ContainSubstring("missing"))
+
+			Eventually(func(g Gomega) {
+				g.Expect(apiReader.Get(context.TODO(), types.NamespacedName{Name: drp.Name}, drp)).To(Succeed())
+				validated := util.FindCondition(drp.Status.Conditions, ramen.DRPolicyValidated)
+				g.Expect(validated).NotTo(BeNil())
+				g.Expect(validated.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(validated.Reason).To(Equal("NADsMissing"))
+				g.Expect(drp.Status.NetworkPeers).To(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+
+			deletePolicy(drp)
+		})
+	})
+
+	When("a NAD is present on clusterB but missing on clusterA", func() {
+		It("sets NetworkAttachmentsValidated=False listing the missing NAD by name", func() {
+			nadDataByCluster[clusterA] = drccWith(clusterA) // empty
+			nadDataByCluster[clusterB] = drccWith(clusterB, nadEntry("bridge-net", "vm-ns", "bridge"))
+
+			drp := newNetworkPolicy("nad-missing-on-a")
+			Expect(k8sClient.Create(context.TODO(), drp)).To(Succeed())
+
+			nadConditionExpect(drp, metav1.ConditionFalse, ContainSubstring("missing"))
+
+			deletePolicy(drp)
+		})
+	})
+
+	When("multiple NADs are all symmetric across both clusters", func() {
+		It("populates NetworkPeers for each NAD", func() {
+			nads := []ramen.NetworkAttachment{
+				nadEntry("net1", "vm-ns", "macvlan"),
+				nadEntry("net2", "vm-ns", "bridge"),
+			}
+			nadDataByCluster[clusterA] = drccWith(clusterA, nads...)
+			nadDataByCluster[clusterB] = drccWith(clusterB, nads...)
+
+			drp := newNetworkPolicy("nad-multi-symmetric")
+			Expect(k8sClient.Create(context.TODO(), drp)).To(Succeed())
+
+			nadConditionExpect(drp, metav1.ConditionTrue, ContainSubstring("symmetric"))
+
+			Eventually(func(g Gomega) {
+				g.Expect(apiReader.Get(context.TODO(), types.NamespacedName{Name: drp.Name}, drp)).To(Succeed())
+				g.Expect(drp.Status.NetworkPeers).To(HaveLen(2))
+			}, timeout, interval).Should(Succeed())
+
+			deletePolicy(drp)
+		})
+	})
+
+	When("NADs are corrected to be symmetric after an initial mismatch", func() {
+		It("transitions NetworkAttachmentsValidated from False to True", func() {
+			// Start with NAD only on clusterA — mismatch.
+			nadDataByCluster[clusterA] = drccWith(clusterA, nadEntry("heal-net", "vm-ns", "macvlan"))
+			nadDataByCluster[clusterB] = drccWith(clusterB)
+
+			drp := newNetworkPolicy("nad-healed")
+			Expect(k8sClient.Create(context.TODO(), drp)).To(Succeed())
+
+			nadConditionExpect(drp, metav1.ConditionFalse, ContainSubstring("missing"))
+
+			// Fix: add the NAD to clusterB, then trigger a reconcile via annotation update.
+			nadDataByCluster[clusterB] = drccWith(clusterB, nadEntry("heal-net", "vm-ns", "macvlan"))
+
+			Eventually(func(g Gomega) {
+				g.Expect(apiReader.Get(context.TODO(), types.NamespacedName{Name: drp.Name}, drp)).To(Succeed())
+				if drp.Annotations == nil {
+					drp.Annotations = map[string]string{}
+				}
+				drp.Annotations["test.ramendr.io/trigger"] = "healed"
+				g.Expect(k8sClient.Update(context.TODO(), drp)).To(Succeed())
+			}, timeout, interval).Should(Succeed())
+
+			nadConditionExpect(drp, metav1.ConditionTrue, ContainSubstring("symmetric"))
+
+			deletePolicy(drp)
+		})
+	})
+})

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -14,6 +14,7 @@ import (
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
 	"github.com/go-logr/logr"
+	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -51,6 +52,7 @@ import (
 	argocdv1alpha1hack "github.com/ramendr/ramen/internal/controller/argocd"
 	testutils "github.com/ramendr/ramen/internal/controller/testutils"
 	"github.com/ramendr/ramen/internal/controller/util"
+
 	// +kubebuilder:scaffold:imports
 	_ "github.com/ramendr/ramen/internal/dummy"
 )
@@ -238,6 +240,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = virtv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = netattdefv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	// +kubebuilder:scaffold:scheme
 


### PR DESCRIPTION
Add Ginkgo/Gomega integration tests for the NetworkAttachmentDefinition
discovery path introduced in updateNetworkAttachmentsStatus.

Changes:
- hack/test: add NAD CRD YAML so envtest loads the k8s.cni.cncf.io/v1
  NetworkAttachmentDefinition resource
- suite_test.go: register netattdefv1 scheme so the client and informer
  cache recognise NAD objects
- drclusterconfig_controller_test.go:
  - add NetworkAttachments field to Classes helper struct
  - extend ensureClassStatus to assert Status.NetworkAttachments
  - add nad1, nad2, nadNamespace variables and baseNAD fixture labelled
    with ramendr.openshift.io/dr-network=true
  - add five ordered When cases covering:
    * single labeled NAD appears in status with correct CNIType
    * labeled NAD deleted → removed from status
    * multiple labeled NADs → all appear in status
    * label removed → NAD leaves status
    * unlabeled NAD → not included in status

The NAD label key matches the controller constant NADDRNetworkLabel
(ramendr.openshift.io/dr-network) and expected CNIType values match
what parseCNIType extracts from spec.config.

Assisted by : IBM BOB v2.0.3