### PR TITLE
fix(cephfscg): pass VSHandler to NewVolumeGroupSourceHandler in test

### DIFF
--- a/internal/controller/cephfscg/volumegroupsourcehandler_test.go
+++ b/internal/controller/cephfscg/volumegroupsourcehandler_test.go
@@ -48,7 +48,11 @@ var _ = Describe("Volumegroupsourcehandler", func() {
 
 	BeforeEach(func() {
 		volumeGroupSourceHandler = cephfscg.NewVolumeGroupSourceHandler(
-			k8sClient, rgs, internalController.DefaultCephFSCSIDriverName, nil, testLogger,
+			k8sClient, rgs, internalController.DefaultCephFSCSIDriverName,
+			volsync.NewVSHandler(context.Background(), k8sClient, testLogger, rgs,
+				&v1alpha1.VRGAsyncSpec{}, internalController.DefaultCephFSCSIDriverName,
+				internalController.DefaultVolSyncCopyMethod, false,
+			), testLogger,
 		)
 
 		CreatePVC(appPVCName)


### PR DESCRIPTION
Commit 72d65433 added calls to EnsureVolSyncMoverJobLabels and EnsureVolSyncServiceImportLabels in CreateOrUpdateReplicationSourceForRestoredPVCs but the BeforeEach in volumegroupsourcehandler_test.go was still passing nil for the vsHandler argument, causing a nil pointer dereference panic.

Replace nil with a properly initialised VSHandler, consistent with the pattern used in replicationgroupsource_test.go and cghandler_test.go.