### PR TITLE
ramendev: restart operator pods on deploy to pick up new image

### DIFF
--- a/docs/devel-quick-start.md
+++ b/docs/devel-quick-start.md
@@ -118,6 +118,17 @@ You can either deploy the *Ramen* operator using the make targets or use the
   ramendev config test/envs/regional-dr.yaml
   ```
 
+## Updating ramen after code changes
+
+After making code changes, rebuild the image and deploy again. This will update
+the *Ramen* operator on all clusters without affecting existing DR-protected
+workloads or configuration.
+
+```sh
+make docker-build
+ramendev deploy test/envs/regional-dr.yaml
+```
+
 ## Testing Ramen
 
 - Read the [testing](./testing.md) guide for test instructions.

--- a/ramendev/README.md
+++ b/ramendev/README.md
@@ -30,6 +30,17 @@ configuration depends on the topology specified in the environment file.
 ramendev config FILENAME
 ```
 
+## Updating ramen on the hub and managed clusters
+
+Running `ramendev deploy` again after rebuilding the image will update the
+operator on all clusters. Existing configuration and DR-protected workloads are
+not affected.
+
+```sh
+make docker-build
+ramendev deploy FILENAME
+```
+
 ## Unconfigure ramen hub operator
 
 Before undeploying *ramen* unconfigure it so undo the changes made by

--- a/ramendev/ramendev/deploy.py
+++ b/ramendev/ramendev/deploy.py
@@ -5,8 +5,11 @@ import concurrent.futures
 import os
 import subprocess
 import tempfile
+from datetime import datetime, timezone
 
 from drenv import kubectl
+from drenv import patch
+from drenv import yaml
 
 from . import command
 
@@ -66,12 +69,18 @@ def load_image(args):
 
 
 def deploy(args, cluster, deploy_type, distro="", timeout=120):
+    deploy = f"ramen-{deploy_type}-operator"
+
     command.info("Deploying ramen operator in cluster '%s'", cluster)
     overlay = os.path.join(args.source_dir, f"config/{deploy_type}/default", distro)
-    yaml = kubectl.kustomize(overlay, load_restrictor="LoadRestrictionsNone")
-    kubectl.apply("--filename=-", input=yaml, context=cluster, log=command.debug)
+    manifests = kubectl.kustomize(overlay, load_restrictor="LoadRestrictionsNone")
+    kubectl.apply(
+        "--filename=-",
+        input=annotate_deployment(manifests, deploy),
+        context=cluster,
+        log=command.debug,
+    )
 
-    deploy = f"ramen-{deploy_type}-operator"
     command.info("Waiting until '%s' is rolled out in cluster '%s'", deploy, cluster)
     kubectl.rollout(
         "status",
@@ -81,3 +90,34 @@ def deploy(args, cluster, deploy_type, distro="", timeout=120):
         context=cluster,
         log=command.debug,
     )
+
+
+def annotate_deployment(manifests, name):
+    """
+    Annotate the Deployment pod template so apply rolls out new pods.
+
+    The operator image tag is always :latest and imagePullPolicy is
+    IfNotPresent. Applying the same manifests does not change spec.template,
+    so Kubernetes keeps the running pods and they never pick up the image
+    loaded by drenv.
+    """
+    timestamp = datetime.now(timezone.utc).isoformat()
+    deployment_patch = {
+        "spec": {
+            "template": {
+                "metadata": {
+                    "annotations": {
+                        "ramendr.openshift.io/deployed-at": timestamp,
+                    }
+                }
+            }
+        }
+    }
+    docs = []
+    for doc in yaml.safe_load_all(manifests):
+        if doc is None:
+            continue
+        if doc["kind"] == "Deployment" and doc["metadata"]["name"] == name:
+            doc = patch.merge(doc, deployment_patch)
+        docs.append(doc)
+    return "".join("---\n" + yaml.safe_dump(doc) for doc in docs)


### PR DESCRIPTION
When re-running `ramendev deploy` after rebuilding the image, the
operator pods were not restarted because the image tag did not change.
This forced developers to unprotect workloads, unconfig, undeploy,
and redeploy just to test a code change.

Annotate the Deployment pod template with a timestamp on each deploy.
The changed annotation triggers Kubernetes to roll out new pods that
pick up the freshly loaded image.

## Testing
### First deploy

$ make docker-build 
```
[2/2] COMMIT quay.io/ramendr/ramen-operator:latest
--> 90c083e2c5d6
Successfully tagged quay.io/ramendr/ramen-operator:latest
90c083e2c5d607cce5798cf844a5788bf6077bb91bcc3856993b8e5c58d84de7
```

$ ramendev deploy test/envs/regional-dr.yaml
```
2026-09-02 13:01:58,927 INFO    [ramendev] Starting deploy
2026-09-02 13:01:58,931 INFO    [ramendev] Preparing resources
2026-09-02 13:02:03,189 INFO    [ramendev] Loading image 'quay.io/ramendr/ramen-operator:latest'
2026-09-02 13:02:07,696 INFO    [ramendev] Deploying ramen operator in cluster 'hub'
2026-09-02 13:02:07,697 INFO    [ramendev] Deploying ramen operator in cluster 'dr1'
2026-09-02 13:02:07,697 INFO    [ramendev] Deploying ramen operator in cluster 'dr2'
2026-09-02 13:02:09,604 INFO    [ramendev] Waiting until 'ramen-hub-operator' is rolled out in cluster 'hub'
2026-09-02 13:02:09,960 INFO    [ramendev] Waiting until 'ramen-dr-cluster-operator' is rolled out in cluster 'dr1'
2026-09-02 13:02:09,988 INFO    [ramendev] Waiting until 'ramen-dr-cluster-operator' is rolled out in cluster 'dr2'
2026-09-02 13:02:22,634 INFO    [ramendev] Finished deploy in 23.71 seconds
```

