### PR TITLE
drenv: match CephFS filesystem.yaml to Rook test example

### DIFF
--- a/test/drenv/addons/rook/cephfs/start-data/filesystem.yaml
+++ b/test/drenv/addons/rook/cephfs/start-data/filesystem.yaml
@@ -26,4 +26,4 @@ spec:
   preserveFilesystemOnDelete: false
   metadataServer:
     activeCount: 1
-    activeStandby: true
+    activeStandby: false


### PR DESCRIPTION
Rook's filesystem-test.yaml sets metadataServer.activeStandby to false. drenv still had true, which was an undocumented drift from upstream (unchanged between Rook 1.19 and 1.20). Align the drenv CephFilesystem with the test example. The remaining intentional change is still omitting CephFilesystemSubVolumeGroup.

Fixes: https://github.com/RamenDR/ramen/issues/2746