### PR TITLE
feat: VM StaticIP: surface explicit status when no eligible NADs are discovered

### DIFF
--- a/internal/controller/drpolicy_controller.go
+++ b/internal/controller/drpolicy_controller.go
@@ -55,6 +55,10 @@ const ReasonDRClustersUnavailable = "DRClustersUnavailable"
 // ReasonDRPolicyConflictFound is set when the DRPolicy has overlapping metro clusters with another DRPolicy
 const ReasonDRPolicyConflictFound = "DRPolicyConflictFound"
 
+// ReasonNoEligibleNetworkAttachments is set on NetworkAttachmentsValidated when no NADs eligible for static-IP
+// translation were discovered on either cluster; symmetry is trivially satisfied.
+const ReasonNoEligibleNetworkAttachments = "NoEligibleNetworkAttachments"
+
 // ReasonSucceeded is set when the DRPolicy validation completes successfully
 const ReasonSucceeded = "Succeeded"
 
@@ -770,13 +774,31 @@ func (v *NetworkMappingValidator) UpdateNADValidationCondition(u *drpolicyUpdate
 		return false, err
 	}
 
-	if len(missing) == 0 {
+	// Distinguish three outcomes:
+	//  1. Both clusters have zero eligible NADs — trivially symmetric but nothing
+	//     usable for static-IP translation.  Surface this explicitly so users are
+	//     not misled into thinking translation is active.
+	//  2. NADs are present and fully symmetric — validation succeeded.
+	//  3. One or more NADs are missing on a peer cluster — validation failed.
+	noEligibleNADs := len(missing) == 0 && len(drPolicy.Status.NetworkPeers) == 0
+
+	switch {
+	case noEligibleNADs:
+		util.GenericStatusConditionSet(drPolicy, &drPolicy.Status.Conditions,
+			ConditionNetworkAttachmentsValidated,
+			metav1.ConditionTrue, ReasonNoEligibleNetworkAttachments,
+			"No NADs eligible for static-IP translation were discovered on either cluster; "+
+				"symmetry is trivially satisfied but no IP translation will occur.",
+			v.log)
+
+	case len(missing) == 0:
 		util.GenericStatusConditionSet(drPolicy, &drPolicy.Status.Conditions,
 			ConditionNetworkAttachmentsValidated,
 			metav1.ConditionTrue, "Validated",
 			"NADs are symmetric across both clusters",
 			v.log)
-	} else {
+
+	default:
 		util.GenericStatusConditionSet(drPolicy, &drPolicy.Status.Conditions,
 			ConditionNetworkAttachmentsValidated,
 			metav1.ConditionFalse, "NADsMissing",


### PR DESCRIPTION
Add a dedicated NetworkAttachmentsValidated condition reason when no NADs eligible for static IP translation are found on either cluster.

Previously, a DRPolicy with zero eligible NADs was reported as successfully validated, which could incorrectly imply that static IP translation was configured and active. This change distinguishes the "no eligible NADs" case from normal successful validation and surfaces a clear status message indicating that symmetry is trivially satisfied but no IP translation will occur.

Assisted by: IBM BOB v2.0.3

Fixes [#2727](https://github.com/RamenDR/ramen/issues/2670?issue=RamenDR%7Cramen%7C2727)