### PR TITLE
hack/test: refresh csi-addons replication CRDs to the vendored version

### DIFF
--- a/hack/test/replication.storage.openshift.io_volumegroupreplicationclasses.yaml
+++ b/hack/test/replication.storage.openshift.io_volumegroupreplicationclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: volumegroupreplicationclasses.replication.storage.openshift.io
 spec:
   group: replication.storage.openshift.io
@@ -11,10 +11,19 @@ spec:
     kind: VolumeGroupReplicationClass
     listKind: VolumeGroupReplicationClassList
     plural: volumegroupreplicationclasses
+    shortNames:
+    - vgrc
     singular: volumegroupreplicationclass
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provisioner
+      name: provisioner
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VolumeGroupReplicationClass is the Schema for the volumegroupreplicationclasses

--- a/hack/test/replication.storage.openshift.io_volumegroupreplicationcontents.yaml
+++ b/hack/test/replication.storage.openshift.io_volumegroupreplicationcontents.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: volumegroupreplicationcontents.replication.storage.openshift.io
 spec:
   group: replication.storage.openshift.io
@@ -11,10 +11,22 @@ spec:
     kind: VolumeGroupReplicationContent
     listKind: VolumeGroupReplicationContentList
     plural: volumegroupreplicationcontents
+    shortNames:
+    - vgrcontent
     singular: volumegroupreplicationcontent
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.volumeGroupReplicationClassName
+      name: VolumeGroupReplicationClass
+      type: string
+    - jsonPath: .spec.volumeGroupReplicationRef.name
+      name: VolumeGroupReplication
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VolumeGroupReplicationContent is the Schema for the volumegroupreplicationcontents
@@ -52,9 +64,9 @@ spec:
                 type: string
               source:
                 description: |-
-                  Source specifies whether the snapshot is (or should be) dynamically provisioned
-                  or already exists, and just requires a Kubernetes object representation.
-                  This field is immutable after creation.
+                  Source specifies whether the volume group is (or should be) dynamically provisioned
+                  or already exists using the volumes listed here, and just requires a
+                  Kubernetes object representation.
                   Required.
                 properties:
                   volumeHandles:
@@ -67,10 +79,20 @@ spec:
                 required:
                 - volumeHandles
                 type: object
+              volumeGroupAttributes:
+                additionalProperties:
+                  type: string
+                description: volumeGroupAttributes holds the contextual information
+                  of the volume group.
+                type: object
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
               volumeGroupReplicationClassName:
                 description: |-
                   VolumeGroupReplicationClassName is the name of the VolumeGroupReplicationClass from
                   which this group replication was (or will be) created.
+                  Required.
                 type: string
               volumeGroupReplicationHandle:
                 description: |-
@@ -83,10 +105,8 @@ spec:
                   VolumeGroupReplicationContent object is bound.
                   VolumeGroupReplication.Spec.VolumeGroupReplicationContentName field must reference to
                   this VolumeGroupReplicationContent's name for the bidirectional binding to be valid.
-                  For a pre-existing VolumeGroupReplicationContent object, name and namespace of the
-                  VolumeGroupReplication object MUST be provided for binding to happen.
-                  This field is immutable after creation.
-                  Required.
+                  For a pre-existing VolumeGroupReplication object, MUST provide an empty/nil value for
+                  VolumeGroupReplicationRef for the auto-binding to happen.
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -100,7 +120,6 @@ spec:
                       the event) or if no container name is specified "spec.containers[2]" (container with
                       index 2 in this pod). This syntax is chosen only to have some well-defined way of
                       referencing a part of an object.
-                      TODO: this design is not final and this field is subject to change in the future.
                     type: string
                   kind:
                     description: |-
@@ -130,25 +149,64 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
                 x-kubernetes-validations:
-                - message: both volumeGroupReplicationRef.name and volumeGroupReplicationRef.namespace
-                    must be set
-                  rule: has(self.name) && has(self.__namespace__)
-                - message: volumeGroupReplicationRef is immutable
-                  rule: self == oldSelf
+                - message: volumeGroupReplicationRef.name, volumeGroupReplicationRef.namespace
+                    and volumeGroupReplicationRef.uid must be set if volumeGroupReplicationRef
+                    is defined
+                  rule: 'self != null ? has(self.name) && has(self.__namespace__)
+                    && has(self.uid) : true'
             required:
             - provisioner
             - source
-            - volumeGroupReplicationHandle
-            - volumeGroupReplicationRef
+            - volumeGroupReplicationClassName
             type: object
           status:
             description: VolumeGroupReplicationContentStatus defines the status of
               VolumeGroupReplicationContent
             properties:
