### PR TITLE
drenv: Log git commit and dirty flag

### DIFF
--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -19,6 +19,7 @@ from . import cache
 from . import cluster
 from . import commands
 from . import envfile
+from . import git
 from . import kubectl
 from . import providers
 from . import ramen
@@ -37,6 +38,16 @@ executors = []
 def main():
     args = parse_args()
     configure_logging(args)
+    git_info = git.info()
+    if git_info:
+        logging.debug(
+            "[main] Using git repo branch=%s commit=%s dirty=%s",
+            git_info["branch"],
+            git_info["commit"],
+            git_info["dirty"],
+        )
+    else:
+        logging.debug("[main] git info not available")
     signal.signal(signal.SIGTERM, handle_termination_signal)
     become_process_group_leader()
     try:

--- a/test/drenv/git.py
+++ b/test/drenv/git.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import shutil
+
+from . import commands
+
+
+def info():
+    """
+    Return git repository info as a dict with keys "branch", "commit", and
+    "dirty", or an empty dict if git is not installed or the current
+    directory is not inside a git repository.
+
+    "dirty" is True if there are changes to tracked files (staged or
+    unstaged); untracked files are ignored.
+    """
+    if not shutil.which("git"):
+        logging.debug("[git] git is not installed")
+        return {}
+
+    if _rev_parse(is_inside_work_tree=True) != "true":
+        logging.debug("[git] Not inside a git repo")
+        return {}
+
+    branch = _rev_parse("HEAD", abbrev_ref=True)
+    commit = _rev_parse("HEAD")
+    # Any output means tracked files have changes; untracked files are
+    # ignored with -uno.
+    status = commands.run("git", "status", "--porcelain", "-uno").strip()
+    dirty = status != ""
+
+    return {"branch": branch, "commit": commit, "dirty": dirty}
+
+
+def _rev_parse(ref=None, abbrev_ref=False, is_inside_work_tree=False):
+    cmd = ["git", "rev-parse"]
+    if abbrev_ref:
+        cmd.append("--abbrev-ref")
+    if is_inside_work_tree:
+        cmd.append("--is-inside-work-tree")
+    if ref:
+        cmd.append(ref)
+    return commands.run(*cmd).strip()

--- a/test/drenv/stress/run.py
+++ b/test/drenv/stress/run.py
@@ -14,6 +14,8 @@ import subprocess
 import sys
 import time
 
+from .. import git
+
 PROGRESS = (
     "[%(done)d/%(runs)d] "
     "%(passed)d passed, "
@@ -210,15 +212,7 @@ def linux_info():
 
 
 def git_info():
-    return {
-        "commit": git("rev-parse", "HEAD"),
-        "branch": git("rev-parse", "--abbrev-ref", "HEAD"),
-    }
-
-
-def git(*args):
-    cmd = ["git", *args]
-    return subprocess.check_output(cmd).decode().strip()
+    return git.info()
 
 
 def sysctl(name):


### PR DESCRIPTION
## Summary

Add Git commit information and a dirty flag to the `drenv` startup log.

## Changes

* Log the Git commit/commit hash used to build or run `drenv`.
* Add a dirty flag to indicate whether the working tree contains uncommitted changes.
* Add a timeout and handle Git execution errors to prevent Git version detection from blocking drenv startup.
* This makes it easier to identify the exact source version and whether local modifications were present when `drenv` was started.

## Why

This helps with debugging and reproducing issues by making the exact Git version of `drenv` visible in the startup logs.

## Testing

* Verified the startup log displays the Git commit information.
* Verified the dirty flag correctly indicates whether the source tree has uncommitted changes.

``` python
(ramen) suchi@suchis-MacBook-Pro test % python -m drenv dump envs/example.yaml
2026-08-22 23:28:30,760 INFO    [main] Using commit a78c2e37-dirty
name: example
templates:
- name: example-cluster
  driver: $vm
  container_runtime: containerd
  workers:
  - addons:
    - name: example
profiles:
- name: ex1
  driver: vfkit
  container_runtime: containerd
```

Fixes #2745 