### PR TITLE
drpc: skip metro DR check when all VRG peer classes are offloaded

### DIFF
--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -508,16 +508,18 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 
 	d.drType = DRTypeAsync
 
-	isMetro, _, err := dRPolicySupportsMetro(drPolicy, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to check if DRPolicy supports Metro: %w", err)
-	}
+	if !allVRGPeerClassesOffloaded(vrgs) {
+		isMetro, _, err := dRPolicySupportsMetro(drPolicy, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check if DRPolicy supports Metro: %w", err)
+		}
 
-	if isMetro {
-		d.volSyncDisabled = true
-		d.drType = DRTypeSync
+		if isMetro {
+			d.volSyncDisabled = true
+			d.drType = DRTypeSync
 
-		log.Info("volsync is set to disabled")
+			log.Info("volsync is set to disabled")
+		}
 	}
 
 	if !d.volSyncDisabled && drpcInAdminNamespace(drpc, ramenConfig) {
@@ -528,6 +530,27 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 	d.instance.Status.DeepCopyInto(&d.savedInstanceStatus)
 
 	return d, nil
+}
+
+// allVRGPeerClassesOffloaded returns true if every PeerClass across all VRGs
+// has its Offloaded field set to true. When true, the workload uses only
+// offloaded storage classes and should never be treated as metro DR.
+func allVRGPeerClassesOffloaded(vrgs map[string]*rmn.VolumeReplicationGroup) bool {
+	found := false
+
+	for _, vrg := range vrgs {
+		if vrg.Spec.Async != nil {
+			for i := range vrg.Spec.Async.PeerClasses {
+				if !vrg.Spec.Async.PeerClasses[i].Offloaded {
+					return false
+				}
+
+				found = true
+			}
+		}
+	}
+
+	return found
 }
 
 func (r *DRPlacementControlReconciler) loadNetworkMapping(


### PR DESCRIPTION
When DRPolicy peer classes are empty (e.g. one managed cluster is unreachable), the fallback heuristic based on SchedulingInterval == 0 incorrectly classifies offloaded async DR as metro DR. This causes failover to require fencing, which is wrong for offloaded workloads.

Check VRG async peer classes before calling dRPolicySupportsMetro. If all peer classes have Offloaded set, the workload is async DR regardless of the scheduling interval, so skip the metro check entirely.

Fixes: https://redhat.atlassian.net/browse/DFBUGS-10140