### PR TITLE
Label all ramen-created transitive resources with created-by-ramen

### DIFF
--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -179,6 +179,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceimports
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ramendr.openshift.io
   resources:
   - drclusterconfigs

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -301,6 +301,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - multicluster.x-k8s.io
+  resources:
+  - serviceimports
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - policy.open-cluster-management.io
   resources:
   - placementbindings

--- a/internal/controller/cephfscg/replicationgroupdestination.go
+++ b/internal/controller/cephfscg/replicationgroupdestination.go
@@ -238,6 +238,8 @@ func (m *rgdMachine) ReconcileRD(
 		return nil, err
 	}
 
+	m.VSHandler.EnsureVolSyncMoverJobLabels(rdSpec.ProtectedPVC.Name, rdSpec.ProtectedPVC.Namespace)
+
 	if m.VSHandler.IsSubmarinerEnabled() {
 		err = m.VSHandler.ReconcileServiceExportForRD(rd)
 		if err != nil {

--- a/internal/controller/cephfscg/replicationgroupdestination.go
+++ b/internal/controller/cephfscg/replicationgroupdestination.go
@@ -239,6 +239,7 @@ func (m *rgdMachine) ReconcileRD(
 	}
 
 	m.VSHandler.EnsureVolSyncMoverJobLabels(rdSpec.ProtectedPVC.Name, rdSpec.ProtectedPVC.Namespace)
+	m.VSHandler.EnsureVolSyncServiceImportLabels(rdSpec.ProtectedPVC.Name, rdSpec.ProtectedPVC.Namespace)
 
 	if m.VSHandler.IsSubmarinerEnabled() {
 		err = m.VSHandler.ReconcileServiceExportForRD(rd)

--- a/internal/controller/cephfscg/volumegroupsourcehandler.go
+++ b/internal/controller/cephfscg/volumegroupsourcehandler.go
@@ -545,6 +545,9 @@ func (h *volumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVC
 		createdOrUpdated = createdOrUpdated ||
 			(op == ctrlutil.OperationResultCreated || op == ctrlutil.OperationResultUpdated)
 
+		h.VSHandler.EnsureVolSyncMoverJobLabels(originalPVCName, replicationSourceNamespace)
+		h.VSHandler.EnsureVolSyncServiceImportLabels(originalPVCName, replicationSourceNamespace)
+
 		replicationSources = append(replicationSources, &corev1.ObjectReference{
 			APIVersion: replicationSource.APIVersion,
 			Kind:       replicationSource.Kind,

--- a/internal/controller/hooks/job_hook.go
+++ b/internal/controller/hooks/job_hook.go
@@ -122,6 +122,7 @@ func (j JobHook) getJobTemplateFromRecipe() (*batchv1.Job, error) {
 
 	job.Labels["ramendr.openshift.io/hook-name"] = j.Hook.Name
 	job.Labels["ramendr.openshift.io/job-name"] = j.Hook.Job.Name
+	job.Labels[util.CreatedByRamenLabel] = "true"
 
 	return job, nil
 }

--- a/internal/controller/kubeobjects/velero/exclude_resources.go
+++ b/internal/controller/kubeobjects/velero/exclude_resources.go
@@ -15,6 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ramendr/ramen/internal/controller/util"
 )
 
 const (
@@ -143,6 +145,7 @@ func (m *ExcludedResourcesManager) createDefaultConfigMap(ctx context.Context) (
 				"app.kubernetes.io/name":       "ramen-dr-cluster-operator",
 				"app.kubernetes.io/component":  "kubeobjects-protection",
 				"app.kubernetes.io/managed-by": "ramen-dr-cluster-operator",
+				util.CreatedByRamenLabel:       "true",
 			},
 			Annotations: map[string]string{
 				"ramen.openshift.io/description": "Default list of resources to exclude from Velero backups. " +

--- a/internal/controller/util/cephfs_cg.go
+++ b/internal/controller/util/cephfs_cg.go
@@ -291,10 +291,18 @@ func GetVolumeSnapshotsOwnedByVolumeGroupSnapshot(
 
 	var volumeSnapshots []vsv1.VolumeSnapshot
 
-	for _, snapshot := range volumeSnapshotList.Items {
+	for i, snapshot := range volumeSnapshotList.Items {
 		for _, owner := range snapshot.ObjectMeta.OwnerReferences {
 			if owner.Kind == "VolumeGroupSnapshot" && owner.Name == vgs.GetName() && owner.UID == vgs.GetUID() {
-				volumeSnapshots = append(volumeSnapshots, snapshot)
+				err := NewResourceUpdater(&volumeSnapshotList.Items[i]).
+					AddLabel(CreatedByRamenLabel, "transitive").
+					Update(ctx, k8sClient)
+				if err != nil {
+					logger.V(1).Info("Failed to label VGS child VolumeSnapshot",
+						"volumeSnapshot", snapshot.Name, "error", err)
+				}
+
+				volumeSnapshots = append(volumeSnapshots, volumeSnapshotList.Items[i])
 
 				break
 			}

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -197,6 +197,8 @@ func (v *VSHandler) ReconcileRD(
 		return nil, nil, err
 	}
 
+	v.ensureVolSyncMoverJobLabels(rdSpec.ProtectedPVC.Name, rdSpec.ProtectedPVC.Namespace)
+
 	if err = v.ReconcileServiceExportForRD(rd); err != nil {
 		return nil, nil, err
 	}
@@ -465,6 +467,8 @@ func (v *VSHandler) ReconcileRS(rsSpec ramendrv1alpha1.VolSyncReplicationSourceS
 	if replicationSource == nil {
 		return false, nil, nil // Requeue
 	}
+
+	v.ensureVolSyncMoverJobLabels(rsSpec.ProtectedPVC.Name, rsSpec.ProtectedPVC.Namespace)
 
 	//
 	// For final sync only - check status to make sure the final sync is complete
@@ -1683,6 +1687,26 @@ func (v *VSHandler) ensureVolSyncServiceLabels(serviceName, namespace string) {
 		if err != nil {
 			v.log.V(1).Info("Failed to label VolSync EndpointSlice",
 				"endpointSlice", epSliceList.Items[i].Name, "error", err)
+		}
+	}
+}
+
+func (v *VSHandler) ensureVolSyncMoverJobLabels(pvcName, namespace string) {
+	for _, prefix := range []string{"volsync-rsync-tls-src-", "volsync-rsync-tls-dst-"} {
+		jobName := util.GetJobName(prefix, pvcName)
+
+		job := &batchv1.Job{}
+
+		err := v.client.Get(v.ctx, types.NamespacedName{Name: jobName, Namespace: namespace}, job)
+		if err != nil {
+			continue
+		}
+
+		err = util.NewResourceUpdater(job).
+			AddLabel(util.CreatedByRamenLabel, "transitive").
+			Update(v.ctx, v.client)
+		if err != nil {
+			v.log.V(1).Info("Failed to label VolSync mover Job", "jobName", jobName, "error", err)
 		}
 	}
 }

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -1719,7 +1719,9 @@ func (v *VSHandler) EnsureVolSyncServiceImportLabels(pvcName, namespace string) 
 
 	err := v.client.Get(v.ctx, types.NamespacedName{Name: serviceName, Namespace: namespace}, svcImport)
 	if err != nil {
-		v.log.V(1).Info("ServiceImport not found yet, skipping label", "serviceName", serviceName)
+		if !errors.IsNotFound(err) {
+			v.log.V(1).Info("Failed to get ServiceImport", "serviceName", serviceName, "error", err)
+		}
 
 		return
 	}
@@ -1740,6 +1742,10 @@ func (v *VSHandler) EnsureVolSyncMoverJobLabels(pvcName, namespace string) {
 
 		err := v.client.Get(v.ctx, types.NamespacedName{Name: jobName, Namespace: namespace}, job)
 		if err != nil {
+			if !errors.IsNotFound(err) {
+				v.log.V(1).Info("Failed to get VolSync mover Job", "jobName", jobName, "error", err)
+			}
+
 			continue
 		}
 

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -197,7 +197,7 @@ func (v *VSHandler) ReconcileRD(
 		return nil, nil, err
 	}
 
-	v.ensureVolSyncMoverJobLabels(rdSpec.ProtectedPVC.Name, rdSpec.ProtectedPVC.Namespace)
+	v.EnsureVolSyncMoverJobLabels(rdSpec.ProtectedPVC.Name, rdSpec.ProtectedPVC.Namespace)
 
 	if err = v.ReconcileServiceExportForRD(rd); err != nil {
 		return nil, nil, err
@@ -468,8 +468,8 @@ func (v *VSHandler) ReconcileRS(rsSpec ramendrv1alpha1.VolSyncReplicationSourceS
 		return false, nil, nil // Requeue
 	}
 
-	v.ensureVolSyncMoverJobLabels(rsSpec.ProtectedPVC.Name, rsSpec.ProtectedPVC.Namespace)
-	v.ensureVolSyncServiceImportLabels(rsSpec.ProtectedPVC.Name, rsSpec.ProtectedPVC.Namespace)
+	v.EnsureVolSyncMoverJobLabels(rsSpec.ProtectedPVC.Name, rsSpec.ProtectedPVC.Namespace)
+	v.EnsureVolSyncServiceImportLabels(rsSpec.ProtectedPVC.Name, rsSpec.ProtectedPVC.Namespace)
 
 	//
 	// For final sync only - check status to make sure the final sync is complete
@@ -1697,7 +1697,7 @@ const (
 	ServiceImportVersion = "v1alpha1"
 )
 
-func (v *VSHandler) ensureVolSyncServiceImportLabels(pvcName, namespace string) {
+func (v *VSHandler) EnsureVolSyncServiceImportLabels(pvcName, namespace string) {
 	if !util.IsSubmarinerEnabled(v.owner.GetAnnotations()) {
 		return
 	}
@@ -1731,7 +1731,7 @@ func (v *VSHandler) ensureVolSyncServiceImportLabels(pvcName, namespace string) 
 	}
 }
 
-func (v *VSHandler) ensureVolSyncMoverJobLabels(pvcName, namespace string) {
+func (v *VSHandler) EnsureVolSyncMoverJobLabels(pvcName, namespace string) {
 	for _, prefix := range []string{"volsync-rsync-tls-src-", "volsync-rsync-tls-dst-"} {
 		jobName := util.GetJobName(prefix, pvcName)
 

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -198,6 +198,7 @@ func (v *VSHandler) ReconcileRD(
 	}
 
 	v.EnsureVolSyncMoverJobLabels(rdSpec.ProtectedPVC.Name, rdSpec.ProtectedPVC.Namespace)
+	v.EnsureVolSyncServiceImportLabels(rdSpec.ProtectedPVC.Name, rdSpec.ProtectedPVC.Namespace)
 
 	if err = v.ReconcileServiceExportForRD(rd); err != nil {
 		return nil, nil, err

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -469,6 +469,7 @@ func (v *VSHandler) ReconcileRS(rsSpec ramendrv1alpha1.VolSyncReplicationSourceS
 	}
 
 	v.ensureVolSyncMoverJobLabels(rsSpec.ProtectedPVC.Name, rsSpec.ProtectedPVC.Namespace)
+	v.ensureVolSyncServiceImportLabels(rsSpec.ProtectedPVC.Name, rsSpec.ProtectedPVC.Namespace)
 
 	//
 	// For final sync only - check status to make sure the final sync is complete
@@ -1688,6 +1689,45 @@ func (v *VSHandler) ensureVolSyncServiceLabels(serviceName, namespace string) {
 			v.log.V(1).Info("Failed to label VolSync EndpointSlice",
 				"endpointSlice", epSliceList.Items[i].Name, "error", err)
 		}
+	}
+}
+
+const (
+	ServiceImportKind    = "ServiceImport"
+	ServiceImportVersion = "v1alpha1"
+)
+
+func (v *VSHandler) ensureVolSyncServiceImportLabels(pvcName, namespace string) {
+	if !util.IsSubmarinerEnabled(v.owner.GetAnnotations()) {
+		return
+	}
+
+	rdName := util.GetReplicationDestinationName(pvcName)
+	serviceName := util.GetLocalServiceNameForRD(rdName)
+
+	if util.IsDiffSyncEnabled(v.owner.GetAnnotations()) {
+		serviceName = util.GetLocalServiceNameForDiffRD(rdName)
+	}
+
+	svcImport := &unstructured.Unstructured{}
+	svcImport.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   ServiceExportGroup,
+		Kind:    ServiceImportKind,
+		Version: ServiceImportVersion,
+	})
+
+	err := v.client.Get(v.ctx, types.NamespacedName{Name: serviceName, Namespace: namespace}, svcImport)
+	if err != nil {
+		v.log.V(1).Info("ServiceImport not found yet, skipping label", "serviceName", serviceName)
+
+		return
+	}
+
+	err = util.NewResourceUpdater(svcImport).
+		AddLabel(util.CreatedByRamenLabel, "transitive").
+		Update(v.ctx, v.client)
+	if err != nil {
+		v.log.V(1).Info("Failed to label ServiceImport", "serviceName", serviceName, "error", err)
 	}
 }
 

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -437,6 +437,7 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=multicluster.x-k8s.io,resources=serviceexports,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=multicluster.x-k8s.io,resources=serviceimports,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch;update;patch

--- a/internal/controller/vrg_staticip.go
+++ b/internal/controller/vrg_staticip.go
@@ -82,6 +82,7 @@ func (v *VRGInstance) resourceModifierConfigMapName() string {
 func (v *VRGInstance) resourceModifierLabels() map[string]string {
 	labels := util.OwnerLabels(v.instance)
 	labels[resourceModifierComponentLabel] = "true"
+	labels[util.CreatedByRamenLabel] = "true"
 
 	return labels
 }


### PR DESCRIPTION
## Summary

Addresses gaps found during QA testing of DFBUGS-5579. Several resource types
created by ramen (directly or transitively) were missing the
`ramendr.openshift.io/created-by-ramen` label, preventing third-party backup
tools (e.g. Cloud Pak for Data backup & restore) from identifying and excluding
them.

### QA-reported unlabeled resources

- **ServiceImport** — created by Submariner on both primary and secondary
  clusters; now labeled transitively during RS/RD reconciliation and in the
  CG code path (RGS/RGD controllers)
- **VolSync mover Jobs** (`volsync-rsync-tls-src-*`, `volsync-rsync-tls-dst-*`) —
  created by the VolSync operator; now discovered and labeled during RS/RD
  reconciliation and in the CG code path, following the
  `ensureVolSyncServiceLabels` pattern
- **VolumeSnapshot** (VGS children) — created by the CSI driver as side-effects
  of a VolumeGroupSnapshot; now labeled when discovered via
  `GetVolumeSnapshotsOwnedByVolumeGroupSnapshot`

### Additional unlabeled resources found in audit

- **Hook Jobs** — Jobs from Recipe hook definitions now include `CreatedByRamenLabel`
- **Excluded Resources ConfigMap** — the default-excluded-resources ConfigMap
  now includes `CreatedByRamenLabel`
- **Static IP ResourceModifier ConfigMap** — the Velero ResourceModifier ConfigMap
  now includes `CreatedByRamenLabel`

### CG code path fix

The initial implementation placed labeling calls inside `VSHandler.ReconcileRS`
and `VSHandler.ReconcileRD`, which are the non-CG VolSync reconciliation
methods. When consistency groups (CG) are enabled, these methods are bypassed —
the RGS/RGD controllers handle RS/RD creation through
`volumeGroupSourceHandler.CreateReplicationSourceForRestoredPVCs` and
`rgdMachine.ReconcileRD` respectively. The labeling calls were added to both
CG code paths, and the methods were exported so the `cephfscg` package can
call them.

### RBAC fix

The `EnsureVolSyncServiceImportLabels` function needs `get`, `list`, `watch`,
`update`, and `patch` access to `serviceimports.multicluster.x-k8s.io`. The
existing role only covered `serviceexports`. Added the kubebuilder RBAC marker
and updated both `config/rbac/role.yaml` (generated) and
`config/dr-cluster/rbac/role.yaml` (manual).

All transitive resources (created by external operators) use the best-effort
label pattern: discover, label, log on failure, continue. This matches the
existing `ensureVolSyncServiceLabels` approach.

Ref: https://redhat.atlassian.net/browse/DFBUGS-5579

## Commits

1. `hooks: label hook Jobs with created-by-ramen`
2. `velero: label excluded-resources ConfigMap with created-by-ramen`
3. `vrg: label static IP ResourceModifier ConfigMap with created-by-ramen`
4. `cephfscg: label VGS child VolumeSnapshots with created-by-ramen`
5. `volsync: label mover Jobs with created-by-ramen`
6. `volsync: label ServiceImport with created-by-ramen`
7. `cephfscg: label mover Jobs and ServiceImport in CG code path`
8. `volsync: add RBAC for ServiceImport to dr-cluster role`
9. `volsync: label ServiceImport on secondary site`

## Test plan

- [x] Deploy with Cloud Pak workload and verify all resources listed in Israel's
  QA checklist now carry `ramendr.openshift.io/created-by-ramen` label
- [x] Verify ServiceImport is labeled on both primary and secondary clusters
  (Submariner enabled)
- [x] Verify volsync mover Jobs (src and dst) are labeled on both clusters
  during active replication with CG enabled
- [x] Verify VGS child VolumeSnapshots are labeled after VGS creation
- [ ] Verify hook Jobs are labeled (requires a workload with job-type Recipe hooks)
- [ ] Verify excluded-resources ConfigMap is labeled (requires fresh ConfigMap
  creation — existing pre-PR ConfigMaps are not retroactively labeled)
- [ ] Verify ResourceModifier ConfigMap is labeled (requires VM workload with
  static IP)
- [x] Run e2e tests to confirm no regressions

### Verified on clusters (2026-08-20)

Tested on a 3-cluster setup (hub + 2 DR sites) running Cloud Pak for Data
with CephFS CG + VolSync + Submariner. Custom image
`quay.io/raghavendra_talur/ramen-operator:rtalur-pr-2718-pr-2731`.

| Resource Type | Creator | Label | Result |
|---|---|---|---|
| VRG | ramen | `true` | PASS |
| VolumeGroupReplication | ramen | `true` | PASS |
| ReplicationSource | ramen | `true` | PASS |
| ReplicationDestination | ramen | `true` | PASS |
| VolSync Services | ramen | `transitive` | PASS |
| ServiceExport | ramen | `true` | PASS |
| ServiceImport (both sites) | Submariner | `transitive` | PASS |
| VolSync mover Jobs (both sites) | VolSync | `transitive` | PASS |
| VolumeGroupSnapshot | ramen | `true` | PASS |
| VolumeSnapshot (VGS child) | CSI driver | `transitive` | PASS |
| vs-* PVCs | ramen | `true` | PASS |
| Secrets (S3 + VolSync) | ramen | `true` | PASS |
| Hook Jobs | ramen | `true` | N/A (no job hooks in workload) |
| Excluded Resources ConfigMap | ramen | `true` | N/A (pre-existing CM) |
| Static IP ResourceModifier CM | ramen | `true` | N/A (no VMs) |
