### PR TITLE
drenv: Bump Rook addons to release-1.20

### DIFF
--- a/test/drenv/addons/rook/cephfs/start-data/filesystem.yaml
+++ b/test/drenv/addons/rook/cephfs/start-data/filesystem.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable-line rule:line-length
-# Source: https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/filesystem-test.yaml
+# Source: https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/examples/filesystem-test.yaml
 # Modifications:
 #  - Remove additional resource CephFilesystemSubVolumeGroup
 

--- a/test/drenv/addons/rook/cephfs/start-data/snapshot-class.yaml
+++ b/test/drenv/addons/rook/cephfs/start-data/snapshot-class.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable-line rule:line-length
-# Source: https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/csi/cephfs/snapshotclass.yaml
+# Source: https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/examples/csi/cephfs/snapshotclass.yaml
 # Modifications:
 #  - Added storageID
 ---

--- a/test/drenv/addons/rook/cephfs/start-data/storage-class.yaml
+++ b/test/drenv/addons/rook/cephfs/start-data/storage-class.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable-line rule:line-length
-# Source: https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/csi/cephfs/storageclass.yaml
+# Source: https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/examples/csi/cephfs/storageclass.yaml
 # Modifications:
 #  - Added storageID
 ---

--- a/test/drenv/addons/rook/cluster/__init__.py
+++ b/test/drenv/addons/rook/cluster/__init__.py
@@ -12,7 +12,7 @@ from drenv import commands
 from drenv import kubectl
 
 PACKAGE_DIR = Path(__file__).parent
-CACHE_KEY = "addons/rook-cluster-1.20.yaml"
+CACHE_KEY = "addons/rook-cluster-1.20-1.yaml"
 
 # The ceph, and ceph-csi images are very large (500m each), using larger
 # timeout to avoid timeouts with flaky network.

--- a/test/drenv/addons/rook/cluster/__init__.py
+++ b/test/drenv/addons/rook/cluster/__init__.py
@@ -12,23 +12,31 @@ from drenv import commands
 from drenv import kubectl
 
 PACKAGE_DIR = Path(__file__).parent
-CACHE_KEY = "addons/rook-cluster-1.19-2.yaml"
+CACHE_KEY = "addons/rook-cluster-1.20.yaml"
 
 # The ceph, and ceph-csi images are very large (500m each), using larger
 # timeout to avoid timeouts with flaky network.
 TIMEOUT = 600
 
-# CSI driver components created by the rook operator as part of the
-# CephCluster reconciliation.
-CSI_COMPONENTS = [
-    {"kind": "daemonset", "name": "csi-rbdplugin"},
-    {"kind": "daemonset", "name": "csi-cephfsplugin"},
-    {"kind": "deployment", "name": "csi-rbdplugin-provisioner"},
-    {"kind": "deployment", "name": "csi-cephfsplugin-provisioner"},
-]
-
 CSIADDONS_TIMEOUT = 300
 CSIADDONS_ATTEMPTS = 3
+
+# Plugin pods start with the operator, before the cluster exists. kubelet
+# projects monitor addresses into the pods after Rook publishes them.
+# Typically about one minute; fail faster than CephCluster image pull.
+CSI_PLUGIN_TIMEOUT = 120
+CSI_PLUGIN_POLL = 5
+
+CSI_PLUGINS = [
+    {
+        "deploy": "deploy/rook-ceph.rbd.csi.ceph.com-ctrlplugin",
+        "container": "csi-rbdplugin",
+    },
+    {
+        "deploy": "deploy/rook-ceph.cephfs.csi.ceph.com-ctrlplugin",
+        "container": "csi-cephfsplugin",
+    },
+]
 
 # CSIAddonsNode resources are created by the csi-addons sidecar in the CSI
 # driver pods. The sidecar registers the node after the pod is ready.
