### PR TITLE
s3: include OrigErr in AWS error wrapping

### DIFF
--- a/internal/controller/s3utils.go
+++ b/internal/controller/s3utils.go
@@ -256,7 +256,7 @@ func (s *s3ObjectStore) HeadBucket() error {
 		Bucket: &s.s3Bucket,
 	})
 	if err != nil {
-		return processAwsError(fmt.Errorf("bucket %s does not exist or is not accessible", s.s3Bucket), err)
+		return processAwsError(fmt.Errorf("failed to head bucket %s", s.s3Bucket), err)
 	}
 
 	return nil

--- a/internal/controller/s3utils.go
+++ b/internal/controller/s3utils.go
@@ -424,12 +424,22 @@ func DeleteTypedObject(s ObjectStorer, keyPrefix, keySuffix string, object inter
 }
 
 func processAwsError(errMsgPrefix, err error) error {
-	var awsErr awserr.Error
-	if errors.As(err, &awsErr) {
-		return fmt.Errorf("%w: code: %s, message: %s", errMsgPrefix, awsErr.Code(), awsErr.Message())
+	if err == nil {
+		return errMsgPrefix
 	}
 
-	return errMsgPrefix
+	var awsErr awserr.Error
+	if !errors.As(err, &awsErr) {
+		return fmt.Errorf("%w: %w", errMsgPrefix, err)
+	}
+
+	if origErr := awsErr.OrigErr(); origErr != nil {
+		return fmt.Errorf("%w: code: %s, message: %s, orig: %v",
+			errMsgPrefix, awsErr.Code(), awsErr.Message(), origErr)
+	}
+
+	return fmt.Errorf("%w: code: %s, message: %s",
+		errMsgPrefix, awsErr.Code(), awsErr.Message())
 }
 
 // UploadObject uploads the given object to the bucket with the given key.


### PR DESCRIPTION
## Summary
- Include `OrigErr()` in `processAwsError` so RequestError logs show the real cause (x509 / timeout / reset) instead of only `send request failed`.
- Rename the HeadBucket error prefix to `failed to head bucket %s` so it names the operation instead of guessing the bucket is missing.
- Fixes #2724 

## Verification

### Connection refused (OrigErr)

Scale MinIO down, then annotate `DRCluster` so the hub re-runs S3 validation:

```bash
kubectl scale deploy/minio -n minio --replicas=0 --context dr1
kubectl annotate drcluster dr1 --context hub ramen.test/s3=$(date +%s) --overwrite
```

```
drcluster.ramendr.openshift.io/dr1 annotated
```


```bash
kubectl get drcluster dr1 --context hub -o jsonpath='{.status.conditions[?(@.type=="Validated")]}{"\n"}'
```

```
{"lastTransitionTime":"2026-09-09T09:20:10Z","message":"minio-on-dr1: failed to head bucket bucket: code: RequestError, message: send request failed, orig: Head \"http://192.168.122.43:30000/bucket\": dial tcp 192.168.122.43:30000: connect: connection refused","observedGeneration":1,"reason":"s3BucketNotFound","status":"False","type":"Validated"}
```

Hub operator logs for the same incident:

```bash
kubectl logs -n ramen-system deploy/ramen-hub-operator -c manager --context hub --since=5m \
  | grep -E 'Reconciler error|s3Profile validate|failed to head bucket|orig:'
```

```
2026-09-09T09:20:10.224Z	INFO	drc	util/conditions.go:39	condition update	{"drc": "dr1", "type": "Validated", "old status": "True", "new status": "False", "old reason": "Succeeded", "new reason": "s3BucketNotFound", "old message": "Validated the cluster", "new message": "minio-on-dr1: failed to head bucket bucket: code: RequestError, message: send request failed, orig: Head \"http://192.168.122.43:30000/bucket\": dial tcp 192.168.122.43:30000: connect: connection refused"}
2026-09-09T09:20:10.239Z	ERROR	controller/controller.go:495	Reconciler error	{"controller": "drcluster", "name": "dr1", "error": "drclusters s3Profile validate: minio-on-dr1: failed to head bucket bucket: code: RequestError, message: send request failed, orig: Head \"http://192.168.122.43:30000/bucket\": dial tcp 192.168.122.43:30000: connect: connection refused"}
```

### HTTPS endpoint (OrigErr)

With MinIO up and both DRClusters `Validated=True`, change only `minio-on-dr1` `s3CompatibleEndpoint` from `http://` to `https://`:

```bash
python3 - <<'PY'
import json, subprocess, sys, yaml
from pathlib import Path
cm = json.loads(subprocess.check_output([
    "kubectl", "get", "cm", "ramen-hub-operator-config",
    "-n", "ramen-system", "--context", "hub", "-o", "json",
]))
cfg = yaml.safe_load(cm["data"]["ramen_manager_config.yaml"])
for p in cfg["s3StoreProfiles"]:
    if p["s3ProfileName"] == "minio-on-dr1":
        ep = p["s3CompatibleEndpoint"]
        if ep.startswith("http://"):
            p["s3CompatibleEndpoint"] = "https://" + ep[len("http://"):]
        print("patched", p["s3ProfileName"], p["s3CompatibleEndpoint"], file=sys.stderr)
        break
Path("/tmp/ramen-cm.patch.json").write_text(json.dumps({
    "data": {"ramen_manager_config.yaml": yaml.safe_dump(cfg)}
}))
PY
kubectl patch cm ramen-hub-operator-config -n ramen-system --context hub --type merge --patch-file=/tmp/ramen-cm.patch.json
```

```
patched minio-on-dr1 https://192.168.122.43:30000
configmap/ramen-hub-operator-config patched
```


```bash
kubectl get drcluster dr1 --context hub -o jsonpath='{.status.conditions[?(@.type=="Validated")]}{"\n"}'
```

```
{"lastTransitionTime":"2026-09-09T09:38:27Z","message":"minio-on-dr1: failed to head bucket bucket: code: RequestError, message: send request failed, orig: Head \"https://192.168.122.43:30000/bucket\": http: server gave HTTP response to HTTPS client","observedGeneration":1,"reason":"s3BucketNotFound","status":"False","type":"Validated"}
```

`dr2` stayed `Validated=True`. Hub operator logs for the same incident:

```bash
kubectl logs -n ramen-system deploy/ramen-hub-operator -c manager --context hub --since=5m \
  | grep -E 'Reconciler error|s3Profile validate|failed to head bucket|orig:'
```

```
2026-09-09T09:38:33.961Z	ERROR	controller/controller.go:495	Reconciler error	{"controller": "drcluster", "name": "dr1", "error": "drclusters s3Profile validate: minio-on-dr1: failed to head bucket bucket: code: RequestError, message: send request failed, orig: Head \"https://192.168.122.43:30000/bucket\": http: server gave HTTP response to HTTPS client"}
```

### Missing bucket (HeadBucket prefix)

Set only `minio-on-dr1` `s3Bucket` to `missing-bucket`:

```bash
python3 - <<'PY'
import json, subprocess, sys, yaml
from pathlib import Path
cm = json.loads(subprocess.check_output([
    "kubectl", "get", "cm", "ramen-hub-operator-config",
    "-n", "ramen-system", "--context", "hub", "-o", "json",
]))
cfg = yaml.safe_load(cm["data"]["ramen_manager_config.yaml"])
for p in cfg["s3StoreProfiles"]:
    if p["s3ProfileName"] == "minio-on-dr1":
        p["s3Bucket"] = "missing-bucket"
        print("patched", p["s3ProfileName"], "s3Bucket", p["s3Bucket"], file=sys.stderr)
        break
Path("/tmp/ramen-cm.patch.json").write_text(json.dumps({
    "data": {"ramen_manager_config.yaml": yaml.safe_dump(cfg)}
}))
PY
kubectl patch cm ramen-hub-operator-config -n ramen-system --context hub --type merge --patch-file=/tmp/ramen-cm.patch.json
```

```
patched minio-on-dr1 s3Bucket missing-bucket
configmap/ramen-hub-operator-config patched
```


```bash
kubectl get drcluster dr1 --context hub -o jsonpath='{.status.conditions[?(@.type=="Validated")]}{"\n"}'
```

```
{"lastTransitionTime":"2026-09-09T09:47:37Z","message":"minio-on-dr1: failed to head bucket missing-bucket: code: NotFound, message: Not Found","observedGeneration":1,"reason":"s3BucketNotFound","status":"False","type":"Validated"}
```

`dr2` stayed `Validated=True`. Hub operator logs:

```bash
kubectl logs -n ramen-system deploy/ramen-hub-operator -c manager --context hub --since=5m \
  | grep -E 'Reconciler error|s3Profile validate|failed to head bucket'
```

```
2026-09-09T09:47:43.954Z	ERROR	controller/controller.go:495	Reconciler error	{"controller": "drcluster", "name": "dr1", "error": "drclusters s3Profile validate: minio-on-dr1: failed to head bucket missing-bucket: code: NotFound, message: Not Found"}
```

A 404 has no transport `OrigErr()`, so there is no `orig:` here. The prefix is `failed to head bucket missing-bucket` instead of `bucket missing-bucket does not exist or is not accessible`.