### PR TITLE
Allow config/ in Docker build context for bundle images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,11 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
 # Ignore everything
 *
-# Except what the Dockerfile needs.
+# Except what the Dockerfiles need.
 !go.mod
 !go.sum
 !api/
 !cmd/
 !internal/
 !LICENSE
+!config/


### PR DESCRIPTION
make bundle-build copies generated files from config/hub/bundle and config/dr-cluster/bundle into the bundle image. .dockerignore allowed only the operator Dockerfile inputs, so podman filtered those paths out:

  COPY config/hub/bundle/manifests /manifests/
  Error: no items matching glob ... (1 filtered out using .dockerignore)

operator-sdk always writes bundle.Dockerfile in the project root with COPY paths relative to that root, so the bundle image must be built from the repository context. Allow config/ in .dockerignore. It is 1.5MB, much smaller than test/out/, so operator builds stay fast.

Assisted-by: Cursor/Grok 4.6