### PR TITLE
test: fix TOCTOU race in kubeObjectProtectionValidate

### DIFF
--- a/internal/controller/protectedvolumereplicationgrouplist_controller_test.go
+++ b/internal/controller/protectedvolumereplicationgrouplist_controller_test.go
@@ -92,42 +92,6 @@ func protectedVrgListExpectIncludeOnly(protectedVrgList *ramen.ProtectedVolumeRe
 	Expect(protectedVrgList.Status.Items).To(ConsistOf(vrgsExpected))
 }
 
-func protectedVrgListExpectInclude(protectedVrgList *ramen.ProtectedVolumeReplicationGroupList,
-	vrgsExpected []ramen.VolumeReplicationGroup,
-) {
-	Eventually(func() bool {
-		if err := protectedVrgListGet(protectedVrgList); err != nil {
-			return false
-		}
-
-		if protectedVrgList.Status == nil || len(protectedVrgList.Status.Items) == 0 {
-			return false
-		}
-
-		for i := range protectedVrgList.Status.Items {
-			vrgNormalizeDecodedFromS3(&protectedVrgList.Status.Items[i])
-		}
-
-		vrgsStatusStateUpdate(protectedVrgList.Status.Items, vrgsExpected)
-
-		matcher := ContainElements(vrgsExpected)
-
-		ok, err := matcher.Match(protectedVrgList.Status.Items)
-		Expect(err).NotTo(HaveOccurred())
-
-		if !ok {
-			protectedVrgList.Status = nil
-			if err := k8sClient.Status().Update(context.TODO(), protectedVrgList); err != nil {
-				return false
-			}
-
-			return false
-		}
-
-		return true
-	}, timeout, interval).Should(BeTrue())
-}
-
 func vrgsStatusStateUpdate(vrgsS3, vrgsK8s []ramen.VolumeReplicationGroup) {
 	for i := range vrgsS3 {
 		vrgS3 := &vrgsS3[i]

--- a/internal/controller/vrg_volrep_test.go
+++ b/internal/controller/vrg_volrep_test.go
@@ -2691,25 +2691,8 @@ func (v *vrgTest) kubeObjectProtectionValidate() *ramendrv1alpha1.VolumeReplicat
 func kubeObjectProtectionValidate(tests []*vrgTest) {
 	for _, v := range tests {
 		v.ensureVRGIsUploadedToS3(true, vrgController.VRGConditionReasonUploaded)
+		v.kubeObjectProtectionValidate()
 	}
-
-	protectedVrgList := protectedVrgListCreateAndStatusWait("protectedvrglist-vrg-"+tests[0].uniqueID, vrgS3ProfileNumber)
-
-	// Refresh the list once all VRGs have been uploaded to S3 store to fix race condition,
-	// since the initial scan may have happened before all uploads completed successfully.
-	protectedVrgListRefresh(protectedVrgList)
-
-	vrgs := make([]ramendrv1alpha1.VolumeReplicationGroup, len(tests))
-
-	for i, v := range tests {
-		vrg := v.kubeObjectProtectionValidate()
-		vrgController.VrgTidyForList(vrg)
-		vrgs[i] = *vrg
-		protectedVrgListExpectInclude(protectedVrgList, vrgs[i:i+1])
-	}
-
-	protectedVrgListExpectInclude(protectedVrgList, vrgs)
-	protectedVrgListDeleteAndNotFoundWait(protectedVrgList)
 }
 
 func (v *vrgTest) cleanupStatusAbsent() {


### PR DESCRIPTION
The kubeObjectProtectionValidate function suffered from a time-of-check/time-of-use race that caused intermittent test failures:

    [FAILED] VolumeReplicationGroupVolRepController
    in primary state status check pending to bound
    [It] protects kube objects
    Timed out after 1.001s.

The old code performed two independent S3 reads and compared them:

  1. Trigger ProtectedVolumeReplicationGroupList controller to read S3 (stores result in list status)
  2. Download the VRG directly from S3 (becomes the "expected" value)
  3. Compare the list status items with the expected value

Between steps 1 and 2, the VRG controller could re-upload the VRG to S3. This happens because vrgObjectProtect uploads mid-reconcile before the final status update. The status update changes the ResourceVersion, so any subsequent reconcile (triggered by owned VolumeReplication resource changes) sees a new ResourceVersion and re-uploads. The two S3 reads then return different versions of the same VRG, and the comparison fails.

The recovery logic (nil the list status to trigger a re-read) does not help because the "expected" value was already captured and the VRG can be re-uploaded again before the controller re-reads, creating a perpetually moving target.

The ProtectedVolumeReplicationGroupList controller is already tested separately in a dedicated test suite
(ProtectedVolumeReplicationGroupListController Describe block) that writes VRGs to the fake S3 store directly and validates the list status without any concurrent VRG controller modifying S3. That test has no race because it controls both sides of the interaction.

The purpose of kubeObjectProtectionValidate is to confirm the VRG controller successfully uploaded the VRG to S3. This requires:

  1. The VRG status shows ClusterDataProtected=True (the controller claims the upload succeeded)
  2. The VRG is downloadable from S3 (the upload actually persisted)

Both checks are already performed by ensureVRGIsUploadedToS3 (condition check) and kubeObjectProtectionValidate per-VRG method (direct S3 download). The ProtectedVolumeReplicationGroupList comparison was redundant and introduced the race.

Simplify the function to only perform the two meaningful checks.

Assisted-by: Cursor/Claude Opus 4