+              destinationVolumeGroupID:
+                description: |-
+                  DestinationVolumeGroupID is the volume group ID on the
+                  destination/target side, as reported by the SP.
+                type: string
+              persistentVolumeMappingList:
+                description: |-
+                  PersistentVolumeMappingList is the list of PVs for the group
+                  replication, enriched with source and destination volume handles.
+                  This replaces PersistentVolumeRefList. When both fields are
+                  present, consumers SHOULD prefer this field.
+                  The maximum number of allowed PVs in the group is 100.
+                items:
+                  description: |-
+                    PersistentVolumeMapping contains the PV reference along with its
+                    source and destination volume handles. The destination handle is
+                    populated only when the SP supports GET_REPLICATION_DESTINATION_INFO
+                    and destination info is available.
+                  properties:
+                    destinationVolumeHandle:
+                      description: |-
+                        DestinationVolumeHandle is the CSI volume handle on the
+                        destination/target cluster, as reported by the SP.
+                        This field is empty when destination info is not available.
+                      type: string
+                    name:
+                      description: Name is the name of the PersistentVolume.
+                      type: string
+                    volumeHandle:
+                      description: |-
+                        VolumeHandle is the CSI volume handle of this PV on the
+                        source cluster (i.e. PV.Spec.CSI.VolumeHandle).
+                      type: string
+                  required:
+                  - name
+                  - volumeHandle
+                  type: object
+                type: array
               persistentVolumeRefList:
                 description: |-
-                  PersistentVolumeRefList is the list of of PV for the group replication
+                  PersistentVolumeRefList is the list of PV for the group replication
                   The maximum number of allowed PV in the group is 100.
+                  Deprecated: Use PersistentVolumeMappingList instead, which includes
+                  source and destination volume handle information per PV.
                 items:
                   description: |-
                     LocalObjectReference contains enough information to let you locate the
@@ -161,9 +219,7 @@ spec:
                         This field is effectively required, but due to backwards compatibility is
                         allowed to be empty. Instances of this type with an empty value here are
                         almost certainly wrong.
-                        TODO: Add other useful fields. apiVersion, kind, uid?
                         More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic

--- a/hack/test/replication.storage.openshift.io_volumegroupreplications.yaml
+++ b/hack/test/replication.storage.openshift.io_volumegroupreplications.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: volumegroupreplications.replication.storage.openshift.io
 spec:
   group: replication.storage.openshift.io
@@ -11,10 +11,28 @@ spec:
     kind: VolumeGroupReplication
     listKind: VolumeGroupReplicationList
     plural: volumegroupreplications
+    shortNames:
+    - vgr
     singular: volumegroupreplication
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.volumeGroupReplicationClassName
+      name: VolumeGroupReplicationClass
+      type: string
+    - jsonPath: .spec.volumeGroupReplicationContentName
+      name: VolumeGroupReplicationContent
+      type: string
+    - jsonPath: .spec.replicationState
+      name: desiredState
+      type: string
+    - jsonPath: .status.state
+      name: currentState
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VolumeGroupReplication is the Schema for the volumegroupreplications
@@ -46,6 +64,15 @@ spec:
                   AutoResync represents the group to be auto resynced when
                   ReplicationState is "secondary"
                 type: boolean
+              external:
+                default: false
+                description: |-
+                  External represents if VolumeGroupReplication should be reconciled by the csi-addons controller
+                  or an external controller managed by the storage vendor.
+                type: boolean
+                x-kubernetes-validations:
+                - message: source is immutable
+                  rule: self == oldSelf
               replicationState:
                 description: |-
                   ReplicationState represents the replication operation to be performed on the group.
@@ -112,6 +139,8 @@ spec:
                     x-kubernetes-validations:
                     - message: selector is immutable
                       rule: self == oldSelf
+                required:
+                - selector
                 type: object
                 x-kubernetes-validations:
                 - message: source is immutable
@@ -131,11 +160,12 @@ spec:
                 - message: volumeGroupReplicationContentName is immutable
                   rule: self == oldSelf
               volumeReplicationClassName:
-                description: volumeReplicationClassName is the volumeReplicationClass
-                  name for VolumeReplication object
+                description: |-
+                  volumeReplicationClassName is the volumeReplicationClass name for the VolumeReplication object
+                  created for this volumeGroupReplication
                 type: string
                 x-kubernetes-validations:
-                - message: volumReplicationClassName is immutable
+                - message: volumeReplicationClassName is immutable
                   rule: self == oldSelf
               volumeReplicationName:
                 description: Name of the VolumeReplication object created for this
