### PR TITLE
test: stabilize "failed to get drclusters" assertion in DRPC tests

### DIFF
--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -1872,21 +1872,19 @@ var _ = Describe("DRPlacementControl Reconciler Errors", func() {
 
 			deleteDRPC()
 
-			errCount := 0
+			Eventually(func() error {
+				_, err := drpcReconcile(DRPCCommonName, DefaultDRPCNamespace)
 
-			for {
-				_, err = drpcReconcile(DRPCCommonName, DefaultDRPCNamespace)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("failed to get drclusters"))
+				return err
+			}, timeout, interval).Should(MatchError(ContainSubstring("failed to get drclusters")))
 
-				errCount++
-				if errCount > 2 {
-					// Found the required error message for more than a second
-					break
-				}
+			// Ensure the expected error is returned consistently, not just once,
+			// guarding against the drclusters being recreated by another actor.
+			Consistently(func() error {
+				_, err := drpcReconcile(DRPCCommonName, DefaultDRPCNamespace)
 
-				time.Sleep(time.Second)
-			}
+				return err
+			}, timeout, interval).Should(MatchError(ContainSubstring("failed to get drclusters")))
 		}, SpecTimeout(time.Second*10))
 	})
 


### PR DESCRIPTION
Previously the test waited up to 10 seconds for the reconciler to return the "failed to get drclusters" error twice, and failed immediately on any successful reconcile or unexpected error (e.g. a 409 conflict if the background reconciler raced to write Phase=Deleting first). Waiting 10 seconds was excessive: ramen itself does not enforce any delay that would require such a long wait.

Now the test uses Eventually to tolerate transient/unexpected errors until the expected error is observed (up to 1 second), then Consistently to confirm the same error keeps being returned for another second, guarding against the drclusters being recreated by another actor.

The example of unit tests failure:
```
Analyze the following failure in unit tests:FAILED] Expected
      <string>: failed to update DRPC status: (Operation cannot be fulfilled on drplacementcontrols.ramendr.openshift.io "drpc-name": the object has been modified; please apply your changes to the latest version and try again)
  to contain substring
      <string>: failed to get drclusters
  In [It] at: /home/runner/work/ramen/ramen/internal/controller/drplacementcontrol_controller_test.go:2010 @ 08/19/26 09:02:30.389
------------------------------
```