### PR TITLE
drenv: Use external-snapshotter 8.6.0 image

### DIFF
--- a/test/drenv/addons/external_snapshotter/config.py
+++ b/test/drenv/addons/external_snapshotter/config.py
@@ -5,4 +5,4 @@ from pathlib import Path
 
 PACKAGE_DIR = Path(__file__).parent
 CRDS_CACHE_KEY = "addons/external-snapshotter-crds-8.6.yaml"
-CONTROLLER_CACHE_KEY = "addons/external-snapshotter-controller-8.6.yaml"
+CONTROLLER_CACHE_KEY = "addons/external-snapshotter-controller-8.6-1.yaml"

--- a/test/drenv/addons/external_snapshotter/start-data/controller/kustomization.yaml
+++ b/test/drenv/addons/external_snapshotter/start-data/controller/kustomization.yaml
@@ -3,6 +3,11 @@ resources:
   - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.6/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml
   - https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/release-8.6/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
 namespace: kube-system
+images:
+  # The 8.6.0 controller uses 8.5.0 image, fixed in master
+  # https://github.com/kubernetes-csi/external-snapshotter/issues/1478
+  - name: registry.k8s.io/sig-storage/snapshot-controller
+    newTag: v8.6.0
 patches:
   # Enable volume group replication support
   - target:


### PR DESCRIPTION
The v8.6.0 manifest released on May 28 is still using the v8.5.0 image[1]. This was fixed[2] on Jun 9 in master but the fix was never released. This seems to be a repeating issue[3].
    
[1] https://github.com/kubernetes-csi/external-snapshotter/issues/1478
[2] https://github.com/kubernetes-csi/external-snapshotter/pull/1439
[3] https://github.com/kubernetes-csi/external-snapshotter/issues/1377

Test results: https://github.com/RamenDR/ramen/pull/2747#issuecomment-5470535586