### PR TITLE
feat: VM StaticIP: drclusterconfig: handle optional NAD CRD when Multus is absent

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,6 +13,8 @@ import (
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
+	// +kubebuilder:scaffold:imports
+	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	publicgroupsnapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -45,7 +47,6 @@ import (
 	controllers "github.com/ramendr/ramen/internal/controller"
 	argocdv1alpha1hack "github.com/ramendr/ramen/internal/controller/argocd"
 	rmnutil "github.com/ramendr/ramen/internal/controller/util"
-	// +kubebuilder:scaffold:imports
 	_ "github.com/ramendr/ramen/internal/dummy"
 )
 
@@ -129,6 +130,7 @@ func configureController() error {
 		utilruntime.Must(clusterv1alpha1.AddToScheme(scheme))
 		utilruntime.Must(virtv1.AddToScheme(scheme))
 		utilruntime.Must(csiaddonsv1alpha1.AddToScheme(scheme))
+		utilruntime.Must(netattdefv1.AddToScheme(scheme))
 	}
 
 	return nil
@@ -183,9 +185,10 @@ func setupReconcilersCluster(mgr ctrl.Manager, ramenConfig *ramendrv1alpha1.Rame
 	}
 
 	if err := (&controllers.DRClusterConfigReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("drcc"),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Log:       ctrl.Log.WithName("drcc"),
+		APIReader: mgr.GetAPIReader(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "DRClusterConfig")
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
+	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7
 	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.6.0
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7 h1:z4P744DR+PIpkjwXSEc6TvN3L6LVzmUquFgmNm8wSUc=
+github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7/go.mod h1:CM7HAH5PNuIsqjMN0fGc1ydM74Uj+0VZFhob620nklw=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=

--- a/internal/controller/drclusterconfig_controller.go
+++ b/internal/controller/drclusterconfig_controller.go
@@ -14,11 +14,11 @@ import (
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
 	"github.com/go-logr/logr"
+	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	"golang.org/x/time/rate"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -53,14 +53,19 @@ const (
 
 	DRClusterConfigS3Reachable   = "Reachable"
 	DRClusterConfigS3Unreachable = "Unreachable"
+	NADCRDMissing                = "NADCRDMissing"
+	NADWatchNotRegistered        = "NADWatchNotRegistered"
+	StaticIPDiscoveryEnabled     = "StaticIPDiscoveryEnabled"
 )
 
 // DRClusterConfigReconciler reconciles a DRClusterConfig object
 type DRClusterConfigReconciler struct {
 	client.Client
-	Scheme      *runtime.Scheme
-	Log         logr.Logger
-	RateLimiter *workqueue.TypedRateLimiter[reconcile.Request]
+	Scheme             *runtime.Scheme
+	APIReader          client.Reader
+	Log                logr.Logger
+	NadWatchRegistered bool
+	RateLimiter        *workqueue.TypedRateLimiter[reconcile.Request]
 }
 
 // NADDRNetworkLabel is an opt-in marker for Ramen's static-IP disaster
@@ -72,7 +77,11 @@ type DRClusterConfigReconciler struct {
 //
 // are included in DR network discovery and validation. NADs labeled
 // "false", or NADs that do not carry this label, are ignored.
-const NADDRNetworkLabel = "ramendr.openshift.io/dr-network"
+const (
+	NADDRNetworkLabel      = "ramendr.openshift.io/dr-network"
+	NADResourceName        = "network-attachment-definitions.k8s.cni.cncf.io"
+	StaticIPDiscoveryReady = "StaticIPDiscoveryReady"
+)
 
 // nadGVK is the GroupVersionKind used when listing NADs via the unstructured client.
 // NAD is not a first-class Go type in this module, so we use dynamic listing.
@@ -297,6 +306,8 @@ func (r *DRClusterConfigReconciler) processCreateOrUpdate(
 
 	setDRClusterConfigConfigurationProcessedCondition(&drCConfig.Status.Conditions, drCConfig.Generation,
 		"Configuration processed and validated", metav1.ConditionTrue, DRClusterConfigConditionConfigurationProcessed)
+
+	r.updateStaticIPDiscoveryCondition(ctx, drCConfig)
 
 	return ctrl.Result{}, nil
 }
@@ -637,8 +648,7 @@ func (r *DRClusterConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&volrep.VolumeReplicationClass{}, drccMapFn, drccPredFn).
 		Watches(&volrep.VolumeGroupReplicationClass{}, drccMapFn, drccPredFn).
 		Watches(&csiaddonsv1alpha1.NetworkFenceClass{}, drccMapFn, drccPredFn).
-		Watches(&csiaddonsv1alpha1.CSIAddonsNode{}, drccMapFn, drccPredFn).
-		Watches(nadObject(), drccMapFn, drccPredFn)
+		Watches(&csiaddonsv1alpha1.CSIAddonsNode{}, drccMapFn, drccPredFn)
 
 	if err := util.EnsureLocalVGSAPI(context.TODO(), mgr.GetAPIReader()); err != nil {
 		r.Log.Info("VolumeGroupSnapshotClass API not available, skipping watch", "reason", err.Error())
@@ -646,16 +656,66 @@ func (r *DRClusterConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		controllerBuilder = util.WatchesVolumeGroupSnapshotClass(controllerBuilder, r.Log, drccMapFn, drccPredFn)
 	}
 
+	// NAD CRD is optional (requires Multus). Only register the watch when the
+	// CRD is already present at startup; on clusters without Multus the
+	// RequeueAfter in processCreateOrUpdate re-checks periodically.
+	if r.nadCRDInstalled(context.Background()) {
+		r.NadWatchRegistered = true
+		controllerBuilder = controller.Watches(&netattdefv1.NetworkAttachmentDefinition{}, drccMapFn, drccPredFn)
+	}
+
 	return controllerBuilder.Complete(r)
 }
 
-// listDRSupportedNADs returns all NetworkAttachmentDefinitions across all
-// namespaces that carry the label ramendr.openshift.io/dr-network.
-//
-// The result is a []NetworkAttachment slice sorted by "namespace/name" so that
-// status comparisons are stable and do not produce spurious updates.
+func (r *DRClusterConfigReconciler) nadCRDInstalled(ctx context.Context) bool {
+	return util.IsCRDInstalled(ctx, r.APIReader, NADResourceName)
+}
+
+// parseCNIType extracts the CNI plugin type from spec.config (a JSON string)
+// of a NetworkAttachmentDefinition.
+// Returns "unknown" with a non-nil error when config is absent or the type field is not set.
+func parseCNIType(nad *netattdefv1.NetworkAttachmentDefinition) (string, error) {
+	if nad.Spec.Config == "" {
+		return "unknown", fmt.Errorf("spec.config is empty")
+	}
+
+	// spec.config is a JSON string containing the CNI configuration.
+	var cfg struct {
+		Type    string `json:"type"`
+		Plugins []struct {
+			Type string `json:"type"`
+		} `json:"plugins"`
+	}
+
+	if err := json.Unmarshal([]byte(nad.Spec.Config), &cfg); err != nil {
+		return "unknown", fmt.Errorf("spec.config is not valid JSON: %w", err)
+	}
+
+	// Simple CNI config.
+	if cfg.Type != "" {
+		return cfg.Type, nil
+	}
+
+	// Multus conflist format: first plugin is the primary CNI.
+	if len(cfg.Plugins) > 0 && cfg.Plugins[0].Type != "" {
+		return cfg.Plugins[0].Type, nil
+	}
+
+	return "unknown", nil
+}
+
 func (r *DRClusterConfigReconciler) listDRSupportedNADs(ctx context.Context) ([]ramen.NetworkAttachment, error) {
-	nadList := &unstructured.UnstructuredList{}
+	// The NAD CRD is optional — it is only present when Multus is installed.
+	if !r.nadCRDInstalled(ctx) {
+		r.Log.Info(
+			"Skipping NAD discovery because the NetworkAttachmentDefinition CRD is not installed",
+			"gvk", nadGVK.String(),
+		)
+
+		return nil, nil
+	}
+
+	nadList := &netattdefv1.NetworkAttachmentDefinitionList{}
 	nadList.SetGroupVersionKind(nadGVK)
 
 	if err := r.Client.List(ctx, nadList,
@@ -664,7 +724,7 @@ func (r *DRClusterConfigReconciler) listDRSupportedNADs(ctx context.Context) ([]
 		return nil, fmt.Errorf("failed to list NADs with label %s=true: %w", NADDRNetworkLabel, err)
 	}
 
-	nads := make([]ramen.NetworkAttachment, 0, len(nadList.Items))
+	nads := []ramen.NetworkAttachment{}
 
 	for i := range nadList.Items {
 		item := &nadList.Items[i]
@@ -704,50 +764,69 @@ func (r *DRClusterConfigReconciler) listDRSupportedNADs(ctx context.Context) ([]
 	return nads, nil
 }
 
-// parseCNIType extracts the CNI plugin type from spec.config (a JSON string)
-// of a NetworkAttachmentDefinition.
-// Returns "unknown" when config is absent or the type field is not set.
-func parseCNIType(nad *unstructured.Unstructured) (string, error) {
-	raw, found, err := unstructured.NestedString(nad.Object, "spec", "config")
-	if err != nil || !found || len(raw) == 0 {
-		return "unknown", fmt.Errorf("spec.config is not a string: %w", err)
-	}
-
-	// spec.config is a JSON string (the CNI config JSON blob).
-	var cfg struct {
-		Type    string `json:"type"`
-		Plugins []struct {
-			Type string `json:"type"`
-		} `json:"plugins"`
-	}
-
-	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
-		return "unknown", fmt.Errorf("spec.config is not valid JSON: %w", err)
-	}
-
-	if cfg.Type != "" {
-		return cfg.Type, nil
-	}
-
-	// Multus conflist format — first plugin type is the primary one.
-	if len(cfg.Plugins) > 0 && cfg.Plugins[0].Type != "" {
-		return cfg.Plugins[0].Type, nil
-	}
-
-	return "unknown", nil
+func setStaticIPDiscoveryCondition(
+	conditions *[]metav1.Condition,
+	status metav1.ConditionStatus,
+	reason, message string,
+) {
+	util.SetStatusCondition(conditions, metav1.Condition{
+		Type:    StaticIPDiscoveryReady,
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	})
 }
 
-// nadObject returns an unstructured NAD object with the GVK set so that the
-// controller-runtime watcher can register an informer for the NAD resource.
-// NAD has no typed Go struct in this module, so we use the dynamic client
-// approach consistent with listDRSupportedNADs in drclusterconfig_nad_discovery.go.
-func nadObject() *unstructured.Unstructured {
-	nad := &unstructured.Unstructured{}
-	nad.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "k8s.cni.cncf.io",
-		Version: "v1",
-		Kind:    "NetworkAttachmentDefinition",
-	})
+// Determine static-IP discovery readiness based on NAD CRD availability
+// and whether the NAD watch was successfully registered at controller startup.
+//
+// Scenarios:
+// 1. NAD CRD absent:
+//   - Static-IP discovery is unavailable.
+//   - Report NADCRDMissing.
+//   - If the CRD is installed later, the controller must be restarted
+//     to register the NAD watch.
+//
+// 2. NAD CRD present but watch not registered:
+//   - Static-IP discovery remains unavailable because NAD changes
+//     cannot be observed.
+//   - Report that a controller restart is required.
+//
+// 3. NAD CRD present and watch registered:
+//   - Static-IP discovery is fully operational.
+//   - NAD create/update/delete events will be observed and processed.
+func (r *DRClusterConfigReconciler) updateStaticIPDiscoveryCondition(
+	ctx context.Context,
+	drCConfig *ramen.DRClusterConfig,
+) {
+	if !r.nadCRDInstalled(ctx) {
+		r.NadWatchRegistered = false
 
-	return nad
+		setStaticIPDiscoveryCondition(
+			&drCConfig.Status.Conditions,
+			metav1.ConditionFalse,
+			NADCRDMissing,
+			"NetworkAttachmentDefinition CRD is not installed on the cluster",
+		)
+
+		return
+	}
+
+	if !r.NadWatchRegistered {
+		setStaticIPDiscoveryCondition(
+			&drCConfig.Status.Conditions,
+			metav1.ConditionFalse,
+			NADWatchNotRegistered,
+			"NetworkAttachmentDefinition CRD is available, but NAD monitoring is disabled until the controller is restarted",
+		)
+
+		return
+	}
+
+	setStaticIPDiscoveryCondition(
+		&drCConfig.Status.Conditions,
+		metav1.ConditionTrue,
+		StaticIPDiscoveryEnabled,
+		"NetworkAttachmentDefinition monitoring is enabled and static IP discovery is operational",
+	)
 }

--- a/internal/controller/drclusterconfig_controller_test.go
+++ b/internal/controller/drclusterconfig_controller_test.go
@@ -182,6 +182,7 @@ var _ = Describe("DRClusterConfigControllerTests", Ordered, func() {
 			Scheme:      k8sManager.GetScheme(),
 			Log:         ctrl.Log.WithName("controllers").WithName("DRClusterConfig"),
 			RateLimiter: &rateLimiter,
+			APIReader:   k8sManager.GetAPIReader(),
 		}).SetupWithManager(k8sManager)).To(Succeed())
 
 		ctx, cancel = context.WithCancel(context.TODO())

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -14,6 +14,8 @@ import (
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
 	"github.com/go-logr/logr"
+	// +kubebuilder:scaffold:imports
+	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -51,7 +53,6 @@ import (
 	argocdv1alpha1hack "github.com/ramendr/ramen/internal/controller/argocd"
 	testutils "github.com/ramendr/ramen/internal/controller/testutils"
 	"github.com/ramendr/ramen/internal/controller/util"
-	// +kubebuilder:scaffold:imports
 	_ "github.com/ramendr/ramen/internal/dummy"
 )
 
@@ -240,6 +241,9 @@ var _ = BeforeSuite(func() {
 	err = virtv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	// +kubebuilder:scaffold:scheme
+
+	err = netv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
 
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION

The dr-cluster operator crashed on startup when the NAD CRD (network-attachment-definitions.k8s.cni.cncf.io) was absent because:

1. netattdefv1 was not registered in the scheme for DRClusterType, causing a panic in Watches() at manager startup.
2. Watches(&NetworkAttachmentDefinition{}) was unconditional, so the informer cache sync failed if the CRD was not installed.

Fix:
- Register netattdefv1.AddToScheme in the DRClusterType branch of cmd/main.go alongside the other optional CRD schemes.
- Add APIReader to DRClusterConfigReconciler (consistent with other reconcilers in this codebase) and use util.IsCRDInstalled to check CRD presence via a direct API server GET — the established project pattern used by VolumeReplicationGroupReconciler and ReplicationGroupSourceReconciler.
- Guard Watches(&NetworkAttachmentDefinition{}) in SetupWithManager behind nadCRDInstalled() so the watch is only registered when the CRD exists at startup.
- In processCreateOrUpdate, return RequeueAfter: maxReconcileBackoff when the CRD is absent. This covers two scenarios without any extra API server traffic: clusters where Multus will never be installed (one cheap GET every 5 min, forever) and clusters where Multus and labelled NAD instances are installed after the operator starts (picked up on the next poll tick, ≤5 min).
- Guard listDRSupportedNADs with the same nadCRDInstalled check so the cached client never sees a missing CRD error regardless of controller-runtime version.

Assisted by: IBM BOB v2.0.3

Fixes: https://github.com/RamenDR/ramen/issues/2729