### PR TITLE
Prevent new CG PVCs from inheriting stale VGR sync time

### DIFF
--- a/internal/controller/vrg_volgrouprep_global.go
+++ b/internal/controller/vrg_volgrouprep_global.go
@@ -323,7 +323,7 @@ func (v *VRGInstance) validateGlobalVGRStatus(
 
 		v.updatePVCDataReadyCondition(pvc.Namespace, pvc.Name, dataReadyReason, dataReadyMsg)
 		v.updatePVCDataProtectedCondition(pvc.Namespace, pvc.Name, VRGConditionReasonDataProtected, dataProtectedMsg)
-		v.updatePVCLastSyncCounters(pvc.Namespace, pvc.Name, status)
+		v.updatePVCLastSyncCounters(pvc, status)
 	}
 
 	v.log.Info("Global VGR status validated", "vgr", volRep.GetName(), "namespace", volRep.GetNamespace(), "state", state)

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -1332,7 +1332,7 @@ func (v *VRGInstance) processVRAsPrimary(vrNamespacedName types.NamespacedName,
 		msg := "PVC in the VolumeReplicationGroup is ready for use"
 		v.updatePVCDataReadyCondition(vrNamespacedName.Namespace, vrNamespacedName.Name, VRGConditionReasonReady, msg)
 		v.updatePVCDataProtectedCondition(vrNamespacedName.Namespace, vrNamespacedName.Name, VRGConditionReasonReady, msg)
-		v.updatePVCLastSyncCounters(vrNamespacedName.Namespace, vrNamespacedName.Name, nil)
+		v.updatePVCLastSyncCounters(pvc, nil)
 
 		return false, true, nil
 	}
@@ -1365,7 +1365,7 @@ func (v *VRGInstance) processVRAsSecondary(vrNamespacedName types.NamespacedName
 		v.updatePVCDataReadyCondition(vrNamespacedName.Namespace, vrNamespacedName.Name, VRGConditionReasonReplicated, msg)
 		v.updatePVCDataProtectedCondition(vrNamespacedName.Namespace, vrNamespacedName.Name, VRGConditionReasonDataProtected,
 			msg)
-		v.updatePVCLastSyncCounters(vrNamespacedName.Namespace, vrNamespacedName.Name, nil)
+		v.updatePVCLastSyncCounters(pvc, nil)
 
 		return false, true, nil
 	}
@@ -1865,7 +1865,7 @@ func (v *VRGInstance) validateVRStatus(pvcs []*corev1.PersistentVolumeClaim, vol
 
 		v.updatePVCDataReadyCondition(pvc.Namespace, pvc.Name, VRGConditionReasonReady, msg)
 		v.updatePVCDataProtectedCondition(pvc.Namespace, pvc.Name, VRGConditionReasonReady, msg)
-		v.updatePVCLastSyncCounters(pvc.Namespace, pvc.Name, status)
+		v.updatePVCLastSyncCounters(pvc, status)
 	}
 
 	v.checkAndUpdateDestinationInfoAvailable(pvcs, status)
@@ -1968,7 +1968,7 @@ func (v *VRGInstance) validateAdditionalVRStatusForSecondary(pvcs []*corev1.Pers
 	for idx := range pvcs {
 		pvc := pvcs[idx]
 
-		v.updatePVCLastSyncCounters(pvc.Namespace, pvc.Name, nil)
+		v.updatePVCLastSyncCounters(pvc, nil)
 	}
 
 	conditionMet, _, _ := isVRConditionMet(volRep, status, volrep.ConditionResyncing, metav1.ConditionTrue)
@@ -2288,8 +2288,10 @@ func (v *VRGInstance) checkAndUpdateDestinationInfoAvailable(
 	}
 }
 