@@ -39,9 +47,9 @@ CSIADDONS_ATTEMPTS = 3
 # CSI driver's replication client, causing VR reconciliation to fail with
 # "no leader for the ControllerService".
 CSIADDONS_NODES = [
-    "daemonset-csi-rbdplugin",
-    "deployment-csi-rbdplugin-provisioner",
-    "deployment-csi-cephfsplugin-provisioner",
+    "daemonset-rook-ceph.rbd.csi.ceph.com-nodeplugin-csi-addons",
+    "deployment-rook-ceph.rbd.csi.ceph.com-ctrlplugin",
+    "deployment-rook-ceph.cephfs.csi.ceph.com-ctrlplugin",
 ]
 
 
@@ -92,16 +100,83 @@ def wait(cluster):
     info = {"ceph cluster status": json.loads(out)}
     print(yaml.dump(info, sort_keys=False))
 
-    for comp in CSI_COMPONENTS:
-        print(f"Waiting until {comp['kind']} 'rook-ceph/{comp['name']}' is rolled out")
-        kubectl.rollout(
-            "status",
-            f"{comp['kind']}/{comp['name']}",
-            "--namespace=rook-ceph",
-            context=cluster,
-        )
-
+    wait_for_csi_plugins(cluster)
     wait_for_csiaddons_nodes(cluster)
+
+
+def wait_for_csi_plugins(cluster):
+    """
+    Wait until CSI provisioners can read this cluster's monitor list.
+
+    CephCluster Ready does not cover CSI: plugins are a separate operator
+    and are Running before the cluster exists. Creating a PVC before they
+    have monitors fails with InvalidArgument, and the provisioner delays
+    retries past the CephFS test timeout.
+    """
+    deadline = time.monotonic() + CSI_PLUGIN_TIMEOUT
+    for plugin in CSI_PLUGINS:
+        deploy = plugin["deploy"]
+        print(f"Waiting until '{deploy}' has ceph monitors")
+        while True:
+            if _csi_plugin_has_monitors(cluster, plugin):
+                break
+            if time.monotonic() >= deadline:
+                raise RuntimeError(f"Timeout waiting for ceph monitors in '{deploy}'")
+            time.sleep(CSI_PLUGIN_POLL)
+
+
+def _csi_plugin_has_monitors(cluster, plugin):
+    deploy = plugin["deploy"]
+    try:
+        data = _csi_plugin_config(cluster, plugin)
+    except commands.Error as e:
+        print(f"failed to read config in '{deploy}': {e.error.rstrip()!r}")
+        return False
+
+    if not data.strip():
+        return False
+
+    try:
+        monitors = _monitors(data)
+    except json.JSONDecodeError as e:
+        print(f"Invalid CSI config in '{deploy}': {e}: {data.rstrip()}")
+        return False
+
+    if monitors:
+        print(f"Found ceph monitors in '{deploy}': {monitors}")
+        return True
+
+    print(f"CSI config in '{deploy}': {data.rstrip()}")
+    return False
+
+
+def _csi_plugin_config(cluster, plugin):
+    # Missing file is expected until kubelet projects the ConfigMap. Return
+    # empty instead of failing so the wait stays quiet. Other exec errors
+    # still raise.
+    return kubectl.exec(
+        plugin["deploy"],
+        "--namespace=rook-ceph",
+        "-c",
+        plugin["container"],
+        "--",
+        "sh",
+        "-c",
+        "if [ -f /etc/ceph-csi-config/config.json ]; then cat /etc/ceph-csi-config/config.json; fi",
+        context=cluster,
+    )
+
+
+def _monitors(data):
+    cfg = json.loads(data)
+    if not isinstance(cfg, list) or not cfg:
+        return []
+    if not isinstance(cfg[0], dict):
+        return []
+    monitors = cfg[0].get("monitors", [])
+    if not isinstance(monitors, list):
+        return []
+    return monitors
 
 
 def wait_for_csiaddons_nodes(cluster):

--- a/test/drenv/addons/rook/cluster/kustomization.yaml
+++ b/test/drenv/addons/rook/cluster/kustomization.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/cluster-test.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/examples/cluster-test.yaml
 patches:
   - target:
       kind: CephCluster

--- a/test/drenv/addons/rook/cluster/kustomization.yaml
+++ b/test/drenv/addons/rook/cluster/kustomization.yaml
@@ -29,7 +29,3 @@ patches:
           enabled: true
           periodicity: daily
           maxLogSize: 50M
