### PR TITLE
stress-test: Remove unneeded git_info() wrapper

### DIFF
--- a/test/drenv/stress/run.py
+++ b/test/drenv/stress/run.py
@@ -31,7 +31,7 @@ def command(args):
     test = {
         "start_time": int(time.time()),
         "host": host_info(),
-        "git": git_info(),
+        "git": git.info(),
         "config": {
             "runs": args.runs,
             "envfile": args.envfile,
@@ -209,10 +209,6 @@ def linux_info():
         "memory_gb": mem / 2**30,
         "python": platform.python_version(),
     }
-
-
-def git_info():
-    return git.info()
 
 
 def sysctl(name):


### PR DESCRIPTION
In commit 453578dc99b ("drenv: Log git commit and dirty flag") we left unneeded git_info() wrapper, remove it.

Testing using:

    % drenv stress-test run -r1 -o out/test envs/vm.yaml
    [1/1] 1 passed, 0 failed, rate: 100.0%, time/run: 107.7s

    % jq .git < out/test/test.json
    {
      "branch": "cleanup-stress-test",
      "commit": "453578dc99b8205b34b14913314edd37ccbfc943",
      "dirty": true
    }