### PR TITLE
drenv: Use CSI-Addons v0.14.0 release

### DIFF
--- a/test/drenv/addons/csi_addons/config.py
+++ b/test/drenv/addons/csi_addons/config.py
@@ -4,4 +4,4 @@
 from pathlib import Path
 
 PACKAGE_DIR = Path(__file__).parent
-CACHE_KEY = "addons/csi-addons-latest-5.yaml"
+CACHE_KEY = "addons/csi-addons-0.14.0.yaml"

--- a/test/drenv/addons/csi_addons/start-data/kustomization.yaml
+++ b/test/drenv/addons/csi_addons/start-data/kustomization.yaml
@@ -2,13 +2,8 @@
 #
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
-#
 ---
 resources:
-  - https://raw.githubusercontent.com/Nikhil-Ladha/kubernetes-csi-addons/refs/heads/cg-support/deploy/controller/crds.yaml
-  - https://raw.githubusercontent.com/Nikhil-Ladha/kubernetes-csi-addons/refs/heads/cg-support/deploy/controller/rbac.yaml
-  - https://raw.githubusercontent.com/Nikhil-Ladha/kubernetes-csi-addons/refs/heads/cg-support/deploy/controller/setup-controller.yaml
-images:
-  - name: quay.io/csiaddons/k8s-controller
-    newName: quay.io/nladha/csiaddons-controller
-    newTag: cg
+  - https://github.com/csi-addons/kubernetes-csi-addons/releases/download/v0.14.0/crds.yaml
+  - https://github.com/csi-addons/kubernetes-csi-addons/releases/download/v0.14.0/rbac.yaml
+  - https://github.com/csi-addons/kubernetes-csi-addons/releases/download/v0.14.0/setup-controller.yaml

--- a/test/drenv/addons/rook/operator/__init__.py
+++ b/test/drenv/addons/rook/operator/__init__.py
@@ -7,7 +7,7 @@ from drenv import cache as _cache
 from drenv import kubectl
 
 PACKAGE_DIR = Path(__file__).parent
-CACHE_KEY = "addons/rook-operator-1.19.yaml"
+CACHE_KEY = "addons/rook-operator-1.19-3.yaml"
 
 
 def start(cluster):

--- a/test/drenv/addons/rook/operator/kustomization.yaml
+++ b/test/drenv/addons/rook/operator/kustomization.yaml
@@ -47,5 +47,3 @@ patches:
                   #   x509: certificate signed by unknown authority
                   - name: ROOK_DISABLE_ADMISSION_CONTROLLER
                     value: 'true'
-                  - name: ROOK_CSIADDONS_IMAGE
-                    value: quay.io/nladha/csiaddons-sidecar:cg

--- a/test/drenv/addons/rook/operator/kustomization.yaml
+++ b/test/drenv/addons/rook/operator/kustomization.yaml
@@ -26,11 +26,6 @@ patches:
       - op: replace
         path: /data/ROOK_USE_CSI_OPERATOR
         value: 'false'
-  # Disable to avoid random failures when restaring the enviroment.
-  #   failed to call webhook:
-  #   Post "https://rook-ceph-admission-controller.rook-ceph.svc:443/
-  #   validate-ceph-rook-io-v1-cephblockpool?timeout=5s":
-  #   x509: certificate signed by unknown authority
   - target:
       kind: Deployment
       name: rook-ceph-operator
@@ -45,6 +40,11 @@ patches:
             containers:
               - name: rook-ceph-operator
                 env:
+                  # Disable to avoid random failures when restaring the enviroment.
+                  #   failed to call webhook:
+                  #   Post "https://rook-ceph-admission-controller.rook-ceph.svc:443/
+                  #   validate-ceph-rook-io-v1-cephblockpool?timeout=5s":
+                  #   x509: certificate signed by unknown authority
                   - name: ROOK_DISABLE_ADMISSION_CONTROLLER
                     value: 'true'
                   - name: ROOK_CSIADDONS_IMAGE


### PR DESCRIPTION
- Deploy the CSI-Addons controller from the v0.14.0 release instead of
  the `cg-support` fork. The volume group replication support (PR #610)
  and all follow-up fixes are included in v0.14.0 (Jan 2026).
- Remove the `ROOK_CSIADDONS_IMAGE` override since Rook 1.19 already
  defaults to `quay.io/csiaddons/k8s-sidecar:v0.14.0`[1].
- Move the Rook webhook comment next to `ROOK_DISABLE_ADMISSION_CONTROLLER`.

[1]: https://github.com/rook/rook/blob/release-1.19/deploy/examples/operator.yaml#L512