-      # Last ceph image that worked on arm64. Since v20.2.1 rbd-mirror is broken on arm64.
-      - op: replace
-        path: /spec/cephVersion/image
-        value: quay.io/ceph/ceph:v20.2.0

--- a/test/drenv/addons/rook/operator/__init__.py
+++ b/test/drenv/addons/rook/operator/__init__.py
@@ -7,15 +7,60 @@ from drenv import cache as _cache
 from drenv import kubectl
 
 PACKAGE_DIR = Path(__file__).parent
-CACHE_KEY = "addons/rook-operator-1.19-3.yaml"
+DEPS_DIR = PACKAGE_DIR / "start-data" / "deps"
+OPERATOR_DIR = PACKAGE_DIR / "start-data" / "operator"
+DEPS_CACHE_KEY = "addons/rook-operator-deps-1.20.yaml"
+OPERATOR_CACHE_KEY = "addons/rook-operator-1.20.yaml"
+
+# operator.yaml includes OperatorConfig and Driver CRs. Those CRDs are in
+# csi-operator.yaml, so they must be established before the second apply.
+CSI_CRDS = (
+    "operatorconfigs.csi.ceph.io",
+    "drivers.csi.ceph.io",
+)
 
 
 def start(cluster):
     """
     Deploy the rook ceph operator and wait until it is ready.
     """
+    deploy_deps(cluster)
+    deploy_operator(cluster)
+
+
+def cache():
+    """
+    Refresh the cached kustomization yaml.
+    """
+    _cache.refresh(str(DEPS_DIR), DEPS_CACHE_KEY)
+    _cache.refresh(str(OPERATOR_DIR), OPERATOR_CACHE_KEY)
+
+
+def deploy_deps(cluster):
+    print("Deploying rook operator dependencies")
+    path = _cache.get(str(DEPS_DIR), DEPS_CACHE_KEY)
+    kubectl.apply("--filename", path, context=cluster)
+
+    print("Waiting until CSI operator CRDs are established")
+    for crd in CSI_CRDS:
+        kubectl.wait(
+            f"crd/{crd}",
+            "--for=condition=established",
+            context=cluster,
+        )
+
+    print("Waiting until ceph-csi operator is rolled out")
+    kubectl.rollout(
+        "status",
+        "deploy/ceph-csi-controller-manager",
+        "--namespace=rook-ceph",
+        context=cluster,
+    )
+
+
+def deploy_operator(cluster):
     print("Deploying rook ceph operator")
-    path = _cache.get(str(PACKAGE_DIR), CACHE_KEY)
+    path = _cache.get(str(OPERATOR_DIR), OPERATOR_CACHE_KEY)
     kubectl.apply("--filename", path, context=cluster)
 
     print("Waiting until rook ceph operator is rolled out")
@@ -36,10 +81,3 @@ def start(cluster):
         "--selector=app=rook-ceph-operator",
         context=cluster,
     )
-
-
-def cache():
-    """
-    Refresh the cached kustomization yaml.
-    """
-    _cache.refresh(str(PACKAGE_DIR), CACHE_KEY)

--- a/test/drenv/addons/rook/operator/start-data/deps/kustomization.yaml
+++ b/test/drenv/addons/rook/operator/start-data/deps/kustomization.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# yamllint disable rule:line-length
+---
+resources:
+  - https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/examples/crds.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/examples/common.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/examples/csi-operator.yaml

--- a/test/drenv/addons/rook/operator/start-data/operator/kustomization.yaml
+++ b/test/drenv/addons/rook/operator/start-data/operator/kustomization.yaml
@@ -4,28 +4,23 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/crds.yaml
-  - https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/common.yaml
-  - https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/operator.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/examples/operator.yaml
 
 patches:
+  # Rook 1.20 manages CSI through ceph-csi-operator CRs. These settings used
+  # to live in rook-ceph-operator-config (CSI_ENABLE_CSIADDONS,
+  # CSI_ENABLE_OMAP_GENERATOR).
   - target:
