### PR TITLE
drpc: persist the FailingOver transition before acting on it

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -902,9 +902,17 @@ func (d *DRPCInstance) checkClusterFenced(cluster string, drClusters []rmn.DRClu
 	return false, fmt.Errorf("failed to get the fencing status for the cluster %s", cluster)
 }
 
-func (d *DRPCInstance) switchToFailoverCluster() (bool, error) {
-	const done = true
-	// Make sure we record the state that we are failing over
+// recordFailoverStart records that a failover is starting (phase, Available
+// and PeerReady conditions, initial progression) and, on the transition into
+// FailingOver, persists the DRPC status before returning. Persisting before
+// acting is the contract: the orchestration that follows promotes the peer
+// cluster's VRG through its ManifestWork, and an observer — or a hub that
+// restarts mid-action — must never find a promoted peer beside a stale
+// stable phase. Requeues already in FailingOver record nothing new and skip
+// the write.
+func (d *DRPCInstance) recordFailoverStart() error {
+	transitioned := d.instance.Status.Phase != rmn.FailingOver
+
 	d.setDRState(rmn.FailingOver)
 	addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 		d.getConditionStatusForTypeAvailable(), string(d.instance.Status.Phase), "Starting failover")
@@ -912,6 +920,20 @@ func (d *DRPCInstance) switchToFailoverCluster() (bool, error) {
 		metav1.ConditionFalse, rmn.ReasonNotStarted,
 		fmt.Sprintf("Started failover to cluster %q", d.instance.Spec.FailoverCluster))
 	d.setProgression(rmn.ProgressionCheckingFailoverPrerequisites)
+
+	if !transitioned {
+		return nil
+	}
+
+	return d.reconciler.updateDRPCStatus(d.ctx, d.instance, d.userPlacement, d.log, d.vrgs)
+}
+
+func (d *DRPCInstance) switchToFailoverCluster() (bool, error) {
+	const done = true
+	// Record and persist that we are failing over before acting on it.
+	if err := d.recordFailoverStart(); err != nil {
+		return !done, fmt.Errorf("failed to record failover start: %w", err)
+	}
 
 	curHomeCluster := d.getCurrentHomeClusterName(d.instance.Spec.FailoverCluster, d.drClusters)
 	if curHomeCluster == "" {

--- a/internal/controller/drplacementcontrol_failover_record_internal_test.go
+++ b/internal/controller/drplacementcontrol_failover_record_internal_test.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	rmn "github.com/ramendr/ramen/api/v1alpha1"
+	rmnutil "github.com/ramendr/ramen/internal/controller/util"
+)
+
+// failoverRecordFixture builds a DRPCInstance around a fake client whose
+// status-subresource writes are counted, so tests can observe whether (and
+// that) the FailingOver transition is persisted rather than only staged in
+// memory.
+func failoverRecordFixture(t *testing.T, phase rmn.DRState, statusErr error) (*DRPCInstance, *int, client.Client) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := rmn.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := plrv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	drpc := &rmn.DRPlacementControl{
+		ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "ramen-ops"},
+		Spec: rmn.DRPlacementControlSpec{
+			Action:          rmn.ActionFailover,
+			FailoverCluster: "dr2",
+		},
+	}
+	drpc.Status.Phase = phase
+
+	statusWrites := 0
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(drpc).
+		WithStatusSubresource(&rmn.DRPlacementControl{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string,
+				obj client.Object, opts ...client.SubResourceUpdateOption,
+			) error {
+				statusWrites++
+
+				if statusErr != nil {
+					return statusErr
+				}
+
+				return c.SubResource(subResourceName).Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	d := &DRPCInstance{
+		ctx:           context.Background(),
+		log:           logr.Discard(),
+		instance:      drpc,
+		userPlacement: &plrv1.PlacementRule{ObjectMeta: metav1.ObjectMeta{Name: "pl", Namespace: "ramen-ops"}},
+		reconciler: &DRPlacementControlReconciler{
+			Client:        cl,
+			Scheme:        scheme,
+			Log:           logr.Discard(),
+			eventRecorder: rmnutil.NewEventReporter(record.NewFakeRecorder(8)),
+		},
+	}
+
+	return d, &statusWrites, cl
+}
+
+// Once the peer cluster's VRG ManifestWork is promoted, any observer — or a
+// hub that restarts mid-action — must find the FailingOver phase already
+// recorded in the API server. recordFailoverStart is that record-before-act
+// step: on the transition into FailingOver it must persist the status, not
+// merely stage it for the end of the reconcile.
+func TestRecordFailoverStartPersistsTransition(t *testing.T) {
+	d, statusWrites, cl := failoverRecordFixture(t, rmn.Deployed, nil)
+
+	if err := d.recordFailoverStart(); err != nil {
+		t.Fatal(err)
+	}
+
+	if *statusWrites == 0 {
+		t.Fatal("FailingOver transition was not persisted before returning")
+	}
+
+	persisted := &rmn.DRPlacementControl{}
+	if err := cl.Get(context.Background(),
+		client.ObjectKeyFromObject(d.instance), persisted); err != nil {
+		t.Fatal(err)
+	}
+
+	if persisted.Status.Phase != rmn.FailingOver {
+		t.Fatalf("persisted phase = %q, want FailingOver", persisted.Status.Phase)
+	}
+
+	var peerReady *metav1.Condition
+
+	for i := range persisted.Status.Conditions {
+		if persisted.Status.Conditions[i].Type == rmn.ConditionPeerReady {
+			peerReady = &persisted.Status.Conditions[i]
+		}
+	}
+
+	if peerReady == nil || peerReady.Status != metav1.ConditionFalse {
+		t.Fatalf("persisted PeerReady=False condition missing, got %+v", persisted.Status.Conditions)
+	}
+}
+
+// Requeues that are already in FailingOver must not add a status write per
+// reconcile; the record is needed only on the transition.
+func TestRecordFailoverStartSkipsPersistWhenAlreadyFailingOver(t *testing.T) {
+	d, statusWrites, _ := failoverRecordFixture(t, rmn.FailingOver, nil)
+
+	if err := d.recordFailoverStart(); err != nil {
+		t.Fatal(err)
+	}
+
+	if *statusWrites != 0 {
+		t.Fatalf("expected no status writes on requeue, got %d", *statusWrites)
+	}
+}
+
+// A failed record must abort the failover attempt: acting on an unrecorded
+// transition is exactly the window this function exists to close.
+func TestRecordFailoverStartPropagatesPersistFailure(t *testing.T) {
+	boom := errors.New("boom")
+	d, _, _ := failoverRecordFixture(t, rmn.Deployed, boom)
+
+	if err := d.recordFailoverStart(); !errors.Is(err, boom) {
+		t.Fatalf("expected persist error to propagate, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

`switchToFailoverCluster` stages `Phase=FailingOver` (and the Available/PeerReady conditions) in memory, then promotes the failover cluster's VRG through its ManifestWork in the same reconcile. The status only reaches the API server when the reconcile ends. Inside that window, the API server shows the previous stable phase (e.g. `Deployed`) while the peer cluster already has a second spec-primary VRG — indistinguishable from split-brain to any external observer, and the recorded state a restarted hub would resume from. On real clusters slow MW application usually masks the window; with fast agents it is observable on every failover.

## Changes

Extract the transition record into `recordFailoverStart`, which:

- persists the DRPC status on the transition into FailingOver, before any orchestration acts on it;
- skips the write on requeues already in FailingOver (no extra status update per reconcile);
- aborts the failover attempt when the record cannot be persisted, so nothing acts on an unrecorded transition.

## Testing

- New unit tests: the transition is persisted (phase + PeerReady=False readable back from the API) before the call returns; requeues in FailingOver perform zero status writes; a persist failure propagates.
- `make test-drpc` passes.
- Verified externally in a 3-cluster envtest environment running the manager binary through failovers with fault injection: in the observed event order, the persisted `FailingOver` phase now always precedes the first appearance of the promoted peer VRG.
- `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)