### PR TITLE
Fix stale metrics.bindAddress and simplify DRClusterConfig tests

### DIFF
--- a/config/samples/ramendr_v1alpha1_ramenconfig.yaml
+++ b/config/samples/ramendr_v1alpha1_ramenconfig.yaml
@@ -3,7 +3,7 @@ kind: RamenConfig
 health:
   healthProbeBindAddress: :8081
 metrics:
-  bindAddress: :8443
+  bindAddress: 0.0.0.0:9289
 webhook:
   port: 9443
 leaderElection:

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -130,7 +130,7 @@ data:
     health:
       healthProbeBindAddress: :8081
     metrics:
-      bindAddress: 127.0.0.1:8080
+      bindAddress: 0.0.0.0:9289
 
     # Leader election
     leaderElection:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -44,10 +44,14 @@ section. Next is to install and configure ramen.
 
 ## 2. Basic testing (no Prometheus required)
 
-If running from minikube or a container, expose the port using `port-forward` on
-the hub. The endpoint exposed is `localhost:8443/metrics`. The metrics endpoint
-is protected by controller-runtime built-in auth; use a service account token
-when scraping.
+The operator serves metrics on pod port 9289 (`metrics.bindAddress`, default
+`0.0.0.0:9289`). The metrics Service (`ramen-hub-operator-metrics-service`)
+exposes HTTPS on service port 8443 and forwards to that pod port.
+
+If running from minikube or a container, port-forward the metrics Service on the
+hub. Use service port 8443; the local endpoint is
+`https://localhost:8443/metrics`. The metrics endpoint is protected by
+controller-runtime built-in auth; use a service account token when scraping.
 
 ### Steps
 
@@ -95,10 +99,10 @@ kubectl get serviceaccount metrics-reader-sa -n ramen-system
 
 #### 2. Port-forward
 
-Start port-forwarding to the Ramen operator:
+Start port-forwarding to the metrics Service (service port 8443):
 
 ```bash
-kubectl port-forward -n ramen-system deployment/ramen-hub-operator 8443:8443
+kubectl port-forward -n ramen-system svc/ramen-hub-operator-metrics-service 8443:8443
 ```
 
 #### 3. Get a token

--- a/examples/dr_cluster_config.yaml
+++ b/examples/dr_cluster_config.yaml
@@ -4,7 +4,7 @@ kind: RamenConfig
 health:
   healthProbeBindAddress: :8081
 metrics:
-  bindAddress: 127.0.0.1:9289
+  bindAddress: 0.0.0.0:9289
 webhook:
   port: 9443
 leaderElection:

--- a/examples/dr_hub_config.yaml
+++ b/examples/dr_hub_config.yaml
@@ -4,7 +4,7 @@ kind: RamenConfig
 health:
   healthProbeBindAddress: :8081
 metrics:
-  bindAddress: 127.0.0.1:9289
+  bindAddress: 0.0.0.0:9289
 webhook:
   port: 9443
 leaderElection:

--- a/internal/controller/drclusterconfig_controller_test.go
+++ b/internal/controller/drclusterconfig_controller_test.go
@@ -24,11 +24,11 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
-	config "k8s.io/component-base/config/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
@@ -144,22 +144,12 @@ var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 
 		By("starting the DRClusterConfig reconciler")
 
-		ramenConfig := &ramen.RamenConfig{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "RamenConfig",
-				APIVersion: ramen.GroupVersion.String(),
-			},
-			LeaderElection: &config.LeaderElectionConfiguration{
-				LeaderElect:  new(bool),
-				ResourceName: ramencontrollers.HubLeaderElectionResourceName,
-			},
-			Metrics: ramen.ControllerMetrics{
+		options := manager.Options{
+			Scheme: scheme.Scheme,
+			Metrics: metricsserver.Options{
 				BindAddress: "0", // Disable metrics
 			},
 		}
-
-		options := manager.Options{Scheme: scheme.Scheme}
-		ramencontrollers.LoadControllerOptions(&options, ramenConfig)
 
 		k8sManager, err := ctrl.NewManager(cfg, options)
 		Expect(err).ToNot(HaveOccurred())

--- a/ramendev/ramendev/resources/configmap.yaml
+++ b/ramendev/ramendev/resources/configmap.yaml
@@ -15,7 +15,7 @@ data:
     health:
       healthProbeBindAddress: :8081
     metrics:
-      bindAddress: :8443
+      bindAddress: 0.0.0.0:9289
     webhook:
       port: 9443
     leaderElection:


### PR DESCRIPTION
Ramendev, samples, examples, and docs used leftover `metrics.bindAddress`
values (Service port or loopback). Those never matched the compiled
default or the metrics Service (8443 → 9289), so a pod started from them
would not be reachable.

- Align ramendev, samples, examples, and docs with the compiled default
  (`0.0.0.0:9289`), and document the pod port vs the Service port.
- Stop building a dummy RamenConfig in the DRClusterConfig tests only to
  disable metrics.
