### PR TITLE
Wait until rbd image is created on secondary cluster

### DIFF
--- a/test/drenv/addons/rook/rbd_mirror/test.py
+++ b/test/drenv/addons/rook/rbd_mirror/test.py
@@ -114,9 +114,9 @@ def _check_rbd_replication(primary, secondary, rbd_image):
     print(f"Waiting until rbd image {rbd_image} is created in cluster '{secondary}'")
     for i in range(60):
         time.sleep(1)
-        out = _rbd("list", cluster=primary)
+        out = _rbd("list", cluster=secondary)
         if rbd_image in out:
-            out = _rbd("info", rbd_image, cluster=primary)
+            out = _rbd("info", rbd_image, cluster=secondary)
             print(out)
             break
     else:


### PR DESCRIPTION
Previously, the test was waiting for image creation on the primary cluster instead of the secondary cluster, which could allow it to proceed before the mirrored image was available on the secondary side.