-      kind: ConfigMap
-      name: rook-ceph-operator-config
+      kind: OperatorConfig
+      name: ceph-csi-operator-config
       namespace: rook-ceph
     patch: |-
-      - op: add
-        path: /data/CSI_ENABLE_CSIADDONS
-        value: 'true'
-      - op: add
-        path: /data/CSI_ENABLE_OMAP_GENERATOR
-        value: 'true'
-      # Rook now uses ceph-csi-operator to deploy CSI by default.
-      # Ramen is not yet configured to use ceph-csi-operator,
-      # so this flag is still required until that is done.
       - op: replace
-        path: /data/ROOK_USE_CSI_OPERATOR
-        value: 'false'
+        path: /spec/driverSpecDefaults/deployCsiAddons
+        value: true
+      - op: replace
+        path: /spec/driverSpecDefaults/generateOMapInfo
+        value: true
   - target:
       kind: Deployment
       name: rook-ceph-operator

--- a/test/drenv/addons/rook/pool/snapshot-class.yaml
+++ b/test/drenv/addons/rook/pool/snapshot-class.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # yamllint disable rule:line-length
-# Drived from https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/csi/rbd/snapshotclass.yaml
+# Drived from https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/examples/csi/rbd/snapshotclass.yaml
 ---
 apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass

--- a/test/drenv/addons/rook/toolbox/__init__.py
+++ b/test/drenv/addons/rook/toolbox/__init__.py
@@ -8,7 +8,7 @@ from drenv import ceph
 from drenv import kubectl
 
 PACKAGE_DIR = Path(__file__).parent
-CACHE_KEY = "addons/rook-toolbox-1.19.yaml"
+CACHE_KEY = "addons/rook-toolbox-1.20.yaml"
 
 
 def start(cluster):

--- a/test/drenv/addons/rook/toolbox/kustomization.yaml
+++ b/test/drenv/addons/rook/toolbox/kustomization.yaml
@@ -4,4 +4,4 @@
 # yamllint disable rule:line-length
 ---
 resources:
-  - https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/toolbox.yaml
+  - https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/examples/toolbox.yaml


### PR DESCRIPTION
Rook 1.20 no longer deploys CSI drivers. CSI is managed by ceph-csi-operator, and CSI settings moved from the rook-ceph-operator-config ConfigMap to OperatorConfig CRs.

The rook-operator addon now installs csi-operator.yaml and patches OperatorConfig (deployCsiAddons, generateOMapInfo) instead of CSI_ENABLE_* and ROOK_USE_CSI_OPERATOR. Plugin waits in rook-cluster use the new nodeplugin/ctrlplugin names.

operator.yaml includes OperatorConfig and Driver CRs, but the csi.ceph.io CRDs live in csi-operator.yaml. Applying them in one kustomize build fails with "no matches for kind Driver/OperatorConfig". Split the cache into deps (crds.yaml, common.yaml, csi-operator.yaml) and operator (operator.yaml). Start applies deps first, waits until the CSI CRDs are established, then applies the operator.

Copied CephFS and RBD examples are unchanged between 1.19 and 1.20. CSI-Addons stays at v0.14.0, matching the sidecar Rook 1.20 ships.

CSI plugin Deployments start with the operator, before the cluster exists. CephCluster Ready does not mean they have monitor addresses yet. Creating a PVC in that window fails with InvalidArgument, and the provisioner delays retries past the CephFS test timeout, so the PVC stays Pending.

After the cluster is Ready, wait until the RBD and CephFS ctrlplugin pods can read monitors from config.json. This adds about 30 seconds after Ready. We log these message when waiting:

    Waiting until 'deploy/rook-ceph.rbd.csi.ceph.com-ctrlplugin' has ceph monitors
    Found ceph monitors in 'deploy/rook-ceph.rbd.csi.ceph.com-ctrlplugin': ['192.168.64.27:6789']

Ceph image updated to latest v20 since the crash on arm64 was fixed in v20.2.3, and current image is v20.2.4.

Assisted-by: Cursor/Grok 4.6