### PR TITLE
Testing #2658

### DIFF
--- a/test/drenv/addons/argocd/start.py
+++ b/test/drenv/addons/argocd/start.py
@@ -29,15 +29,11 @@ def wait_for_clusters(clusters):
 def deploy_argocd(cluster):
     print("Deploying argocd")
     path = _cache.get(str(PACKAGE_DIR / "start-data"), CACHE_KEY)
-    # Using Server-side Apply to avoid this failure:
-    #   The CustomResourceDefinition "applicationsets.argoproj.io" is invalid:
-    #   metadata.annotations: Too long: may not be more than 262144 bytes
     kubectl.apply(
         "--filename",
         path,
         "--namespace",
         "argocd",
-        "--server-side=true",
         context=cluster,
     )
 

--- a/test/drenv/addons/olm/start.py
+++ b/test/drenv/addons/olm/start.py
@@ -17,12 +17,8 @@ def start(cluster):
 def deploy(cluster):
     print("Deploying olm crds")
 
-    # Using Server-side Apply to avoid this failure:
-    #   The CustomResourceDefinition "clusterserviceversions.operators.coreos.com"
-    #   is invalid: metadata.annotations: Too long: must have at most 262144 bytes
-    # See https://medium.com/pareture/kubectl-install-crd-failed-annotations-too-long-2ebc91b40c7d
     path = _cache.get(str(PACKAGE_DIR / "start-data" / "crds"), CRDS_CACHE_KEY)
