### PR TITLE
drenv: Remove unused macOS qemu requirement

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -184,7 +184,6 @@ environment.
        minikube \
        minio-mc \
        python3 \
-       qemu \
        velero \
        vfkit \
        virtctl


### PR DESCRIPTION
Fixes #1790.

Remove QEMU from the macOS Homebrew prerequisites. The current Minikube configuration uses the vfkit driver on macOS, so QEMU is unused.

Validation: mdformat 1.0.0, package-list assertion, and `git diff --check`.

Developed with OpenAI Codex; reviewed and tested by the author.
