### PR TITLE
Simplify Git info handling when repository is unavailable

### DIFF
--- a/test/drenv/__main__.py
+++ b/test/drenv/__main__.py
@@ -40,16 +40,16 @@ width = options.terminal_width()
 def main():
     args = parse_args()
     configure_logging(args)
-    git_info = git.info()
-    if git_info:
+    try:
+        git_info = git.info()
         logging.debug(
             "[main] Using git repo branch=%s commit=%s dirty=%s",
             git_info["branch"],
             git_info["commit"],
             git_info["dirty"],
         )
-    else:
-        logging.debug("[main] git info not available")
+    except commands.Error as e:
+        logging.debug("[main] git info not available: %s", e)
     signal.signal(signal.SIGTERM, handle_termination_signal)
     become_process_group_leader()
     try:

--- a/test/drenv/git.py
+++ b/test/drenv/git.py
@@ -1,29 +1,20 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
-import shutil
-
 from . import commands
 
 
 def info():
     """
     Return git repository info as a dict with keys "branch", "commit", and
-    "dirty", or an empty dict if git is not installed or the current
-    directory is not inside a git repository.
+    "dirty".
 
     "dirty" is True if there are changes to tracked files (staged or
     unstaged); untracked files are ignored.
+
+    Raises commands.Error if git is not installed, the current directory is
+    not inside a git repository, or any git command fails.
     """
-    if not shutil.which("git"):
-        logging.debug("[git] git is not installed")
-        return {}
-
-    if _rev_parse(is_inside_work_tree=True) != "true":
-        logging.debug("[git] Not inside a git repo")
-        return {}
-
     branch = _rev_parse("HEAD", abbrev_ref=True)
     commit = _rev_parse("HEAD")
     # Any output means tracked files have changes; untracked files are
@@ -34,12 +25,10 @@ def info():
     return {"branch": branch, "commit": commit, "dirty": dirty}
 
 
-def _rev_parse(ref=None, abbrev_ref=False, is_inside_work_tree=False):
+def _rev_parse(ref=None, abbrev_ref=False):
     cmd = ["git", "rev-parse"]
     if abbrev_ref:
         cmd.append("--abbrev-ref")
-    if is_inside_work_tree:
-        cmd.append("--is-inside-work-tree")
     if ref:
         cmd.append(ref)
     return commands.run(*cmd).strip()

--- a/test/drenv/stress/run.py
+++ b/test/drenv/stress/run.py
@@ -6,6 +6,7 @@ Run stress test.
 """
 
 import json
+import logging
 import os
 import platform
 import re
@@ -14,6 +15,7 @@ import subprocess
 import sys
 import time
 
+from .. import commands
 from .. import git
 
 PROGRESS = (
@@ -31,7 +33,7 @@ def command(args):
     test = {
         "start_time": int(time.time()),
         "host": host_info(),
-        "git": git.info(),
+        "git": git_info(),
         "config": {
             "runs": args.runs,
             "envfile": args.envfile,
@@ -167,6 +169,17 @@ def drenv(
         cmd.extend(("--directory", directory))
     cmd.append(envfile)
     return subprocess.run(cmd, stderr=subprocess.DEVNULL, check=check)
+
+
+def git_info():
+    """
+    Return git repository info, or an empty dict if git info is not available.
+    """
+    try:
+        return git.info()
+    except commands.Error as e:
+        logging.debug("Git info not available: %s", e)
+        return {}
 
 
 def host_info():


### PR DESCRIPTION
## Description 

git.info() called git rev-parse --is-inside-work-tree to detect repo membership, but that command exits with an error outside a git repo. That caused drenv to fail instead of skipping optional git metadata.

Run git commands directly and raise NotInstalledError when git is not installed and git.Error for other failures such as not being in a repo. Callers catch git.Error, log the error, and continue since git info is only a debugging aid.

Fixes #2766 