-    kubectl.apply("--filename", path, "--server-side=true", context=cluster)
+    kubectl.apply("--filename", path, context=cluster)
 
     print("Waiting until cdrs are established")
     kubectl.wait(

--- a/test/drenv/kubectl.py
+++ b/test/drenv/kubectl.py
@@ -16,6 +16,21 @@ JSONPATH_NEWLINE = '{"\\n"}'
 # distinguishable for rollout() (only "status" supports --timeout).
 _DEFAULT_TIMEOUT = sentinel.Duration(300)
 
+_APPLY_FLAGS_WITH_VALUE = frozenset(
+    ("-f", "--filename", "-k", "--kustomize", "--template")
+)
+
+
+def _apply_flags(args):
+    """Yield flags while skipping values consumed by preceding options."""
+    previous = None
+    for arg in args:
+        if previous in _APPLY_FLAGS_WITH_VALUE:
+            previous = None
+            continue
+        previous = arg
+        yield arg
+
 
 def version(context=None, output=None):
     """
@@ -76,10 +91,19 @@ def exec(*args, context=None):
     return _run("exec", *args, context=context)
 
 
-def apply(*args, input=None, context=None, log=print):
+def apply(*args, server_side=True, input=None, context=None, log=print):
     """
     Run kubectl apply ... logging progress messages.
+
+    Server-side apply is enabled by default to avoid the large
+    last-applied-configuration annotation created by client-side apply.
     """
+    args = list(args)
+    for flag in _apply_flags(args):
+        if flag == "--server-side" or flag.startswith("--server-side="):
+            raise ValueError("use server_side argument instead of --server-side flag")
+    if server_side:
+        args.append("--server-side=true")
     _watch("apply", *args, input=input, context=context, log=log)
 
 

--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -17,9 +17,10 @@ from drenv.addons import example
 # Avoid random timeouts in github.
 TIMEOUT = 30
 
-pytestmark = pytest.mark.cluster
+LAST_APPLIED_CONFIGURATION = "kubectl.kubernetes.io/last-applied-configuration"
 
 
+@pytest.mark.cluster
 def test_version(tmpenv):
     out = kubectl.version(output="json", context=tmpenv.profile)
     info = json.loads(out)
@@ -28,16 +29,19 @@ def test_version(tmpenv):
     assert "clientVersion" in info
 
 
+@pytest.mark.cluster
 def test_get(tmpenv):
     out = kubectl.get("deploy", "--output=name", context=tmpenv.profile)
     assert out.strip() == "deployment.apps/example-deployment"
 
 
+@pytest.mark.cluster
 def test_config(tmpenv):
     out = kubectl.config("view", "--output=json")
     json.loads(out)
 
 
+@pytest.mark.cluster
 def test_exec(tmpenv):
     out = kubectl.exec(
         "deploy/example-deployment",
@@ -48,12 +52,93 @@ def test_exec(tmpenv):
     assert out.startswith("example-deployment-")
 
 
+@pytest.mark.cluster
 def test_apply(tmpenv, capsys):
     kubectl.apply(f"--filename={example.DEPLOYMENT}", context=tmpenv.profile)
     out, err = capsys.readouterr()
-    assert out.strip() == "deployment.apps/example-deployment unchanged"
+    assert out.strip() == "deployment.apps/example-deployment serverside-applied"
 
 
+@pytest.mark.cluster
+@pytest.mark.parametrize("server_side", [None, True])
+def test_apply_server_side(tmpenv, tmp_path, server_side):
+    name = f"test-apply-server-side-{server_side}".lower()
+    resource = f"configmap/{name}"
+    manifest = tmp_path / "configmap.yaml"
+    manifest.write_text(f"""\
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {name}
+""")
+
+    kwargs = {} if server_side is None else {"server_side": server_side}
+    kubectl.apply(f"--filename={manifest}", **kwargs, context=tmpenv.profile)
+    try:
+        annotations = _get_annotations(resource, tmpenv.profile)
+        assert LAST_APPLIED_CONFIGURATION not in annotations
+    finally:
+        kubectl.delete(resource, context=tmpenv.profile)
+
+
+@pytest.mark.cluster
+def test_apply_client_side(tmpenv, tmp_path):
+    name = "test-apply-client-side"
+    resource = f"configmap/{name}"
+    manifest = tmp_path / "configmap.yaml"
+    manifest.write_text(f"""\
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {name}
+""")
+
+    kubectl.apply(f"--filename={manifest}", server_side=False, context=tmpenv.profile)
+    try:
+        annotations = _get_annotations(resource, tmpenv.profile)
+        assert LAST_APPLIED_CONFIGURATION in annotations
+    finally:
+        kubectl.delete(resource, context=tmpenv.profile)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        ("--server-side", "true"),
+        ("--server-side", "false"),
+        ("--server-side=true",),
+        ("--server-side=false",),
+    ],
+)
+def test_apply_rejects_raw_server_side_flags(args):
+    with pytest.raises(
+        ValueError,
+        match="use server_side argument instead of --server-side flag",
+    ):
+        kubectl.apply(
+            "--filename=resource.yaml",
+            *args,
+            context="non-existing",
+        )
+
+
+@pytest.mark.parametrize(
+    "args,expected",
+    [
+        (["--filename", "VALUE", "--all"], ["--filename", "--all"]),
+        (["-f", "VALUE", "--all"], ["-f", "--all"]),
+        (["-k", "VALUE", "--prune"], ["-k", "--prune"]),
+        (["--kustomize", "VALUE", "--prune"], ["--kustomize", "--prune"]),
+        (["--template", "VALUE", "--all"], ["--template", "--all"]),
+        (["--filename=VALUE", "--all"], ["--filename=VALUE", "--all"]),
+        (["--all", "--filename", "VALUE"], ["--all", "--filename"]),
+    ],
+)
+def test_apply_flags(args, expected):
+    assert list(kubectl._apply_flags(args)) == expected
+
+
+@pytest.mark.cluster
 def test_rollout_status(tmpenv, capsys):
     kubectl.rollout(
         "status",
@@ -65,6 +150,7 @@ def test_rollout_status(tmpenv, capsys):
     assert out.strip() == 'deployment "example-deployment" successfully rolled out'
 
 
+@pytest.mark.cluster
 def test_rollout_status_default_timeout(tmpenv, capsys):
     kubectl.rollout(
         "status",
@@ -75,6 +161,7 @@ def test_rollout_status_default_timeout(tmpenv, capsys):
     assert out.strip() == 'deployment "example-deployment" successfully rolled out'
 
 
+@pytest.mark.cluster
 def test_rollout_restart(tmpenv, capsys):
     kubectl.rollout(
         "restart",
@@ -104,6 +191,7 @@ def test_rollout_restart_unsupported_timeout():
         )
 
 
+@pytest.mark.cluster
 def test_wait(tmpenv, capsys):
     kubectl.wait(
         "deploy/example-deployment",
@@ -115,6 +203,7 @@ def test_wait(tmpenv, capsys):
     assert out.strip() == "deployment.apps/example-deployment condition met"
 
 
+@pytest.mark.cluster
 def test_wait_for_create(tmpenv):
     """Wait for a resource that does not exist yet."""
     name = f"test-wait-create-{secrets.token_hex(4)}"
@@ -143,6 +232,7 @@ def test_wait_for_create(tmpenv):
         kubectl.delete(resource, context=tmpenv.profile, log=logging.debug)
 
 
+@pytest.mark.cluster
 def test_wait_for_jsonpath_value(tmpenv):
     """Wait for a jsonpath field that does not exist yet."""
     name = f"test-wait-jsonpath-{secrets.token_hex(4)}"
@@ -179,6 +269,7 @@ def test_wait_for_jsonpath_value(tmpenv):
         kubectl.delete(resource, context=tmpenv.profile, log=logging.debug)
 
 
+@pytest.mark.cluster
 def test_wait_for_jsonpath_any_value(tmpenv):
     """Wait for a jsonpath field to have any non-empty value."""
     name = f"test-wait-any-{secrets.token_hex(4)}"
@@ -215,6 +306,7 @@ def test_wait_for_jsonpath_any_value(tmpenv):
         kubectl.delete(resource, context=tmpenv.profile, log=logging.debug)
 
 
+@pytest.mark.cluster
 def test_patch(tmpenv, capsys):
     pod = _current_pod(tmpenv.profile)
     kubectl.patch(
@@ -227,6 +319,7 @@ def test_patch(tmpenv, capsys):
     assert out.strip() == f"{pod} patched"
 
 
+@pytest.mark.cluster
 def test_label(tmpenv, capsys):
     pod = _current_pod(tmpenv.profile)
     name = f"test-{secrets.token_hex(8)}"
@@ -240,6 +333,7 @@ def test_label(tmpenv, capsys):
     assert out.strip() == f"{pod} labeled"
 
 
+@pytest.mark.cluster
 def test_annotate(tmpenv, capsys):
     pod = _current_pod(tmpenv.profile)
     annotation = f"test-{secrets.token_hex(8)}"
@@ -262,6 +356,7 @@ def test_annotate(tmpenv, capsys):
     assert annotation not in _get_annotations(pod, tmpenv.profile)
 
 
+@pytest.mark.cluster
 def test_delete(tmpenv, capsys):
     pod = _current_pod(tmpenv.profile)
     kubectl.delete(pod, context=tmpenv.profile)
@@ -270,6 +365,7 @@ def test_delete(tmpenv, capsys):
     assert out.strip().startswith(f'pod "{name}" deleted')
 
 
+@pytest.mark.cluster
 def test_watch(tmpenv):
     pod_name = kubectl.get(
         "pod",
@@ -286,6 +382,7 @@ def test_watch(tmpenv):
     assert pod["metadata"]["name"] == pod_name
 
 
+@pytest.mark.cluster
 def test_watch_leaf(tmpenv):
     pod_name = kubectl.get(
         "pod",
@@ -305,6 +402,7 @@ def test_watch_leaf(tmpenv):
     assert line == pod_name
 
 
+@pytest.mark.cluster
 def test_watch_jsonpath(tmpenv):
     pod_name = kubectl.get(
         "pod",
@@ -331,6 +429,7 @@ def test_watch_jsonpath(tmpenv):
     assert container["name"] == container_name
 
 
+@pytest.mark.cluster
 def test_watch_events(tmpenv):
     deploy = "deploy/example-deployment"
     label = f"test-{secrets.token_hex(8)}"
@@ -364,6 +463,7 @@ def test_watch_events(tmpenv):
             raise RuntimeError("Timeout waiting for event")
 
 
+@pytest.mark.cluster
 def test_watch_timeout(tmpenv):
     output = []
     with pytest.raises(commands.Timeout):


### PR DESCRIPTION
Default kubectl.apply() to server-side apply while preserving an explicit client-side opt-out. Reject raw --server-side arguments so callers use the typed option consistently.

Update the Argo CD and OLM callers, and cover default, explicit, validation, cleanup, and command-output behavior.