### PR TITLE
Fix for Granular VM DR Consistency Group Issue

### DIFF
--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1008,7 +1008,12 @@ func (v *VRGInstance) getCGLabelValue(scName *string, pvcName, pvcNamespace stri
 		return "", fmt.Errorf("missing storageID for PVC %s/%s", pvcNamespace, pvcName)
 	}
 
-	return util.GenerateCombinedName(pvcNamespace, storageID), nil
+	// Include VRG name to ensure CG label is unique per VRG in the same namespace.
+	// This prevents PVCs from different VRGs in the same namespace from being
+	// grouped into the same consistency group in granular VM DR scenarios.
+	vrgIdentifier := pvcNamespace + "-" + v.instance.GetName()
+
+	return util.GenerateCombinedName(vrgIdentifier, storageID), nil
 }
 
 func (v *VRGInstance) updateReplicationClassList() error {


### PR DESCRIPTION
#### Problem:

Multiple VolumeReplicationGroups (VRGs) in the same namespace were sharing the same Consistency Group (CG) because the CG label was generated using only namespace + storageID, which is identical for all VRGs in the same namespace using the same storage class.

#### Root Cause:

The getCGLabelValue() function at line 1011 generated labels as: return util.GenerateCombinedName(pvcNamespace, storageID), nil

#### Solution:

Modified the function to include the VRG name in the identifier: vrgIdentifier := pvcNamespace + "-" + v.instance.GetName() return util.GenerateCombinedName(vrgIdentifier, storageID), nil

#### Result:

- Before: CG label = <namespace>-<storageID> → All VRGs share one CG ❌
- After: CG label = <namespace>-<vrgName>-<storageID> → Each VRG has its own CG ✓

The fix ensures that in granular VM DR scenarios, each VRG maintains its own isolated consistency group, preventing PVCs from different VMs in the same namespace from being incorrectly grouped together.

Assisted by: Claude Sonnet 4.5