### PR TITLE
Move manager wiring options from RamenConfig to command line flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,10 +234,10 @@ build: generate manifests  ## Build manager binary.
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run-hub: generate manifests ## Run DR Orchestrator controller from your host.
-	go run ./cmd/main.go --config=examples/dr_hub_config.yaml
+	RAMEN_CONTROLLER_TYPE=dr-hub POD_NAMESPACE=$${POD_NAMESPACE:-ramen-system} go run ./cmd/main.go
 
 run-dr-cluster: generate manifests ## Run DR manager controller from your host.
-	go run ./cmd/main.go --config=examples/dr_cluster_config.yaml
+	RAMEN_CONTROLLER_TYPE=dr-cluster POD_NAMESPACE=$${POD_NAMESPACE:-ramen-system} go run ./cmd/main.go
 
 docker-build: ## Build docker image with the manager.
 	$(DOCKERCMD) build --platform linux/$(PLATFORM) -t ${IMG} .

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -54,7 +54,6 @@ import (
 var (
 	scheme               = runtime.NewScheme()
 	setupLog             = ctrl.Log.WithName("setup")
-	configFile           string
 	metricsAddr          string
 	probeAddr            string
 	enableLeaderElection bool
@@ -83,10 +82,6 @@ func configureLogOptions() *zap.Options {
 // bindFlags takes a list of functions that bind flags to variables.
 // In addition, any ramen specific flags are bound here.
 func bindFlags(bindfuncs ...func(*flag.FlagSet)) {
-	flag.StringVar(&configFile, "config", "",
-		"The controller will load its initial configuration from this file. "+
-			"Omit this flag to use the default configuration values. "+
-			"Command-line flags override configuration from this file.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0.0.0.0:9289",
 		"The address the metrics endpoint binds to. Use \"0\" to disable the metrics server.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081",
@@ -303,7 +298,7 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(logOpts)))
 
-	ramenConfig := controllers.LoadControllerConfig(configFile, setupLog)
+	ramenConfig := controllers.LoadControllerConfig(setupLog)
 
 	restCfg := ctrl.GetConfigOrDie()
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -52,9 +52,12 @@ import (
 )
 
 var (
-	scheme     = runtime.NewScheme()
-	setupLog   = ctrl.Log.WithName("setup")
-	configFile string
+	scheme               = runtime.NewScheme()
+	setupLog             = ctrl.Log.WithName("setup")
+	configFile           string
+	metricsAddr          string
+	probeAddr            string
+	enableLeaderElection bool
 )
 
 func init() {
@@ -84,6 +87,13 @@ func bindFlags(bindfuncs ...func(*flag.FlagSet)) {
 		"The controller will load its initial configuration from this file. "+
 			"Omit this flag to use the default configuration values. "+
 			"Command-line flags override configuration from this file.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "0.0.0.0:9289",
+		"The address the metrics endpoint binds to. Use \"0\" to disable the metrics server.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081",
+		"The address the probe endpoint binds to.")
+	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.")
 
 	for _, f := range bindfuncs {
 		f(flag.CommandLine)
@@ -92,7 +102,13 @@ func bindFlags(bindfuncs ...func(*flag.FlagSet)) {
 
 func buildOptions(restCfg *rest.Config, ramenConfig *ramendrv1alpha1.RamenConfig,
 ) (*ctrl.Options, *ramendrv1alpha1.RamenConfig) {
-	ctrlOptions := ctrl.Options{Scheme: scheme}
+	ctrlOptions := ctrl.Options{
+		Scheme:                 scheme,
+		HealthProbeBindAddress: probeAddr,
+		Metrics:                controllers.MetricsServerOptions(metricsAddr),
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       controllers.LeaderElectionResourceName(controllers.ControllerType),
+	}
 
 	c, err := client.New(restCfg, client.Options{Scheme: scheme})
 	if err != nil {
@@ -107,7 +123,9 @@ func buildOptions(restCfg *rest.Config, ramenConfig *ramendrv1alpha1.RamenConfig
 		os.Exit(1)
 	}
 
-	controllers.LoadControllerOptions(&ctrlOptions, ramenConfig)
+	for _, warning := range controllers.DeprecatedManagerOptionWarnings(ramenConfig, &ctrlOptions) {
+		setupLog.Info(warning)
+	}
 
 	return &ctrlOptions, ramenConfig
 }

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,10 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=0.0.0.0:9289
+        - --leader-elect
         image: controller
         imagePullPolicy: IfNotPresent
         name: manager

--- a/config/samples/ramendr_v1alpha1_ramenconfig.yaml
+++ b/config/samples/ramendr_v1alpha1_ramenconfig.yaml
@@ -1,14 +1,5 @@
 apiVersion: ramendr.openshift.io/v1alpha1
 kind: RamenConfig
-health:
-  healthProbeBindAddress: :8081
-metrics:
-  bindAddress: 0.0.0.0:9289
-webhook:
-  port: 9443
-leaderElection:
-  leaderElect: true
-  resourceName: leaderelection.ramendr.openshift.io
 s3StoreProfiles:
   - s3ProfileName: s3-profile-of-east
     s3CompatibleEndpoint: http://rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.east:80

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -126,17 +126,6 @@ data:
     apiVersion: ramendr.openshift.io/v1alpha1
     kind: RamenConfig
 
-    # Health check and monitoring
-    health:
-      healthProbeBindAddress: :8081
-    metrics:
-      bindAddress: 0.0.0.0:9289
-
-    # Leader election
-    leaderElection:
-      enabled: true
-      resourceName: hub.ramendr.openshift.io
-
     # Volume replication configuration
     volSync:
       disabled: false

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -44,9 +44,10 @@ section. Next is to install and configure ramen.
 
 ## 2. Basic testing (no Prometheus required)
 
-The operator serves metrics on pod port 9289 (`metrics.bindAddress`, default
-`0.0.0.0:9289`). The metrics Service (`ramen-hub-operator-metrics-service`)
-exposes HTTPS on service port 8443 and forwards to that pod port.
+The operator serves metrics on pod port 9289 (the `--metrics-bind-address` flag,
+default `0.0.0.0:9289`). The metrics Service
+(`ramen-hub-operator-metrics-service`) exposes HTTPS on service port 8443 and
+forwards to that pod port.
 
 If running from minikube or a container, port-forward the metrics Service on the
 hub. Use service port 8443; the local endpoint is

--- a/examples/dr_cluster_config.yaml
+++ b/examples/dr_cluster_config.yaml
@@ -1,15 +1,5 @@
 ---
 apiVersion: ramendr.openshift.io/v1alpha1
 kind: RamenConfig
-health:
-  healthProbeBindAddress: :8081
-metrics:
-  bindAddress: 0.0.0.0:9289
-webhook:
-  port: 9443
-leaderElection:
-  # leaderElect: true // enable during in cluster execution
-  leaderElect: false
-  resourceName: dr-cluster.ramendr.openshift.io
 ramenControllerType: "dr-cluster"
 maxConcurrentReconciles: 50

--- a/examples/dr_hub_config.yaml
+++ b/examples/dr_hub_config.yaml
@@ -1,15 +1,5 @@
 ---
 apiVersion: ramendr.openshift.io/v1alpha1
 kind: RamenConfig
-health:
-  healthProbeBindAddress: :8081
-metrics:
-  bindAddress: 0.0.0.0:9289
-webhook:
-  port: 9443
-leaderElection:
-  # leaderElect: true // enable during in cluster execution
-  leaderElect: false
-  resourceName: hub.ramendr.openshift.io
 ramenControllerType: "dr-hub"
 maxConcurrentReconciles: 50

--- a/internal/controller/drcluster_drcconfig_test.go
+++ b/internal/controller/drcluster_drcconfig_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
@@ -120,7 +121,7 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 
 		options := manager.Options{Scheme: scheme.Scheme}
 		options.Controller.SkipNameValidation = ptr.To(true)
-		ramencontrollers.LoadControllerOptions(&options, ramenConfig)
+		options.Metrics = metricsserver.Options{BindAddress: "0"}
 
 		k8sManager, err := ctrl.NewManager(cfg, options)
 		Expect(err).ToNot(HaveOccurred())

--- a/internal/controller/drcluster_mmode_test.go
+++ b/internal/controller/drcluster_mmode_test.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
@@ -154,7 +155,7 @@ var _ = Describe("DRClusterMModeTests", Ordered, func() {
 
 		options := manager.Options{Scheme: scheme.Scheme}
 		options.Controller.SkipNameValidation = ptr.To(true)
-		ramencontrollers.LoadControllerOptions(&options, ramenConfig)
+		options.Metrics = metricsserver.Options{BindAddress: "0"}
 
 		Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/drclusters.go
+++ b/internal/controller/drclusters.go
@@ -114,7 +114,16 @@ func objectsToDeploy(hubOperatorRamenConfig *rmn.RamenConfig) ([]interface{}, er
 	drClusterOperatorRamenConfig := *hubOperatorRamenConfig
 	ramenConfig := &drClusterOperatorRamenConfig
 	drClusterOperatorNamespaceName := drClusterOperatorNamespaceNameOrDefault(ramenConfig)
-	ramenConfig.LeaderElection.ResourceName = drClusterLeaderElectionResourceName
+
+	// leaderElection is deprecated and ignored by the operator and may be
+	// absent from the hub ConfigMap. When present, rewrite the resource name
+	// for the dr-cluster operator on a copy: the shallow config copy above
+	// shares the LeaderElection pointer with the hub's config.
+	if ramenConfig.LeaderElection != nil {
+		leaderElection := *ramenConfig.LeaderElection
+		leaderElection.ResourceName = drClusterLeaderElectionResourceName
+		ramenConfig.LeaderElection = &leaderElection
+	}
 
 	drClusterOperatorConfigMap, err := ConfigMapNew(
 		drClusterOperatorNamespaceName,

--- a/internal/controller/drclusters_internal_test.go
+++ b/internal/controller/drclusters_internal_test.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"testing"
+
+	configv1alpha1 "k8s.io/component-base/config/v1alpha1"
+
+	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
+)
+
+func TestObjectsToDeployWithoutLeaderElection(t *testing.T) {
+	// A hub ConfigMap without the deprecated leaderElection field must not
+	// panic the dr-cluster deploy path.
+	cfg := &ramendrv1alpha1.RamenConfig{}
+
+	objects, err := objectsToDeploy(cfg)
+	if err != nil {
+		t.Fatalf("objectsToDeploy failed: %v", err)
+	}
+
+	if len(objects) == 0 {
+		t.Error("expected objects to deploy")
+	}
+}
+
+func TestObjectsToDeployKeepsHubLeaderElection(t *testing.T) {
+	// The hub's in-memory config must not be mutated when deriving the
+	// dr-cluster config: the copied config shares the LeaderElection pointer.
+	cfg := &ramendrv1alpha1.RamenConfig{
+		LeaderElection: &configv1alpha1.LeaderElectionConfiguration{
+			ResourceName: HubLeaderElectionResourceName,
+		},
+	}
+
+	if _, err := objectsToDeploy(cfg); err != nil {
+		t.Fatalf("objectsToDeploy failed: %v", err)
+	}
+
+	if cfg.LeaderElection.ResourceName != HubLeaderElectionResourceName {
+		t.Errorf("hub config leader election resource name mutated to %q",
+			cfg.LeaderElection.ResourceName)
+	}
+}

--- a/internal/controller/manager_options_test.go
+++ b/internal/controller/manager_options_test.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers_test
+
+import (
+	"testing"
+
+	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
+	controllers "github.com/ramendr/ramen/internal/controller"
+)
+
+func TestMetricsServerOptionsDisabled(t *testing.T) {
+	options := controllers.MetricsServerOptions("0")
+
+	if options.BindAddress != "0" {
+		t.Errorf("expected BindAddress \"0\", got %q", options.BindAddress)
+	}
+
+	if options.SecureServing {
+		t.Error("expected SecureServing disabled when metrics are disabled")
+	}
+
+	if options.FilterProvider != nil {
+		t.Error("expected no FilterProvider when metrics are disabled")
+	}
+}
+
+func TestMetricsServerOptionsEnabled(t *testing.T) {
+	options := controllers.MetricsServerOptions("0.0.0.0:9289")
+
+	if options.BindAddress != "0.0.0.0:9289" {
+		t.Errorf("expected BindAddress \"0.0.0.0:9289\", got %q", options.BindAddress)
+	}
+
+	if !options.SecureServing {
+		t.Error("expected SecureServing enabled")
+	}
+
+	if options.CertDir != "/etc/metrics-certs" {
+		t.Errorf("expected CertDir \"/etc/metrics-certs\", got %q", options.CertDir)
+	}
+
+	if options.FilterProvider == nil {
+		t.Error("expected FilterProvider to be set")
+	}
+}
+
+func TestLeaderElectionResourceName(t *testing.T) {
+	name := controllers.LeaderElectionResourceName(ramendrv1alpha1.DRHubType)
+	if name != "hub.ramendr.openshift.io" {
+		t.Errorf("expected hub leader election resource name, got %q", name)
+	}
+
+	name = controllers.LeaderElectionResourceName(ramendrv1alpha1.DRClusterType)
+	if name != "dr-cluster.ramendr.openshift.io" {
+		t.Errorf("expected dr-cluster leader election resource name, got %q", name)
+	}
+}

--- a/internal/controller/manager_options_test.go
+++ b/internal/controller/manager_options_test.go
@@ -4,7 +4,11 @@
 package controllers_test
 
 import (
+	"strings"
 	"testing"
+
+	configv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
 	controllers "github.com/ramendr/ramen/internal/controller"
@@ -43,6 +47,86 @@ func TestMetricsServerOptionsEnabled(t *testing.T) {
 
 	if options.FilterProvider == nil {
 		t.Error("expected FilterProvider to be set")
+	}
+}
+
+func TestDeprecatedManagerOptionWarningsNone(t *testing.T) {
+	leaderElect := true
+	cfg := &ramendrv1alpha1.RamenConfig{
+		Health:  ramendrv1alpha1.ControllerHealth{HealthProbeBindAddress: ":8081"},
+		Metrics: ramendrv1alpha1.ControllerMetrics{BindAddress: "0.0.0.0:9289"},
+		LeaderElection: &configv1alpha1.LeaderElectionConfiguration{
+			LeaderElect:  &leaderElect,
+			ResourceName: "hub.ramendr.openshift.io",
+		},
+	}
+	options := &ctrl.Options{
+		HealthProbeBindAddress: ":8081",
+		Metrics:                controllers.MetricsServerOptions("0.0.0.0:9289"),
+		LeaderElection:         true,
+		LeaderElectionID:       "hub.ramendr.openshift.io",
+	}
+
+	warnings := controllers.DeprecatedManagerOptionWarnings(cfg, options)
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings, got %v", warnings)
+	}
+}
+
+func TestDeprecatedManagerOptionWarningsEmptyConfig(t *testing.T) {
+	cfg := &ramendrv1alpha1.RamenConfig{}
+	options := &ctrl.Options{
+		HealthProbeBindAddress: ":8081",
+		Metrics:                controllers.MetricsServerOptions("0.0.0.0:9289"),
+		LeaderElection:         true,
+		LeaderElectionID:       "hub.ramendr.openshift.io",
+	}
+
+	warnings := controllers.DeprecatedManagerOptionWarnings(cfg, options)
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for unset config fields, got %v", warnings)
+	}
+}
+
+func TestDeprecatedManagerOptionWarningsStaleValues(t *testing.T) {
+	leaderElect := false
+	cfg := &ramendrv1alpha1.RamenConfig{
+		Health:  ramendrv1alpha1.ControllerHealth{HealthProbeBindAddress: ":8082"},
+		Metrics: ramendrv1alpha1.ControllerMetrics{BindAddress: ":8443"},
+		LeaderElection: &configv1alpha1.LeaderElectionConfiguration{
+			LeaderElect:  &leaderElect,
+			ResourceName: "stale.ramendr.openshift.io",
+		},
+	}
+	options := &ctrl.Options{
+		HealthProbeBindAddress: ":8081",
+		Metrics:                controllers.MetricsServerOptions("0.0.0.0:9289"),
+		LeaderElection:         true,
+		LeaderElectionID:       "hub.ramendr.openshift.io",
+	}
+
+	warnings := controllers.DeprecatedManagerOptionWarnings(cfg, options)
+	if len(warnings) != 4 {
+		t.Fatalf("expected 4 warnings, got %d: %v", len(warnings), warnings)
+	}
+
+	for _, substring := range []string{
+		"health.healthProbeBindAddress",
+		"metrics.bindAddress",
+		"leaderElection.leaderElect",
+		"leaderElection.resourceName",
+	} {
+		found := false
+
+		for _, w := range warnings {
+			if strings.Contains(w, substring) {
+				found = true
+			}
+		}
+
+		if !found {
+			t.Errorf("expected a warning mentioning %q, got %v", substring, warnings)
+		}
 	}
 }
 

--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -113,9 +113,7 @@ func DefaultRamenConfig(controllerType ramendrv1alpha1.ControllerType) *ramendrv
 	return cfg
 }
 
-func LoadControllerConfig(configFile string,
-	log logr.Logger,
-) (ramenConfig *ramendrv1alpha1.RamenConfig) {
+func LoadControllerConfig(log logr.Logger) (ramenConfig *ramendrv1alpha1.RamenConfig) {
 	controllerType := os.Getenv("RAMEN_CONTROLLER_TYPE")
 	if controllerType == "" {
 		panic(fmt.Errorf("RAMEN_CONTROLLER_TYPE environment variable must be set"))

--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -61,17 +61,21 @@ const NoS3StoreAvailable = "NoS3"
 
 var ControllerType ramendrv1alpha1.ControllerType
 
-func DefaultRamenConfig(controllerType ramendrv1alpha1.ControllerType) *ramendrv1alpha1.RamenConfig {
-	var leaderElectionResourceName string
-
+// LeaderElectionResourceName returns the leader election lease name for the
+// given controller type.
+func LeaderElectionResourceName(controllerType ramendrv1alpha1.ControllerType) string {
 	switch controllerType {
 	case ramendrv1alpha1.DRHubType:
-		leaderElectionResourceName = HubLeaderElectionResourceName
+		return HubLeaderElectionResourceName
 	case ramendrv1alpha1.DRClusterType:
-		leaderElectionResourceName = drClusterLeaderElectionResourceName
+		return drClusterLeaderElectionResourceName
 	default:
 		panic(fmt.Sprintf("unknown controller type %q", controllerType))
 	}
+}
+
+func DefaultRamenConfig(controllerType ramendrv1alpha1.ControllerType) *ramendrv1alpha1.RamenConfig {
+	leaderElectionResourceName := LeaderElectionResourceName(controllerType)
 
 	leaderElect := true
 
@@ -136,20 +140,7 @@ func LoadControllerOptions(options *ctrl.Options, ramenConfig *ramendrv1alpha1.R
 	}
 
 	options.HealthProbeBindAddress = ramenConfig.Health.HealthProbeBindAddress
-
-	if ramenConfig.Metrics.BindAddress == "0" {
-		options.Metrics = metricsserver.Options{BindAddress: "0"}
-	} else {
-		// Use /etc/metrics-certs for OpenShift Service CA or
-		// cert-manager certs. Falls back to auto-generated certs if
-		// directory doesn't exist
-		options.Metrics = metricsserver.Options{
-			BindAddress:    ramenConfig.Metrics.BindAddress,
-			SecureServing:  true,
-			CertDir:        "/etc/metrics-certs",
-			FilterProvider: filters.WithAuthenticationAndAuthorization,
-		}
-	}
+	options.Metrics = MetricsServerOptions(ramenConfig.Metrics.BindAddress)
 
 	if ramenConfig.LeaderElection != nil {
 		if ramenConfig.LeaderElection.LeaderElect != nil {
@@ -159,6 +150,24 @@ func LoadControllerOptions(options *ctrl.Options, ramenConfig *ramendrv1alpha1.R
 		if ramenConfig.LeaderElection.ResourceName != "" {
 			options.LeaderElectionID = ramenConfig.LeaderElection.ResourceName
 		}
+	}
+}
+
+// MetricsServerOptions returns the manager metrics server options for the
+// given bind address. A bind address of "0" disables the metrics server.
+func MetricsServerOptions(bindAddress string) metricsserver.Options {
+	if bindAddress == "0" {
+		return metricsserver.Options{BindAddress: "0"}
+	}
+
+	// Use /etc/metrics-certs for OpenShift Service CA or
+	// cert-manager certs. Falls back to auto-generated certs if
+	// directory doesn't exist
+	return metricsserver.Options{
+		BindAddress:    bindAddress,
+		SecureServing:  true,
+		CertDir:        "/etc/metrics-certs",
+		FilterProvider: filters.WithAuthenticationAndAuthorization,
 	}
 }
 

--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -153,6 +153,50 @@ func LoadControllerOptions(options *ctrl.Options, ramenConfig *ramendrv1alpha1.R
 	}
 }
 
+// DeprecatedManagerOptionWarnings returns a warning for each manager option
+// still present in the RamenConfig that differs from the effective manager
+// options. These RamenConfig fields are deprecated and ignored: the manager
+// options are set only via command line flags.
+func DeprecatedManagerOptionWarnings(ramenConfig *ramendrv1alpha1.RamenConfig, options *ctrl.Options) []string {
+	var warnings []string
+
+	deprecated := func(field, configValue, effectiveValue, flag string) {
+		warnings = append(warnings, fmt.Sprintf(
+			"RamenConfig %s %q is deprecated and ignored; the manager uses %q from the %s flag",
+			field, configValue, effectiveValue, flag))
+	}
+
+	if address := ramenConfig.Health.HealthProbeBindAddress; address != "" &&
+		address != options.HealthProbeBindAddress {
+		deprecated("health.healthProbeBindAddress", address,
+			options.HealthProbeBindAddress, "--health-probe-bind-address")
+	}
+
+	if address := ramenConfig.Metrics.BindAddress; address != "" &&
+		address != options.Metrics.BindAddress {
+		deprecated("metrics.bindAddress", address,
+			options.Metrics.BindAddress, "--metrics-bind-address")
+	}
+
+	if ramenConfig.LeaderElection != nil {
+		if leaderElect := ramenConfig.LeaderElection.LeaderElect; leaderElect != nil &&
+			*leaderElect != options.LeaderElection {
+			deprecated("leaderElection.leaderElect", fmt.Sprintf("%t", *leaderElect),
+				fmt.Sprintf("%t", options.LeaderElection), "--leader-elect")
+		}
+
+		if name := ramenConfig.LeaderElection.ResourceName; name != "" &&
+			name != options.LeaderElectionID {
+			warnings = append(warnings, fmt.Sprintf(
+				"RamenConfig leaderElection.resourceName %q is deprecated and ignored; "+
+					"the manager uses %q derived from the controller type",
+				name, options.LeaderElectionID))
+		}
+	}
+
+	return warnings
+}
+
 // MetricsServerOptions returns the manager metrics server options for the
 // given bind address. A bind address of "0" disables the metrics server.
 func MetricsServerOptions(bindAddress string) metricsserver.Options {

--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -134,25 +134,6 @@ func LoadControllerConfig(configFile string,
 	return DefaultRamenConfig(ct)
 }
 
-func LoadControllerOptions(options *ctrl.Options, ramenConfig *ramendrv1alpha1.RamenConfig) {
-	if ramenConfig == nil {
-		return
-	}
-
-	options.HealthProbeBindAddress = ramenConfig.Health.HealthProbeBindAddress
-	options.Metrics = MetricsServerOptions(ramenConfig.Metrics.BindAddress)
-
-	if ramenConfig.LeaderElection != nil {
-		if ramenConfig.LeaderElection.LeaderElect != nil {
-			options.LeaderElection = *ramenConfig.LeaderElection.LeaderElect
-		}
-
-		if ramenConfig.LeaderElection.ResourceName != "" {
-			options.LeaderElectionID = ramenConfig.LeaderElection.ResourceName
-		}
-	}
-}
-
 // DeprecatedManagerOptionWarnings returns a warning for each manager option
 // still present in the RamenConfig that differs from the effective manager
 // options. These RamenConfig fields are deprecated and ignored: the manager

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -44,6 +44,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
@@ -336,7 +337,7 @@ var _ = BeforeSuite(func() {
 	s3ProfilesUpdate()
 
 	options := manager.Options{Scheme: scheme.Scheme}
-	ramencontrollers.LoadControllerOptions(&options, ramenConfig)
+	options.Metrics = metricsserver.Options{BindAddress: "0"}
 
 	Expect(err).NotTo(HaveOccurred())
 

--- a/ramendev/ramendev/resources/configmap.yaml
+++ b/ramendev/ramendev/resources/configmap.yaml
@@ -12,15 +12,6 @@ data:
   ramen_manager_config.yaml: |
     apiVersion: ramendr.openshift.io/v1alpha1
     kind: RamenConfig
-    health:
-      healthProbeBindAddress: :8081
-    metrics:
-      bindAddress: 0.0.0.0:9289
-    webhook:
-      port: 9443
-    leaderElection:
-      leaderElect: true
-      resourceName: hub.ramendr.openshift.io
     maxConcurrentReconciles: 50
     drClusterOperator:
       deploymentAutomationEnabled: $auto_deploy


### PR DESCRIPTION
Fixes #2736

## Problem

Since #2552 the operator reads the merged ConfigMap before creating the
manager, so the manager options stored in the RamenConfig
(`metrics.bindAddress`, `health.healthProbeBindAddress`, `leaderElection`)
became effective for the first time. That exposes an upgrade break:
ConfigMaps persisted by older ramen versions carry stale values for these
fields — `127.0.0.1:9289` from the kube-rbac-proxy era, or `:8443` from the
proxy-removal era — and the defaults/user merge cannot distinguish a stale
shipped value from a deliberate user override. On upgrade the manager would
bind metrics on the stale address while the metrics Service forwards
`8443 -> 9289`, breaking Prometheus scraping (or, for loopback values,
making metrics unreachable entirely).

These options are also not meaningful user options: changing the bind
address requires matching Service, certificate, and scrape configuration
changes that a ConfigMap edit cannot deliver.

## Approach

Move the manager wiring options out of the RamenConfig to the standard
controller-runtime command line flags, owned by the shipped Deployment:

- `--metrics-bind-address` (default `0.0.0.0:9289`, `0` disables)
- `--health-probe-bind-address` (default `:8081`)
- `--leader-elect` (default true; the lease name is derived from the
  controller type)

The Deployment manifests are re-applied on every release, so a future port
change ships atomically with the matching Service change and never fights
persisted config. The corresponding RamenConfig fields are now deprecated
and ignored; a startup warning is logged for any that differ from the
effective options, so upgraded clusters with stale values keep working and
say why.

The dead `--config` flag is removed as well: it has been non-functional
since configuration loading moved to compiled defaults merged with the
ConfigMap. The `run-hub`/`run-dr-cluster` Makefile targets now set
`RAMEN_CONTROLLER_TYPE`/`POD_NAMESPACE` instead, which they need since the
config file stopped providing the controller type.

Samples, examples, the ramendev ConfigMap template, and the docs no longer
show the deprecated fields, so they are not copied into user ConfigMaps.

## Commits

Each commit builds and vets standalone; implementation and tests are
separate commits:

1. `config: extract manager option helpers` (+ tests)
2. `config: add DeprecatedManagerOptionWarnings` (+ tests)
3. `cmd: build manager options from command line flags`
4. `controller tests: build envtest manager options directly`
5. `config: remove unused LoadControllerOptions`
6. `cmd: remove the --config flag`
7. `config: pass manager option flags in the deployment`
8. `docs: drop deprecated manager options from sample configs`
9. `drclusters: tolerate absent leaderElection in hub config` (+ tests) —
   the e2e run caught a latent nil dereference: `objectsToDeploy` assumed
   `leaderElection` is always present in the hub ConfigMap, which is no
   longer true once the deprecated field is dropped. The fix also stops
   mutating the hub's in-memory config through the shared
   LeaderElection pointer.

## Not in this PR

- The RamenConfig API fields are left in place (marking them
  `// Deprecated:` is an easy follow-up).
- The merge still persists old values into the ConfigMap; they are ignored
  with a warning. Stripping them on write-back, or a full user-overlay
  config model, is a separate design discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
