### PR TITLE
Drop verbose controller logs

### DIFF
--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -99,8 +99,6 @@ func (r *DRClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return []reconcile.Request{}
 			}
 
-			ctrl.Log.Info(fmt.Sprintf("DRCluster: Filtering DRPC (%s/%s)", drpc.Name, drpc.Namespace))
-
 			return filterDRPC(drpc)
 		}))
 
@@ -113,8 +111,6 @@ func (r *DRClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return []reconcile.Request{}
 			}
 
-			ctrl.Log.Info(fmt.Sprintf("DRCluster: Filtering ManifestWork (%s/%s)", mw.Name, mw.Namespace))
-
 			return filterDRClusterMW(mw)
 		}))
 
@@ -126,8 +122,6 @@ func (r *DRClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			if !ok {
 				return []reconcile.Request{}
 			}
-
-			ctrl.Log.Info(fmt.Sprintf("DRCluster: Filtering MCV (%s/%s)", mcv.Name, mcv.Namespace))
 
 			return filterDRClusterMCV(mcv)
 		}))
@@ -409,8 +403,6 @@ func (r *DRClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 //nolint:cyclop,funlen
 func (r DRClusterReconciler) processCreateOrUpdate(u *drclusterInstance) (ctrl.Result, error) {
 	var requeue bool
-
-	u.log.Info("create/update")
 
 	_, ramenConfig, err := ConfigMapGet(u.ctx, r.APIReader)
 	if err != nil {
@@ -794,8 +786,6 @@ func (u *drclusterInstance) statusUpdate() error {
 
 		return nil
 	}
-
-	u.log.Info(fmt.Sprintf("Nothing to update (%s/%s)", u.object.Name, u.object.Namespace))
 
 	return nil
 }

--- a/internal/controller/drpc_networkmapping.go
+++ b/internal/controller/drpc_networkmapping.go
@@ -8,12 +8,9 @@ package controllers
 //
 // # ConfigMap contract
 //
-// The DRPC carries an annotation:
-//
-//	drplacementcontrol.ramendr.openshift.io/network-mapping: "<configmap-name>"
-//
-// That annotation references a ConfigMap in the same namespace as the DRPC.
-// The ConfigMap's "mappings.yaml" data key contains a YAML document.
+// The DRPolicy carries Spec.NetworkMappingRef, which points to a ConfigMap
+// in the same namespace as the DRPC. The ConfigMap's "mappings.yaml" data
+// key contains a YAML document.
 // Cluster names (dr1/dr2) come from drpolicy.spec.drClusters[0] and [1].
 //
 // # Schema — each block maps one NAD and may carry any combination of rules
@@ -260,7 +257,7 @@ func NewDRPCNetworkMappingManager(c client.Client, log logr.Logger) *DRPCNetwork
 }
 
 // LoadNetworkMapping returns the parsed NetworkMappingRules for the DRPC, or
-// (nil, nil) if the DRPC does not carry the annotation.
+// (nil, nil) if the DRPolicy does not define a networkMappingRef.
 //
 // drPolicy is required to resolve cluster names from drpolicy.spec.drClusters.
 func (m *DRPCNetworkMappingManager) LoadNetworkMapping(
@@ -277,7 +274,7 @@ func (m *DRPCNetworkMappingManager) LoadNetworkMapping(
 	}
 
 	if len(cmName) == 0 {
-		m.log.V(1).Info("DRPC has no network-mapping annotation; skipping",
+		m.log.V(1).Info("DRPolicy is not configured with networkMappingRef; skipping",
 			"drpc", drpc.Name)
 
 		return nil, nil

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -303,13 +303,11 @@ func (r *DRPlacementControlReconciler) recordFailure(ctx context.Context, drpc *
 }
 
 func (r *DRPlacementControlReconciler) setLastSyncTimeMetric(syncMetrics *SyncTimeMetrics,
-	t *metav1.Time, log logr.Logger,
+	t *metav1.Time,
 ) {
 	if syncMetrics == nil {
 		return
 	}
-
-	log.Info(fmt.Sprintf("Setting metric: (%s)", LastSyncTimestampSeconds))
 
 	if t == nil {
 		syncMetrics.LastSyncTime.Set(0)
@@ -321,13 +319,11 @@ func (r *DRPlacementControlReconciler) setLastSyncTimeMetric(syncMetrics *SyncTi
 }
 
 func (r *DRPlacementControlReconciler) setLastSyncDurationMetric(syncDurationMetrics *SyncDurationMetrics,
-	t *metav1.Duration, log logr.Logger,
+	t *metav1.Duration,
 ) {
 	if syncDurationMetrics == nil {
 		return
 	}
-
-	log.Info(fmt.Sprintf("setting metric: (%s)", LastSyncDurationSeconds))
 
 	if t == nil {
 		syncDurationMetrics.LastSyncDuration.Set(0)
@@ -339,13 +335,11 @@ func (r *DRPlacementControlReconciler) setLastSyncDurationMetric(syncDurationMet
 }
 
 func (r *DRPlacementControlReconciler) setLastSyncBytesMetric(syncDataBytesMetrics *SyncDataBytesMetrics,
-	b *int64, log logr.Logger,
+	b *int64,
 ) {
 	if syncDataBytesMetrics == nil {
 		return
 	}
-
-	log.Info(fmt.Sprintf("setting metric: (%s)", LastSyncDataBytes))
 
 	if b == nil {
 		syncDataBytesMetrics.LastSyncDataBytes.Set(0)
@@ -359,13 +353,11 @@ func (r *DRPlacementControlReconciler) setLastSyncBytesMetric(syncDataBytesMetri
 // setWorkloadProtectionMetric sets the workload protection info metric, where 0 indicates not protected and
 // 1 indicates protected
 func (r *DRPlacementControlReconciler) setWorkloadProtectionMetric(workloadProtectionMetrics *WorkloadProtectionMetrics,
-	conditions []metav1.Condition, log logr.Logger,
+	conditions []metav1.Condition,
 ) {
 	if workloadProtectionMetrics == nil {
 		return
 	}
-
-	log.Info(fmt.Sprintf("setting metric: (%s)", WorkloadProtectionStatus))
 
 	protected := 0
 
@@ -384,13 +376,11 @@ func (r *DRPlacementControlReconciler) setWorkloadProtectionMetric(workloadProte
 // where 0 indicates consistency grouping is not enabled
 // and 1 indicates consistency grouping is enabled
 func (r *DRPlacementControlReconciler) setCGEnabledMetric(drpc *rmn.DRPlacementControl,
-	cgEnabledMetrics *CGEnabledMetrics, log logr.Logger,
+	cgEnabledMetrics *CGEnabledMetrics,
 ) {
 	if cgEnabledMetrics == nil {
 		return
 	}
-
-	log.Info(fmt.Sprintf("setting metric: (%s)", CGEnabled))
 
 	enabled := 0
 
@@ -405,13 +395,11 @@ func (r *DRPlacementControlReconciler) setCGEnabledMetric(drpc *rmn.DRPlacementC
 // setGlobalActionMetric sets the global action consensus metric for a DRPC.
 // 1 indicates consensus reached, 0 indicates blocked. Only emitted for global VGR DRPCs.
 func (r *DRPlacementControlReconciler) setGlobalActionMetric(
-	drpc *rmn.DRPlacementControl, metric *GlobalActionMetrics, log logr.Logger,
+	drpc *rmn.DRPlacementControl, metric *GlobalActionMetrics,
 ) {
 	if metric == nil {
 		return
 	}
-
-	log.Info(fmt.Sprintf("Setting metric: (%s)", GlobalActionStatus))
 
 	consensus := 0
 
@@ -428,13 +416,11 @@ func (r *DRPlacementControlReconciler) setGlobalActionMetric(
 }
 
 func (r *DRPlacementControlReconciler) setDRProgressionStateMetric(drpc *rmn.DRPlacementControl,
-	drProgressionStateMetrics *DRProgressionStateMetrics, log logr.Logger,
+	drProgressionStateMetrics *DRProgressionStateMetrics,
 ) {
 	if drProgressionStateMetrics == nil {
 		return
 	}
-
-	log.Info(fmt.Sprintf("setting metric: (%s)", DRProgressionState))
 
 	currentState := string(drpc.Status.Progression)
 	for _, trackedState := range trackedDRProgressionStates {
@@ -688,10 +674,8 @@ func (r *DRPlacementControlReconciler) reconcileDRPCInstance(d *DRPCInstance, lo
 	}
 
 	requeue := d.startProcessing()
-	log.Info("Finished processing", "Requeue?", requeue)
 
 	if !requeue {
-		log.Info("Done reconciling", "state", d.getLastDRState())
 		r.Callback(d.instance.Name, string(d.getLastDRState()))
 	}
 
@@ -1562,8 +1546,6 @@ func (r *DRPlacementControlReconciler) updateDRPCStatus(
 	ctx context.Context, drpc *rmn.DRPlacementControl,
 	userPlacement client.Object, log logr.Logger, vrgs map[string]*rmn.VolumeReplicationGroup,
 ) error {
-	log.Info("Updating DRPC status")
-
 	// Account any DR action phase transition and persist the action count
 	// annotation before the status update, so that a failed status update
 	// cannot lose an already observed transition
@@ -1601,8 +1583,6 @@ func (r *DRPlacementControlReconciler) updateDRPCStatus(
 	}
 
 	if reflect.DeepEqual(r.savedInstanceStatus, drpc.Status) {
-		log.Info("No need to update DRPC Status")
-
 		return nil
 	}
 
@@ -1875,16 +1855,14 @@ func (r *DRPlacementControlReconciler) clusterForVRGStatus(
 func (r *DRPlacementControlReconciler) setDRPCMetrics(ctx context.Context,
 	drpc *rmn.DRPlacementControl, log logr.Logger,
 ) error {
-	log.Info("setting WorkloadProtectionMetrics")
-
 	workloadProtectionMetrics := r.createWorkloadProtectionMetricsInstance(drpc)
-	r.setWorkloadProtectionMetric(workloadProtectionMetrics, drpc.Status.Conditions, log)
+	r.setWorkloadProtectionMetric(workloadProtectionMetrics, drpc.Status.Conditions)
 
 	cgEnabledMetrics := r.createCGEnabledMetricsInstance(drpc)
-	r.setCGEnabledMetric(drpc, cgEnabledMetrics, log)
+	r.setCGEnabledMetric(drpc, cgEnabledMetrics)
 
 	globalActionMetrics := r.createGlobalActionMetricsInstance(drpc)
-	r.setGlobalActionMetric(drpc, globalActionMetrics, log)
+	r.setGlobalActionMetric(drpc, globalActionMetrics)
 
 	drPolicy, err := GetDRPolicy(ctx, r.Client, drpc, log)
 	if err != nil {
@@ -1906,17 +1884,15 @@ func (r *DRPlacementControlReconciler) setDRPCMetrics(ctx context.Context,
 		return nil
 	}
 
-	log.Info("setting SyncMetrics")
-
 	syncMetrics := r.createSyncMetricsInstance(drPolicy, drpc)
 
 	if syncMetrics != nil {
-		r.setLastSyncTimeMetric(&syncMetrics.SyncTimeMetrics, drpc.Status.LastGroupSyncTime, log)
-		r.setLastSyncDurationMetric(&syncMetrics.SyncDurationMetrics, drpc.Status.LastGroupSyncDuration, log)
-		r.setLastSyncBytesMetric(&syncMetrics.SyncDataBytesMetrics, drpc.Status.LastGroupSyncBytes, log)
+		r.setLastSyncTimeMetric(&syncMetrics.SyncTimeMetrics, drpc.Status.LastGroupSyncTime)
+		r.setLastSyncDurationMetric(&syncMetrics.SyncDurationMetrics, drpc.Status.LastGroupSyncDuration)
+		r.setLastSyncBytesMetric(&syncMetrics.SyncDataBytesMetrics, drpc.Status.LastGroupSyncBytes)
 	}
 
-	r.setDRProgressionStateMetric(drpc, &DRProgressionStateMetrics{}, log)
+	r.setDRProgressionStateMetric(drpc, &DRProgressionStateMetrics{})
 
 	return nil
 }

--- a/internal/controller/drplacementcontrol_watcher.go
+++ b/internal/controller/drplacementcontrol_watcher.go
@@ -62,8 +62,6 @@ func ManifestWorkPredicateFunc() predicate.Funcs {
 				return false
 			}
 
-			log.Info(fmt.Sprintf("Update event for MW %s/%s", oldMW.Name, oldMW.Namespace))
-
 			return !reflect.DeepEqual(oldMW.Status, newMW.Status)
 		},
 	}
@@ -114,8 +112,6 @@ func ManagedClusterViewPredicateFunc() predicate.Funcs {
 				return false
 			}
 
-			log.Info(fmt.Sprintf("Update event for MCV %s/%s", oldMCV.Name, oldMCV.Namespace))
-
 			return !reflect.DeepEqual(oldMCV.Status, newMCV.Status)
 		},
 	}
@@ -140,7 +136,6 @@ func filterMCV(mcv *viewv1beta1.ManagedClusterView) []ctrl.Request {
 }
 
 func PlacementRulePredicateFunc() predicate.Funcs {
-	log := ctrl.Log.WithName("DRPCPredicate").WithName("UserPlRule")
 	usrPlRulePredicate := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			return false
@@ -152,8 +147,6 @@ func PlacementRulePredicateFunc() predicate.Funcs {
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			log.Info("Delete event")
-
 			return true
 		},
 	}
@@ -178,7 +171,6 @@ func filterUsrPlRule(usrPlRule *plrv1.PlacementRule) []ctrl.Request {
 }
 
 func PlacementPredicateFunc() predicate.Funcs {
-	log := ctrl.Log.WithName("DRPCPredicate").WithName("UserPlmnt")
 	usrPlmntPredicate := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			return false
@@ -190,8 +182,6 @@ func PlacementPredicateFunc() predicate.Funcs {
 			return false
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			log.Info("Delete event")
-
 			return true
 		},
 	}
@@ -216,7 +206,6 @@ func filterUsrPlmnt(usrPlmnt *clrapiv1beta1.Placement) []ctrl.Request {
 }
 
 func DRClusterPredicateFunc() predicate.Funcs {
-	log := ctrl.Log.WithName("DRPCPredicate").WithName("DRCluster")
 	drClusterPredicate := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			return false
@@ -228,8 +217,6 @@ func DRClusterPredicateFunc() predicate.Funcs {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			log.Info("Update event")
-
 			drcOld, ok := e.ObjectOld.(*rmn.DRCluster)
 			if !ok {
 				return false
@@ -248,7 +235,6 @@ func DRClusterPredicateFunc() predicate.Funcs {
 }
 
 func DRPolicyPredicateFunc() predicate.Funcs {
-	log := ctrl.Log.WithName("DRPCPredicate").WithName("DRPolicy")
 	drPolicyPredicate := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			return false
@@ -260,8 +246,6 @@ func DRPolicyPredicateFunc() predicate.Funcs {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			log.Info("Update event")
-
 			drpOld, ok := e.ObjectOld.(*rmn.DRPolicy)
 			if !ok {
 				return false
@@ -735,10 +719,6 @@ func manifestWorkMapFunc() handler.EventHandler {
 				return nil
 			}
 
-			ctrl.Log.Info(
-				fmt.Sprintf("DRPC: Filtering ManifestWork (%s/%s)",
-					mw.Name, mw.Namespace))
-
 			return filterMW(mw)
 		},
 	)
@@ -752,8 +732,6 @@ func managedClusterViewMapFunc() handler.EventHandler {
 				return []reconcile.Request{}
 			}
 
-			ctrl.Log.Info(fmt.Sprintf("DRPC: Filtering MCV (%s/%s)", mcv.Name, mcv.Namespace))
-
 			return filterMCV(mcv)
 		}))
 }
@@ -765,8 +743,6 @@ func placementRuleMapFunc() handler.EventHandler {
 			if !ok {
 				return []reconcile.Request{}
 			}
-
-			ctrl.Log.Info(fmt.Sprintf("DRPC: Filtering User PlacementRule (%s/%s)", usrPlRule.Name, usrPlRule.Namespace))
 
 			return filterUsrPlRule(usrPlRule)
 		}))
@@ -780,8 +756,6 @@ func placementMapFunc() handler.EventHandler {
 				return []reconcile.Request{}
 			}
 
-			ctrl.Log.Info(fmt.Sprintf("DRPC: Filtering User Placement (%s/%s)", usrPlmnt.Name, usrPlmnt.Namespace))
-
 			return filterUsrPlmnt(usrPlmnt)
 		}))
 }
@@ -794,8 +768,6 @@ func (r *DRPlacementControlReconciler) drClusterMapFunc() handler.EventHandler {
 				return []reconcile.Request{}
 			}
 
-			ctrl.Log.Info(fmt.Sprintf("DRPC Map: Filtering DRCluster (%s)", drCluster.Name))
-
 			return r.FilterDRCluster(drCluster)
 		}))
 }
@@ -807,8 +779,6 @@ func (r *DRPlacementControlReconciler) drPolicyMapFunc() handler.EventHandler {
 			if !ok {
 				return []reconcile.Request{}
 			}
-
-			ctrl.Log.Info(fmt.Sprintf("DRPC Map: Filtering DRPolicy (%s)", drPolicy.Name))
 
 			return r.FilterDRPCsForDRPolicyUpdate(drPolicy)
 		}))

--- a/internal/controller/drpolicy_controller.go
+++ b/internal/controller/drpolicy_controller.go
@@ -141,8 +141,6 @@ func (r *DRPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, u.deleteDRPolicy(drclusters, secretsUtil, ramenConfig)
 	}
 
-	log.Info("create/update")
-
 	reason, err := validateDRPolicy(drpolicy, drclusters)
 	if err != nil {
 		statusErr := u.validatedSetFalse(reason, err)
@@ -346,8 +344,6 @@ func validateDRPolicy(drpolicy *ramen.DRPolicy,
 }
 
 func (r *DRPolicyReconciler) setDRPolicyMetrics(drPolicy *ramen.DRPolicy) error {
-	r.Log.Info(fmt.Sprintf("Setting metric: (%v)", DRPolicySyncIntervalSeconds))
-
 	syncIntervalMetricsLabels := DRPolicySyncIntervalMetricLabels(drPolicy)
 	metric := NewDRPolicySyncIntervalMetrics(syncIntervalMetricsLabels)
 

--- a/internal/controller/protectedvolumereplicationgrouplist_controller.go
+++ b/internal/controller/protectedvolumereplicationgrouplist_controller.go
@@ -125,10 +125,6 @@ func (s *ProtectedVolumeReplicationGroupListInstance) getNamespacesAndVrgPrefixe
 		return prefixNamespaceVRG, fmt.Errorf("error during ParseResultListFromReplicaStore: %w", err)
 	}
 
-	for index, val := range prefixNamespaceVRG {
-		s.log.Info(fmt.Sprintf("prefixNamespaceVRG[%d]=%s", index, val))
-	}
-
 	return prefixNamespaceVRG, nil
 }
 
@@ -140,8 +136,6 @@ func (s *ProtectedVolumeReplicationGroupListInstance) getVrgContentsFromS3(prefi
 	const NoPrefixToRemove = ""
 
 	namespaceNamesList := getUniqueStringsFromList(prefixNamespaceVRG, ParseSingleSlash, NoPrefixToRemove)
-
-	s.log.Info("namespaceNames:")
 
 	for _, namespace := range namespaceNamesList {
 		namespaceAndVRG := getUniqueStringsFromList(prefixNamespaceVRG, ParseRemoveSlashes, namespace)
@@ -157,13 +151,14 @@ func (s *ProtectedVolumeReplicationGroupListInstance) getVrgContentsFromS3(prefi
 			// add all VRGs found to list
 			for i := range vrgs {
 				vrg := &vrgs[i]
-				s.log.Info(fmt.Sprintf("downloaded VRG with name '%s' in namespace '%s'", vrg.Name, vrg.Namespace))
 				VrgTidyForList(vrg)
 
 				vrgsAll = append(vrgsAll, *vrg)
 			}
 		}
 	}
+
+	s.log.Info("downloaded VRGs from S3", "count", len(vrgsAll))
 
 	return vrgsAll, nil
 }

--- a/internal/controller/reconcile_result.go
+++ b/internal/controller/reconcile_result.go
@@ -10,9 +10,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func delayResetIfRequeueTrue(result *ctrl.Result, log logr.Logger) {
+func delayResetIfRequeueTrue(result *ctrl.Result, _ logr.Logger) {
 	if result.Requeue {
-		log.Info("Delay reset because requeue trumps delay", "delay", result.RequeueAfter)
 		result.RequeueAfter = 0
 	}
 }
@@ -21,16 +20,10 @@ func delaySetMinimum(result *ctrl.Result) {
 	result.RequeueAfter = time.Nanosecond
 }
 
-func delaySetIfLess(result *ctrl.Result, delay time.Duration, log logr.Logger) {
+func delaySetIfLess(result *ctrl.Result, delay time.Duration, _ logr.Logger) {
 	if result.RequeueAfter > 0 && result.RequeueAfter <= delay {
-		log.Info("Delay not set because current delay is more than zero and less than new delay",
-			"current", result.RequeueAfter, "new", delay)
-
 		return
 	}
-
-	log.Info("Delay set because current delay is zero or more than new delay",
-		"current", result.RequeueAfter, "new", delay)
 
 	result.RequeueAfter = delay
 }

--- a/internal/controller/replicationgroupdestination_controller.go
+++ b/internal/controller/replicationgroupdestination_controller.go
@@ -68,8 +68,6 @@ func (r *ReplicationGroupDestinationReconciler) getRGDConfig(
 	done bool,
 	err error,
 ) {
-	logger.Info("Get ReplicationGroupDestination")
-
 	rgd = &ramendrv1alpha1.ReplicationGroupDestination{}
 	if err = r.Client.Get(ctx, req.NamespacedName, rgd); err != nil {
 		if !k8serrors.IsNotFound(err) {
@@ -84,8 +82,6 @@ func (r *ReplicationGroupDestinationReconciler) getRGDConfig(
 
 		return nil, nil, nil, true, nil
 	}
-
-	logger.Info("Get vrg from ReplicationGroupDestination")
 
 	vrg = &ramendrv1alpha1.VolumeReplicationGroup{}
 	if err = r.Client.Get(ctx, types.NamespacedName{
@@ -103,8 +99,6 @@ func (r *ReplicationGroupDestinationReconciler) getRGDConfig(
 
 		return nil, nil, nil, true, nil
 	}
-
-	logger.Info("Get ramen config from configmap")
 
 	_, ramenConfig, err = ConfigMapGet(ctx, r.Client)
 	if err != nil {
@@ -126,8 +120,6 @@ func (r *ReplicationGroupDestinationReconciler) runRGDReconcile(
 ) (ctrl.Result, error) {
 	adminNamespaceVRG := vrgInAdminNamespace(vrg, ramenConfig)
 	defaultCephFSCSIDriverName := cephFSCSIDriverNameOrDefault(ramenConfig)
-
-	logger.Info("Run ReplicationGroupDestination state machine", "DefaultCephFSCSIDriverName", defaultCephFSCSIDriverName)
 
 	result, err := statemachine.Run(
 		ctx,

--- a/internal/controller/replicationgroupsource_controller.go
+++ b/internal/controller/replicationgroupsource_controller.go
@@ -85,7 +85,7 @@ func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ct
 	defaultCephFSCSIDriverName := cephFSCSIDriverNameOrDefault(ramenConfig)
 	vsHandler, vgsHandler := r.buildVGSHandler(ctx, logger, rgs, vrg, ramenConfig, defaultCephFSCSIDriverName)
 
-	return r.runRGSReconcile(ctx, logger, rgs, vrg, vsHandler, vgsHandler, defaultCephFSCSIDriverName)
+	return r.runRGSReconcile(ctx, logger, rgs, vrg, vsHandler, vgsHandler)
 }
 
 // getRGSConfig fetches the RGS object, ramen config, and the owning VRG.
@@ -107,8 +107,6 @@ func (r *ReplicationGroupSourceReconciler) getRGSConfig(
 				"Please install VolumeGroupSnapshot CRD and restart the operator", req.Namespace, req.Name)
 	}
 
-	logger.Info("Get ReplicationGroupSource")
-
 	rgs = &ramendrv1alpha1.ReplicationGroupSource{}
 	if err = r.Client.Get(ctx, req.NamespacedName, rgs); err != nil {
 		if !k8serrors.IsNotFound(err) {
@@ -118,16 +116,12 @@ func (r *ReplicationGroupSourceReconciler) getRGSConfig(
 		return nil, nil, nil, true, client.IgnoreNotFound(err)
 	}
 
-	logger.Info("Get ramen config from configmap")
-
 	_, ramenConfig, err = ConfigMapGet(ctx, r.Client)
 	if err != nil {
 		logger.Error(err, "Failed to get ramen config")
 
 		return nil, nil, nil, true, err
 	}
-
-	logger.Info("Get vrg from ReplicationGroupSource")
 
 	vrg = &ramendrv1alpha1.VolumeReplicationGroup{}
 	if err = r.Client.Get(ctx, types.NamespacedName{
@@ -181,7 +175,6 @@ func (r *ReplicationGroupSourceReconciler) runRGSReconcile(
 	vrg *ramendrv1alpha1.VolumeReplicationGroup,
 	vsHandler *volsync.VSHandler,
 	vgsHandler cephfscg.VolumeGroupSourceHandler,
-	defaultCephFSCSIDriverName string,
 ) (ctrl.Result, error) {
 	if cephfscg.IsPrepareForFinalSyncTriggered(rgs) {
 		logger.Info("Detected request for final sync preparation, waiting for confirmation to continue")
@@ -190,8 +183,6 @@ func (r *ReplicationGroupSourceReconciler) runRGSReconcile(
 
 		return ctrl.Result{RequeueAfter: retryDelay}, vgsHandler.CleanVolumeGroupSnapshot(ctx)
 	}
-
-	logger.Info("Run ReplicationGroupSource state machine", "DefaultCephFSCSIDriverName", defaultCephFSCSIDriverName)
 
 	result, err := statemachine.Run(
 		ctx,

--- a/internal/controller/util/cephfs_cg.go
+++ b/internal/controller/util/cephfs_cg.go
@@ -287,7 +287,7 @@ func GetVolumeSnapshotsOwnedByVolumeGroupSnapshot(
 		return nil, err
 	}
 
-	logger.Info("GetVolumeSnapshotsOwnedByVolumeGroupSnapshot", "VolumeSnapshotList", volumeSnapshotList.Items)
+	logger.Info("GetVolumeSnapshotsOwnedByVolumeGroupSnapshot", "count", len(volumeSnapshotList.Items))
 
 	var volumeSnapshots []vsv1.VolumeSnapshot
 

--- a/internal/controller/util/conditions.go
+++ b/internal/controller/util/conditions.go
@@ -29,10 +29,6 @@ func GenericStatusConditionSet(
 			condition.Reason == reason &&
 			condition.Message == message &&
 			condition.ObservedGeneration == generation {
-			log.Info("condition unchanged", "type", conditionType,
-				"status", status, "reason", reason, "message", message, "generation", generation,
-			)
-
 			return !updated
 		}
 

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -106,9 +106,7 @@ func NewVSHandler(ctx context.Context, client client.Client, log logr.Logger, ow
 	}
 
 	vrg, ok := owner.(*ramendrv1alpha1.VolumeReplicationGroup)
-	if !ok {
-		log.Info("VolumeReplicationGroup(PVC) map function received non-VRG resource")
-	} else {
+	if ok {
 		vsHandler.moverConfig = append([]ramendrv1alpha1.MoverConfig(nil), vrg.Spec.VolSync.MoverConfig...)
 	}
 

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -389,6 +389,8 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 		// this. If not found, then reconcile request would not be sent
 		selector, err := metav1.LabelSelectorAsSelector(&pvcSelector.LabelSelector)
 		if err != nil {
+			log1.Error(err, "Failed to convert PVC label selector", "vrg", vrg.Name)
+
 			continue
 		}
 
@@ -655,7 +657,19 @@ func (v *VRGInstance) processVRG() ctrl.Result {
 		return v.invalid(err, "Failed to get recipe", false)
 	}
 
-	v.log.Info("Recipe", "elements", v.recipeElements)
+	captureNames := make([]string, 0, len(v.recipeElements.CaptureWorkflow))
+
+	for _, step := range v.recipeElements.CaptureWorkflow {
+		captureNames = append(captureNames, step.Name)
+	}
+
+	v.log.Info("Recipe",
+		"namespaces", v.recipeElements.PvcSelector.NamespaceNames,
+		"captureSteps", captureNames,
+		"recoverSteps", len(v.recipeElements.RecoverWorkflow),
+		"captureFailOn", v.recipeElements.CaptureFailOn,
+		"restoreFailOn", v.recipeElements.RestoreFailOn,
+	)
 
 	if err := v.updatePVCList(); err != nil {
 		return v.invalid(err, "Failed to process list of PVCs to protect", true)
@@ -1946,9 +1960,6 @@ func (v *VRGInstance) updateVRGStatus(result ctrl.Result) ctrl.Result {
 
 		return result
 	}
-
-	v.log.Info(fmt.Sprintf("Nothing to update VolRep pvccount (%d), VolSync pvccount(%d)",
-		len(v.volRepPVCs), len(v.volSyncPVCs)))
 
 	return result
 }

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -163,12 +163,6 @@ func (v *VRGInstance) reconcilePVCAsVolSyncPrimary(pvc corev1.PersistentVolumeCl
 	}
 
 	if skip {
-		v.log.Info("Skipping PVC for VolSync",
-			"PVC", pvc.Name,
-			"namespace", pvc.Namespace,
-			"reason", "not valid for unprotection",
-		)
-
 		return false
 	}
 
@@ -188,7 +182,6 @@ func (v *VRGInstance) reconcilePVCAsVolSyncPrimary(pvc corev1.PersistentVolumeCl
 		rsSpec = *rsSpecInfo
 	}
 
-	v.log.Info("PVC has CG label?", "name", pvc.Name, "Labels", pvc.Labels)
 	cg, ok := v.getCGLablelFromPVC(&pvc, v.instance.Spec.RunFinalSync)
 
 	isCGEnabled := ok && util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader)
@@ -370,7 +363,13 @@ func (v *VRGInstance) reconcileVolSyncAsSecondary() bool {
 		}
 
 		v.instance.Status.ProtectedPVCs = v.instance.Status.ProtectedPVCs[:idx]
-		v.log.Info("Protected PVCs left", "ProtectedPVCs", v.instance.Status.ProtectedPVCs)
+		names := make([]string, 0, len(v.instance.Status.ProtectedPVCs))
+
+		for _, pvc := range v.instance.Status.ProtectedPVCs {
+			names = append(names, pvc.Namespace+"/"+pvc.Name)
+		}
+
+		v.log.Info("Protected PVCs left", "count", len(names), "names", names)
 
 		if requeue := v.updateWorkloadActivityAsSecondary(); requeue {
 			v.log.Info("Workload is still active, requeueing for VolSync reconciliation as Secondary")


### PR DESCRIPTION
## Summary
- Delete high-frequency Info logs that fire on every watch event or idle reconcile (Filtering/Update chatter, unchanged conditions, metric setters, status no-ops, Get/Run).
- Slim large dumps to counts/names instead of full objects (Recipe, Protected PVCs, VolumeSnapshot list).
- Align the DRPC network-mapping skip log and comment with `DRPolicy.Spec.NetworkMappingRef`.