### PR TITLE
Run make bundle-build from unit tests

### DIFF
--- a/internal/olm/olm_test.go
+++ b/internal/olm/olm_test.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package olm_test tests OLM bundle image builds.
+package olm_test
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+func TestBundleBuild(t *testing.T) {
+	runMake(t, "bundle-build")
+}
+
+func runMake(t *testing.T, target string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "make", target)
+	cmd.Dir = "../.."
+
+	out, err := cmd.CombinedOutput()
+	t.Logf("make %s\n%s", target, out)
+
+	if err != nil {
+		t.Fatalf("make %s failed: %v\n%s", target, err, out)
+	}
+}


### PR DESCRIPTION
CI only built bundle images in the publish job after merge, so a broken
bundle-build (for example .dockerignore filtering COPY paths) was not
caught on PRs.

catalog-build is not included: opm index add pulls bundle images from
the registry, and a local HTTP registry needs insecure TLS exceptions.

The test is included in `make test`. To run only the new test run:

    % go test ./internal/olm
    ok          github.com/ramendr/ramen/internal/olm   5.784s


---
Assisted-by: Cursor/Grok 4.6
Based on #2776 for testing.