### PR TITLE
e2e: wait for source VRG secondary and workload cleanup after failover/relocate

### DIFF
--- a/e2e/deployers/retry.go
+++ b/e2e/deployers/retry.go
@@ -70,3 +70,47 @@ func WaitWorkloadHealth(ctx types.TestContext, cluster *types.Cluster) error {
 		}
 	}
 }
+
+func WaitWorkloadAbsent(ctx types.TestContext, cluster *types.Cluster) error {
+	log := ctx.Logger()
+	w := ctx.Workload()
+	start := time.Now()
+
+	log.Debugf("Waiting until workload \"%s/%s\" is removed from cluster %q",
+		ctx.AppNamespace(), w.GetAppName(), cluster.Name)
+
+	for {
+		absent, err := workloadAbsentOnCluster(ctx, cluster)
+		if err != nil {
+			return err
+		}
+
+		if absent {
+			elapsed := time.Since(start)
+			log.Debugf("Workload \"%s/%s\" removed from cluster %q in %.3f seconds",
+				ctx.AppNamespace(), w.GetAppName(), cluster.Name, elapsed.Seconds())
+
+			return nil
+		}
+
+		if err := util.Sleep(ctx.Context(), util.RetryInterval); err != nil {
+			return fmt.Errorf("workload \"%s/%s\" still present on cluster %q: %w",
+				ctx.AppNamespace(), w.GetAppName(), cluster.Name, err)
+		}
+	}
+}
+
+func workloadAbsentOnCluster(ctx types.TestContext, cluster *types.Cluster) (bool, error) {
+	statuses, err := ctx.Workload().Status(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	for _, status := range statuses {
+		if status.ClusterName == cluster.Name {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}

--- a/e2e/dractions/actions.go
+++ b/e2e/dractions/actions.go
@@ -276,6 +276,14 @@ func failoverRelocate(
 		return err
 	}
 
+	if err := util.WaitVRGSecondaryOnCluster(ctx, currentCluster, managementNamespace, drpcName); err != nil {
+		return err
+	}
+
+	if err := deployers.WaitWorkloadAbsent(ctx, currentCluster); err != nil {
+		return err
+	}
+
 	return deployers.WaitWorkloadHealth(ctx, targetCluster)
 }
 

--- a/e2e/util/vrg.go
+++ b/e2e/util/vrg.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"fmt"
+	"time"
+
+	ramen "github.com/ramendr/ramen/api/v1alpha1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	"github.com/ramendr/ramen/e2e/types"
+)
+
+func GetVRG(ctx types.Context, cluster *types.Cluster, namespace, name string) (*ramen.VolumeReplicationGroup, error) {
+	vrg := &ramen.VolumeReplicationGroup{}
+	key := k8stypes.NamespacedName{Namespace: namespace, Name: name}
+
+	err := cluster.Client.Get(ctx.Context(), key, vrg)
+	if err != nil {
+		return nil, err
+	}
+
+	return vrg, nil
+}
+
+func vrgSecondaryReady(vrg *ramen.VolumeReplicationGroup) bool {
+	return vrg.Status.State == ramen.SecondaryState &&
+		vrg.Status.ObservedGeneration == vrg.Generation
+}
+
+// WaitVRGSecondaryOnCluster waits until the VRG on cluster is secondary or deleted.
+// This mirrors ensureVRGIsSecondaryOnCluster in the DRPC controller.
+func WaitVRGSecondaryOnCluster(ctx types.Context, cluster *types.Cluster, namespace, name string) error {
+	log := ctx.Logger()
+	start := time.Now()
+
+	log.Debugf("Waiting until vrg \"%s/%s\" is secondary in cluster %q", namespace, name, cluster.Name)
+
+	for {
+		vrg, err := GetVRG(ctx, cluster, namespace, name)
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				elapsed := time.Since(start)
+				log.Debugf("vrg \"%s/%s\" not found in cluster %q in %.3f seconds",
+					namespace, name, cluster.Name, elapsed.Seconds())
+
+				return nil
+			}
+
+			return err
+		}
+
+		if vrgSecondaryReady(vrg) {
+			elapsed := time.Since(start)
+			log.Debugf("vrg \"%s/%s\" is secondary in cluster %q in %.3f seconds",
+				namespace, name, cluster.Name, elapsed.Seconds())
+
+			return nil
+		}
+
+		if err := Sleep(ctx.Context(), RetryInterval); err != nil {
+			return fmt.Errorf("vrg %q is not secondary in cluster %q (spec: %q, status: %q, generation: %d, observed: %d): %w",
+				name, cluster.Name, vrg.Spec.ReplicationState, vrg.Status.State,
+				vrg.Generation, vrg.Status.ObservedGeneration, err)
+		}
+	}
+}

--- a/e2e/util/vrg_test.go
+++ b/e2e/util/vrg_test.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Disabling testpackage linter to test unexported functions in the util package.
+//
+//nolint:testpackage
+package util
+
+import (
+	"testing"
+
+	ramen "github.com/ramendr/ramen/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestVRGSecondaryReady(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		vrg  ramen.VolumeReplicationGroup
+		want bool
+	}{
+		{
+			name: "secondary with matching generation",
+			vrg: ramen.VolumeReplicationGroup{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: ramen.VolumeReplicationGroupStatus{
+					State:              ramen.SecondaryState,
+					ObservedGeneration: 2,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "secondary with stale generation",
+			vrg: ramen.VolumeReplicationGroup{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Status: ramen.VolumeReplicationGroupStatus{
+					State:              ramen.SecondaryState,
+					ObservedGeneration: 1,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "unknown state",
+			vrg: ramen.VolumeReplicationGroup{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: ramen.VolumeReplicationGroupStatus{
+					State:              ramen.UnknownState,
+					ObservedGeneration: 1,
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := vrgSecondaryReady(&tt.vrg); got != tt.want {
+				t.Fatalf("vrgSecondaryReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

- Add `WaitVRGSecondaryOnCluster()` to poll until the source-cluster VRG reaches Secondary with a matching `ObservedGeneration`, or is deleted (mirrors DRPC controller logic).
- Wait for the workload to be removed from the source cluster before declaring failover/relocate complete.
- Apply these checks in `failoverRelocate()` for managed deployers (appset/subscription), fixing premature PASS when the old primary still runs the app and VRG `CURRENTSTATE` is `Unknown`.

Fixes #2694