@@ -149,7 +179,6 @@ spec:
             - replicationState
             - source
             - volumeGroupReplicationClassName
-            - volumeReplicationClassName
             type: object
           status:
             description: VolumeGroupReplicationStatus defines the observed state of
@@ -158,16 +187,8 @@ spec:
               conditions:
                 description: Conditions are the list of conditions and their status.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource.\n---\nThis struct is intended for
-                    direct use as an array at the field path .status.conditions.  For
-                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
-                    observations of a foo's current state.\n\t    // Known .status.conditions.type
-                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
-                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
-                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
-                    \   // other fields\n\t}"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
                       description: |-
@@ -208,12 +229,7 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: |-
-                        type of condition in CamelCase or in foo.example.com/CamelCase.
-                        ---
-                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-                        useful (see .node.status.conditions), the ability to deconflict is important.
-                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -225,6 +241,12 @@ spec:
                   - type
                   type: object
                 type: array
+              destinationVolumeID:
+                description: |-
+                  DestinationVolumeID is the volume ID on the destination/target side.
+                  This field is set when the SP reports different source and destination
+                  volume IDs.
+                type: string
               lastCompletionTime:
                 format: date-time
                 type: string
@@ -246,6 +268,27 @@ spec:
                   operator has dealt with
                 format: int64
                 type: integer
+              persistentVolumeClaimsRefList:
+                description: |-
+                  PersistentVolumeClaimsRefList is the list of PVCs for the volume group replication.
+                  The maximum number of allowed PVCs in the group is 100.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
               state:
                 description: State captures the latest state of the replication operation.
                 type: string

--- a/hack/test/replication.storage.openshift.io_volumereplicationclasses.yaml
+++ b/hack/test/replication.storage.openshift.io_volumereplicationclasses.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: volumereplicationclasses.replication.storage.openshift.io
 spec:
   group: replication.storage.openshift.io
@@ -22,53 +20,68 @@ spec:
     - jsonPath: .spec.provisioner
       name: provisioner
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:
         description: VolumeReplicationClass is the Schema for the volumereplicationclasses
-          API
+          API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
-            description: VolumeReplicationClassSpec specifies parameters that an underlying
-              storage system uses when creating a volume replica. A specific VolumeReplicationClass
-              is used by specifying its name in a VolumeReplication object.
+            description: |-
+              VolumeReplicationClassSpec specifies parameters that an underlying storage system uses
+              when creating a volume replica. A specific VolumeReplicationClass is used by specifying
+              its name in a VolumeReplication object.
             properties:
               parameters:
                 additionalProperties:
                   type: string
-                description: Parameters is a key-value map with storage provisioner
-                  specific configurations for creating volume replicas
+                description: |-
+                  Parameters is a key-value map with storage provisioner specific configurations for
+                  creating volume replicas
                 type: object
+                x-kubernetes-validations:
+                - message: parameters are immutable
+                  rule: self == oldSelf
               provisioner:
                 description: Provisioner is the name of storage provisioner
                 type: string
+                x-kubernetes-validations:
+                - message: provisioner is immutable
+                  rule: self == oldSelf
             required:
             - provisioner
             type: object
+            x-kubernetes-validations:
+            - message: parameters are immutable
+              rule: has(self.parameters) == has(oldSelf.parameters)
           status:
             description: VolumeReplicationClassStatus defines the observed state of
-              VolumeReplicationClass
+              VolumeReplicationClass.
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/hack/test/replication.storage.openshift.io_volumereplications.yaml
+++ b/hack/test/replication.storage.openshift.io_volumereplications.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.20.1
   name: volumereplications.replication.storage.openshift.io
 spec:
   group: replication.storage.openshift.io
@@ -24,8 +23,11 @@ spec:
     - jsonPath: .spec.volumeReplicationClass
       name: volumeReplicationClass
       type: string
+    - jsonPath: .spec.dataSource.kind
+      name: SourceKind
+      type: string
     - jsonPath: .spec.dataSource.name
-      name: pvcName
+      name: SourceName
       type: string
     - jsonPath: .spec.replicationState
       name: desiredState
@@ -39,14 +41,19 @@ spec:
         description: VolumeReplication is the Schema for the volumereplications API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -54,18 +61,20 @@ spec:
             description: VolumeReplicationSpec defines the desired state of VolumeReplication.
             properties:
               autoResync:
-                description: AutoResync represents the volume to be auto resynced
-                  when ReplicationState is "secondary"
+                default: false
+                description: |-
+                  AutoResync represents the volume to be auto resynced when
+                  ReplicationState is "secondary"
                 type: boolean
               dataSource:
                 description: DataSource represents the object associated with the
                   volume
                 properties:
                   apiGroup:
-                    description: APIGroup is the group for the resource being referenced.
-                      If APIGroup is not specified, the specified Kind must be in
-                      the core API group. For any other third-party types, APIGroup
-                      is required.
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
                     type: string
                   kind:
                     description: Kind is the type of resource being referenced
@@ -78,14 +87,17 @@ spec:
                 - name
                 type: object
                 x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: dataSource is immutable
+                  rule: self == oldSelf
               replicationHandle:
                 description: replicationHandle represents an existing (but new) replication
                   id
                 type: string
               replicationState:
-                description: ReplicationState represents the replication operation
-                  to be performed on the volume. Supported operations are "primary",
-                  "secondary" and "resync"
+                description: |-
+                  ReplicationState represents the replication operation to be performed on the volume.
+                  Supported operations are "primary", "secondary" and "resync"
                 enum:
                 - primary
                 - secondary
@@ -95,6 +107,9 @@ spec:
                 description: VolumeReplicationClass is the VolumeReplicationClass
                   name for this VolumeReplication resource
                 type: string
+                x-kubernetes-validations:
+                - message: volumeReplicationClass is immutable
+                  rule: self == oldSelf
             required:
             - autoResync
             - dataSource
@@ -107,43 +122,35 @@ spec:
               conditions:
                 description: Conditions are the list of conditions and their status.
                 items:
-                  description: "Condition contains details for one aspect of the current
-                    state of this API Resource. --- This struct is intended for direct
-                    use as an array at the field path .status.conditions.  For example,
-                    \n type FooStatus struct{ // Represents the observations of a
-                    foo's current state. // Known .status.conditions.type are: \"Available\",
-                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
-                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
-                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another. This should be when
-                        the underlying condition changed.  If that is not known, then
-                        using the time when the API field changed is acceptable.
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating
-                        details about the transition. This may be an empty string.
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation
-                        that the condition was set based upon. For instance, if .metadata.generation
-                        is currently 12, but the .status.conditions[x].observedGeneration
-                        is 9, the condition is out of date with respect to the current
-                        state of the instance.
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating
-                        the reason for the condition's last transition. Producers
-                        of specific condition types may define expected values and
-                        meanings for this field, and whether the values are considered
-                        a guaranteed API. The value should be a CamelCase string.
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
                         This field may not be empty.
                       maxLength: 1024
                       minLength: 1
@@ -158,10 +165,6 @@ spec:
                       type: string
                     type:
                       description: type of condition in CamelCase or in foo.example.com/CamelCase.
-                        --- Many .condition.type values are consistent across resources
-                        like Available, but because arbitrary conditions can be useful
-                        (see .node.status.conditions), the ability to deconflict is
-                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -173,11 +176,22 @@ spec:
                   - type
                   type: object
                 type: array
+              destinationVolumeID:
+                description: |-
+                  DestinationVolumeID is the volume ID on the destination/target side.
+                  This field is set when the SP reports different source and destination
+                  volume IDs.
+                type: string
               lastCompletionTime:
                 format: date-time
                 type: string
               lastStartTime:
                 format: date-time
+                type: string
+              lastSyncBytes:
+                format: int64
+                type: integer
+              lastSyncDuration:
                 type: string
               lastSyncTime:
                 format: date-time
@@ -193,6 +207,8 @@ spec:
                 description: State captures the latest state of the replication operation.
                 type: string
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true


### PR DESCRIPTION
The checked-in replication.storage.openshift.io CRDs predate the csi-addons version ramen vendors in go.mod. The stale VolumeGroupReplicationContent schema marks `volumeGroupReplicationRef` required, but ramen legitimately clears that field before uploading a VGRC to S3 (`cleanupVGRCForRestore`) — so on these CRDs every consistency-group failover restore is rejected with `spec.volumeGroupReplicationRef: Required value` and the workload never comes up on the failover cluster. The vendored CRD instead requires `provisioner`, `source`, and `volumeGroupReplicationClassName`.

Found by running the unmodified manager binary through a full CG failover/relocate lifecycle against envtest clusters provisioned from hack/test.

This refreshes all five replication.storage CRDs from the vendored module, on the same principle as #2750 and #2752: hack/test should match what a current cluster serves.

Validated with `make test-vrg-vr` and `make test-drclusterconfig` on the refreshed CRDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)