### PR TITLE
config: deprecate ignored metrics.bindAddress

### DIFF
--- a/api/v1alpha1/ramenconfig_types.go
+++ b/api/v1alpha1/ramenconfig_types.go
@@ -80,9 +80,8 @@ type S3StoreProfile struct {
 
 // ControllerMetrics defines the controller metrics configuration
 type ControllerMetrics struct {
-	// BindAddress is the TCP address that the controller should bind to
-	// for serving prometheus metrics.
-	// It can be set to "0" to disable the metrics serving.
+	// Deprecated: Ignored. The metrics listen address is not a user setting; the operator always
+	// binds 0.0.0.0:9289, which the metrics Service, NetworkPolicy, and scrape config assume.
 	// +optional
 	BindAddress string `json:"bindAddress,omitempty"`
 }

--- a/config/samples/ramendr_v1alpha1_ramenconfig.yaml
+++ b/config/samples/ramendr_v1alpha1_ramenconfig.yaml
@@ -2,8 +2,6 @@ apiVersion: ramendr.openshift.io/v1alpha1
 kind: RamenConfig
 health:
   healthProbeBindAddress: :8081
-metrics:
-  bindAddress: :8443
 webhook:
   port: 9443
 leaderElection:

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -129,8 +129,6 @@ data:
     # Health check and monitoring
     health:
       healthProbeBindAddress: :8081
-    metrics:
-      bindAddress: 127.0.0.1:8080
 
     # Leader election
     leaderElection:
@@ -184,6 +182,13 @@ kubectl get pods -n ramen-system -w
 
 Wait for the hub operator pod to reach `Running` state with `2/2` containers
 ready.
+
+## Deprecated options
+
+**`metrics.bindAddress`** is deprecated and ignored. The operator always listens
+on `0.0.0.0:9289`. The metrics Service, NetworkPolicy, and Prometheus scrape
+config assume that port, so it is not a user setting. See
+[metrics.md](metrics.md).
 
 ## Create DRCluster Resources
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,6 +10,9 @@ registry in each controller. There are two ways where you can look at the
 metrics in ramen. One way is use prometheus stack(recommended) and the other way
 is to use curl or postman. More details on each of these in the below sections.
 
+`metrics.bindAddress` in the operator ConfigMap is deprecated and ignored. See
+[Deprecated options](configure.md#deprecated-options).
+
 More information on metrics is
 [here](https://book.kubebuilder.io/reference/metrics.html)
 

--- a/examples/dr_cluster_config.yaml
+++ b/examples/dr_cluster_config.yaml
@@ -3,8 +3,6 @@ apiVersion: ramendr.openshift.io/v1alpha1
 kind: RamenConfig
 health:
   healthProbeBindAddress: :8081
-metrics:
-  bindAddress: 127.0.0.1:9289
 webhook:
   port: 9443
 leaderElection:

--- a/examples/dr_hub_config.yaml
+++ b/examples/dr_hub_config.yaml
@@ -3,8 +3,6 @@ apiVersion: ramendr.openshift.io/v1alpha1
 kind: RamenConfig
 health:
   healthProbeBindAddress: :8081
-metrics:
-  bindAddress: 127.0.0.1:9289
 webhook:
   port: 9443
 leaderElection:

--- a/internal/controller/drcluster_drcconfig_test.go
+++ b/internal/controller/drcluster_drcconfig_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
@@ -102,9 +103,6 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 				LeaderElect:  new(bool),
 				ResourceName: ramencontrollers.HubLeaderElectionResourceName,
 			},
-			Metrics: ramen.ControllerMetrics{
-				BindAddress: "0", // Disable metrics
-			},
 		}
 		ramenConfig.DrClusterOperator.DeploymentAutomationEnabled = true
 		ramenConfig.DrClusterOperator.S3SecretDistributionEnabled = true
@@ -118,9 +116,13 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 
 		By("starting the DRCluster reconciler")
 
-		options := manager.Options{Scheme: scheme.Scheme}
+		options := manager.Options{
+			Scheme: scheme.Scheme,
+			Metrics: metricsserver.Options{
+				BindAddress: "0", // Disable metrics
+			},
+		}
 		options.Controller.SkipNameValidation = ptr.To(true)
-		ramencontrollers.LoadControllerOptions(&options, ramenConfig)
 
 		k8sManager, err := ctrl.NewManager(cfg, options)
 		Expect(err).ToNot(HaveOccurred())

--- a/internal/controller/drcluster_mmode_test.go
+++ b/internal/controller/drcluster_mmode_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
@@ -118,9 +119,6 @@ var _ = Describe("DRClusterMModeTests", Ordered, func() {
 				LeaderElect:  new(bool),
 				ResourceName: ramencontrollers.HubLeaderElectionResourceName,
 			},
-			Metrics: rmn.ControllerMetrics{
-				BindAddress: "0", // Disable metrics
-			},
 			S3StoreProfiles: []rmn.S3StoreProfile{
 				{
 					S3ProfileName:        "fake",
@@ -152,9 +150,13 @@ var _ = Describe("DRClusterMModeTests", Ordered, func() {
 
 		By("starting the DRCluster reconciler")
 
-		options := manager.Options{Scheme: scheme.Scheme}
+		options := manager.Options{
+			Scheme: scheme.Scheme,
+			Metrics: metricsserver.Options{
+				BindAddress: "0", // Disable metrics
+			},
+		}
 		options.Controller.SkipNameValidation = ptr.To(true)
-		ramencontrollers.LoadControllerOptions(&options, ramenConfig)
 
 		Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/drclusterconfig_controller_test.go
+++ b/internal/controller/drclusterconfig_controller_test.go
@@ -24,11 +24,11 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
-	config "k8s.io/component-base/config/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
@@ -144,22 +144,12 @@ var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 
 		By("starting the DRClusterConfig reconciler")
 
-		ramenConfig := &ramen.RamenConfig{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "RamenConfig",
-				APIVersion: ramen.GroupVersion.String(),
-			},
-			LeaderElection: &config.LeaderElectionConfiguration{
-				LeaderElect:  new(bool),
-				ResourceName: ramencontrollers.HubLeaderElectionResourceName,
-			},
-			Metrics: ramen.ControllerMetrics{
+		options := manager.Options{
+			Scheme: scheme.Scheme,
+			Metrics: metricsserver.Options{
 				BindAddress: "0", // Disable metrics
 			},
 		}
-
-		options := manager.Options{Scheme: scheme.Scheme}
-		ramencontrollers.LoadControllerOptions(&options, ramenConfig)
 
 		k8sManager, err := ctrl.NewManager(cfg, options)
 		Expect(err).ToNot(HaveOccurred())

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -44,6 +44,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
@@ -335,8 +336,12 @@ var _ = BeforeSuite(func() {
 	s3ProfilesSecretNamespaceNameSet()
 	s3ProfilesUpdate()
 
-	options := manager.Options{Scheme: scheme.Scheme}
-	ramencontrollers.LoadControllerOptions(&options, ramenConfig)
+	options := manager.Options{
+		Scheme: scheme.Scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0", // Disable metrics
+		},
+	}
 
 	Expect(err).NotTo(HaveOccurred())
 

--- a/ramendev/ramendev/resources/configmap.yaml
+++ b/ramendev/ramendev/resources/configmap.yaml
@@ -14,8 +14,6 @@ data:
     kind: RamenConfig
     health:
       healthProbeBindAddress: :8081
-    metrics:
-      bindAddress: :8443
     webhook:
       port: 9443
     leaderElection:


### PR DESCRIPTION
c0367077 ("Load RamenConfig from defaults") stopped applying the ConfigMap when starting the manager. metrics.bindAddress is stored but never used; the operator always binds 0.0.0.0:9289. That drop was unintentional, but we are keeping the behavior.

The listen port is wired to the metrics Service (8443 -> 9289), NetworkPolicy, and Prometheus scrape config. Honoring a user value would break upgrades — existing ConfigMaps still contain leftover addresses such as :8443 or 127.0.0.1:9289 — and changing the port in the ConfigMap alone is not practical.

The same commit left other manager options unused (health probes, leader election, ramenControllerType). This change handles only metrics.bindAddress.

Document the field as deprecated and remove it from samples and examples so users do not treat it as a setting.

Tests used the same field with LoadControllerOptions to disable the metrics listener. That taught tests that ConfigMap metrics.bindAddress configures the manager, which it does not. Disable metrics on manager.Options directly (BindAddress: "0"), matching the volsync and cephfscg suites, and drop LoadControllerOptions from tests. Production remains the only caller.

LoadControllerOptions only copies health, metrics, and leader-election fields into ctrl.Options. It does not mutate ramenConfig or write the ConfigMap. Tests still create the ConfigMap from the ramenConfig struct, so dropping the call does not change ConfigMap contents used by reconcilers.