### PR TITLE
feat: VM staticIP: Enable static IP translation for all VM protection patterns

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -3762,11 +3762,6 @@ func (d *DRPCInstance) shouldInjectStaticIPTranslationSpec(
 // restore on secondary clusters and should not remain configured on the
 // promoted primary after failover/relocation.
 func (d *DRPCInstance) ResetVMStaticIPSpecOnPrimary(clusterName string) error {
-	// Only process if we have static IP VMs (regardless of recipe or protection type)
-	if len(d.instance.Status.ResourceConditions.ResourceMeta.ProtectedStaticIPVMs) == 0 {
-		return nil
-	}
-
 	mw, err := d.mwu.FindManifestWorkByType(rmnutil.MWTypeVRG, clusterName)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -3744,12 +3744,9 @@ func (d *DRPCInstance) updateVRGStaticIPTranslationSpec(
 func (d *DRPCInstance) shouldInjectStaticIPTranslationSpec(
 	vrg *rmn.VolumeReplicationGroup,
 ) (bool, string) {
-	if !d.isVMRecipeInUse() {
-		return false, "VM recipe not in use"
-	}
-
+	// Check if we have any VMs with static IPs (regardless of recipe or protection type)
 	if len(d.instance.Status.ResourceConditions.ResourceMeta.ProtectedStaticIPVMs) == 0 {
-		return false, "VMs are not configured with static IP."
+		return false, "No VMs configured with static IP"
 	}
 
 	if vrg.Spec.ReplicationState != rmn.Secondary {
@@ -3765,7 +3762,8 @@ func (d *DRPCInstance) shouldInjectStaticIPTranslationSpec(
 // restore on secondary clusters and should not remain configured on the
 // promoted primary after failover/relocation.
 func (d *DRPCInstance) ResetVMStaticIPSpecOnPrimary(clusterName string) error {
-	if !d.isVMRecipeInUse() {
+	// Only process if we have static IP VMs (regardless of recipe or protection type)
+	if len(d.instance.Status.ResourceConditions.ResourceMeta.ProtectedStaticIPVMs) == 0 {
 		return nil
 	}
 

--- a/internal/controller/util/vm_util.go
+++ b/internal/controller/util/vm_util.go
@@ -77,6 +77,64 @@ func ListVMsByLabelSelector(
 	return foundVMs, nil
 }
 
+// DiscoverVMsByRecipeLabelSelector discovers VMs matching custom recipe label selectors.
+// This uses a FIXED label key (ramendr.openshift.io/k8s-resource-selector) and matches
+// VMs where the label value is IN the provided labelSelector array.
+//
+// Used for custom recipe patterns that specify K8S_RESOURCE_SELECTOR in RecipeParameters.
+// NOT used for vm-recipe (which has its own validation flow via ListVMsByLabelSelector).
+//
+// Returns full VM objects with deduplication across selector values.
+func DiscoverVMsByRecipeLabelSelector(
+	ctx context.Context,
+	k8sclient client.Client,
+	logger logr.Logger,
+	labelSelector []string,
+	namespaces []string,
+) ([]virtv1.VirtualMachine, error) {
+	var foundVMs []virtv1.VirtualMachine
+
+	seenVMs := make(map[types.NamespacedName]struct{}) // Deduplicate across selector values
+
+	for _, ns := range namespaces {
+		for _, ls := range labelSelector {
+			// Custom recipe pattern: fixed label key, value from selector array
+			matchLabels := map[string]string{
+				core.VMLabelSelector: ls,
+			}
+
+			listOptions := []client.ListOption{
+				client.InNamespace(ns),
+				client.MatchingLabels(matchLabels),
+			}
+
+			vmList := &virtv1.VirtualMachineList{}
+			if err := k8sclient.List(ctx, vmList, listOptions...); err != nil {
+				return nil, fmt.Errorf("failed to list VMs with label %s=%s in namespace %s: %w",
+					core.VMLabelSelector, ls, ns, err)
+			}
+
+			for _, vm := range vmList.Items {
+				vmKey := types.NamespacedName{
+					Namespace: vm.Namespace,
+					Name:      vm.Name,
+				}
+				// Deduplicate VMs (in case multiple selector values match the same VM)
+				if _, seen := seenVMs[vmKey]; !seen {
+					foundVMs = append(foundVMs, vm)
+					seenVMs[vmKey] = struct{}{}
+				}
+			}
+
+			logger.Info(
+				fmt.Sprintf("VMs with label %s=%s in NS[%s]: %d matches",
+					core.VMLabelSelector, ls, ns, len(vmList.Items)))
+		}
+	}
+
+	return foundVMs, nil
+}
+
 func ListVMsByVMNamespace(
 	ctx context.Context,
 	k8sclient client.Client,
@@ -116,6 +174,30 @@ func ListVMsByVMNamespace(
 	}
 
 	return foundVMs, nil
+}
+
+// ListAllVMsInNamespaces lists all VirtualMachine resources across the given namespaces
+// without any filtering. Returns all VMs regardless of labels or static IP configuration.
+// Used for discovering VMs that may have static IPs in namespace-level or custom recipe protection.
+func ListAllVMsInNamespaces(
+	ctx context.Context,
+	k8sclient client.Client,
+	log logr.Logger,
+	namespaces []string,
+) ([]virtv1.VirtualMachine, error) {
+	var allVMs []virtv1.VirtualMachine
+
+	for _, ns := range namespaces {
+		vmList := &virtv1.VirtualMachineList{}
+		if err := k8sclient.List(ctx, vmList, client.InNamespace(ns)); err != nil {
+			return nil, fmt.Errorf("failed to list VMs in namespace %s: %w", ns, err)
+		}
+
+		log.Info("Found VMs in namespace", "namespace", ns, "count", len(vmList.Items))
+		allVMs = append(allVMs, vmList.Items...)
+	}
+
+	return allVMs, nil
 }
 
 // IsVMDeletionInProgress returns true if any listed KubeVirt VM within the given protected NS is in deletion state.

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -3038,14 +3038,13 @@ func (v *VRGInstance) validateAndRecordStaticIPDiscovery(vmList []string, vmName
 }
 
 // discoverAndValidateStaticIPsForAllProtectedVMs performs VM static IP discovery
-// for any discovered app, regardless of recipe type. It scans all protected namespaces,
-// finds all VMs, and records those with static IP annotations.
+// for discovered apps (non-vm-recipe). Handles three scenarios:
 //
-// This handles:
-// - vm-recipe: VMs explicitly listed in RecipeParameters
-// - namespace-level protection: all VMs in ProtectedNamespaces
-// - custom recipes: any VMs in namespaces being protected
-// - mixed workloads: only VMs with static IP annotations are recorded
+// 1. Namespace-level with kubeObjectSelector: filters VMs by kubeObjectSelector
+// 2. Custom recipe with RecipeParameters[K8SLabelSelector]: filters VMs by recipe selector
+// 3. Pure namespace-level: discovers all VMs in ProtectedNamespaces
+//
+// Note: vm-recipe is handled separately by validateVMsForStandaloneProtection()
 func (v *VRGInstance) discoverAndValidateStaticIPsForAllProtectedVMs() error {
 	// Only run on Primary during steady state
 	if v.instance.Spec.ReplicationState != ramendrv1alpha1.Primary {
@@ -3064,16 +3063,14 @@ func (v *VRGInstance) discoverAndValidateStaticIPsForAllProtectedVMs() error {
 		return nil
 	}
 
-	v.log.Info("Scanning for VMs with static IPs", "namespaces", namespacesToScan)
-
-	// Discover all VMs across all protected namespaces
-	allVMs, err := v.discoverVMsInNamespaces(namespacesToScan)
+	// Discover VMs based on protection type
+	allVMs, err := v.discoverVMsBasedOnProtectionType(namespacesToScan)
 	if err != nil {
 		return fmt.Errorf("failed to discover VMs in protected namespaces: %w", err)
 	}
 
 	if len(allVMs) == 0 {
-		v.log.Info("No VMs found in protected namespaces")
+		v.log.Info("No VMs found matching protection criteria")
 		// Clear any previous discovery status
 		v.instance.Status.StaticIPDiscoveryStatus = nil
 
@@ -3091,6 +3088,108 @@ func (v *VRGInstance) discoverAndValidateStaticIPsForAllProtectedVMs() error {
 
 	// Validate and record static IPs (filters to only VMs with static IP annotations)
 	return v.validateAndRecordStaticIPDiscovery(vmNames, vmNamespaces)
+}
+
+// discoverVMsBasedOnProtectionType discovers VMs based on the protection configuration:
+// Priority order:
+// 1. vm-recipe: handled separately (should not reach here)
+// 2. Custom recipe with K8SLabelSelector: filter by recipe label selector
+// 3. Namespace-level with kubeObjectSelector: filter by kubeObjectSelector
+// 4. Pure namespace-level: discover all VMs
+func (v *VRGInstance) discoverVMsBasedOnProtectionType(namespaces []string) ([]virtv1.VirtualMachine, error) {
+	// Safety check: vm-recipe should be handled by validateVMsForStandaloneProtection()
+	if v.isVMRecipeProtection() {
+		v.log.Info("vm-recipe protection detected but should have been handled earlier")
+
+		return nil, fmt.Errorf("vm-recipe should be handled by validateVMsForStandaloneProtection")
+	}
+
+	// Priority 1: Check for custom recipe with K8SLabelSelector in RecipeParameters
+	recipeLabelSelectors := v.getRecipeLabelSelectors()
+	if len(recipeLabelSelectors) > 0 {
+		v.log.Info("Custom recipe protection: discovering VMs by recipe label selector",
+			"namespaces", namespaces, "labelSelectors", recipeLabelSelectors)
+
+		return v.discoverVMsByRecipeLabelSelector(namespaces, recipeLabelSelectors)
+	}
+
+	// Priority 2: Check for kubeObjectSelector (namespace-level protection)
+	kubeObjectSelector := v.getKubeObjectSelector()
+	if kubeObjectSelector != nil {
+		v.log.Info("Namespace-level protection: discovering VMs by kubeObjectSelector",
+			"namespaces", namespaces, "selector", kubeObjectSelector)
+
+		return v.discoverVMsByKubeObjectSelector(namespaces, kubeObjectSelector)
+	}
+
+	// Priority 3: Pure namespace-level protection without selectors
+	v.log.Info("Pure namespace-level protection: discovering all VMs", "namespaces", namespaces)
+
+	return util.ListAllVMsInNamespaces(v.ctx, v.reconciler.Client, v.log, namespaces)
+}
+
+// getRecipeLabelSelectors returns K8SLabelSelector from RecipeParameters if present.
+// This is used by custom recipes to filter which VMs to protect.
+func (v *VRGInstance) getRecipeLabelSelectors() []string {
+	if v.instance.Spec.KubeObjectProtection == nil ||
+		v.instance.Spec.KubeObjectProtection.RecipeParameters == nil {
+		return nil
+	}
+
+	return v.instance.Spec.KubeObjectProtection.RecipeParameters[recipecore.K8SLabelSelector]
+}
+
+// getKubeObjectSelector returns the kubeObjectSelector from KubeObjectProtection if present.
+// This is used by namespace-level protection to filter which resources to protect.
+func (v *VRGInstance) getKubeObjectSelector() *metav1.LabelSelector {
+	if v.instance.Spec.KubeObjectProtection == nil {
+		return nil
+	}
+
+	return v.instance.Spec.KubeObjectProtection.KubeObjectSelector
+}
+
+// discoverVMsByRecipeLabelSelector discovers VMs matching the recipe's K8SLabelSelector.
+// Used by custom recipes that specify label selectors in RecipeParameters.
+func (v *VRGInstance) discoverVMsByRecipeLabelSelector(
+	namespaces []string,
+	labelSelectors []string,
+) ([]virtv1.VirtualMachine, error) {
+	return util.DiscoverVMsByRecipeLabelSelector(v.ctx, v.reconciler.Client, v.log,
+		labelSelectors, namespaces)
+}
+
+// discoverVMsByKubeObjectSelector discovers VMs matching the kubeObjectSelector.
+// Used by namespace-level protection with label-based filtering.
+func (v *VRGInstance) discoverVMsByKubeObjectSelector(
+	namespaces []string,
+	selector *metav1.LabelSelector,
+) ([]virtv1.VirtualMachine, error) {
+	var allVMs []virtv1.VirtualMachine
+
+	// Convert metav1.LabelSelector to client.ListOptions
+	labelSelector, err := metav1.LabelSelectorAsSelector(selector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert kubeObjectSelector to selector: %w", err)
+	}
+
+	for _, ns := range namespaces {
+		vmList := &virtv1.VirtualMachineList{}
+		listOptions := []client.ListOption{
+			client.InNamespace(ns),
+			client.MatchingLabelsSelector{Selector: labelSelector},
+		}
+
+		if err := v.reconciler.Client.List(v.ctx, vmList, listOptions...); err != nil {
+			return nil, fmt.Errorf("failed to list VMs in namespace %s with kubeObjectSelector: %w", ns, err)
+		}
+
+		v.log.Info("Found VMs matching kubeObjectSelector",
+			"namespace", ns, "count", len(vmList.Items))
+		allVMs = append(allVMs, vmList.Items...)
+	}
+
+	return allVMs, nil
 }
 
 // getProtectedNamespaces returns the list of namespaces being protected,
@@ -3122,24 +3221,6 @@ func (v *VRGInstance) getProtectedNamespaces() []string {
 	}
 
 	return result
-}
-
-// discoverVMsInNamespaces lists all VirtualMachine resources across the given namespaces.
-// Returns VMs regardless of whether they have static IP annotations (filtering happens later).
-func (v *VRGInstance) discoverVMsInNamespaces(namespaces []string) ([]virtv1.VirtualMachine, error) {
-	var allVMs []virtv1.VirtualMachine
-
-	for _, ns := range namespaces {
-		vmList := &virtv1.VirtualMachineList{}
-		if err := v.reconciler.Client.List(v.ctx, vmList, client.InNamespace(ns)); err != nil {
-			return nil, fmt.Errorf("failed to list VMs in namespace %s: %w", ns, err)
-		}
-
-		v.log.Info("Found VMs in namespace", "namespace", ns, "count", len(vmList.Items))
-		allVMs = append(allVMs, vmList.Items...)
-	}
-
-	return allVMs, nil
 }
 
 // ValidateStaticIPNetworkMapping inspects every protected VM in the VRG and

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1681,10 +1681,31 @@ func (v *VRGInstance) reconcileAsPrimary() {
 		vrg.Status.PrepareForFinalSyncComplete = finalSyncPrepared.volSync
 	}
 
-	if !v.result.Requeue && v.isVMRecipeProtection() {
+	// Discover VMs with static IPs for all discovered apps (any recipe, any namespace)
+	v.discoverStaticIPsForProtectedVMs()
+}
+
+// discoverStaticIPsForProtectedVMs performs VM static IP discovery for discovered apps.
+// For vm-recipe: validates VM list matches label selector, then discovers static IPs.
+// For other discovered apps: scans namespaces for VMs with static IPs.
+func (v *VRGInstance) discoverStaticIPsForProtectedVMs() {
+	if v.result.Requeue || !v.isDiscoveredApp() {
+		return
+	}
+
+	if v.isVMRecipeProtection() {
+		// vm-recipe: validate VM list matches label selector, then discover static IPs
 		if err := v.validateVMsForStandaloneProtection(); err != nil {
 			v.result.Requeue = true
 		}
+
+		return
+	}
+
+	// All other discovered apps: scan namespaces for VMs with static IPs
+	if err := v.discoverAndValidateStaticIPsForAllProtectedVMs(); err != nil {
+		v.log.Error(err, "Failed to discover static IPs for protected VMs")
+		v.result.Requeue = true
 	}
 }
 
@@ -3014,6 +3035,111 @@ func (v *VRGInstance) validateAndRecordStaticIPDiscovery(vmList []string, vmName
 		"totalVMs", len(infos), "staticIPVMs", len(resources))
 
 	return nil
+}
+
+// discoverAndValidateStaticIPsForAllProtectedVMs performs VM static IP discovery
+// for any discovered app, regardless of recipe type. It scans all protected namespaces,
+// finds all VMs, and records those with static IP annotations.
+//
+// This handles:
+// - vm-recipe: VMs explicitly listed in RecipeParameters
+// - namespace-level protection: all VMs in ProtectedNamespaces
+// - custom recipes: any VMs in namespaces being protected
+// - mixed workloads: only VMs with static IP annotations are recorded
+func (v *VRGInstance) discoverAndValidateStaticIPsForAllProtectedVMs() error {
+	// Only run on Primary during steady state
+	if v.instance.Spec.ReplicationState != ramendrv1alpha1.Primary {
+		return nil
+	}
+
+	if v.IsDRActionInProgress() {
+		return nil
+	}
+
+	// Determine which namespaces to scan
+	namespacesToScan := v.getProtectedNamespaces()
+	if len(namespacesToScan) == 0 {
+		v.log.Info("No protected namespaces found; skipping VM static IP discovery")
+
+		return nil
+	}
+
+	v.log.Info("Scanning for VMs with static IPs", "namespaces", namespacesToScan)
+
+	// Discover all VMs across all protected namespaces
+	allVMs, err := v.discoverVMsInNamespaces(namespacesToScan)
+	if err != nil {
+		return fmt.Errorf("failed to discover VMs in protected namespaces: %w", err)
+	}
+
+	if len(allVMs) == 0 {
+		v.log.Info("No VMs found in protected namespaces")
+		// Clear any previous discovery status
+		v.instance.Status.StaticIPDiscoveryStatus = nil
+
+		return nil
+	}
+
+	// Extract VM names and namespaces for validation
+	vmNames := make([]string, 0, len(allVMs))
+	vmNamespaces := make([]string, 0, len(allVMs))
+
+	for _, vm := range allVMs {
+		vmNames = append(vmNames, vm.Name)
+		vmNamespaces = append(vmNamespaces, vm.Namespace)
+	}
+
+	// Validate and record static IPs (filters to only VMs with static IP annotations)
+	return v.validateAndRecordStaticIPDiscovery(vmNames, vmNamespaces)
+}
+
+// getProtectedNamespaces returns the list of namespaces being protected,
+// handling both vm-recipe (RecipeParameters) and namespace-level protection.
+func (v *VRGInstance) getProtectedNamespaces() []string {
+	namespaces := make(map[string]struct{})
+
+	// Check ProtectedNamespaces (namespace-level protection, custom recipes)
+	if v.instance.Spec.ProtectedNamespaces != nil {
+		for _, ns := range *v.instance.Spec.ProtectedNamespaces {
+			namespaces[ns] = struct{}{}
+		}
+	}
+
+	// Check RecipeParameters (vm-recipe, custom recipes)
+	if v.instance.Spec.KubeObjectProtection != nil &&
+		v.instance.Spec.KubeObjectProtection.RecipeParameters != nil {
+		if vmNamespaces, ok := v.instance.Spec.KubeObjectProtection.RecipeParameters[recipecore.ProtectedVMNamespace]; ok {
+			for _, ns := range vmNamespaces {
+				namespaces[ns] = struct{}{}
+			}
+		}
+	}
+
+	// Convert to slice
+	result := make([]string, 0, len(namespaces))
+	for ns := range namespaces {
+		result = append(result, ns)
+	}
+
+	return result
+}
+
+// discoverVMsInNamespaces lists all VirtualMachine resources across the given namespaces.
+// Returns VMs regardless of whether they have static IP annotations (filtering happens later).
+func (v *VRGInstance) discoverVMsInNamespaces(namespaces []string) ([]virtv1.VirtualMachine, error) {
+	var allVMs []virtv1.VirtualMachine
+
+	for _, ns := range namespaces {
+		vmList := &virtv1.VirtualMachineList{}
+		if err := v.reconciler.Client.List(v.ctx, vmList, client.InNamespace(ns)); err != nil {
+			return nil, fmt.Errorf("failed to list VMs in namespace %s: %w", ns, err)
+		}
+
+		v.log.Info("Found VMs in namespace", "namespace", ns, "count", len(vmList.Items))
+		allVMs = append(allVMs, vmList.Items...)
+	}
+
+	return allVMs, nil
 }
 
 // ValidateStaticIPNetworkMapping inspects every protected VM in the VRG and


### PR DESCRIPTION
Enable static IP translation for VMs protected through vm-recipe,
namespace-level protection, and custom recipes. VMs with OVN-K8s static
IP annotations are now automatically discovered and translated during DR
operations across all protection patterns.

Problem
Static IP translation was previously limited to VMs protected using the
vm-recipe pattern. VMs protected through namespace-level protection or
custom recipes were not discovered, which could lead to IP conflicts
during failover.

Solution
Extend VM discovery logic to support all DRPC protection patterns:

vm-recipe:
Discover VMs using the existing K8S_RESOURCE_SELECTOR label selector.

Custom recipes:
Use K8S_RESOURCE_SELECTOR when defined, otherwise fall back to
namespace-level discovery.

Namespace-level protection:
Filter VMs using kubeObjectSelector when configured.
Otherwise discover all VMs in protected namespaces.

Key Changes
Added VM discovery workflow in the VRG controller to identify protected
VMs for static IP translation.

Added support for discovering all VMs across protected namespaces.

Updated DRPC reconciliation to trigger static IP discovery for all
supported protection types.

Detect VMs with network.kubevirt.io/addresses annotations and include
them in static IP translation.

Benefits
Static IP translation now works consistently across all DRPC protection
patterns.

Prevents IP conflicts during failover and relocation.

Supports OVN-K8s UDN/CUDN networks.

Maintains backward compatibility with existing vm-recipe workflows.

Backward Compatibility
No breaking changes. Existing vm-recipe-based protection continues to
work unchanged, while namespace-level and custom recipe protection now
also support static IP translation.

Assisted by: Claude Sonnet 4.5

Fixes : #2763