image digest
```
=== hub ===
sha256:90c083e2c5d607cce5798cf844a5788bf6077bb91bcc3856993b8e5c58d84de7
=== dr1 ===
sha256:90c083e2c5d607cce5798cf844a5788bf6077bb91bcc3856993b8e5c58d84de7
=== dr2 ===
sha256:90c083e2c5d607cce5798cf844a5788bf6077bb91bcc3856993b8e5c58d84de7
```

Verify annotation on deployment:
$ kubectl get deploy ramen-hub-operator -n ramen-system --context hub -o jsonpath='{.spec.template.metadata.annotations}'
```
{"kubectl.kubernetes.io/default-container":"manager","ramendr.openshift.io/deployed-at":"2026-09-02T07:32:07.866352+00:00"}
```

Verify pods started:
for ctx in hub dr1 dr2; do echo "=== $ctx ===" && kubectl get pods -n ramen-system --context $ctx; done
```
=== hub ===
NAME                                  READY   STATUS    RESTARTS   AGE
ramen-hub-operator-6cdbf664f4-4k6xd   1/1     Running   0          2m35s
=== dr1 ===
NAME                                         READY   STATUS    RESTARTS   AGE
ramen-dr-cluster-operator-7795945464-m4ppq   1/1     Running   0          2m34s
=== dr2 ===
NAME                                         READY   STATUS    RESTARTS   AGE
ramen-dr-cluster-operator-6b84ddc94d-j7hbh   1/1     Running   0          2m34s
```

### Make a temp go file change, rebuild and deploy again
$ make docker-build 
```
[2/2] COMMIT quay.io/ramendr/ramen-operator:latest
--> 7a9bced31a08
Successfully tagged quay.io/ramendr/ramen-operator:latest
7a9bced31a0817b5bde1224fbfebe799f72fde399dcdb8ab95f7d13548431092
```

$ ramendev deploy test/envs/regional-dr.yaml
```
2026-09-02 13:06:15,910 INFO    [ramendev] Starting deploy
2026-09-02 13:06:15,914 INFO    [ramendev] Preparing resources
2026-09-02 13:06:19,859 INFO    [ramendev] Loading image 'quay.io/ramendr/ramen-operator:latest'
2026-09-02 13:06:24,309 INFO    [ramendev] Deploying ramen operator in cluster 'hub'
2026-09-02 13:06:24,309 INFO    [ramendev] Deploying ramen operator in cluster 'dr1'
2026-09-02 13:06:24,309 INFO    [ramendev] Deploying ramen operator in cluster 'dr2'
2026-09-02 13:06:25,955 INFO    [ramendev] Waiting until 'ramen-hub-operator' is rolled out in cluster 'hub'
2026-09-02 13:06:26,079 INFO    [ramendev] Waiting until 'ramen-dr-cluster-operator' is rolled out in cluster 'dr2'
2026-09-02 13:06:26,105 INFO    [ramendev] Waiting until 'ramen-dr-cluster-operator' is rolled out in cluster 'dr1'
2026-09-02 13:06:38,629 INFO    [ramendev] Finished deploy in 22.72 seconds
```

Verify image digest changed:
```
=== hub ===
sha256:7a9bced31a0817b5bde1224fbfebe799f72fde399dcdb8ab95f7d13548431092
=== dr1 ===
sha256:7a9bced31a0817b5bde1224fbfebe799f72fde399dcdb8ab95f7d13548431092
=== dr2 ===
sha256:7a9bced31a0817b5bde1224fbfebe799f72fde399dcdb8ab95f7d13548431092
```

Verify pods restarted (new names, fresh AGE):
$ for ctx in hub dr1 dr2; do echo "=== $ctx ===" && kubectl get pods -n ramen-system --context $ctx; done
```
=== hub ===
NAME                                  READY   STATUS    RESTARTS   AGE
ramen-hub-operator-5b88d9c756-lb5q2   1/1     Running   0          39s
=== dr1 ===
NAME                                        READY   STATUS    RESTARTS   AGE
ramen-dr-cluster-operator-fc96cb95f-mgszp   1/1     Running   0          39s
=== dr2 ===
NAME                                         READY   STATUS    RESTARTS   AGE
ramen-dr-cluster-operator-86c79c55d6-jl7xn   1/1     Running   0          39s
```

Verify annotation on re-deployment:
$ kubectl get deploy ramen-hub-operator -n ramen-system --context hub -o jsonpath='{.spec.template.metadata.annotations}'
```
{"kubectl.kubernetes.io/default-container":"manager","ramendr.openshift.io/deployed-at":"2026-09-02T07:36:24.482359+00:00"}
```

Fixes #2759 