### PR TITLE
test: Update minikube to 1.39.0

### DIFF
--- a/docs/user-quick-start.md
+++ b/docs/user-quick-start.md
@@ -95,7 +95,8 @@ clusters. *Ramen* makes this easy using minikube, but you need enough resources:
    minikube version
    ```
 
-   Tested with version v1.38.0.
+   **NOTE**: minikube version 1.39.0 or later is required, latest version is
+   recommended.
 
 1. Install the `kubectl` tool
 
@@ -108,7 +109,7 @@ clusters. *Ramen* makes this easy using minikube, but you need enough resources:
 
    For more info see
    [Install and Set Up kubectl on Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
-   Tested with version v1.34.1.
+   Tested with version v1.37.0.
 
 1. Validate the installation
 

--- a/test/README.md
+++ b/test/README.md
@@ -38,7 +38,8 @@ environment.
    minikube version
    ```
 
-   Tested with version v1.38.0.
+   **NOTE**: minikube version 1.39.0 or later is required, latest version is
+   recommended. Tested with version v1.39.0.
 
 1. Install the `kubectl` tool
 
@@ -51,7 +52,7 @@ environment.
 
    For more info see
    [Install and Set Up kubectl on Linux](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
-   Tested with version v1.34.1.
+   Tested with version v1.37.0.
 
 1. Install the `clusteradm` tool
 
@@ -189,7 +190,7 @@ environment.
        virtctl
    ```
 
-   **NOTE**: minikube version 1.38.0 or later is required, latest version is
+   **NOTE**: minikube version 1.39.0 or later is required, latest version is
    recommended.
 
 1. Install `vmnet-helper`

--- a/test/scripts/bootstrap-linux
+++ b/test/scripts/bootstrap-linux
@@ -67,9 +67,9 @@ LIBVIRT_DRIVERS = [
 TOOLS = [
     {
         "name": "minikube",
-        "version": "v1.38.1",
+        "version": "v1.39.0",
         "url": "https://github.com/kubernetes/minikube/releases/download/{version}/minikube-{goos}-{goarch}",
-        "digest": "099477eaf248bcb5bcea8ce78a2898e93ac01461c35189da1848c3de82ecd22e",
+        "digest": "b738496da01be06bbaf80c688f57ce25acd3849fbb518155f3a88e03ef555aa4",
         "verify": ["minikube", "version"],
     },
     {
@@ -85,9 +85,9 @@ TOOLS = [
     },
     {
         "name": "kubectl",
-        "version": "v1.36.1",
+        "version": "v1.37.0",
         "url": "https://dl.k8s.io/release/{version}/bin/{goos}/{goarch}/kubectl",
-        "digest": "629d3f410e09bf49b64ae7079f7f0bda1191efed311f7d37fdbab0ad5b0ec2b7",
+        "digest": "6129359f4e1f3848a5572ccb0b26cf28b8ca08cef38c95a765b2f64a2c961a2f",
         "verify": ["kubectl", "version", "--client"],
     },
     {


### PR DESCRIPTION
Update to the latest version to consume new features, performance improvements and bug fixes. See release notes for complete changes: https://github.com/kubernetes/minikube/releases/tag/v1.39.0

To upgrade your Linux VM run:

    test/scripts/bootstrap-linux

To upgrade macOS machine run:

    brew update
    brew upgrade