-func (v *VRGInstance) updatePVCLastSyncCounters(pvcNamespace, pvcName string, status *volrep.VolumeReplicationStatus) {
-	protectedPVC := v.findProtectedPVC(pvcNamespace, pvcName)
+func (v *VRGInstance) updatePVCLastSyncCounters(pvc *corev1.PersistentVolumeClaim,
+	status *volrep.VolumeReplicationStatus,
+) {
+	protectedPVC := v.findProtectedPVC(pvc.Namespace, pvc.Name)
 	if protectedPVC == nil {
 		return
 	}
@@ -2302,6 +2304,13 @@ func (v *VRGInstance) updatePVCLastSyncCounters(pvcNamespace, pvcName string, st
 			protectedPVC.LastSyncBytes = nil
 		}
 	} else {
+		// Check if CG is enabled for this PVC
+		_, cgEnabled := v.isCGEnabled(pvc)
+
+		if cgEnabled && !v.isPVCSyncedInVGR(pvc, protectedPVC, status.LastSyncTime) {
+			return
+		}
+
 		protectedPVC.LastSyncTime = status.LastSyncTime
 		protectedPVC.LastSyncDuration = status.LastSyncDuration
 
@@ -2309,6 +2318,88 @@ func (v *VRGInstance) updatePVCLastSyncCounters(pvcNamespace, pvcName string, st
 			protectedPVC.LastSyncBytes = status.LastSyncBytes
 		}
 	}
+}
+
+// isPVCSyncedInVGR checks if a PVC should receive sync time updates from VGR.
+// It ensures:
+//  1. The PVC is in the grouped list (storage backend included it)
+//  2. The VGR sync time is newer than the PVC creation time (sync actually included this PVC)
+//  3. If the PVC has never been synced, the VGR sync time is not already recorded on
+//     other group members (the PVC joined after that sync completed)
+func (v *VRGInstance) isPVCSyncedInVGR(pvc *corev1.PersistentVolumeClaim,
+	protectedPVC *ramendrv1alpha1.ProtectedPVC,
+	vgrSyncTime *metav1.Time,
+) bool {
+	if vgrSyncTime == nil {
+		return true
+	}
+
+	if !v.pvcInGroupedList(pvc.Name) {
+		v.log.Info("Skipping sync time update for PVC not in VGR grouped list",
+			"pvc", pvc.Name)
+
+		return false
+	}
+
+	if !vgrSyncTime.After(pvc.CreationTimestamp.Time) {
+		v.log.Info("Skipping sync time update - VGR sync time is not after PVC creation",
+			"pvc", pvc.Name,
+			"pvcCreationTime", pvc.CreationTimestamp,
+			"vgrSyncTime", vgrSyncTime)
+
+		return false
+	}
+
+	if protectedPVC.LastSyncTime == nil &&
+		v.groupAlreadyHasThisSyncTime(pvc.Name, vgrSyncTime) {
+		v.log.Info("Skipping sync time update - PVC joined after this VGR sync time",
+			"pvc", pvc.Name,
+			"vgrSyncTime", vgrSyncTime)
+
+		return false
+	}
+
+	return true
+}
+
+func (v *VRGInstance) pvcInGroupedList(pvcName string) bool {
+	for _, group := range v.instance.Status.PVCGroups {
+		if slices.Contains(group.Grouped, pvcName) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// groupAlreadyHasThisSyncTime reports whether another PVC in the same Groups.Grouped
+// entry already recorded vgrSyncTime at the start of this reconcile. That means the
+// sync completed before this PVC joined. savedInstanceStatus is used so LastSyncTime
+// updates earlier in this reconcile cannot hide a later, real group sync from a
+// newly joined PVC.
+func (v *VRGInstance) groupAlreadyHasThisSyncTime(pvcName string, vgrSyncTime *metav1.Time) bool {
+	if vgrSyncTime == nil {
+		return false
+	}
+
+	for i := range v.savedInstanceStatus.ProtectedPVCs {
+		otherPVC := &v.savedInstanceStatus.ProtectedPVCs[i]
+		if otherPVC.Name == pvcName || otherPVC.LastSyncTime == nil {
+			continue
+		}
+
+		if !otherPVC.LastSyncTime.Equal(vgrSyncTime) {
+			continue
+		}
+
+		for _, group := range v.instance.Status.PVCGroups {
+			if slices.Contains(group.Grouped, pvcName) && slices.Contains(group.Grouped, otherPVC.Name) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 // ensureVRDeletedFromAPIServer adds an additional step to ensure that we wait for volumereplication deletion


### PR DESCRIPTION
# Summary

Prevent newly added PVCs in Consistency Groups from receiving a stale group sync time.

Previously, a new PVC could immediately inherit the latest VGR sync time even if that VGR sync happened before the PVC was actually included in the Consistency Group on the storage side. This could cause the PVC to be reported as `Synced` prematurely in DRPC.

# Cases

**1. PVC not in the grouped list**

The PVC is protected by the VRG but is not in `Status.PVCGroups` yet (from `VGR.Status.PersistentVolumeClaimsRefList`) — CSI has not listed it as a member, or `PVCGroups` still reflects the previous reconcile. The current VGR `LastSyncTime` is not applied.

Log: `Skipping sync time update for PVC not in VGR grouped list`

**2. PVC created after the last sync**

The PVC is in the grouped list, but it was created after `LastSyncTime` (for example a new volume that joined while VGR still reports an older group sync). That sync cannot have included this PVC.

Log: `Skipping sync time update - VGR sync time is older than PVC creation`

**3. PVC joined after this sync time**

The PVC is in the grouped list and existed before `LastSyncTime`, but it was unprotected / not in the group when that sync ran. Another grouped PVC already has this same `LastSyncTime`, so this volume must not inherit it.

Log: `Skipping sync time update - PVC joined after this VGR sync time`

After the next group sync with a newer `LastSyncTime`, none of these skips apply and that PVC gets the new time.

# Result

This ensures that a new PVC receives the VGR sync time only after a group sync that could actually have included it, preventing premature `Synced` status in DRPC.

Fixes: https://redhat.atlassian.net/browse/DFBUGS-5635