### PR TITLE
controller: tighten Metro DR guard in allVRGPeerClassesOffloaded

### DIFF
--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -539,14 +539,16 @@ func allVRGPeerClassesOffloaded(vrgs map[string]*rmn.VolumeReplicationGroup) boo
 	found := false
 
 	for _, vrg := range vrgs {
-		if vrg.Spec.Async != nil {
-			for i := range vrg.Spec.Async.PeerClasses {
-				if !vrg.Spec.Async.PeerClasses[i].Offloaded {
-					return false
-				}
+		if vrg.Spec.Async == nil || len(vrg.Spec.Async.PeerClasses) == 0 {
+			return false
+		}
 
-				found = true
+		for i := range vrg.Spec.Async.PeerClasses {
+			if !vrg.Spec.Async.PeerClasses[i].Offloaded {
+				return false
 			}
+
+			found = true
 		}
 	}
 


### PR DESCRIPTION
Require Async peer classes on every VRG.

`found` only proves that one VRG has an offloaded peer class. A second VRG with `Spec.Async == nil` or an empty PeerClasses list does not return false. The helper then returns true and skips Metro DR detection. This leaves `d.drType` as async and can keep VolSync enabled for a Metro DR workload.

Return false immediately when any VRG has a nil Spec.Async or an empty PeerClasses slice, instead of silently skipping those VRGs. A VRG without async peer-class information indicates a Metro DR deployment and must not bypass the Metro DR path.