### PR TITLE
fix: match ApplicationSet by placement name and namespace in VRG namespace selection

### DIFF
--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -2376,7 +2376,7 @@ func getApplicationDestinationNamespace(
 		if len(appSet.Spec.Generators) > 0 &&
 			appSet.Spec.Generators[0].ClusterDecisionResource != nil {
 			name := appSet.Spec.Generators[0].ClusterDecisionResource.LabelSelector.MatchLabels[clrapiv1beta1.PlacementLabel]
-			if name == placement.GetName() {
+			if name == placement.GetName() && appSet.Namespace == placement.GetNamespace() {
 				log.Info("Found ApplicationSet for Placement", "name", appSet.Name, "placement", placement.GetName())
 				// Retrieving the Destination.Namespace from Application.Spec requires iterating through all Applications
 				// and checking their ownerReferences, which can be time-consuming. Alternatively, we can get the same


### PR DESCRIPTION
getApplicationDestinationNamespace matched an ApplicationSet generator label against the DRPC Placement name only, with no namespace check. This caused a false match when a Subscription workload and an ApplicationSet workload had Placement objects with the same name in different namespaces, resulting in the Subscription workload's VRG being created in the ApplicationSet workload's namespace instead of its own.

The wrong namespace was then persisted as the
drplacementcontrol.ramendr.openshift.io/app-namespace annotation on the first reconcile and used as a cache from that point on, leaving the Subscription workload's PVCs unprotected.

Add a namespace check so that an ApplicationSet only matches the Placement that belongs to it:

  if name == placement.GetName() && appSet.Namespace == placement.GetNamespace()

Fixes: https://redhat.atlassian.net/browse/DFBUGS-487